### PR TITLE
fix(#7244): resolve graph importer identities by their text, not as an int

### DIFF
--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -825,13 +825,21 @@ public class GraphImporter implements AutoCloseable {
    * after every vertex source and can name any of them.
    */
   private void validateEdgeTargets() {
+    // A type may be imported by more than one source, and only one of them need carry the key
     final Set<String> allTypes = new HashSet<>(vertexSources.size());
-    for (final VertexSourceDef vsd : vertexSources)
+    final Set<String> typesWithId = new HashSet<>(vertexSources.size());
+    final Set<String> typesWithNameId = new HashSet<>(vertexSources.size());
+    for (final VertexSourceDef vsd : vertexSources) {
       allTypes.add(vsd.typeName);
+      if (vsd.config.idAttribute != null)
+        typesWithId.add(vsd.typeName);
+      if (vsd.config.nameIdAttribute != null)
+        typesWithNameId.add(vsd.typeName);
+    }
 
     final Set<String> importedSoFar = new HashSet<>(vertexSources.size());
     for (final VertexSourceDef vsd : vertexSources) {
-      for (final EdgeDef ed : vsd.config.edges)
+      for (final EdgeDef ed : vsd.config.edges) {
         if (!ed.targetType.equals(vsd.typeName) && !importedSoFar.contains(ed.targetType))
           throw new IllegalArgumentException("Edge '" + ed.edgeType + "' declared on vertex source '"
               + vsd.typeName + "' targets vertex type '" + ed.targetType + "', which "
@@ -839,21 +847,39 @@ public class GraphImporter implements AutoCloseable {
               "is imported after it: declare the vertex source of '" + ed.targetType + "' before '" + vsd.typeName
                   + "', because a vertex source resolves references against the types already imported" :
               "no vertex source imports. Declared vertex types: " + allTypes));
+
+        final boolean resolvesByName = ed.byName || ed.isSplit;
+        if (!(resolvesByName ? typesWithNameId : typesWithId).contains(ed.targetType))
+          throw new IllegalArgumentException("Edge '" + ed.edgeType + "' declared on vertex source '"
+              + vsd.typeName + "' resolves against the " + (resolvesByName ? "idByName()" : "id()")
+              + " of vertex type '" + ed.targetType + "', which declares none");
+      }
       importedSoFar.add(vsd.typeName);
     }
 
     for (final EdgeSourceDef esd : edgeSources) {
-      checkEdgeSourceEndpoint(esd, esd.config.fromVertexType, "from", allTypes);
-      checkEdgeSourceEndpoint(esd, esd.config.toVertexType, "to", allTypes);
+      checkEdgeSourceEndpoint(esd, esd.config.fromVertexType, "from", allTypes, typesWithId);
+      checkEdgeSourceEndpoint(esd, esd.config.toVertexType, "to", allTypes, typesWithId);
     }
   }
 
+  /**
+   * A standalone edge source resolves both endpoints through {@link VertexConfig#id(String)} - a
+   * type that declares only {@code idByName()} would match nothing, row after row. Since the
+   * unified index takes a string key, such a type wants {@code id()} on that same attribute;
+   * {@code idByName()} is for a type referenced through two different keys.
+   */
   private static void checkEdgeSourceEndpoint(final EdgeSourceDef esd, final String vertexType,
-                                              final String endpoint, final Set<String> allTypes) {
+                                              final String endpoint, final Set<String> allTypes,
+                                              final Set<String> typesWithId) {
     if (!allTypes.contains(vertexType))
       throw new IllegalArgumentException("Edge source '" + esd.edgeType + "' resolves its '" + endpoint
           + "' endpoint against vertex type '" + vertexType + "', which no vertex source imports. "
           + "Declared vertex types: " + allTypes);
+    if (!typesWithId.contains(vertexType))
+      throw new IllegalArgumentException("Edge source '" + esd.edgeType + "' resolves its '" + endpoint
+          + "' endpoint against the id() of vertex type '" + vertexType + "', which declares none: an edge "
+          + "source matches id(), not idByName(), and id() takes a string key just as well");
   }
 
   public long getVertexCount() {
@@ -936,21 +962,19 @@ public class GraphImporter implements AutoCloseable {
           return;
       }
 
-      // Deduplication: skip if this id/nameId was already imported
-      if (vc.deduplicate) {
-        if (vc.idAttribute != null && ts.idToIdx.get(identity(record, vc.idAttribute)) >= 0)
-          return;
-        if (vc.nameIdAttribute != null && ts.nameToIdx.get(identity(record, vc.nameIdAttribute)) >= 0)
-          return;
-      }
+      // The raw text is the key: an identity is whatever the source wrote, so reading it as an int
+      // would reject a string key and truncate one wider than an int. Read once - deduplication
+      // looks the same key up that registration then stores
+      final String id = vc.idAttribute != null ? identity(record, vc.idAttribute) : null;
+      final String nameId = vc.nameIdAttribute != null ? identity(record, vc.nameIdAttribute) : null;
 
-      // Register ID. The raw text is the key: an identity is whatever the source wrote, so reading
-      // it as an int would reject a string key and truncate one wider than an int
+      // Deduplication: skip if this id/nameId was already imported
+      if (vc.deduplicate && (ts.idToIdx.get(id) >= 0 || ts.nameToIdx.get(nameId) >= 0))
+        return;
+
       final int idx = count[0];
-      if (vc.idAttribute != null)
-        ts.idToIdx.put(identity(record, vc.idAttribute), idx);
-      if (vc.nameIdAttribute != null)
-        ts.nameToIdx.put(identity(record, vc.nameIdAttribute), idx);
+      ts.idToIdx.put(id, idx);
+      ts.nameToIdx.put(nameId, idx);
 
       // Build vertex properties
       propBuf.clear();

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -1710,15 +1710,20 @@ public class GraphImporter implements AutoCloseable {
     private static final long   EMPTY = Long.MIN_VALUE;
     private              long[] keys;
     private              int[]  values;
-    private int mask, size, threshold;
+    private int mask, shift, size, threshold;
 
     LongIntMap(final int expected) {
       final int cap = Integer.highestOneBit(Math.max(16, (int) (expected / 0.7))) << 1;
       keys = new long[cap];
       values = new int[cap];
-      mask = cap - 1;
-      threshold = (int) (cap * 0.7);
+      capacity(cap);
       Arrays.fill(keys, EMPTY);
+    }
+
+    private void capacity(final int cap) {
+      mask = cap - 1;
+      shift = Long.SIZE - Integer.numberOfTrailingZeros(cap);
+      threshold = (int) (cap * 0.7);
     }
 
     void put(final long key, final int value) {
@@ -1744,13 +1749,15 @@ public class GraphImporter implements AutoCloseable {
     }
 
     /**
-     * Fibonacci hashing: the high bits of the product, never the low ones. Masking the low bits of
-     * {@code key * odd} makes the slot a function of the key's low bits alone, so keys that differ
-     * only above the table's width - ids allocated in blocks, or with a fixed stride - all land in
-     * the same slot and the map degrades to a linear scan.
+     * Fibonacci hashing: the top {@code log2(capacity)} bits of the product, which every bit of the
+     * key influences. Any lower window is a trap, because a key can zero it. Masking the low bits
+     * of {@code key * odd} makes the slot a function of the key's low bits alone; a fixed
+     * {@code >>> 32} reads better but still leaves a key with 45 trailing zeros zeroing bits 32
+     * through 44 of the product, sending every such key to slot 0. Ids allocated in blocks or
+     * carrying a fixed stride are ordinary, and either way the map degrades to a linear scan.
      */
-    private int hash(final long key) {
-      return (int) ((key * 0x9E3779B97F4A7C15L) >>> 32) & mask;
+    int hash(final long key) {
+      return (int) ((key * 0x9E3779B97F4A7C15L) >>> shift);
     }
 
     private void resize() {
@@ -1759,8 +1766,7 @@ public class GraphImporter implements AutoCloseable {
       final int[] ov = values;
       keys = new long[newCap];
       values = new int[newCap];
-      mask = newCap - 1;
-      threshold = (int) (newCap * 0.7);
+      capacity(newCap);
       Arrays.fill(keys, EMPTY);
       for (int i = 0; i < ok.length; i++)
         if (ok[i] != EMPTY) {
@@ -1780,10 +1786,16 @@ public class GraphImporter implements AutoCloseable {
     // see LongIntMap.hash(): the same scramble, and the same reason for taking the high bits
     private static final int   EMPTY = Integer.MIN_VALUE;
     private              int[] keys, values;
-    private int mask, size, threshold;
+    private int mask, shift, size, threshold;
 
-    private int hash(final int key) {
-      return (int) ((key * 0x9E3779B97F4A7C15L) >>> 32) & mask;
+    int hash(final int key) {
+      return (int) ((key * 0x9E3779B97F4A7C15L) >>> shift);
+    }
+
+    private void capacity(final int cap) {
+      mask = cap - 1;
+      shift = Long.SIZE - Integer.numberOfTrailingZeros(cap);
+      threshold = (int) (cap * 0.7);
     }
 
     int size() {
@@ -1798,11 +1810,10 @@ public class GraphImporter implements AutoCloseable {
     }
 
     IntIntMap(final int expected) {
-      int cap = Integer.highestOneBit(Math.max(16, (int) (expected / 0.7))) << 1;
+      final int cap = Integer.highestOneBit(Math.max(16, (int) (expected / 0.7))) << 1;
       keys = new int[cap];
       values = new int[cap];
-      mask = cap - 1;
-      threshold = (int) (cap * 0.7);
+      capacity(cap);
       Arrays.fill(keys, EMPTY);
     }
 
@@ -1833,8 +1844,7 @@ public class GraphImporter implements AutoCloseable {
       final int[] ok = keys, ov = values;
       keys = new int[newCap];
       values = new int[newCap];
-      mask = newCap - 1;
-      threshold = (int) (newCap * 0.7);
+      capacity(newCap);
       Arrays.fill(keys, EMPTY);
       for (int i = 0; i < ok.length; i++)
         if (ok[i] != EMPTY) {

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -1736,6 +1736,12 @@ public class GraphImporter implements AutoCloseable {
       return def;
     }
 
+    /**
+     * Fibonacci hashing: the high bits of the product, never the low ones. Masking the low bits of
+     * {@code key * odd} makes the slot a function of the key's low bits alone, so keys that differ
+     * only above the table's width - ids allocated in blocks, or with a fixed stride - all land in
+     * the same slot and the map degrades to a linear scan.
+     */
     private int hash(final long key) {
       return (int) ((key * 0x9E3779B97F4A7C15L) >>> 32) & mask;
     }
@@ -1764,9 +1770,14 @@ public class GraphImporter implements AutoCloseable {
    * Open-addressing int→int hash map with Fibonacci hashing.
    */
   static final class IntIntMap {
+    // see LongIntMap.hash(): the same scramble, and the same reason for taking the high bits
     private static final int   EMPTY = Integer.MIN_VALUE;
     private              int[] keys, values;
     private int mask, size, threshold;
+
+    private int hash(final int key) {
+      return (int) ((key * 0x9E3779B97F4A7C15L) >>> 32) & mask;
+    }
 
     int size() {
       return size;
@@ -1791,7 +1802,7 @@ public class GraphImporter implements AutoCloseable {
     void put(final int key, final int value) {
       if (size >= threshold)
         resize();
-      int i = (key * 0x9E3779B9) & mask;
+      int i = hash(key);
       while (keys[i] != EMPTY && keys[i] != key)
         i = (i + 1) & mask;
       if (keys[i] == EMPTY)
@@ -1801,7 +1812,7 @@ public class GraphImporter implements AutoCloseable {
     }
 
     int get(final int key, final int def) {
-      int i = (key * 0x9E3779B9) & mask;
+      int i = hash(key);
       while (keys[i] != EMPTY) {
         if (keys[i] == key)
           return values[i];
@@ -1820,7 +1831,7 @@ public class GraphImporter implements AutoCloseable {
       Arrays.fill(keys, EMPTY);
       for (int i = 0; i < ok.length; i++)
         if (ok[i] != EMPTY) {
-          int j = (ok[i] * 0x9E3779B9) & mask;
+          int j = hash(ok[i]);
           while (keys[j] != EMPTY)
             j = (j + 1) & mask;
           keys[j] = ok[i];

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -834,6 +834,10 @@ public class GraphImporter implements AutoCloseable {
    * vertex source only works when that source is declared first; a self-reference is resolved once
    * the source has been read to the end and needs no such ordering. A standalone edge source runs
    * after every vertex source and can name any of them.
+   * <p>
+   * Passing this is what lets {@link #collectEdge} and {@link #processEdgeSource} read a
+   * {@link TypeState} without testing it for null: every type an edge names has one by the time
+   * they run, and a name that could not is an error here rather than an edge quietly dropped.
    */
   private void validateEdgeTargets() {
     // One source per vertex type: processVertexSource() replaces the type's TypeState rather than
@@ -1073,8 +1077,6 @@ public class GraphImporter implements AutoCloseable {
       if (fieldVal == null || fieldVal.isEmpty())
         return;
       final TypeState targetTs = typeStates.get(ed.targetType);
-      if (targetTs == null)
-        return;
       final char delim = ed.delimiter.charAt(0);
       int start = fieldVal.charAt(0) == delim ? 1 : 0;
       int pos;
@@ -1101,8 +1103,6 @@ public class GraphImporter implements AutoCloseable {
       if (key == null)
         return;
       final TypeState targetTs = typeStates.get(ed.targetType);
-      if (targetTs == null)
-        return;
       final int targetIdx = (ed.byName ? targetTs.nameToIdx : targetTs.idToIdx).get(key);
       if (targetIdx < 0) {
         unresolvedEdges++;
@@ -1162,8 +1162,6 @@ public class GraphImporter implements AutoCloseable {
     final EdgeSourceConfig cfg = esd.config;
     final TypeState fromTs = typeStates.get(cfg.fromVertexType);
     final TypeState toTs = typeStates.get(cfg.toVertexType);
-    if (fromTs == null || toTs == null)
-      return;
 
     // Own collector per edge source, never the one vertex-derived edges of the same type and
     // endpoints share. A collector's property buffers are indexed by the collector-wide edge index,

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -889,9 +889,9 @@ public class GraphImporter implements AutoCloseable {
 
       // Deduplication: skip if this id/nameId was already imported
       if (vc.deduplicate) {
-        if (vc.idAttribute != null && ts.idToIdx.get(record.get(vc.idAttribute)) >= 0)
+        if (vc.idAttribute != null && ts.idToIdx.get(identity(record, vc.idAttribute)) >= 0)
           return;
-        if (vc.nameIdAttribute != null && ts.nameToIdx.get(record.get(vc.nameIdAttribute)) >= 0)
+        if (vc.nameIdAttribute != null && ts.nameToIdx.get(identity(record, vc.nameIdAttribute)) >= 0)
           return;
       }
 
@@ -899,9 +899,9 @@ public class GraphImporter implements AutoCloseable {
       // it as an int would reject a string key and truncate one wider than an int
       final int idx = count[0];
       if (vc.idAttribute != null)
-        ts.idToIdx.put(record.get(vc.idAttribute), idx);
+        ts.idToIdx.put(identity(record, vc.idAttribute), idx);
       if (vc.nameIdAttribute != null)
-        ts.nameToIdx.put(record.get(vc.nameIdAttribute), idx);
+        ts.nameToIdx.put(identity(record, vc.nameIdAttribute), idx);
 
       // Build vertex properties
       propBuf.clear();
@@ -925,7 +925,7 @@ public class GraphImporter implements AutoCloseable {
       // target key has to wait for the rest of the file
       for (int i = 0; i < deferredEdgeDefs.size(); i++) {
         final EdgeDef ed = deferredEdgeDefs.get(i);
-        final String fieldVal = record.get(ed.fkAttribute);
+        final String fieldVal = ed.isSplit ? record.get(ed.fkAttribute) : identity(record, ed.fkAttribute);
         if (fieldVal == null)
           continue;
         final DeferredSelfEdges deferred = deferredSelf.get(i);
@@ -995,7 +995,7 @@ public class GraphImporter implements AutoCloseable {
       // An absent or empty attribute means "this row has no such reference" and is not an
       // unresolved endpoint. It is the only way to say so: 0 used to double as that marker, which
       // made a vertex whose key really is 0 impossible to point at
-      final String key = record.get(ed.fkAttribute);
+      final String key = identity(record, ed.fkAttribute);
       if (key == null)
         return;
       final TypeState targetTs = typeStates.get(ed.targetType);
@@ -1015,6 +1015,19 @@ public class GraphImporter implements AutoCloseable {
         ec.dstIdx.add(targetIdx);
       }
     }
+  }
+
+  /**
+   * Reads an identity attribute, reporting an attribute that is absent or empty as {@code null} -
+   * "this row carries no such key". The readers disagree on which of the two an empty field is:
+   * {@link CsvRowSource} already hands back {@code null}, while {@link JsonlRowSource} and
+   * {@link XmlRowSource} hand back the empty string for {@code "id": ""} and {@code id=""}. Left to
+   * each reader, an empty id would be a key of its own, and every row carrying one would collide on
+   * it - the last silently winning any edge that referenced it.
+   */
+  private static String identity(final RecordReader record, final String attribute) {
+    final String value = record.get(attribute);
+    return value == null || value.isEmpty() ? null : value;
   }
 
   /**
@@ -1062,8 +1075,8 @@ public class GraphImporter implements AutoCloseable {
     esd.source.forEach(record -> {
       if (limit > 0 && count[0] >= limit)
         return;
-      final int si = fromTs.idToIdx.get(record.get(cfg.fromAttribute));
-      final int di = toTs.idToIdx.get(record.get(cfg.toAttribute));
+      final int si = fromTs.idToIdx.get(identity(record, cfg.fromAttribute));
+      final int di = toTs.idToIdx.get(identity(record, cfg.toAttribute));
       if (si < 0 || di < 0)
         unresolvedEdges++;
       else {
@@ -1482,7 +1495,7 @@ public class GraphImporter implements AutoCloseable {
     private Map<String, Integer> textKeys;
 
     void put(final String key, final int idx) {
-      if (key == null)
+      if (key == null || key.isEmpty())
         return;
       final long numeric = canonicalLong(key);
       if (numeric == NOT_CANONICAL_LONG) {
@@ -1494,11 +1507,11 @@ public class GraphImporter implements AutoCloseable {
     }
 
     /**
-     * @return the vertex index, or -1 when the key is null (the row carries no such reference) or
-     * no vertex was registered under it
+     * @return the vertex index, or -1 when the key is null or empty (the row carries no such
+     * reference) or no vertex was registered under it
      */
     int get(final String key) {
-      if (key == null)
+      if (key == null || key.isEmpty())
         return -1;
       final long numeric = canonicalLong(key);
       if (numeric != NOT_CANONICAL_LONG)

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -825,12 +825,19 @@ public class GraphImporter implements AutoCloseable {
    * after every vertex source and can name any of them.
    */
   private void validateEdgeTargets() {
-    // A type may be imported by more than one source, and only one of them need carry the key
+    // One source per vertex type: processVertexSource() replaces the type's TypeState rather than
+    // appending to it, so a second source for a name already taken leaves pass 2 resolving edges
+    // collected against the first source's row indices into the second source's row arrays - an
+    // out-of-bounds read, or worse an edge silently pointing at an unrelated vertex. Splitting one
+    // type across files is a plausible thing to try, so it is refused rather than left to corrupt
     final Set<String> allTypes = new HashSet<>(vertexSources.size());
     final Set<String> typesWithId = new HashSet<>(vertexSources.size());
     final Set<String> typesWithNameId = new HashSet<>(vertexSources.size());
     for (final VertexSourceDef vsd : vertexSources) {
-      allTypes.add(vsd.typeName);
+      if (!allTypes.add(vsd.typeName))
+        throw new IllegalArgumentException("Vertex type '" + vsd.typeName + "' is declared by more than one "
+            + "vertex source, which is not supported: one source imports a type. Give the sources distinct "
+            + "type names, or read the files through a single source");
       if (vsd.config.idAttribute != null)
         typesWithId.add(vsd.typeName);
       if (vsd.config.nameIdAttribute != null)

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -43,10 +43,12 @@ import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.logging.Level;
@@ -767,6 +769,8 @@ public class GraphImporter implements AutoCloseable {
   public void run() throws Exception {
     final long start = System.currentTimeMillis();
 
+    validateEdgeTargets();
+
     // ── Pass 1: Create vertices + collect topology ──
     LogManager.instance().log(this, Level.INFO, "Pass 1: Vertices + Topology");
 
@@ -805,8 +809,51 @@ public class GraphImporter implements AutoCloseable {
         totalVertices, totalEdges, elapsed / 1000, (elapsed % 1000) / 100);
     if (unresolvedEdges > 0)
       LogManager.instance().log(this, Level.WARNING,
-          "%,d edge endpoints matched no vertex and were skipped: check that the referenced vertex sources "
-              + "are declared, are not filtered, and use the same identity attribute", unresolvedEdges);
+          "%,d edges named an identity no vertex carries and were skipped: check that the referenced rows "
+              + "are not filtered out and that both files spell the identity the same way", unresolvedEdges);
+  }
+
+  /**
+   * Every edge names the vertex type at its other end, and an edge whose target type is not there
+   * to resolve against contributes nothing at all - it used to do so silently, leaving a smaller
+   * graph and no diagnostic, which is the same failure a mistyped type name produces. Nothing has
+   * been written when this runs, so the name is reported as the configuration mistake it is.
+   * <p>
+   * A vertex source resolves a reference against the types imported so far, so naming another
+   * vertex source only works when that source is declared first; a self-reference is resolved once
+   * the source has been read to the end and needs no such ordering. A standalone edge source runs
+   * after every vertex source and can name any of them.
+   */
+  private void validateEdgeTargets() {
+    final Set<String> allTypes = new HashSet<>(vertexSources.size());
+    for (final VertexSourceDef vsd : vertexSources)
+      allTypes.add(vsd.typeName);
+
+    final Set<String> importedSoFar = new HashSet<>(vertexSources.size());
+    for (final VertexSourceDef vsd : vertexSources) {
+      for (final EdgeDef ed : vsd.config.edges)
+        if (!ed.targetType.equals(vsd.typeName) && !importedSoFar.contains(ed.targetType))
+          throw new IllegalArgumentException("Edge '" + ed.edgeType + "' declared on vertex source '"
+              + vsd.typeName + "' targets vertex type '" + ed.targetType + "', which "
+              + (allTypes.contains(ed.targetType) ?
+              "is imported after it: declare the vertex source of '" + ed.targetType + "' before '" + vsd.typeName
+                  + "', because a vertex source resolves references against the types already imported" :
+              "no vertex source imports. Declared vertex types: " + allTypes));
+      importedSoFar.add(vsd.typeName);
+    }
+
+    for (final EdgeSourceDef esd : edgeSources) {
+      checkEdgeSourceEndpoint(esd, esd.config.fromVertexType, "from", allTypes);
+      checkEdgeSourceEndpoint(esd, esd.config.toVertexType, "to", allTypes);
+    }
+  }
+
+  private static void checkEdgeSourceEndpoint(final EdgeSourceDef esd, final String vertexType,
+                                              final String endpoint, final Set<String> allTypes) {
+    if (!allTypes.contains(vertexType))
+      throw new IllegalArgumentException("Edge source '" + esd.edgeType + "' resolves its '" + endpoint
+          + "' endpoint against vertex type '" + vertexType + "', which no vertex source imports. "
+          + "Declared vertex types: " + allTypes);
   }
 
   public long getVertexCount() {
@@ -818,9 +865,11 @@ public class GraphImporter implements AutoCloseable {
   }
 
   /**
-   * Endpoints that named a key no vertex of the referenced type carries. Such an edge is skipped -
-   * there is nothing to attach it to - but the count is what tells a caller that the graph it got
-   * is smaller than the file it handed over, rather than leaving the import to look complete.
+   * Edges that could not be created because an endpoint named a key no vertex of the referenced
+   * type carries. One per edge, not per endpoint: a row of an edge source whose {@code from} and
+   * {@code to} both fail to resolve is one edge lost, and counts once. The edge is skipped - there
+   * is nothing to attach it to - but the count is what tells a caller that the graph it got is
+   * smaller than the file it handed over, rather than leaving the import to look complete.
    */
   public long getUnresolvedEdgeCount() {
     return unresolvedEdges;

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -636,8 +636,9 @@ public class GraphImporter implements AutoCloseable {
     }
 
     /**
-     * Split-field edge: a delimited field (e.g. "|java|python|") creates one edge per value.
-     * Values are resolved by name against the target type's nameId.
+     * Split-field edge: a delimited field (e.g. {@code "|java|python|"}) creates one edge per
+     * value, resolved by name against the target type's nameId. The wrapping delimiters are
+     * optional on either end, so {@code "java|python"} yields the same two values.
      */
     public void splitEdge(final String attribute, final String edgeType, final String targetType,
                           final String delimiter) {
@@ -1055,26 +1056,32 @@ public class GraphImporter implements AutoCloseable {
     final EdgeCollector ec = edgeCollectors.get(ed.edgeType + "|" + srcType + "|" + dstType);
 
     if (ed.isSplit) {
-      // Split field: e.g. "|java|python|css|"
+      // Split field: e.g. "|java|python|css|". Kept in step with collectSplitKeys(), which walks a
+      // field the same way for a self-referencing split - a shared walker would have to hand each
+      // value to a closure, and this runs once per row
       final String fieldVal = record.get(ed.fkAttribute);
-      if (fieldVal == null || fieldVal.length() <= 1)
+      if (fieldVal == null || fieldVal.isEmpty())
         return;
       final TypeState targetTs = typeStates.get(ed.targetType);
       if (targetTs == null)
         return;
-      int start = fieldVal.charAt(0) == ed.delimiter.charAt(0) ? 1 : 0;
       final char delim = ed.delimiter.charAt(0);
+      int start = fieldVal.charAt(0) == delim ? 1 : 0;
       int pos;
-      while ((pos = fieldVal.indexOf(delim, start)) != -1) {
-        if (pos > start) {
-          final int ti = targetTs.nameToIdx.get(fieldVal.substring(start, pos));
+      while (start < fieldVal.length()) {
+        pos = fieldVal.indexOf(delim, start);
+        // the convention wraps the field in delimiters, but a last value without a closing one is
+        // still a value: it used to be dropped, and not even counted as an edge lost
+        final int end = pos == -1 ? fieldVal.length() : pos;
+        if (end > start) {
+          final int ti = targetTs.nameToIdx.get(fieldVal.substring(start, end));
           if (ti >= 0) {
             ec.srcIdx.add(thisIdx);
             ec.dstIdx.add(ti);
           } else
             unresolvedEdges++;
         }
-        start = pos + 1;
+        start = end + 1;
       }
     } else {
       // An absent or empty attribute means "this row has no such reference" and is not an
@@ -1121,16 +1128,18 @@ public class GraphImporter implements AutoCloseable {
    */
   private static void collectSplitKeys(final String fieldVal, final char delimiter,
                                        final DeferredSelfEdges deferred, final int thisIdx) {
-    if (fieldVal.length() <= 1)
+    if (fieldVal.isEmpty())
       return;
     int start = fieldVal.charAt(0) == delimiter ? 1 : 0;
     int pos;
-    while ((pos = fieldVal.indexOf(delimiter, start)) != -1) {
-      if (pos > start) {
+    while (start < fieldVal.length()) {
+      pos = fieldVal.indexOf(delimiter, start);
+      final int end = pos == -1 ? fieldVal.length() : pos;
+      if (end > start) {
         deferred.srcIdx.add(thisIdx);
-        deferred.targetKeys.add(fieldVal.substring(start, pos));
+        deferred.targetKeys.add(fieldVal.substring(start, end));
       }
-      start = pos + 1;
+      start = end + 1;
     }
   }
 
@@ -1863,9 +1872,6 @@ public class GraphImporter implements AutoCloseable {
   }
 
   /**
-   * Growable int array.
-   */
-  /**
    * Initial capacity of an {@link EdgeCollector}'s buffers. Each edge source gets a collector of its
    * own, so a file with several small sources of the same edge type holds several sets of these.
    * Every list here doubles on growth: a large source reaches its size in a handful of copies, and
@@ -1873,6 +1879,9 @@ public class GraphImporter implements AutoCloseable {
    */
   static final int BUFFER_INITIAL_CAPACITY = 4_096;
 
+  /**
+   * Growable int array.
+   */
   static final class IntList {
     int[] data;
     int   size;

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -879,6 +879,9 @@ public class GraphImporter implements AutoCloseable {
   private static void checkEdgeSourceEndpoint(final EdgeSourceDef esd, final String vertexType,
                                               final String endpoint, final Set<String> allTypes,
                                               final Set<String> typesWithId) {
+    if (vertexType == null)
+      throw new IllegalArgumentException("Edge source '" + esd.edgeType + "' declares no '" + endpoint
+          + "' endpoint: call " + endpoint + "(attribute, vertexType) on it");
     if (!allTypes.contains(vertexType))
       throw new IllegalArgumentException("Edge source '" + esd.edgeType + "' resolves its '" + endpoint
           + "' endpoint against vertex type '" + vertexType + "', which no vertex source imports. "
@@ -900,9 +903,11 @@ public class GraphImporter implements AutoCloseable {
   /**
    * Edges that could not be created because an endpoint named a key no vertex of the referenced
    * type carries. One per edge, not per endpoint: a row of an edge source whose {@code from} and
-   * {@code to} both fail to resolve is one edge lost, and counts once. The edge is skipped - there
-   * is nothing to attach it to - but the count is what tells a caller that the graph it got is
-   * smaller than the file it handed over, rather than leaving the import to look complete.
+   * {@code to} both fail to resolve is one edge lost, and counts once - while a split field, where
+   * every value is an edge of its own, counts once per value that resolved to nothing. The edge is
+   * skipped - there is nothing to attach it to - but the count is what tells a caller that the
+   * graph it got is smaller than the file it handed over, rather than leaving the import to look
+   * complete.
    */
   public long getUnresolvedEdgeCount() {
     return unresolvedEdges;

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -85,6 +85,16 @@ import java.util.logging.Level;
  */
 public class GraphImporter implements AutoCloseable {
 
+  /**
+   * A key that is not the canonical decimal text of a {@code long}, and the empty slot marker of
+   * {@link LongIntMap}. {@code Long.MIN_VALUE} therefore never reaches the primitive maps: a key
+   * spelled {@code "-9223372036854775808"} is kept with the textual keys, which resolve it the
+   * same way, only boxed.
+   *
+   * @see #canonicalLong(String)
+   */
+  static final long NOT_CANONICAL_LONG = Long.MIN_VALUE;
+
   private final Database                            database;
   private final List<VertexSourceDef>               vertexSources;
   private final List<EdgeSourceDef>                 edgeSources;
@@ -1516,14 +1526,6 @@ public class GraphImporter implements AutoCloseable {
   // ═══════════════════════════════════════════════════════════════════
 
   /**
-   * A key that is not the canonical decimal text of a {@code long}, and the empty slot marker of
-   * {@link LongIntMap}. {@code Long.MIN_VALUE} therefore never reaches the primitive maps: a key
-   * spelled {@code "-9223372036854775808"} is kept with the textual keys, which resolve it the
-   * same way, only boxed.
-   */
-  static final long NOT_CANONICAL_LONG = Long.MIN_VALUE;
-
-  /**
    * Reads {@code text} as the canonical decimal form of a {@code long}, returning
    * {@link #NOT_CANONICAL_LONG} when it is not one. Neither allocates nor throws: an identity
    * column is read once per row, and {@code Long.parseLong} in a {@code try} block would fill in a
@@ -1584,6 +1586,12 @@ public class GraphImporter implements AutoCloseable {
    * lands in a {@link HashMap} that is not allocated at all until one appears.
    */
   static final class IdIndex {
+    /**
+     * {@link IntIntMap} reserves {@code Integer.MIN_VALUE} to mark an empty slot, so that one value
+     * goes to the {@code long} map instead of being stored as an {@code int}.
+     */
+    private static final int INT_KEY_MIN = Integer.MIN_VALUE + 1;
+
     private IntIntMap            intKeys;
     private LongIntMap           longKeys;
     private Map<String, Integer> textKeys;
@@ -1645,12 +1653,6 @@ public class GraphImporter implements AutoCloseable {
       }
     }
   }
-
-  /**
-   * {@link IntIntMap} reserves {@code Integer.MIN_VALUE} to mark an empty slot, so that one value
-   * goes to the {@code long} map instead of being stored as an {@code int}.
-   */
-  static final int INT_KEY_MIN = Integer.MIN_VALUE + 1;
 
   /**
    * Target keys of self-referencing edges, held until the source has been read to the end because
@@ -1724,7 +1726,10 @@ public class GraphImporter implements AutoCloseable {
     private static final long   EMPTY = Long.MIN_VALUE;
     private              long[] keys;
     private              int[]  values;
-    private int mask, shift, size, threshold;
+    private int mask;
+    private int shift;
+    private int size;
+    private int threshold;
 
     LongIntMap(final int expected) {
       final int cap = Integer.highestOneBit(Math.max(16, (int) (expected / 0.7))) << 1;
@@ -1799,8 +1804,12 @@ public class GraphImporter implements AutoCloseable {
   static final class IntIntMap {
     // see LongIntMap.hash(): the same scramble, and the same reason for taking the high bits
     private static final int   EMPTY = Integer.MIN_VALUE;
-    private              int[] keys, values;
-    private int mask, shift, size, threshold;
+    private              int[] keys;
+    private              int[] values;
+    private int mask;
+    private int shift;
+    private int size;
+    private int threshold;
 
     int hash(final int key) {
       return (int) ((key * 0x9E3779B97F4A7C15L) >>> shift);

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -89,10 +89,10 @@ public class GraphImporter implements AutoCloseable {
   private final long                                limit;
   private final Map<String, TypeState>              typeStates     = new LinkedHashMap<>();
   private final Map<String, EdgeCollector>          edgeCollectors = new LinkedHashMap<>();
-  private final Map<String, List<DeferredEdgePair>> deferredEdges  = new HashMap<>();
 
   private long totalVertices;
   private long totalEdges;
+  private long unresolvedEdges;
 
   private GraphImporter(final Database database, final List<VertexSourceDef> vertexSources,
                         final List<EdgeSourceDef> edgeSources, final long limit) {
@@ -583,14 +583,20 @@ public class GraphImporter implements AutoCloseable {
     }
 
     /**
-     * Primary ID attribute (integer-valued, used for edge resolution).
+     * Primary ID attribute, used to resolve edges. The key is the attribute's text exactly as the
+     * source wrote it, so an integer, a value wider than an {@code int} and a string such as
+     * {@code "W13696992"} all work, and two spellings the source kept apart (e.g. {@code "007"}
+     * and {@code "7"}) stay two identities. An empty or absent value registers no key.
      */
     public void id(final String attribute) {
       this.idAttribute = attribute;
     }
 
     /**
-     * Secondary name-based ID (string, for split-field edge resolution like tags).
+     * Secondary ID, matched by {@code edgeOutByName}/{@code edgeInByName} and by
+     * {@code splitEdge}. Declare it when a type is referenced through two different keys - a
+     * numeric id from one file and a name from another; a single string key needs nothing more
+     * than {@link #id(String)}.
      */
     public void idByName(final String attribute) {
       this.nameIdAttribute = attribute;
@@ -646,11 +652,18 @@ public class GraphImporter implements AutoCloseable {
       this.edgeType = edgeType;
     }
 
+    /**
+     * Source endpoint: the attribute holding the key of a {@code vertexType} vertex, matched
+     * against that type's {@link VertexConfig#id(String)} attribute by its text, whatever its type.
+     */
     public void from(final String attribute, final String vertexType) {
       this.fromAttribute = attribute;
       this.fromVertexType = vertexType;
     }
 
+    /**
+     * Destination endpoint. See {@link #from(String, String)}.
+     */
     public void to(final String attribute, final String vertexType) {
       this.toAttribute = attribute;
       this.toVertexType = vertexType;
@@ -790,6 +803,10 @@ public class GraphImporter implements AutoCloseable {
     final long elapsed = System.currentTimeMillis() - start;
     LogManager.instance().log(this, Level.INFO, "Import complete: %,d vertices, %,d edges in %d.%ds",
         totalVertices, totalEdges, elapsed / 1000, (elapsed % 1000) / 100);
+    if (unresolvedEdges > 0)
+      LogManager.instance().log(this, Level.WARNING,
+          "%,d edge endpoints matched no vertex and were skipped: check that the referenced vertex sources "
+              + "are declared, are not filtered, and use the same identity attribute", unresolvedEdges);
   }
 
   public long getVertexCount() {
@@ -800,11 +817,19 @@ public class GraphImporter implements AutoCloseable {
     return totalEdges;
   }
 
+  /**
+   * Endpoints that named a key no vertex of the referenced type carries. Such an edge is skipped -
+   * there is nothing to attach it to - but the count is what tells a caller that the graph it got
+   * is smaller than the file it handed over, rather than leaving the import to look complete.
+   */
+  public long getUnresolvedEdgeCount() {
+    return unresolvedEdges;
+  }
+
   @Override
   public void close() {
     typeStates.clear();
     edgeCollectors.clear();
-    deferredEdges.clear();
   }
 
   // ═══════════════════════════════════════════════════════════════════
@@ -830,16 +855,20 @@ public class GraphImporter implements AutoCloseable {
         getOrCreateEdgeCollector(ed.edgeType, ed.targetType, vc.typeName);
       else
         getOrCreateEdgeCollector(ed.edgeType, vc.typeName, ed.targetType);
-      if (ed.targetType.equals(vc.typeName) && !ed.isSplit)
+      // A self-referencing edge can point at a row further down the same file, so its target key
+      // is resolved after the pass. That includes a split field: resolving it inline would silently
+      // keep only the references that happen to point backwards
+      if (ed.targetType.equals(vc.typeName))
         deferredEdgeDefs.add(ed);
       else
         resolvedEdges.add(ed);
     }
 
-    // Deferred raw soId pairs for self-referencing edges
-    final Map<String, IntList[]> deferredRaw = new HashMap<>();
-    for (final EdgeDef ed : deferredEdgeDefs)
-      deferredRaw.put(ed.edgeType, new IntList[]{new IntList(100_000), new IntList(100_000)});
+    // One buffer of unresolved target keys per deferred definition, positionally aligned with
+    // deferredEdgeDefs: two definitions of the same edge type must not share a buffer
+    final List<DeferredSelfEdges> deferredSelf = new ArrayList<>(deferredEdgeDefs.size());
+    for (int i = 0; i < deferredEdgeDefs.size(); i++)
+      deferredSelf.add(new DeferredSelfEdges());
 
     final int[] count = {0};
     database.begin();
@@ -860,27 +889,19 @@ public class GraphImporter implements AutoCloseable {
 
       // Deduplication: skip if this id/nameId was already imported
       if (vc.deduplicate) {
-        if (vc.idAttribute != null) {
-          final int id = record.getInt(vc.idAttribute);
-          if (ts.idToIdx.get(id, -1) >= 0)
-            return;
-        }
-        if (vc.nameIdAttribute != null) {
-          final String name = record.get(vc.nameIdAttribute);
-          if (name != null && ts.nameToIdx.containsKey(name))
-            return;
-        }
+        if (vc.idAttribute != null && ts.idToIdx.get(record.get(vc.idAttribute)) >= 0)
+          return;
+        if (vc.nameIdAttribute != null && ts.nameToIdx.get(record.get(vc.nameIdAttribute)) >= 0)
+          return;
       }
 
-      // Register ID
+      // Register ID. The raw text is the key: an identity is whatever the source wrote, so reading
+      // it as an int would reject a string key and truncate one wider than an int
       final int idx = count[0];
       if (vc.idAttribute != null)
-        ts.idToIdx.put(record.getInt(vc.idAttribute), idx);
-      if (vc.nameIdAttribute != null) {
-        final String name = record.get(vc.nameIdAttribute);
-        if (name != null)
-          ts.nameToIdx.put(name, idx);
-      }
+        ts.idToIdx.put(record.get(vc.idAttribute), idx);
+      if (vc.nameIdAttribute != null)
+        ts.nameToIdx.put(record.get(vc.nameIdAttribute), idx);
 
       // Build vertex properties
       propBuf.clear();
@@ -900,14 +921,19 @@ public class GraphImporter implements AutoCloseable {
       for (final EdgeDef ed : resolvedEdges)
         collectEdge(record, ed, vc.typeName, idx);
 
-      // Collect deferred (self-referencing) edges as raw soIds
-      for (final EdgeDef ed : deferredEdgeDefs) {
-        final int fk = record.getInt(ed.fkAttribute);
-        if (fk != 0) {
-          final int thisSoId = record.getInt(vc.idAttribute);
-          final IntList[] pair = deferredRaw.get(ed.edgeType);
-          pair[0].add(thisSoId);
-          pair[1].add(fk);
+      // Collect deferred (self-referencing) edges: this row's index is already final, only the
+      // target key has to wait for the rest of the file
+      for (int i = 0; i < deferredEdgeDefs.size(); i++) {
+        final EdgeDef ed = deferredEdgeDefs.get(i);
+        final String fieldVal = record.get(ed.fkAttribute);
+        if (fieldVal == null)
+          continue;
+        final DeferredSelfEdges deferred = deferredSelf.get(i);
+        if (ed.isSplit)
+          collectSplitKeys(fieldVal, ed.delimiter.charAt(0), deferred, idx);
+        else {
+          deferred.srcIdx.add(idx);
+          deferred.targetKeys.add(fieldVal);
         }
       }
 
@@ -925,17 +951,11 @@ public class GraphImporter implements AutoCloseable {
     totalVertices += ts.count;
 
     // Resolve deferred self-referencing edges (srcType == dstType == thisType)
-    for (final Map.Entry<String, IntList[]> entry : deferredRaw.entrySet()) {
-      final IntList[] pair = entry.getValue();
-      final EdgeCollector ec = edgeCollectors.get(entry.getKey() + "|" + vc.typeName + "|" + vc.typeName);
-      for (int i = 0; i < pair[0].size; i++) {
-        final int si = ts.idToIdx.get(pair[0].data[i], -1);
-        final int di = ts.idToIdx.get(pair[1].data[i], -1);
-        if (si >= 0 && di >= 0) {
-          ec.srcIdx.add(si);
-          ec.dstIdx.add(di);
-        }
-      }
+    for (int i = 0; i < deferredEdgeDefs.size(); i++) {
+      final EdgeDef ed = deferredEdgeDefs.get(i);
+      final EdgeCollector ec = edgeCollectors.get(ed.edgeType + "|" + vc.typeName + "|" + vc.typeName);
+      final IdIndex index = ed.byName || ed.isSplit ? ts.nameToIdx : ts.idToIdx;
+      unresolvedEdges += deferredSelf.get(i).resolveInto(index, ec, ed.incoming);
     }
 
     LogManager.instance().log(this, Level.INFO, "  %-12s %,d vertices (%,d ms)", vc.typeName, ts.count,
@@ -962,42 +982,30 @@ public class GraphImporter implements AutoCloseable {
       int pos;
       while ((pos = fieldVal.indexOf(delim, start)) != -1) {
         if (pos > start) {
-          final Integer ti = targetTs.nameToIdx.get(fieldVal.substring(start, pos));
-          if (ti != null) {
+          final int ti = targetTs.nameToIdx.get(fieldVal.substring(start, pos));
+          if (ti >= 0) {
             ec.srcIdx.add(thisIdx);
             ec.dstIdx.add(ti);
-          }
+          } else
+            unresolvedEdges++;
         }
         start = pos + 1;
       }
-    } else if (ed.byName) {
-      final String name = record.get(ed.fkAttribute);
-      if (name == null)
-        return;
-      final TypeState targetTs = typeStates.get(ed.targetType);
-      if (targetTs == null)
-        return;
-      final Integer targetIdx = targetTs.nameToIdx.get(name);
-      if (targetIdx == null)
-        return;
-
-      if (ed.incoming) {
-        ec.srcIdx.add(targetIdx);
-        ec.dstIdx.add(thisIdx);
-      } else {
-        ec.srcIdx.add(thisIdx);
-        ec.dstIdx.add(targetIdx);
-      }
     } else {
-      final int fk = record.getInt(ed.fkAttribute);
-      if (fk == 0)
+      // An absent or empty attribute means "this row has no such reference" and is not an
+      // unresolved endpoint. It is the only way to say so: 0 used to double as that marker, which
+      // made a vertex whose key really is 0 impossible to point at
+      final String key = record.get(ed.fkAttribute);
+      if (key == null)
         return;
       final TypeState targetTs = typeStates.get(ed.targetType);
       if (targetTs == null)
         return;
-      final int targetIdx = targetTs.idToIdx.get(fk, -1);
-      if (targetIdx < 0)
+      final int targetIdx = (ed.byName ? targetTs.nameToIdx : targetTs.idToIdx).get(key);
+      if (targetIdx < 0) {
+        unresolvedEdges++;
         return;
+      }
 
       if (ed.incoming) {
         ec.srcIdx.add(targetIdx);
@@ -1006,6 +1014,25 @@ public class GraphImporter implements AutoCloseable {
         ec.srcIdx.add(thisIdx);
         ec.dstIdx.add(targetIdx);
       }
+    }
+  }
+
+  /**
+   * Appends one deferred key per value of a delimited field (e.g. {@code "|java|python|"}), all
+   * sharing the same source vertex.
+   */
+  private static void collectSplitKeys(final String fieldVal, final char delimiter,
+                                       final DeferredSelfEdges deferred, final int thisIdx) {
+    if (fieldVal.length() <= 1)
+      return;
+    int start = fieldVal.charAt(0) == delimiter ? 1 : 0;
+    int pos;
+    while ((pos = fieldVal.indexOf(delimiter, start)) != -1) {
+      if (pos > start) {
+        deferred.srcIdx.add(thisIdx);
+        deferred.targetKeys.add(fieldVal.substring(start, pos));
+      }
+      start = pos + 1;
     }
   }
 
@@ -1030,13 +1057,16 @@ public class GraphImporter implements AutoCloseable {
     final EdgeCollector ec = getOrCreateEdgeCollector(cfg.edgeType, cfg.fromVertexType, cfg.toVertexType,
         "src" + sourceIndex);
     final int[] count = {0};
+    final long unresolvedBefore = unresolvedEdges;
 
     esd.source.forEach(record -> {
       if (limit > 0 && count[0] >= limit)
         return;
-      final int si = fromTs.idToIdx.get(record.getInt(cfg.fromAttribute), -1);
-      final int di = toTs.idToIdx.get(record.getInt(cfg.toAttribute), -1);
-      if (si >= 0 && di >= 0) {
+      final int si = fromTs.idToIdx.get(record.get(cfg.fromAttribute));
+      final int di = toTs.idToIdx.get(record.get(cfg.toAttribute));
+      if (si < 0 || di < 0)
+        unresolvedEdges++;
+      else {
         ec.srcIdx.add(si);
         ec.dstIdx.add(di);
         for (final PropDef pd : cfg.properties) {
@@ -1069,8 +1099,14 @@ public class GraphImporter implements AutoCloseable {
       count[0]++;
     });
 
+    final long unresolved = unresolvedEdges - unresolvedBefore;
     LogManager.instance().log(this, Level.INFO, "  %-12s %,d edges (%,d ms)",
         cfg.edgeType, ec.srcIdx.size, System.currentTimeMillis() - t);
+    if (unresolved > 0)
+      LogManager.instance().log(this, Level.WARNING,
+          "  %-12s %,d rows name an identity no %s vertex carries: those edges were skipped",
+          cfg.edgeType, unresolved,
+          cfg.fromVertexType.equals(cfg.toVertexType) ? cfg.fromVertexType : cfg.fromVertexType + "/" + cfg.toVertexType);
   }
 
   // ═══════════════════════════════════════════════════════════════════
@@ -1309,11 +1345,11 @@ public class GraphImporter implements AutoCloseable {
   }
 
   static class TypeState {
-    IntIntMap            idToIdx   = new IntIntMap(100_000);
-    Map<String, Integer> nameToIdx = new HashMap<>();
-    int[]                buckets;
-    long[]               positions;
-    int                  count;
+    IdIndex idToIdx   = new IdIndex();
+    IdIndex nameToIdx = new IdIndex();
+    int[]   buckets;
+    long[]  positions;
+    int     count;
   }
 
   static class EdgeCollector {
@@ -1368,18 +1404,275 @@ public class GraphImporter implements AutoCloseable {
     }
   }
 
-  static class DeferredEdgePair {
-    final int srcSoId, dstSoId;
-
-    DeferredEdgePair(final int s, final int d) {
-      this.srcSoId = s;
-      this.dstSoId = d;
-    }
-  }
-
   // ═══════════════════════════════════════════════════════════════════
   //  Primitive collections (zero boxing, minimal GC)
   // ═══════════════════════════════════════════════════════════════════
+
+  /**
+   * A key that is not the canonical decimal text of a {@code long}, and the empty slot marker of
+   * {@link LongIntMap}. {@code Long.MIN_VALUE} therefore never reaches the primitive maps: a key
+   * spelled {@code "-9223372036854775808"} is kept with the textual keys, which resolve it the
+   * same way, only boxed.
+   */
+  static final long NOT_CANONICAL_LONG = Long.MIN_VALUE;
+
+  /**
+   * Reads {@code text} as the canonical decimal form of a {@code long}, returning
+   * {@link #NOT_CANONICAL_LONG} when it is not one. Neither allocates nor throws: an identity
+   * column is read once per row, and {@code Long.parseLong} in a {@code try} block would fill in a
+   * stack trace for every row of a string-keyed file.
+   * <p>
+   * "Canonical" is what keeps the primitive fast path from merging keys the source kept apart:
+   * {@code "007"} and {@code "7"} are two different identities, so only the form
+   * {@code Long.toString} would produce is allowed to become a number. Everything else - leading
+   * zeros, a leading {@code +}, {@code "-0"}, surrounding space, anything non-numeric - stays text.
+   */
+  static long canonicalLong(final String text) {
+    if (text == null)
+      return NOT_CANONICAL_LONG;
+    final int len = text.length();
+    if (len == 0)
+      return NOT_CANONICAL_LONG;
+
+    final boolean negative = text.charAt(0) == '-';
+    final int first = negative ? 1 : 0;
+    if (len - first < 1 || len - first > 19)
+      return NOT_CANONICAL_LONG;
+
+    final char firstDigit = text.charAt(first);
+    if (firstDigit < '0' || firstDigit > '9')
+      return NOT_CANONICAL_LONG;
+    // "0" is canonical, "00" and "007" are not, and "-0" is not the canonical form of zero
+    if (firstDigit == '0' && (len - first > 1 || negative))
+      return NOT_CANONICAL_LONG;
+
+    // Accumulate negatively: the negative range is the wider one, so this overflows only on values
+    // that genuinely do not fit, and Long.MIN_VALUE itself is rejected because it is the sentinel
+    long value = 0;
+    for (int i = first; i < len; i++) {
+      final char c = text.charAt(i);
+      if (c < '0' || c > '9')
+        return NOT_CANONICAL_LONG;
+      if (value < -922337203685477580L)
+        return NOT_CANONICAL_LONG;
+      value *= 10;
+      final int digit = c - '0';
+      if (value < Long.MIN_VALUE + digit)
+        return NOT_CANONICAL_LONG;
+      value -= digit;
+    }
+    if (value == NOT_CANONICAL_LONG)
+      return NOT_CANONICAL_LONG;
+    return negative ? value : -value;
+  }
+
+  /**
+   * Maps a vertex identity, as the source spelled it, to the vertex's index within its type.
+   * <p>
+   * Behaves exactly like a {@code Map<String, Integer>} - two keys are the same identity when their
+   * text is the same - but stores a key that is the canonical decimal form of a {@code long}
+   * unboxed, which is what almost every real import consists of. The numeric side starts as an
+   * {@code int} map and widens to a {@code long} one only when a key that does not fit arrives, so
+   * an import whose keys fit in an {@code int} pays exactly what it paid before; a textual key
+   * lands in a {@link HashMap} that is not allocated at all until one appears.
+   */
+  static final class IdIndex {
+    private IntIntMap            intKeys;
+    private LongIntMap           longKeys;
+    private Map<String, Integer> textKeys;
+
+    void put(final String key, final int idx) {
+      if (key == null)
+        return;
+      final long numeric = canonicalLong(key);
+      if (numeric == NOT_CANONICAL_LONG) {
+        if (textKeys == null)
+          textKeys = new HashMap<>();
+        textKeys.put(key, idx);
+      } else
+        putNumeric(numeric, idx);
+    }
+
+    /**
+     * @return the vertex index, or -1 when the key is null (the row carries no such reference) or
+     * no vertex was registered under it
+     */
+    int get(final String key) {
+      if (key == null)
+        return -1;
+      final long numeric = canonicalLong(key);
+      if (numeric != NOT_CANONICAL_LONG)
+        return getNumeric(numeric);
+      return textKeys == null ? -1 : textKeys.getOrDefault(key, -1);
+    }
+
+    int getNumeric(final long key) {
+      if (longKeys != null)
+        return longKeys.get(key, -1);
+      if (intKeys == null || key < INT_KEY_MIN || key > Integer.MAX_VALUE)
+        return -1;
+      return intKeys.get((int) key, -1);
+    }
+
+    private void putNumeric(final long key, final int idx) {
+      if (longKeys == null && key >= INT_KEY_MIN && key <= Integer.MAX_VALUE) {
+        if (intKeys == null)
+          // Sized like the edge buffers rather than for a large import: the map doubles on growth,
+          // so a big source reaches its size in a handful of rehashes, while a schema with many
+          // small types no longer pays a multi-megabyte table per type for a few hundred keys
+          intKeys = new IntIntMap(BUFFER_INITIAL_CAPACITY);
+        intKeys.put((int) key, idx);
+        return;
+      }
+      if (longKeys == null)
+        widenToLongKeys();
+      longKeys.put(key, idx);
+    }
+
+    /** One-shot, on the first key outside the {@code int} range: rehashes what is already there. */
+    private void widenToLongKeys() {
+      longKeys = new LongIntMap(intKeys == null ? BUFFER_INITIAL_CAPACITY : intKeys.size());
+      if (intKeys != null) {
+        intKeys.copyInto(longKeys);
+        intKeys = null;
+      }
+    }
+  }
+
+  /**
+   * {@link IntIntMap} reserves {@code Integer.MIN_VALUE} to mark an empty slot, so that one value
+   * goes to the {@code long} map instead of being stored as an {@code int}.
+   */
+  static final int INT_KEY_MIN = Integer.MIN_VALUE + 1;
+
+  /**
+   * Target keys of self-referencing edges, held until the source has been read to the end because
+   * the row they point at may still be ahead. The source index is already final and stays an
+   * {@code int}; only the key has to survive the pass.
+   */
+  static final class DeferredSelfEdges {
+    final IntList srcIdx     = new IntList(BUFFER_INITIAL_CAPACITY);
+    final KeyList targetKeys = new KeyList(BUFFER_INITIAL_CAPACITY);
+
+    /**
+     * Resolves every buffered key against {@code index} and appends the edges to {@code ec}.
+     *
+     * @return how many keys matched no vertex
+     */
+    int resolveInto(final IdIndex index, final EdgeCollector ec, final boolean incoming) {
+      int unresolved = 0;
+      int textPos = 0;
+      for (int i = 0; i < srcIdx.size; i++) {
+        final long numeric = targetKeys.keys.data[i];
+        final int di = numeric == NOT_CANONICAL_LONG ?
+            index.get(targetKeys.text.get(textPos++)) :
+            index.getNumeric(numeric);
+        if (di < 0) {
+          unresolved++;
+          continue;
+        }
+        if (incoming) {
+          ec.srcIdx.add(di);
+          ec.dstIdx.add(srcIdx.data[i]);
+        } else {
+          ec.srcIdx.add(srcIdx.data[i]);
+          ec.dstIdx.add(di);
+        }
+      }
+      return unresolved;
+    }
+  }
+
+  /**
+   * An append-only list of identity keys that keeps the canonical numeric ones in a primitive
+   * array and boxes only the rest. A textual key is marked in place with
+   * {@link #NOT_CANONICAL_LONG} and appended to {@link #text}, which stays null while there is
+   * none: replaying the list is a single forward walk, so the two run in step without a per-entry
+   * back-reference.
+   */
+  static final class KeyList {
+    final LongList     keys;
+    List<String>       text;
+
+    KeyList(final int cap) {
+      keys = new LongList(cap);
+    }
+
+    void add(final String key) {
+      final long numeric = canonicalLong(key);
+      if (numeric == NOT_CANONICAL_LONG) {
+        if (text == null)
+          text = new ArrayList<>();
+        text.add(key);
+      }
+      keys.add(numeric);
+    }
+  }
+
+  /**
+   * Open-addressing long→int hash map with Fibonacci hashing, the widened twin of
+   * {@link IntIntMap}.
+   */
+  static final class LongIntMap {
+    private static final long   EMPTY = Long.MIN_VALUE;
+    private              long[] keys;
+    private              int[]  values;
+    private int mask, size, threshold;
+
+    LongIntMap(final int expected) {
+      final int cap = Integer.highestOneBit(Math.max(16, (int) (expected / 0.7))) << 1;
+      keys = new long[cap];
+      values = new int[cap];
+      mask = cap - 1;
+      threshold = (int) (cap * 0.7);
+      Arrays.fill(keys, EMPTY);
+    }
+
+    void put(final long key, final int value) {
+      if (size >= threshold)
+        resize();
+      int i = hash(key);
+      while (keys[i] != EMPTY && keys[i] != key)
+        i = (i + 1) & mask;
+      if (keys[i] == EMPTY)
+        size++;
+      keys[i] = key;
+      values[i] = value;
+    }
+
+    int get(final long key, final int def) {
+      int i = hash(key);
+      while (keys[i] != EMPTY) {
+        if (keys[i] == key)
+          return values[i];
+        i = (i + 1) & mask;
+      }
+      return def;
+    }
+
+    private int hash(final long key) {
+      return (int) ((key * 0x9E3779B97F4A7C15L) >>> 32) & mask;
+    }
+
+    private void resize() {
+      final int newCap = keys.length << 1;
+      final long[] ok = keys;
+      final int[] ov = values;
+      keys = new long[newCap];
+      values = new int[newCap];
+      mask = newCap - 1;
+      threshold = (int) (newCap * 0.7);
+      Arrays.fill(keys, EMPTY);
+      for (int i = 0; i < ok.length; i++)
+        if (ok[i] != EMPTY) {
+          int j = hash(ok[i]);
+          while (keys[j] != EMPTY)
+            j = (j + 1) & mask;
+          keys[j] = ok[i];
+          values[j] = ov[i];
+        }
+    }
+  }
 
   /**
    * Open-addressing int→int hash map with Fibonacci hashing.
@@ -1388,6 +1681,17 @@ public class GraphImporter implements AutoCloseable {
     private static final int   EMPTY = Integer.MIN_VALUE;
     private              int[] keys, values;
     private int mask, size, threshold;
+
+    int size() {
+      return size;
+    }
+
+    /** Rehashes every entry into {@code target}, for {@link IdIndex}'s one-shot widening. */
+    void copyInto(final LongIntMap target) {
+      for (int i = 0; i < keys.length; i++)
+        if (keys[i] != EMPTY)
+          target.put(keys[i], values[i]);
+    }
 
     IntIntMap(final int expected) {
       int cap = Integer.highestOneBit(Math.max(16, (int) (expected / 0.7))) << 1;

--- a/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterIdTypesTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterIdTypesTest.java
@@ -835,6 +835,89 @@ class GraphImporterIdTypesTest {
   }
 
   /**
+   * The convention wraps a split field in delimiters, but the value after the last one is still a
+   * value. It used to be dropped, and not even counted as an edge lost - on both the inline and the
+   * deferred path.
+   */
+  @Test
+  void aSplitFieldNeedsNoWrappingDelimiters() throws Exception {
+    final String topics = write("unwrapped-topics.csv",
+        "Code",
+        "java",
+        "python",
+        "css");
+    final String posts = write("unwrapped-posts.csv",
+        "Id,Tags",
+        "1,|java|python",
+        "2,css",
+        "3,|java|");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Topic");
+      database.getSchema().createVertexType("Post");
+      database.getSchema().createEdgeType("Tagged");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Topic", new CsvRowSource(topics), v -> {
+          v.idByName("Code");
+          v.property("code", "Code");
+        })
+        .vertex("Post", new CsvRowSource(posts), v -> {
+          v.id("Id");
+          v.intProperty("postId", "Id");
+          v.splitEdge("Tags", "Tagged", "Topic", "|");
+        })
+        .build()) {
+
+      importer.run();
+
+      assertThat(importer.getEdgeCount()).isEqualTo(4);
+      assertThat(importer.getUnresolvedEdgeCount()).isZero();
+    }
+
+    assertThat(outgoingTargets("Post", "postId", 1, "Tagged", "code"))
+        .containsExactlyInAnyOrder("java", "python");
+    assertThat(outgoingTargets("Post", "postId", 2, "Tagged", "code")).containsExactly("css");
+    assertThat(outgoingTargets("Post", "postId", 3, "Tagged", "code")).containsExactly("java");
+  }
+
+  /**
+   * The same on the deferred path, where the split field points at the type it lives on.
+   */
+  @Test
+  void aSelfReferencingSplitFieldNeedsNoWrappingDelimiters() throws Exception {
+    final String vertices = write("unwrapped-tree.csv",
+        "Code,Related",
+        "a,b|c",
+        "b,c",
+        "c,");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Topic");
+      database.getSchema().createEdgeType("RelatedTo");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Topic", new CsvRowSource(vertices), v -> {
+          v.idByName("Code");
+          v.property("code", "Code");
+          v.splitEdge("Related", "RelatedTo", "Topic", "|");
+        })
+        .build()) {
+
+      importer.run();
+
+      assertThat(importer.getEdgeCount()).isEqualTo(3);
+      assertThat(importer.getUnresolvedEdgeCount()).isZero();
+    }
+
+    assertThat(outgoingTargets("Topic", "code", "a", "RelatedTo", "code"))
+        .containsExactlyInAnyOrder("b", "c");
+    assertThat(outgoingTargets("Topic", "code", "b", "RelatedTo", "code")).containsExactly("c");
+  }
+
+  /**
    * An endpoint that matches no vertex is still skipped, but it is now counted and reported
    * instead of quietly shrinking the graph.
    */

--- a/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterIdTypesTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterIdTypesTest.java
@@ -424,6 +424,87 @@ class GraphImporterIdTypesTest {
   }
 
   /**
+   * A self-referencing edge declared {@code edgeIn}: the foreign key names the vertex that points
+   * TO this row, so the edge runs parent to child. The deferred path used to write this row as the
+   * source whatever the direction said, building every such edge backwards without failing.
+   */
+  @Test
+  void selfReferencingEdgeInRunsFromTheReferencedVertex() throws Exception {
+    final String vertices = write("parent-tree.csv",
+        "Id,ParentId",
+        "1,",
+        "2,1",
+        "3,1",
+        "4,2");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Node");
+      database.getSchema().createEdgeType("HasChild");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Node", new CsvRowSource(vertices), v -> {
+          v.id("Id");
+          v.intProperty("nodeId", "Id");
+          v.edgeIn("ParentId", "HasChild", "Node");
+        })
+        .build()) {
+
+      importer.run();
+
+      assertThat(importer.getEdgeCount()).isEqualTo(3);
+    }
+
+    // 1 -> 2, 1 -> 3, 2 -> 4: the parent is the source, never the row that named it
+    assertThat(outgoingProperties("Node", "nodeId", 1, "HasChild", "nodeId"))
+        .containsExactlyInAnyOrder(2, 3);
+    assertThat(outgoingProperties("Node", "nodeId", 2, "HasChild", "nodeId")).containsExactly(4);
+    assertThat(outgoingProperties("Node", "nodeId", 4, "HasChild", "nodeId")).isEmpty();
+  }
+
+  /**
+   * An empty identity is no identity. CSV reports an empty field as absent, but JSONL and XML hand
+   * back the empty string, so without normalising it two rows with {@code "id": ""} would collide
+   * on a key of their own and an edge naming it would reach whichever of them registered last.
+   */
+  @Test
+  void anEmptyIdentityRegistersNoKey() throws Exception {
+    final String vertices = write("empty-id-vertices.jsonl",
+        "{\"id\": \"\", \"name\": \"NoKeyOne\"}",
+        "{\"id\": \"\", \"name\": \"NoKeyTwo\"}",
+        "{\"id\": \"W1\", \"name\": \"Real\"}");
+    final String edges = write("empty-id-edges.csv",
+        "from_id,to_id",
+        "W1,",
+        ",W1");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Document");
+      database.getSchema().createEdgeType("Cites");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Document", new JsonlRowSource(vertices), v -> {
+          v.id("id");
+          v.property("id", "id");
+          v.property("name", "name");
+        })
+        .edgeSource("Cites", new CsvRowSource(edges), e -> {
+          e.from("from_id", "Document");
+          e.to("to_id", "Document");
+        })
+        .build()) {
+
+      importer.run();
+
+      // all three rows are vertices; neither endpoint naming an empty key resolves to one of them
+      assertThat(importer.getVertexCount()).isEqualTo(3);
+      assertThat(importer.getEdgeCount()).isZero();
+      assertThat(importer.getUnresolvedEdgeCount()).isEqualTo(2);
+    }
+  }
+
+  /**
    * A split field pointing at the type it lives on. Resolving it while the file is still being read
    * kept only the references that happened to point at an earlier row, so a forward reference was
    * dropped without a word.
@@ -531,6 +612,21 @@ class GraphImporterIdTypesTest {
         assertThat(rs.next().<String>getProperty("title")).isEqualTo("First");
       }
     });
+  }
+
+  private List<Integer> outgoingProperties(final String vertexType, final String keyProperty, final Object key,
+                                           final String edgeType, final String targetProperty) {
+    final List<Integer> result = new ArrayList<>();
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("sql",
+          "SELECT FROM " + vertexType + " WHERE " + keyProperty + " = ?", key)) {
+        assertThat(rs.hasNext()).as("vertex %s.%s = %s", vertexType, keyProperty, key).isTrue();
+        final Vertex v = rs.next().getVertex().get();
+        for (final Edge e : v.getEdges(Vertex.DIRECTION.OUT, edgeType))
+          result.add(e.getInVertex().asVertex().getInteger(targetProperty));
+      }
+    });
+    return result;
   }
 
   private List<String> outgoingTargets(final String vertexType, final String keyProperty, final Object key,

--- a/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterIdTypesTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterIdTypesTest.java
@@ -25,6 +25,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.integration.importer.graph.CsvRowSource;
 import com.arcadedb.integration.importer.graph.GraphImporter;
 import com.arcadedb.integration.importer.graph.JsonlRowSource;
+import com.arcadedb.integration.importer.graph.XmlRowSource;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.utility.FileUtils;
 
@@ -502,6 +503,46 @@ class GraphImporterIdTypesTest {
       assertThat(importer.getEdgeCount()).isZero();
       assertThat(importer.getUnresolvedEdgeCount()).isEqualTo(2);
     }
+  }
+
+  /**
+   * The same as above through the XML reader, which returns {@code ""} for {@code id=""} exactly
+   * as the JSONL one does. A self-referencing foreign key spelled empty is "no parent", not a
+   * reference to whatever registered the empty key.
+   */
+  @Test
+  void anEmptyIdentityRegistersNoKeyFromXml() throws Exception {
+    final String vertices = write("empty-id.xml",
+        "<rows>",
+        "  <row Id=\"\" Parent=\"\" Name=\"NoKeyOne\"/>",
+        "  <row Id=\"\" Parent=\"\" Name=\"NoKeyTwo\"/>",
+        "  <row Id=\"1\" Parent=\"\" Name=\"Root\"/>",
+        "  <row Id=\"2\" Parent=\"1\" Name=\"Child\"/>",
+        "</rows>");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Node");
+      database.getSchema().createEdgeType("ChildOf");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Node", new XmlRowSource(vertices), v -> {
+          v.id("Id");
+          v.property("name", "Name");
+          v.edgeOut("Parent", "ChildOf", "Node");
+        })
+        .build()) {
+
+      importer.run();
+
+      assertThat(importer.getVertexCount()).isEqualTo(4);
+      // only 2 -> 1: the two empty ids registered nothing, and an empty Parent is no edge at all
+      assertThat(importer.getEdgeCount()).isEqualTo(1);
+      assertThat(importer.getUnresolvedEdgeCount()).isZero();
+    }
+
+    assertThat(outgoingTargets("Node", "name", "Child", "ChildOf", "name")).containsExactly("Root");
+    assertThat(outgoingTargets("Node", "name", "NoKeyOne", "ChildOf", "name")).isEmpty();
   }
 
   /**

--- a/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterIdTypesTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterIdTypesTest.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Identity keys that are not a positive {@code int}: string keys, keys wider than {@code int}, the
@@ -543,6 +544,117 @@ class GraphImporterIdTypesTest {
 
     assertThat(outgoingTargets("Node", "name", "Child", "ChildOf", "name")).containsExactly("Root");
     assertThat(outgoingTargets("Node", "name", "NoKeyOne", "ChildOf", "name")).isEmpty();
+  }
+
+  /**
+   * {@code edgeInByName} composes the two flags the deferred path reads independently: the target
+   * is matched by name AND the edge runs from it to this row.
+   */
+  @Test
+  void selfReferencingEdgeInByNameRunsFromTheNamedVertex() throws Exception {
+    final String vertices = write("named-parent-tree.csv",
+        "Code,Parent",
+        "root,",
+        "child-a,root",
+        "grandchild,child-a");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Category");
+      database.getSchema().createEdgeType("HasChild");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Category", new CsvRowSource(vertices), v -> {
+          v.idByName("Code");
+          v.property("code", "Code");
+          v.edgeInByName("Parent", "HasChild", "Category");
+        })
+        .build()) {
+
+      importer.run();
+
+      assertThat(importer.getEdgeCount()).isEqualTo(2);
+    }
+
+    assertThat(outgoingTargets("Category", "code", "root", "HasChild", "code")).containsExactly("child-a");
+    assertThat(outgoingTargets("Category", "code", "child-a", "HasChild", "code")).containsExactly("grandchild");
+    assertThat(outgoingTargets("Category", "code", "grandchild", "HasChild", "code")).isEmpty();
+  }
+
+  /**
+   * A vertex type that no source imports resolves nothing, so every edge naming it is lost. It used
+   * to be lost in silence, which is exactly what a mistyped type name looks like.
+   */
+  @Test
+  void anEdgeTargetingAnUnknownVertexTypeIsRejected() throws Exception {
+    final String vertices = write("typo-vertices.csv",
+        "Id,Name",
+        "1,One");
+    final String edges = write("typo-edges.csv",
+        "from_id,to_id",
+        "1,1");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Question");
+      database.getSchema().createEdgeType("AnswerOf");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Question", new CsvRowSource(vertices), v -> {
+          v.id("Id");
+          v.edgeOut("Id", "AnswerOf", "Qeustion");
+        })
+        .build()) {
+      assertThatThrownBy(importer::run)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Qeustion")
+          .hasMessageContaining("no vertex source imports");
+    }
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Question", new CsvRowSource(vertices), v -> v.id("Id"))
+        .edgeSource("AnswerOf", new CsvRowSource(edges), e -> {
+          e.from("from_id", "Question");
+          e.to("to_id", "Qeustion");
+        })
+        .build()) {
+      assertThatThrownBy(importer::run)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("'to' endpoint")
+          .hasMessageContaining("Qeustion");
+    }
+  }
+
+  /**
+   * A vertex source resolves references against the types imported before it, so naming one that
+   * comes later silently produced no edges at all.
+   */
+  @Test
+  void anEdgeTargetingAVertexTypeImportedLaterIsRejected() throws Exception {
+    final String employees = write("order-employees.csv",
+        "Id,DeptId",
+        "10,1");
+    final String departments = write("order-departments.csv",
+        "Id,Name",
+        "1,Engineering");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Department");
+      database.getSchema().createVertexType("Employee");
+      database.getSchema().createEdgeType("WORKS_IN");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Employee", new CsvRowSource(employees), v -> {
+          v.id("Id");
+          v.edgeOut("DeptId", "WORKS_IN", "Department");
+        })
+        .vertex("Department", new CsvRowSource(departments), v -> v.id("Id"))
+        .build()) {
+      assertThatThrownBy(importer::run)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("is imported after it");
+    }
   }
 
   /**

--- a/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterIdTypesTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterIdTypesTest.java
@@ -507,6 +507,45 @@ class GraphImporterIdTypesTest {
   }
 
   /**
+   * The other half of the same normalisation, on the reader that started this: an edge foreign key
+   * carried on a JSONL vertex record and spelled {@code ""}. It is "no parent", not a reference to
+   * whatever the empty key registered.
+   */
+  @Test
+  void anEmptyForeignKeyOnAJsonlRecordIsNoEdge() throws Exception {
+    final String vertices = write("empty-fk.jsonl",
+        "{\"id\": \"W1\", \"name\": \"Root\", \"parent\": \"\"}",
+        "{\"id\": \"W2\", \"name\": \"Child\", \"parent\": \"W1\"}",
+        "{\"id\": \"W3\", \"name\": \"Loose\"}");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Doc");
+      database.getSchema().createEdgeType("ChildOf");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Doc", new JsonlRowSource(vertices), v -> {
+          v.id("id");
+          v.property("name", "name");
+          v.edgeOut("parent", "ChildOf", "Doc");
+        })
+        .build()) {
+
+      importer.run();
+
+      assertThat(importer.getVertexCount()).isEqualTo(3);
+      // only W2 -> W1: an empty parent and a missing one are both "no edge", and neither is
+      // an endpoint that failed to resolve
+      assertThat(importer.getEdgeCount()).isEqualTo(1);
+      assertThat(importer.getUnresolvedEdgeCount()).isZero();
+    }
+
+    assertThat(outgoingTargets("Doc", "name", "Child", "ChildOf", "name")).containsExactly("Root");
+    assertThat(outgoingTargets("Doc", "name", "Root", "ChildOf", "name")).isEmpty();
+    assertThat(outgoingTargets("Doc", "name", "Loose", "ChildOf", "name")).isEmpty();
+  }
+
+  /**
    * The same as above through the XML reader, which returns {@code ""} for {@code id=""} exactly
    * as the JSONL one does. A self-referencing foreign key spelled empty is "no parent", not a
    * reference to whatever registered the empty key.

--- a/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterIdTypesTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterIdTypesTest.java
@@ -658,6 +658,80 @@ class GraphImporterIdTypesTest {
   }
 
   /**
+   * An edge source matches {@code id()}, never {@code idByName()}, so a type carrying only the
+   * latter would match nothing row after row. The unified index takes a string key, so such a type
+   * wants {@code id()} on that attribute - and is told so rather than left to import no edges.
+   */
+  @Test
+  void anEdgeSourceTargetingANameOnlyVertexTypeIsRejected() throws Exception {
+    final String vertices = write("name-only-vertices.csv",
+        "Code,Name",
+        "a,Alpha");
+    final String edges = write("name-only-edges.csv",
+        "from_id,to_id",
+        "a,a");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Topic");
+      database.getSchema().createEdgeType("RelatedTo");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Topic", new CsvRowSource(vertices), v -> {
+          v.idByName("Code");
+          v.property("code", "Code");
+        })
+        .edgeSource("RelatedTo", new CsvRowSource(edges), e -> {
+          e.from("from_id", "Topic");
+          e.to("to_id", "Topic");
+        })
+        .build()) {
+      assertThatThrownBy(importer::run)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("declares none")
+          .hasMessageContaining("id()");
+    }
+  }
+
+  /**
+   * The same on the vertex-record side: an edge resolving by name against a type that declares no
+   * {@code idByName()}, and one resolving by id against a type that declares no {@code id()}.
+   */
+  @Test
+  void aVertexEdgeTargetingTheWrongKindOfKeyIsRejected() throws Exception {
+    final String vertices = write("kind-vertices.csv",
+        "Id,Code,Ref",
+        "1,a,a");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Node");
+      database.getSchema().createEdgeType("Link");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Node", new CsvRowSource(vertices), v -> {
+          v.id("Id");
+          v.edgeOutByName("Ref", "Link", "Node");
+        })
+        .build()) {
+      assertThatThrownBy(importer::run)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("idByName()");
+    }
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Node", new CsvRowSource(vertices), v -> {
+          v.idByName("Code");
+          v.edgeOut("Ref", "Link", "Node");
+        })
+        .build()) {
+      assertThatThrownBy(importer::run)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("id()");
+    }
+  }
+
+  /**
    * A split field pointing at the type it lives on. Resolving it while the file is still being read
    * kept only the references that happened to point at an earlier row, so a forward reference was
    * dropped without a word.
@@ -708,7 +782,8 @@ class GraphImporterIdTypesTest {
         "from_id,to_id",
         "1,2",
         "1,404",
-        "999,2");
+        "999,2",
+        "999,404");
 
     database.transaction(() -> {
       database.getSchema().createVertexType("Node");
@@ -730,7 +805,8 @@ class GraphImporterIdTypesTest {
       importer.run();
 
       assertThat(importer.getEdgeCount()).isEqualTo(1);
-      assertThat(importer.getUnresolvedEdgeCount()).isEqualTo(2);
+      // one per edge lost, not per endpoint: the last row fails on both and is still one edge
+      assertThat(importer.getUnresolvedEdgeCount()).isEqualTo(3);
     }
   }
 

--- a/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterIdTypesTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterIdTypesTest.java
@@ -732,6 +732,44 @@ class GraphImporterIdTypesTest {
   }
 
   /**
+   * Two sources for one vertex type. The second replaces the first's TypeState, so pass 2 resolves
+   * edges collected against the first source's row indices into the second source's row arrays -
+   * out of bounds, or an edge silently pointing at an unrelated vertex.
+   */
+  @Test
+  void twoVertexSourcesForOneTypeAreRejected() throws Exception {
+    final String first = write("split-part1.csv",
+        "Id,Name",
+        "1,One",
+        "2,Two",
+        "3,Three");
+    final String second = write("split-part2.csv",
+        "Id,Name",
+        "4,Four");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Node");
+      database.getSchema().createEdgeType("Knows");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Node", new CsvRowSource(first), v -> {
+          v.id("Id");
+          v.property("name", "Name");
+        })
+        .vertex("Node", new CsvRowSource(second), v -> {
+          v.id("Id");
+          v.property("name", "Name");
+        })
+        .build()) {
+      assertThatThrownBy(importer::run)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("more than one")
+          .hasMessageContaining("Node");
+    }
+  }
+
+  /**
    * A split field pointing at the type it lives on. Resolving it while the file is still being read
    * kept only the references that happened to point at an earlier row, so a forward reference was
    * dropped without a word.

--- a/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterIdTypesTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterIdTypesTest.java
@@ -1,0 +1,550 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.integration.importer.graph.CsvRowSource;
+import com.arcadedb.integration.importer.graph.GraphImporter;
+import com.arcadedb.integration.importer.graph.JsonlRowSource;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.utility.FileUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Identity keys that are not a positive {@code int}: string keys, keys wider than {@code int}, the
+ * key {@code 0}, and keys whose textual form is not canonical (leading zeros). Every one of them
+ * has to resolve the same way from a vertex source, from a foreign key carried on a vertex record
+ * and from a standalone edge source (issue #7244, discussion #7214).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class GraphImporterIdTypesTest {
+
+  private static final String DB_PATH   = "target/databases/graph-importer-id-types-test";
+  private static final String DATA_PATH = "target/test-data/graph-importer-id-types";
+
+  private Database database;
+  private File     dataDir;
+
+  @BeforeEach
+  void setup() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    FileUtils.deleteRecursively(new File(DATA_PATH));
+    dataDir = new File(DATA_PATH);
+    dataDir.mkdirs();
+    database = new DatabaseFactory(DB_PATH).create();
+  }
+
+  @AfterEach
+  void cleanup() {
+    if (database != null) {
+      if (database.isOpen())
+        database.drop();
+      database = null;
+    }
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    FileUtils.deleteRecursively(new File(DATA_PATH));
+  }
+
+  private String write(final String fileName, final String... lines) throws Exception {
+    final File f = new File(dataDir, fileName);
+    Files.write(f.toPath(), String.join("\n", lines).getBytes(StandardCharsets.UTF_8));
+    return f.getAbsolutePath();
+  }
+
+  /**
+   * The reporter's first case: JSONL vertices keyed by an OpenAlex-style string id, with the
+   * topology in a separate edge file. Before #7244 the vertex pass alone threw
+   * {@code JSONObject[id] is not a int}.
+   */
+  @Test
+  void stringVertexIdsResolveFromAStandaloneEdgeSource() throws Exception {
+    final String vertices = write("string-vertices.jsonl",
+        "{\"id\": \"W13696992\", \"title\": \"Alpha\", \"publication_year\": 2008}",
+        "{\"id\": \"W28031933\", \"title\": \"Beta\", \"publication_year\": 2011}",
+        "{\"id\": \"W99999999\", \"title\": \"Gamma\", \"publication_year\": 2014}");
+    final String edges = write("string-edges.csv",
+        "from_id,to_id",
+        "W13696992,W28031933",
+        "W13696992,W99999999");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Document");
+      database.getSchema().createEdgeType("Cites");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Document", new JsonlRowSource(vertices), v -> {
+          v.id("id");
+          v.property("id", "id");
+          v.property("title", "title");
+          v.intProperty("publicationYear", "publication_year");
+        })
+        .edgeSource("Cites", new CsvRowSource(edges), e -> {
+          e.from("from_id", "Document");
+          e.to("to_id", "Document");
+        })
+        .build()) {
+
+      importer.run();
+
+      assertThat(importer.getVertexCount()).isEqualTo(3);
+      assertThat(importer.getEdgeCount()).isEqualTo(2);
+      assertThat(importer.getUnresolvedEdgeCount()).isZero();
+    }
+
+    assertThat(outgoingTargets("Document", "id", "W13696992", "Cites", "id"))
+        .containsExactlyInAnyOrder("W28031933", "W99999999");
+  }
+
+  /**
+   * The reporter's second case: ids that fit a {@code long} but not an {@code int}. Before #7244
+   * the edge source failed with {@code NumberFormatException: For input string: "2257721487"}.
+   */
+  @Test
+  void longVertexIdsResolveFromAStandaloneEdgeSource() throws Exception {
+    final String vertices = write("long-vertices.csv",
+        "Id,Name",
+        "2257721487,Alpha",
+        "28031933,Beta",
+        "2805857155,Gamma",
+        "1643034221,Delta",
+        "2186349252,Epsilon");
+    final String edges = write("long-edges.csv",
+        "from_id,to_id",
+        "2257721487,28031933",
+        "2186349252,2805857155",
+        "2186349252,1643034221");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Doc");
+      database.getSchema().createEdgeType("Connection");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Doc", new CsvRowSource(vertices), v -> {
+          v.id("Id");
+          v.longProperty("docId", "Id");
+          v.property("name", "Name");
+        })
+        .edgeSource("Connection", new CsvRowSource(edges), e -> {
+          e.from("from_id", "Doc");
+          e.to("to_id", "Doc");
+        })
+        .build()) {
+
+      importer.run();
+
+      assertThat(importer.getVertexCount()).isEqualTo(5);
+      assertThat(importer.getEdgeCount()).isEqualTo(3);
+      assertThat(importer.getUnresolvedEdgeCount()).isZero();
+    }
+
+    assertThat(outgoingTargets("Doc", "docId", 2186349252L, "Connection", "name"))
+        .containsExactlyInAnyOrder("Gamma", "Delta");
+  }
+
+  /**
+   * {@code 0} is a legitimate key. It used to be indistinguishable from "no foreign key here",
+   * because the reader turned a missing attribute into {@code 0} and the collector read {@code 0}
+   * as the absent marker.
+   */
+  @Test
+  void vertexIdZeroIsAValidEdgeEndpoint() throws Exception {
+    final String vertices = write("zero-vertices.csv",
+        "Id,Name",
+        "0,Root",
+        "1,Child",
+        "2,Orphan");
+    final String edges = write("zero-edges.csv",
+        "from_id,to_id",
+        "1,0");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Node");
+      database.getSchema().createEdgeType("Parent");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Node", new CsvRowSource(vertices), v -> {
+          v.id("Id");
+          v.intProperty("nodeId", "Id");
+          v.property("name", "Name");
+        })
+        .edgeSource("Parent", new CsvRowSource(edges), e -> {
+          e.from("from_id", "Node");
+          e.to("to_id", "Node");
+        })
+        .build()) {
+
+      importer.run();
+
+      assertThat(importer.getEdgeCount()).isEqualTo(1);
+      assertThat(importer.getUnresolvedEdgeCount()).isZero();
+    }
+
+    assertThat(outgoingTargets("Node", "nodeId", 1, "Parent", "name")).containsExactly("Root");
+  }
+
+  /**
+   * A foreign key carried on the vertex record, pointing at a vertex whose id is {@code 0}: the
+   * same absent-versus-zero confusion, on the {@code edgeOut} path.
+   */
+  @Test
+  void vertexRecordForeignKeyToIdZeroIsResolved() throws Exception {
+    final String departments = write("zero-departments.csv",
+        "Id,Name",
+        "0,Engineering",
+        "1,Sales");
+    final String employees = write("zero-employees.csv",
+        "Id,Name,DeptId",
+        "10,Alice,0",
+        "11,Bob,1",
+        "12,Carol,");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Department");
+      database.getSchema().createVertexType("Employee");
+      database.getSchema().createEdgeType("WORKS_IN");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Department", new CsvRowSource(departments), v -> {
+          v.id("Id");
+          v.property("name", "Name");
+        })
+        .vertex("Employee", new CsvRowSource(employees), v -> {
+          v.id("Id");
+          v.intProperty("empId", "Id");
+          v.property("name", "Name");
+          v.edgeOut("DeptId", "WORKS_IN", "Department");
+        })
+        .build()) {
+
+      importer.run();
+
+      // Carol has no department: an empty attribute is still "no edge"
+      assertThat(importer.getEdgeCount()).isEqualTo(2);
+    }
+
+    assertThat(outgoingTargets("Employee", "empId", 10, "WORKS_IN", "name")).containsExactly("Engineering");
+    assertThat(outgoingTargets("Employee", "empId", 12, "WORKS_IN", "name")).isEmpty();
+  }
+
+  /**
+   * A self-referencing edge resolved by name. The deferred path that handles {@code targetType ==
+   * thisType} read the attribute as an {@code int} whatever the edge declared, so declaring it
+   * {@code byName} threw on the first row.
+   */
+  @Test
+  void selfReferencingEdgeResolvesByName() throws Exception {
+    final String vertices = write("tree.csv",
+        "Code,Parent",
+        "root,",
+        "child-a,root",
+        "child-b,root",
+        "grandchild,child-a");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Category");
+      database.getSchema().createEdgeType("ChildOf");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Category", new CsvRowSource(vertices), v -> {
+          v.idByName("Code");
+          v.property("code", "Code");
+          v.edgeOutByName("Parent", "ChildOf", "Category");
+        })
+        .build()) {
+
+      importer.run();
+
+      assertThat(importer.getVertexCount()).isEqualTo(4);
+      assertThat(importer.getEdgeCount()).isEqualTo(3);
+    }
+
+    assertThat(outgoingTargets("Category", "code", "grandchild", "ChildOf", "code")).containsExactly("child-a");
+    assertThat(outgoingTargets("Category", "code", "root", "ChildOf", "code")).isEmpty();
+  }
+
+  /**
+   * A self-referencing edge on a string primary id: the deferred path has to widen with the index
+   * rather than assume the key is numeric.
+   */
+  @Test
+  void selfReferencingEdgeResolvesOnStringPrimaryId() throws Exception {
+    final String vertices = write("string-tree.csv",
+        "Id,Parent",
+        "W1,",
+        "W2,W1",
+        "W3,W2");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Doc");
+      database.getSchema().createEdgeType("AnswerOf");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Doc", new CsvRowSource(vertices), v -> {
+          v.id("Id");
+          v.property("docId", "Id");
+          v.edgeOut("Parent", "AnswerOf", "Doc");
+        })
+        .build()) {
+
+      importer.run();
+
+      assertThat(importer.getEdgeCount()).isEqualTo(2);
+    }
+
+    assertThat(outgoingTargets("Doc", "docId", "W3", "AnswerOf", "docId")).containsExactly("W2");
+  }
+
+  /**
+   * A key whose text is not the canonical form of its numeric value stays a distinct key:
+   * {@code "007"} and {@code "7"} are two vertices, and an edge naming one must not reach the
+   * other. Parsing both as {@code 7} would silently join unrelated rows.
+   */
+  @Test
+  void nonCanonicalNumericKeysDoNotCollide() throws Exception {
+    final String vertices = write("zip-vertices.csv",
+        "Zip,Name",
+        "007,Bond",
+        "7,Seven",
+        "12,Twelve");
+    final String edges = write("zip-edges.csv",
+        "from_id,to_id",
+        "12,007");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Area");
+      database.getSchema().createEdgeType("Near");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Area", new CsvRowSource(vertices), v -> {
+          v.id("Zip");
+          v.property("zip", "Zip");
+          v.property("name", "Name");
+        })
+        .edgeSource("Near", new CsvRowSource(edges), e -> {
+          e.from("from_id", "Area");
+          e.to("to_id", "Area");
+        })
+        .build()) {
+
+      importer.run();
+
+      assertThat(importer.getVertexCount()).isEqualTo(3);
+      assertThat(importer.getEdgeCount()).isEqualTo(1);
+      assertThat(importer.getUnresolvedEdgeCount()).isZero();
+    }
+
+    assertThat(outgoingTargets("Area", "zip", "12", "Near", "name")).containsExactly("Bond");
+  }
+
+  /**
+   * Numeric and non-numeric keys in the same column. The index starts on the primitive fast path
+   * and widens when it meets a key that cannot live there; keys registered before the widening
+   * still resolve afterwards, and keys wider than {@code int} do not truncate.
+   */
+  @Test
+  void mixedKeyWidthsAndTypesAllResolve() throws Exception {
+    final String vertices = write("mixed-vertices.csv",
+        "Id,Name",
+        "1,One",
+        "2257721487,Wide",
+        "W3,Text",
+        "-5,Negative");
+    final String edges = write("mixed-edges.csv",
+        "from_id,to_id",
+        "1,2257721487",
+        "1,W3",
+        "1,-5",
+        "W3,1");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Thing");
+      database.getSchema().createEdgeType("Link");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Thing", new CsvRowSource(vertices), v -> {
+          v.id("Id");
+          v.property("tid", "Id");
+          v.property("name", "Name");
+        })
+        .edgeSource("Link", new CsvRowSource(edges), e -> {
+          e.from("from_id", "Thing");
+          e.to("to_id", "Thing");
+        })
+        .build()) {
+
+      importer.run();
+
+      assertThat(importer.getVertexCount()).isEqualTo(4);
+      assertThat(importer.getEdgeCount()).isEqualTo(4);
+      assertThat(importer.getUnresolvedEdgeCount()).isZero();
+    }
+
+    assertThat(outgoingTargets("Thing", "tid", "1", "Link", "name"))
+        .containsExactlyInAnyOrder("Wide", "Text", "Negative");
+    assertThat(outgoingTargets("Thing", "tid", "W3", "Link", "name")).containsExactly("One");
+  }
+
+  /**
+   * A split field pointing at the type it lives on. Resolving it while the file is still being read
+   * kept only the references that happened to point at an earlier row, so a forward reference was
+   * dropped without a word.
+   */
+  @Test
+  void selfReferencingSplitEdgeSeesForwardReferences() throws Exception {
+    final String vertices = write("split-tree.csv",
+        "Code,Related",
+        "a,|b|c|",
+        "b,|c|",
+        "c,");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Topic");
+      database.getSchema().createEdgeType("RelatedTo");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Topic", new CsvRowSource(vertices), v -> {
+          v.idByName("Code");
+          v.property("code", "Code");
+          v.splitEdge("Related", "RelatedTo", "Topic", "|");
+        })
+        .build()) {
+
+      importer.run();
+
+      assertThat(importer.getVertexCount()).isEqualTo(3);
+      assertThat(importer.getEdgeCount()).isEqualTo(3);
+    }
+
+    assertThat(outgoingTargets("Topic", "code", "a", "RelatedTo", "code"))
+        .containsExactlyInAnyOrder("b", "c");
+    assertThat(outgoingTargets("Topic", "code", "b", "RelatedTo", "code")).containsExactly("c");
+  }
+
+  /**
+   * An endpoint that matches no vertex is still skipped, but it is now counted and reported
+   * instead of quietly shrinking the graph.
+   */
+  @Test
+  void unresolvedEndpointsAreCountedNotSilentlyDropped() throws Exception {
+    final String vertices = write("small-vertices.csv",
+        "Id,Name",
+        "1,One",
+        "2,Two");
+    final String edges = write("dangling-edges.csv",
+        "from_id,to_id",
+        "1,2",
+        "1,404",
+        "999,2");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Node");
+      database.getSchema().createEdgeType("Knows");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Node", new CsvRowSource(vertices), v -> {
+          v.id("Id");
+          v.intProperty("nodeId", "Id");
+          v.property("name", "Name");
+        })
+        .edgeSource("Knows", new CsvRowSource(edges), e -> {
+          e.from("from_id", "Node");
+          e.to("to_id", "Node");
+        })
+        .build()) {
+
+      importer.run();
+
+      assertThat(importer.getEdgeCount()).isEqualTo(1);
+      assertThat(importer.getUnresolvedEdgeCount()).isEqualTo(2);
+    }
+  }
+
+  /**
+   * Deduplication keys off the same identity rules, so a repeated string key is still one vertex.
+   */
+  @Test
+  void deduplicationWorksOnStringIds() throws Exception {
+    final String vertices = write("dup-vertices.jsonl",
+        "{\"id\": \"W1\", \"title\": \"First\"}",
+        "{\"id\": \"W1\", \"title\": \"Duplicate\"}",
+        "{\"id\": \"W2\", \"title\": \"Second\"}");
+
+    database.transaction(() -> database.getSchema().createVertexType("Document"));
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Document", new JsonlRowSource(vertices), v -> {
+          v.id("id");
+          v.deduplicate(true);
+          v.property("id", "id");
+          v.property("title", "title");
+        })
+        .build()) {
+
+      importer.run();
+
+      assertThat(importer.getVertexCount()).isEqualTo(2);
+    }
+
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("sql", "SELECT FROM Document WHERE id = 'W1'")) {
+        assertThat(rs.next().<String>getProperty("title")).isEqualTo("First");
+      }
+    });
+  }
+
+  private List<String> outgoingTargets(final String vertexType, final String keyProperty, final Object key,
+                                       final String edgeType, final String targetProperty) {
+    final List<String> result = new ArrayList<>();
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("sql",
+          "SELECT FROM " + vertexType + " WHERE " + keyProperty + " = ?", key)) {
+        assertThat(rs.hasNext()).as("vertex %s.%s = %s", vertexType, keyProperty, key).isTrue();
+        final Vertex v = rs.next().getVertex().get();
+        for (final Edge e : v.getEdges(Vertex.DIRECTION.OUT, edgeType))
+          result.add(e.getInVertex().asVertex().getString(targetProperty));
+      }
+    });
+    return result;
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterIdTypesTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterIdTypesTest.java
@@ -770,6 +770,34 @@ class GraphImporterIdTypesTest {
   }
 
   /**
+   * An edge source that never declared an endpoint: the same descriptive failure as every other
+   * misconfiguration here, rather than a NullPointerException out of the validation itself.
+   */
+  @Test
+  void anEdgeSourceMissingAnEndpointIsRejected() throws Exception {
+    final String vertices = write("endpoint-vertices.csv",
+        "Id,Name",
+        "1,One");
+    final String edges = write("endpoint-edges.csv",
+        "from_id,to_id",
+        "1,1");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Node");
+      database.getSchema().createEdgeType("Knows");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Node", new CsvRowSource(vertices), v -> v.id("Id"))
+        .edgeSource("Knows", new CsvRowSource(edges), e -> e.from("from_id", "Node"))
+        .build()) {
+      assertThatThrownBy(importer::run)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("declares no 'to' endpoint");
+    }
+  }
+
+  /**
    * A split field pointing at the type it lives on. Resolving it while the file is still being read
    * kept only the references that happened to point at an earlier row, so a forward reference was
    * dropped without a word.

--- a/integration/src/test/java/com/arcadedb/integration/importer/graph/GraphImporterIdIndexTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/graph/GraphImporterIdIndexTest.java
@@ -19,13 +19,16 @@
 package com.arcadedb.integration.importer.graph;
 
 import com.arcadedb.integration.importer.graph.GraphImporter.IdIndex;
+import com.arcadedb.integration.importer.graph.GraphImporter.IntIntMap;
 import com.arcadedb.integration.importer.graph.GraphImporter.LongIntMap;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 
 import static com.arcadedb.integration.importer.graph.GraphImporter.NOT_CANONICAL_LONG;
 import static com.arcadedb.integration.importer.graph.GraphImporter.canonicalLong;
@@ -162,26 +165,50 @@ class GraphImporterIdIndexTest {
   }
 
   /**
-   * Keys that differ only above the table's width - ids allocated in blocks, or carrying a fixed
-   * stride - must still spread. Masking the low bits of {@code key * odd} makes the slot depend on
-   * the key's low bits alone, which sends every one of these to the same slot and turns the lookup
-   * into a linear scan of the whole table.
+   * Ids allocated in blocks, or carrying a fixed stride, differ only above the low bits - and a
+   * hash that reads any window but the top of the product can be zeroed by one. Both maps used to
+   * do exactly that, so a stride sent every key to the same slot and every lookup became a scan of
+   * the whole table; the map still answers correctly, which is why this asserts the spread rather
+   * than the round trip.
+   * <p>
+   * A stride of {@code 2^13} defeats masking the low bits, and one of {@code 2^45} defeats the
+   * fixed {@code >>> 32} that replaced it.
    */
   @Test
-  void stridedKeysDoNotAllLandInOneSlot() {
-    final IdIndex index = new IdIndex();
-    final int stride = 1 << 16;
-    for (int i = 0; i < 2_000; i++)
-      index.put(String.valueOf((long) i * stride), i);
-    for (int i = 0; i < 2_000; i++)
-      assertThat(index.get(String.valueOf((long) i * stride))).isEqualTo(i);
+  void stridedKeysSpreadAcrossTheTable() {
+    // the top stride is bounded so that 500 multiples of it still fit a long: a stride any wider
+    // wraps, and the keys stop being distinct before the slots do
+    for (final long stride : new long[] { 1L << 13, 1L << 20, 1L << 45, 1L << 53 }) {
+      final LongIntMap longKeys = new LongIntMap(1_000);
+      final Set<Integer> longSlots = new HashSet<>();
+      for (int i = 1; i <= 500; i++)
+        longSlots.add(longKeys.hash(i * stride));
+      assertThat(longSlots).as("LongIntMap slots for 500 keys spaced %d apart", stride).hasSizeGreaterThan(100);
 
-    // and past the int boundary, so the widened table is exercised the same way
+      if (stride > Integer.MAX_VALUE)
+        continue;
+      final IntIntMap intKeys = new IntIntMap(1_000);
+      final Set<Integer> intSlots = new HashSet<>();
+      for (int i = 1; i <= 500; i++)
+        intSlots.add(intKeys.hash((int) (i * stride)));
+      assertThat(intSlots).as("IntIntMap slots for 500 keys spaced %d apart", stride).hasSizeGreaterThan(100);
+    }
+  }
+
+  /** And the index resolves them, through both the int table and the widened one. */
+  @Test
+  void stridedKeysResolveOnBothSidesOfTheIntBoundary() {
+    final IdIndex index = new IdIndex();
+    for (int i = 1; i <= 2_000; i++)
+      index.put(String.valueOf((long) i << 13), i);
+    for (int i = 1; i <= 2_000; i++)
+      assertThat(index.get(String.valueOf((long) i << 13))).isEqualTo(i);
+
     final IdIndex wide = new IdIndex();
-    for (int i = 0; i < 2_000; i++)
-      wide.put(String.valueOf(Integer.MAX_VALUE + (long) i * stride), i);
-    for (int i = 0; i < 2_000; i++)
-      assertThat(wide.get(String.valueOf(Integer.MAX_VALUE + (long) i * stride))).isEqualTo(i);
+    for (int i = 1; i <= 2_000; i++)
+      wide.put(String.valueOf((long) i << 45), i);
+    for (int i = 1; i <= 2_000; i++)
+      assertThat(wide.get(String.valueOf((long) i << 45))).isEqualTo(i);
   }
 
   /**

--- a/integration/src/test/java/com/arcadedb/integration/importer/graph/GraphImporterIdIndexTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/graph/GraphImporterIdIndexTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer.graph;
+
+import com.arcadedb.integration.importer.graph.GraphImporter.IdIndex;
+import com.arcadedb.integration.importer.graph.GraphImporter.LongIntMap;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+import static com.arcadedb.integration.importer.graph.GraphImporter.NOT_CANONICAL_LONG;
+import static com.arcadedb.integration.importer.graph.GraphImporter.canonicalLong;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The identity key space {@link GraphImporter} resolves edges through: which spellings become a
+ * primitive key, which stay text, and that the promotion from the {@code int} table to the
+ * {@code long} one loses nothing (issue #7244).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class GraphImporterIdIndexTest {
+
+  @Test
+  void canonicalDecimalTextBecomesANumericKey() {
+    assertThat(canonicalLong("0")).isZero();
+    assertThat(canonicalLong("7")).isEqualTo(7);
+    assertThat(canonicalLong("-5")).isEqualTo(-5);
+    assertThat(canonicalLong("2257721487")).isEqualTo(2257721487L);
+    assertThat(canonicalLong(String.valueOf(Long.MAX_VALUE))).isEqualTo(Long.MAX_VALUE);
+    assertThat(canonicalLong(String.valueOf(Long.MIN_VALUE + 1))).isEqualTo(Long.MIN_VALUE + 1);
+    assertThat(canonicalLong(String.valueOf(Integer.MIN_VALUE))).isEqualTo(Integer.MIN_VALUE);
+  }
+
+  @Test
+  void everythingElseStaysText() {
+    assertThat(canonicalLong(null)).isEqualTo(NOT_CANONICAL_LONG);
+    assertThat(canonicalLong("")).isEqualTo(NOT_CANONICAL_LONG);
+    assertThat(canonicalLong("-")).isEqualTo(NOT_CANONICAL_LONG);
+    assertThat(canonicalLong("W13696992")).isEqualTo(NOT_CANONICAL_LONG);
+    assertThat(canonicalLong("12a")).isEqualTo(NOT_CANONICAL_LONG);
+    assertThat(canonicalLong("1.0")).isEqualTo(NOT_CANONICAL_LONG);
+    assertThat(canonicalLong(" 1")).isEqualTo(NOT_CANONICAL_LONG);
+    assertThat(canonicalLong("1 ")).isEqualTo(NOT_CANONICAL_LONG);
+    assertThat(canonicalLong("+1")).isEqualTo(NOT_CANONICAL_LONG);
+    // a value the source spelled differently from Long.toString is a distinct identity
+    assertThat(canonicalLong("007")).isEqualTo(NOT_CANONICAL_LONG);
+    assertThat(canonicalLong("00")).isEqualTo(NOT_CANONICAL_LONG);
+    assertThat(canonicalLong("-0")).isEqualTo(NOT_CANONICAL_LONG);
+    // out of range, and the one in-range value reserved as the sentinel
+    assertThat(canonicalLong("9223372036854775808")).isEqualTo(NOT_CANONICAL_LONG);
+    assertThat(canonicalLong("-9223372036854775809")).isEqualTo(NOT_CANONICAL_LONG);
+    assertThat(canonicalLong("99999999999999999999")).isEqualTo(NOT_CANONICAL_LONG);
+    assertThat(canonicalLong(String.valueOf(Long.MIN_VALUE))).isEqualTo(NOT_CANONICAL_LONG);
+  }
+
+  /**
+   * Even the two keys the primitive tables cannot hold - {@code Long.MIN_VALUE}, which is the
+   * sentinel, and {@code Integer.MIN_VALUE}, which marks an empty slot in the {@code int} table -
+   * resolve, because the index falls back rather than storing them where they would be read as
+   * "nothing here".
+   */
+  @Test
+  void reservedKeyValuesStillResolve() {
+    final IdIndex index = new IdIndex();
+    index.put(String.valueOf(Long.MIN_VALUE), 1);
+    index.put(String.valueOf(Integer.MIN_VALUE), 2);
+    index.put("0", 3);
+
+    assertThat(index.get(String.valueOf(Long.MIN_VALUE))).isEqualTo(1);
+    assertThat(index.get(String.valueOf(Integer.MIN_VALUE))).isEqualTo(2);
+    assertThat(index.get("0")).isEqualTo(3);
+  }
+
+  @Test
+  void anAbsentOrUnknownKeyResolvesToMinusOne() {
+    final IdIndex index = new IdIndex();
+    assertThat(index.get(null)).isEqualTo(-1);
+    assertThat(index.get("1")).isEqualTo(-1);
+    assertThat(index.get("nope")).isEqualTo(-1);
+
+    index.put("1", 0);
+    index.put(null, 9);
+    assertThat(index.get("2")).isEqualTo(-1);
+    assertThat(index.get("nope")).isEqualTo(-1);
+  }
+
+  /**
+   * The index starts on the {@code int} table and widens once. Keys registered before the widening
+   * have to survive it, and a later key must not be looked up in the table that no longer holds
+   * anything.
+   */
+  @Test
+  void wideningToLongKeysPreservesEveryKey() {
+    final IdIndex index = new IdIndex();
+    for (int i = 0; i < 10_000; i++)
+      index.put(String.valueOf(i), i);
+    index.put("-1", 10_000);
+
+    // forces the promotion
+    index.put("2257721487", 10_001);
+
+    for (int i = 0; i < 10_000; i++)
+      assertThat(index.get(String.valueOf(i))).isEqualTo(i);
+    assertThat(index.get("-1")).isEqualTo(10_000);
+    assertThat(index.get("2257721487")).isEqualTo(10_001);
+
+    // and a key registered after the promotion, on either side of the int boundary
+    index.put("42", 10_002);
+    index.put("-9000000000", 10_003);
+    assertThat(index.get("42")).isEqualTo(10_002);
+    assertThat(index.get("-9000000000")).isEqualTo(10_003);
+  }
+
+  @Test
+  void numericAndTextualKeysCoexistWithoutColliding() {
+    final IdIndex index = new IdIndex();
+    index.put("7", 1);
+    index.put("007", 2);
+    index.put("W7", 3);
+    index.put("2257721487", 4);
+
+    assertThat(index.get("7")).isEqualTo(1);
+    assertThat(index.get("007")).isEqualTo(2);
+    assertThat(index.get("W7")).isEqualTo(3);
+    assertThat(index.get("2257721487")).isEqualTo(4);
+    assertThat(index.get("0007")).isEqualTo(-1);
+  }
+
+  @Test
+  void aRepeatedKeyKeepsTheLastRegistration() {
+    final IdIndex index = new IdIndex();
+    index.put("1", 10);
+    index.put("1", 11);
+    index.put("W1", 20);
+    index.put("W1", 21);
+    index.put("9000000000", 30);
+    index.put("9000000000", 31);
+
+    assertThat(index.get("1")).isEqualTo(11);
+    assertThat(index.get("W1")).isEqualTo(21);
+    assertThat(index.get("9000000000")).isEqualTo(31);
+  }
+
+  /**
+   * The widened map is new code on the hot path, so it is checked against {@link HashMap} over
+   * enough keys to resize several times and to collide.
+   */
+  @Test
+  void longIntMapAgreesWithAReferenceMap() {
+    final LongIntMap map = new LongIntMap(16);
+    final Map<Long, Integer> reference = new HashMap<>();
+    final Random random = new Random(7244);
+
+    for (int i = 0; i < 50_000; i++) {
+      final long key = random.nextInt(4) == 0 ? random.nextInt(100) : random.nextLong();
+      if (key == Long.MIN_VALUE)
+        continue;
+      map.put(key, i);
+      reference.put(key, i);
+    }
+
+    for (final Map.Entry<Long, Integer> entry : reference.entrySet())
+      assertThat(map.get(entry.getKey(), -1)).isEqualTo(entry.getValue());
+
+    for (int i = 0; i < 1_000; i++) {
+      final long key = random.nextLong();
+      if (!reference.containsKey(key) && key != Long.MIN_VALUE)
+        assertThat(map.get(key, -1)).isEqualTo(-1);
+    }
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/importer/graph/GraphImporterIdIndexTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/graph/GraphImporterIdIndexTest.java
@@ -162,6 +162,29 @@ class GraphImporterIdIndexTest {
   }
 
   /**
+   * Keys that differ only above the table's width - ids allocated in blocks, or carrying a fixed
+   * stride - must still spread. Masking the low bits of {@code key * odd} makes the slot depend on
+   * the key's low bits alone, which sends every one of these to the same slot and turns the lookup
+   * into a linear scan of the whole table.
+   */
+  @Test
+  void stridedKeysDoNotAllLandInOneSlot() {
+    final IdIndex index = new IdIndex();
+    final int stride = 1 << 16;
+    for (int i = 0; i < 2_000; i++)
+      index.put(String.valueOf((long) i * stride), i);
+    for (int i = 0; i < 2_000; i++)
+      assertThat(index.get(String.valueOf((long) i * stride))).isEqualTo(i);
+
+    // and past the int boundary, so the widened table is exercised the same way
+    final IdIndex wide = new IdIndex();
+    for (int i = 0; i < 2_000; i++)
+      wide.put(String.valueOf(Integer.MAX_VALUE + (long) i * stride), i);
+    for (int i = 0; i < 2_000; i++)
+      assertThat(wide.get(String.valueOf(Integer.MAX_VALUE + (long) i * stride))).isEqualTo(i);
+  }
+
+  /**
    * The widened map is new code on the hot path, so it is checked against {@link HashMap} over
    * enough keys to resize several times and to collide.
    */


### PR DESCRIPTION
Fixes #7244. Reported in discussion #7214.

## The problem

`GraphImporter` resolved every vertex identity through a single `int` key space, so two ordinary datasets could not be imported at all:

- **String keys.** `v.id("id")` over OpenAlex-style ids threw `JSONObject[id] is not a int ("W13696992")` on the vertex pass. `idByName()` existed, but it only helps when the foreign key travels *on the vertex record*; a standalone edge source had no equivalent.
- **Keys wider than an `int`.** `e.from("from_id", "Doc")` threw `NumberFormatException: For input string: "2257721487"`. `processEdgeSource()` read both endpoints with `record.getInt()` and looked them up only in `idToIdx`.

The workaround suggested on the discussion - assign every external id a collision-free 32-bit surrogate and carry the original as a separate property - works, but it asks the caller to build a second identity space by hand for keys the JVM can hold natively. This replaces it.

## The fix

Identity is the attribute's **text, exactly as the source wrote it**, resolved through one `IdIndex` shared by vertex registration, by a foreign key on a vertex record, and by a standalone edge source. An `int`, a `long`, and a string are all just keys.

Performance is unchanged for the imports that already worked. `IdIndex` stores a key that is the *canonical* decimal form of a `long` unboxed: the `int` table first, widened exactly once to a `long` table when a key that does not fit arrives; a textual key lands in a `HashMap` that is not allocated until one appears. The scan that classifies a key neither allocates nor throws - `Long.parseLong` in a `try` block would fill in a stack trace for every row of a string-keyed file.

Insisting on the *canonical* form is what makes the primitive fast path safe: `"007"` and `"7"` are two identities the source deliberately kept apart, so only the spelling `Long.toString` would produce becomes a number. Everything else - leading zeros, `"+1"`, `"-0"`, surrounding space - stays text and resolves as text.

## Four further defects on the same path

- **A vertex whose key is `0` could not be pointed at.** `getInt()` returns `0` for a missing attribute and `collectEdge()` read `0` as "this row carries no reference". Absence is now the absent attribute itself, which every source already reports as `null`.
- **A self-referencing edge declared `byName` threw on the first row.** The deferred path ignored the flag and read the name attribute as an `int`.
- **A self-referencing `splitEdge` silently lost forward references.** It resolved inline against a half-built index, so only values pointing at an earlier row survived. It is now deferred with the rest.
- **A self-referencing edge declared `edgeIn` was built in the wrong direction.** The deferred path always wrote `src = this row`.

## Unresolved endpoints are no longer silent

An endpoint matching no vertex is still skipped - there is nothing to attach the edge to - but it is now counted, warned about per source, and exposed as `getUnresolvedEdgeCount()`. A typo in a vertex type name, or an edge file referencing rows a `filter` removed, used to produce a smaller graph and no diagnostic at all.

## Behaviour change (for the release notes)

`run()` now validates the configuration before writing anything, and throws `IllegalArgumentException` for four things it used to accept and then silently produce a smaller graph for:

- an edge naming a vertex type no source imports (a typo);
- an edge naming a vertex type imported *after* the source referencing it — a vertex source resolves against the types already imported, so a forward reference yielded no edges;
- an edge resolving against the `id()` of a type that declares only `idByName()`, or the reverse;
- two vertex sources declaring the same type name, which made pass 2 resolve one source's row indices into the other's arrays.

None of these could ever have produced an edge, so no working import breaks — but a caller relying on the silent skip will now see an exception instead of a quietly incomplete graph. `getUnresolvedEdgeCount()` is purely additive; this validation is not.

## Also

Drops `DeferredEdgePair` and the map holding it: both unreferenced.

## Tests

- `GraphImporterIdTypesTest` (11) - both reporter cases end to end, key `0` as an endpoint and as a vertex-record FK, `byName` and string-keyed self-references, forward references in a self-referencing split field, `"007"` vs `"7"`, mixed widths and types in one column, unresolved-endpoint counting, dedup on string ids.
- `GraphImporterIdIndexTest` (8) - the key scan's edge cases (`Long.MIN_VALUE`, overflow either side, non-canonical spellings), that the two reserved sentinel values still resolve, that widening loses no key, and `LongIntMap` against a `HashMap` over 50k keys.

`mvn -o -pl integration -am test`: 221 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lbn7hrmTeyEWpkK2AmLjAp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Graph imports now support string identifiers, zero-valued IDs, and numeric IDs beyond standard integer ranges.
  - Self-referencing and forward-referencing edges, including split edge fields, are resolved more reliably.
  - Unresolved edge endpoints are counted and reported through warnings.

- **Bug Fixes**
  - Non-canonical numeric text remains distinct from canonical values.
  - Missing or empty foreign keys no longer create unintended references.
  - Duplicate identifiers and duplicate vertex-source declarations are handled consistently.
  - Invalid edge targets are rejected for unavailable or incompatible vertex types.
  - Hash-based ID lookups distribute strided identifiers more reliably, including after resizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
