### PR TITLE
fix(#7223,#7222,#7224): disk space on the databases' filesystem, strict boolean on the configuration path, pg_type joined to pg_namespace

### DIFF
--- a/e2e-studio/tests/apexcharts-upgrade.spec.ts
+++ b/e2e-studio/tests/apexcharts-upgrade.spec.ts
@@ -94,7 +94,7 @@ test.describe('ApexCharts v5 Upgrade Validation', () => {
     await expect(page.locator('#summRamUsed')).toBeVisible({ timeout: 10000 });
     await expect(page.locator('#summRamTotal')).toBeVisible({ timeout: 10000 });
 
-    // OS Disk card
+    // Databases Disk card
     await expect(page.locator('#summDiskUsed')).toBeVisible({ timeout: 10000 });
     await expect(page.locator('#summDiskTotal')).toBeVisible({ timeout: 10000 });
 

--- a/e2e-studio/tests/apexcharts-upgrade.spec.ts
+++ b/e2e-studio/tests/apexcharts-upgrade.spec.ts
@@ -94,9 +94,11 @@ test.describe('ApexCharts v5 Upgrade Validation', () => {
     await expect(page.locator('#summRamUsed')).toBeVisible({ timeout: 10000 });
     await expect(page.locator('#summRamTotal')).toBeVisible({ timeout: 10000 });
 
-    // Databases Disk card
+    // Databases Disk card - the directory (#7223) names the filesystem the two figures beside it describe, so it
+    // has to reach the page and not only displayServerSummary()
     await expect(page.locator('#summDiskUsed')).toBeVisible({ timeout: 10000 });
     await expect(page.locator('#summDiskTotal')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('#summDiskDir')).toBeVisible({ timeout: 10000 });
 
     // Read Cache card
     await expect(page.locator('#summCacheUsed')).toBeVisible({ timeout: 10000 });

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2867,33 +2867,6 @@ public enum GlobalConfiguration {
   }
 
   /**
-   * Converts {@code iValue} to this setting's declared {@link #getType() type}, or throws
-   * {@link IllegalArgumentException} naming the key, the type and the offending value when it does not parse.
-   * <p>
-   * Issue #6875: this is the single place a value is turned into a setting's type, so that {@link #setValue(Object)}
-   * and the administrative writers that store into a {@link ContextConfiguration} instead
-   * ({@code set_server_setting} and {@code POST /api/v1/server "set server setting"}) accept and refuse exactly
-   * the same strings. Before it existed the writers stored whatever they were handed and the
-   * {@code NumberFormatException} surfaced later, inside whichever component read the setting next.
-   * <p>
-   * The integral parse is {@link FileUtils#getSizeAsNumber(Object)} on the trimmed text, which is what
-   * {@link #getValueAsInteger()} and {@link #getValueAsLong()} have always used to read one back; it is a strict
-   * superset of {@code Integer.parseInt}/{@code Long.parseLong}, so nothing that parsed before stops parsing.
-   * <p>
-   * {@code Boolean} stays as permissive as {@code Boolean.parseBoolean}, because this method cannot be the place
-   * that refuses: it is reachable from this class's static initializer, where a throw becomes an
-   * {@code ExceptionInInitializerError} that takes the whole engine down instead of the setting. The refusal lives
-   * one level up, in {@link #coerceFromAdminCommand(Object)} and
-   * {@link #setValueFromConfigurationSource(Object, String)}, which every writer of raw external text now goes
-   * through - {@link #readConfiguration()} included, since issue #7222.
-   *
-   * @param iValue the value to convert, or {@code null}
-   *
-   * @return the value as an instance of {@link #getType()}, or {@code null} when {@code iValue} is {@code null}
-   *
-   * @throws IllegalArgumentException if {@code iValue} cannot be represented as this setting's type
-   */
-  /**
    * The conversion {@link #coerce(Object)} performs, but STRICT about a {@code Boolean} setting: a text value that is
    * neither {@code true} nor {@code false} is refused instead of silently reading as {@code false}.
    * <p>
@@ -2936,6 +2909,33 @@ public enum GlobalConfiguration {
     return coerce(iValue);
   }
 
+  /**
+   * Converts {@code iValue} to this setting's declared {@link #getType() type}, or throws
+   * {@link IllegalArgumentException} naming the key, the type and the offending value when it does not parse.
+   * <p>
+   * Issue #6875: this is the single place a value is turned into a setting's type, so that {@link #setValue(Object)}
+   * and the administrative writers that store into a {@link ContextConfiguration} instead
+   * ({@code set_server_setting} and {@code POST /api/v1/server "set server setting"}) accept and refuse exactly
+   * the same strings. Before it existed the writers stored whatever they were handed and the
+   * {@code NumberFormatException} surfaced later, inside whichever component read the setting next.
+   * <p>
+   * The integral parse is {@link FileUtils#getSizeAsNumber(Object)} on the trimmed text, which is what
+   * {@link #getValueAsInteger()} and {@link #getValueAsLong()} have always used to read one back; it is a strict
+   * superset of {@code Integer.parseInt}/{@code Long.parseLong}, so nothing that parsed before stops parsing.
+   * <p>
+   * {@code Boolean} stays as permissive as {@code Boolean.parseBoolean}, because this method cannot be the place
+   * that refuses: it is reachable from this class's static initializer, where a throw becomes an
+   * {@code ExceptionInInitializerError} that takes the whole engine down instead of the setting. The refusal lives
+   * one level up, in {@link #coerceFromAdminCommand(Object)} and
+   * {@link #setValueFromConfigurationSource(Object, String)}, which every writer of raw external text now goes
+   * through - {@link #readConfiguration()} included, since issue #7222.
+   *
+   * @param iValue the value to convert, or {@code null}
+   *
+   * @return the value as an instance of {@link #getType()}, or {@code null} when {@code iValue} is {@code null}
+   *
+   * @throws IllegalArgumentException if {@code iValue} cannot be represented as this setting's type
+   */
   public Object coerce(final Object iValue) {
     if (iValue == null)
       return null;

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2908,6 +2908,18 @@ public enum GlobalConfiguration {
    * <p>
    * {@link #coerce(Object)} therefore remains the conversion of a value that is already typed, or one whose caller
    * has its own reason to be lenient; nothing routes raw external text through it any more.
+   * <p>
+   * <b>One writer is still outside all of this, and counting it is the point:</b> #7222 happened because an
+   * enumeration of writers went stale, so this one says what it does not cover.
+   * {@link ContextConfiguration#fromJSON(String)} - the server configuration FILE - stores what it read straight
+   * into the overlay map with a plain {@code put}, touching neither this method nor {@link #setValue(Object)}, so a
+   * {@code "yes"} written there survives as the string {@code "yes"}. That is not the #7222 failure, which was a
+   * value silently BECOMING {@code false}: the text is still intact, so a reader can still refuse it, and
+   * {@code PrometheusMetricsPlugin.isAuthenticationRequired} does exactly that by re-applying this method at its own
+   * read site. A reader that instead trusts "the strict parse already happened on entry" and calls
+   * {@link ContextConfiguration#getValueAsBoolean(GlobalConfiguration)} would get {@code Boolean.parseBoolean} and
+   * reopen the bug through the configuration file. Until the file path coerces too, the read-site re-parse is what
+   * a security-relevant Boolean has to keep doing.
    *
    * @param iValue the value to convert, or {@code null}
    *

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2794,11 +2794,26 @@ public enum GlobalConfiguration {
       return true;
     } catch (final Exception e) {
       if (LogManager.instance() != null)
-        LogManager.instance().log(this, Level.WARNING,
-            "Invalid value '%s' for setting '%s' of type %s set as %s: %s. Keeping '%s'", iValue, key,
-            type.getSimpleName(), source, e.getMessage(), getValue());
+        LogManager.instance().log(this, Level.WARNING, "Invalid value %s for setting '%s' of type %s set as %s: %s. Keeping %s",
+            redactIfHidden(iValue), key, type.getSimpleName(), source,
+            // The cause is redacted along with the value: its message quotes the value back.
+            isHidden() ? "not a valid " + type.getSimpleName() : e.getMessage(), redactIfHidden(getValue()));
       return false;
     }
+  }
+
+  /**
+   * How a value of this setting may be written into a log. The rejected TEXT is what makes the message above
+   * actionable - "'yes' is not a boolean" is the whole point of reporting it - but it is text an operator typed, so
+   * a {@link #isHidden() hidden} setting reports only that there was one. Same rule {@link #dumpConfiguration} is
+   * already under for the values it prints.
+   * <p>
+   * No hidden setting is currently of a type that can fail to coerce - they are all {@code String}, which accepts
+   * anything - so this does not redact anything today. It is here so the first hidden setting that is not a
+   * {@code String} does not have to notice.
+   */
+  String redactIfHidden(final Object value) {
+    return isHidden() ? "<hidden>" : "'" + value + "'";
   }
 
   public <T> T getValue() {

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2750,12 +2750,28 @@ public enum GlobalConfiguration {
         source = "environment variable";
       }
 
-      if (prop != null)
-        config.setValueFromConfigurationSource(prop, source);
-      else if (config.callbackIfNoSet != null) {
-        config.setValue(config.callbackIfNoSet.call(null));
-      }
+      config.applyConfigurationSource(prop, source);
     }
+  }
+
+  /**
+   * Applies one setting's system property or environment variable, or its absence, as {@link #readConfiguration()}
+   * does. Split out so the composition below is reachable from a test: what it does with a value it cannot read is
+   * not visible from either half alone.
+   * <p>
+   * A REFUSED value takes the same branch as an ABSENT one, which is the only reading of "keep the default" that is
+   * true for every setting: a setting with a {@code callbackIfNoSet} has no compiled-in default worth having, it has
+   * one it computes. {@code QUERY_MAX_RANGE_SIZE} scales its cap with the JVM heap that way, and its
+   * {@code defValue} is the unbounded-heap figure - so leaving a refused value to fall through to {@code defValue}
+   * would RAISE the cap on a small-heap JVM, which for a setting that exists to bound the memory one query can ask
+   * for is the wrong direction. A typo must not do that.
+   *
+   * @param prop   the raw text the property or variable carried, or {@code null} when neither was set
+   * @param source what to name as its origin when reporting a value that cannot be read
+   */
+  void applyConfigurationSource(final String prop, final String source) {
+    if ((prop == null || !setValueFromConfigurationSource(prop, source)) && callbackIfNoSet != null)
+      setValue(callbackIfNoSet.call(null));
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1356,8 +1356,10 @@ public enum GlobalConfiguration {
   SERVER_METRICS_PROMETHEUS_REQUIRE_AUTHENTICATION("arcadedb.serverMetrics.prometheus.requireAuthentication", SCOPE.SERVER, """
       True (the default) to require authentication on the /prometheus scrape endpoint. Issue #7124: the plugin \
       reads this setting with a STRICT parse and treats anything that is neither `true` nor `false` as `true`, so a \
-      typo cannot silently publish the endpoint unauthenticated - unlike the permissive coercion every other \
-      Boolean setting gets, which reads an unparseable value as false.""", Boolean.class, true),
+      typo cannot silently publish the endpoint unauthenticated. Issue #7222 made that promise hold on every \
+      writer: a value that is neither `true` nor `false` is refused where it enters - by an admin command, and by \
+      a system property or environment variable - and the setting keeps its default of true.""", Boolean.class,
+      true),
 
   SERVER_METRICS_TRACING_ENABLED("arcadedb.serverMetrics.tracing.enabled", SCOPE.SERVER,
       "Enable OpenTelemetry distributed tracing (requires the optional tracing plugin on the classpath). Note: query/command spans include the statement text as the db.statement span attribute, which may contain sensitive data, so secure the OTLP collector endpoint",
@@ -2730,21 +2732,72 @@ public enum GlobalConfiguration {
   }
 
   /**
-   * Assign configuration values by reading system properties.
+   * Assign configuration values by reading system properties and environment variables.
+   * <p>
+   * Both go through {@link #setValueFromConfigurationSource(Object, String)} rather than {@link #setValue(Object)},
+   * so a value the setting's type cannot read is reported and dropped instead of being coerced into whatever the
+   * type's permissive parse makes of it - which for a {@code Boolean} was {@code false}, for every input (#7222).
    */
   public static void readConfiguration() {
     String prop;
 
     for (final GlobalConfiguration config : values()) {
+      String source = "system property";
+
       prop = System.getProperty(config.key);
-      if (prop == null)
+      if (prop == null) {
         prop = System.getenv(config.key);
+        source = "environment variable";
+      }
 
       if (prop != null)
-        config.setValue(prop);
+        config.setValueFromConfigurationSource(prop, source);
       else if (config.callbackIfNoSet != null) {
         config.setValue(config.callbackIfNoSet.call(null));
       }
+    }
+  }
+
+  /**
+   * Stores a value that arrived from the PROCESS's own configuration - a system property or an environment variable
+   * - applying the strict parse of {@link #coerceFromAdminCommand(Object)} but REPORTING what it cannot read
+   * instead of throwing, so the setting is dropped rather than the engine.
+   * <p>
+   * Issue #7222. {@code arcadedb.serverMetrics.prometheus.requireAuthentication} is documented as parsed strictly
+   * "so a typo cannot silently publish the endpoint unauthenticated", and that held on the administrative writers
+   * and not here: this path used {@link #setValue(Object)}, whose {@code Boolean} arm is
+   * {@code Boolean.parseBoolean} and therefore maps {@code yes}, {@code 1}, {@code on} and every typo to
+   * {@code false} without a word. The value then reached the plugin ALREADY a {@code Boolean}, where the strict
+   * guard is skipped because the text that produced it is gone - so {@code requireAuthentication=yes} published
+   * {@code /prometheus} unauthenticated while the operator believed they had turned the protection on. A
+   * Kubernetes deployment configures exactly through this path.
+   * <p>
+   * A refusal leaves the setting exactly as it was, which from {@link #readConfiguration()} is its compiled-in
+   * DEFAULT. Reading an unparseable boolean as {@code true} instead would fail closed for this one setting and flip
+   * every setting whose safe side is the other one; refusing to guess is the property that holds for all of them,
+   * and it is what makes this one fail closed, its default being {@code true}. {@link #isChanged()} stays
+   * {@code false} too, because nothing was chosen.
+   * <p>
+   * This cannot throw: {@link #readConfiguration()} runs inside this class's static initializer, where an exception
+   * becomes an {@code ExceptionInInitializerError} that takes the whole engine down over one mistyped variable.
+   * That is the constraint {@link #coerce(Object)} was left permissive for, and the reason the strictness lives in
+   * a separate method here rather than in {@code coerce} itself.
+   *
+   * @param iValue the value to store, typically the raw text of the property or variable
+   * @param source what to name as its origin when reporting a value that cannot be read
+   *
+   * @return {@code true} when the value was stored, {@code false} when it was refused and the default kept
+   */
+  public boolean setValueFromConfigurationSource(final Object iValue, final String source) {
+    try {
+      setValue(coerceFromAdminCommand(iValue));
+      return true;
+    } catch (final Exception e) {
+      if (LogManager.instance() != null)
+        LogManager.instance().log(this, Level.WARNING,
+            "Invalid value '%s' for setting '%s' of type %s set as %s: %s. Keeping '%s'", iValue, key,
+            type.getSimpleName(), source, e.getMessage(), getValue());
+      return false;
     }
   }
 
@@ -2812,10 +2865,12 @@ public enum GlobalConfiguration {
    * {@link #getValueAsInteger()} and {@link #getValueAsLong()} have always used to read one back; it is a strict
    * superset of {@code Integer.parseInt}/{@code Long.parseLong}, so nothing that parsed before stops parsing.
    * <p>
-   * {@code Boolean} stays as permissive as {@code Boolean.parseBoolean}, deliberately: {@link #readConfiguration()}
-   * feeds every system property and environment variable through here during this class's static initializer, so
-   * turning a boolean typo into a throw would turn it into an {@code ExceptionInInitializerError} that takes the
-   * whole engine down instead of the setting.
+   * {@code Boolean} stays as permissive as {@code Boolean.parseBoolean}, because this method cannot be the place
+   * that refuses: it is reachable from this class's static initializer, where a throw becomes an
+   * {@code ExceptionInInitializerError} that takes the whole engine down instead of the setting. The refusal lives
+   * one level up, in {@link #coerceFromAdminCommand(Object)} and
+   * {@link #setValueFromConfigurationSource(Object, String)}, which every writer of raw external text now goes
+   * through - {@link #readConfiguration()} included, since issue #7222.
    *
    * @param iValue the value to convert, or {@code null}
    *
@@ -2836,10 +2891,19 @@ public enum GlobalConfiguration {
    * cannot read here ({@code abc} for an {@code Integer} throws); {@code Boolean} was the one that did not.
    * <p>
    * This is the entry point for a value that arrived from an administrative command, where refusing loudly is an
-   * error the operator can read and act on. All four writers use it: the {@code set server setting} and
+   * error the operator can read and act on. All four such writers use it: the {@code set server setting} and
    * {@code set database setting} HTTP commands, the {@code set_server_setting} MCP tool, and
-   * {@code ALTER DATABASE ... SETTING} in SQL. Every other conversion path keeps using {@link #coerce(Object)} -
-   * notably this class's own static initializer, which is the reason the two have to be separate methods.
+   * {@code ALTER DATABASE ... SETTING} in SQL.
+   * <p>
+   * There is a FIFTH writer of raw text, and issue #7222 is what it cost to leave it out of that list:
+   * {@link #readConfiguration()}, the system-property and environment-variable path, which used
+   * {@link #setValue(Object)} and so got the permissive {@code Boolean.parseBoolean} - a container deployment
+   * configures through exactly that path, and {@code requireAuthentication=yes} silently became {@code false}. It
+   * now applies this same strict parse through {@link #setValueFromConfigurationSource(Object, String)}, which
+   * differs only in what it does with a refusal: it cannot throw, so it reports and keeps the default.
+   * <p>
+   * {@link #coerce(Object)} therefore remains the conversion of a value that is already typed, or one whose caller
+   * has its own reason to be lenient; nothing routes raw external text through it any more.
    *
    * @param iValue the value to convert, or {@code null}
    *

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -3070,6 +3070,7 @@ public enum GlobalConfiguration {
 
   public void setValue(final Object iValue) {
     final Object oldValue = value;
+    final boolean wasExplicitlySet = explicitlySet;
     explicitlySet = true;
 
     try {
@@ -3083,8 +3084,12 @@ public enum GlobalConfiguration {
               "Global setting '" + key + "=" + value + "' is not valid. Allowed values are " + allowed);
 
     } catch (final Exception e) {
-      // RESTORE THE PREVIOUS VALUE
+      // RESTORE THE PREVIOUS VALUE - INCLUDING WHETHER THERE WAS ONE. A WRITE THAT WAS ROLLED BACK IS NOT A CHOICE
+      // ANYONE MADE, AND LEAVING explicitlySet ON AFTER ONE MADE isChanged() REPORT A SETTING AS CONFIGURED WHILE IT
+      // SAT AT ITS DEFAULT. THAT IS WHAT setValueFromConfigurationSource PROMISES ABOUT A REFUSED VALUE (#7222), AND
+      // IT COULD ONLY HOLD FOR SETTINGS WHOSE callback AND allowed SET CANNOT THROW.
       value = oldValue;
+      explicitlySet = wasExplicitlySet;
       throw e;
     }
   }

--- a/engine/src/main/java/com/arcadedb/Profiler.java
+++ b/engine/src/main/java/com/arcadedb/Profiler.java
@@ -116,8 +116,11 @@ public class Profiler {
    * The overlay {@link #diskSpaceDirectory()} reads the database directory through. An empty
    * {@link ContextConfiguration} is a pure proxy for the process-wide settings - it holds nothing and nothing here
    * writes to it - so one shared instance is what a per-call {@code new} was already asking for.
+   * <p>
+   * <b>Never write to it.</b> A {@code setValue} here would be a process-wide override installed by whoever happened
+   * to be reading a disk figure, which is not what any caller of this class means to do.
    */
-  private static final ContextConfiguration GLOBAL_SETTINGS = new ContextConfiguration();
+  private static final ContextConfiguration GLOBAL_SETTINGS = new ContextConfiguration(); // READ-ONLY: see above
 
   protected Profiler() {
   }

--- a/engine/src/main/java/com/arcadedb/Profiler.java
+++ b/engine/src/main/java/com/arcadedb/Profiler.java
@@ -105,6 +105,13 @@ public class Profiler {
    */
   private final long[] retainedStats = new long[MONOTONIC_STATS];
 
+  /**
+   * The last {@code {absolute, canonical}} pair {@link #diskSpaceDirectory()} computed, or null before the first
+   * call. Volatile rather than synchronized: it is a pure function of its first element, so a reader that misses a
+   * write only pays for one more canonicalisation.
+   */
+  private static volatile File[] canonicalDiskSpaceDirectory;
+
   protected Profiler() {
   }
 
@@ -465,14 +472,29 @@ public class Profiler {
    * <p>
    * Canonicalised, because the path is REPORTED here and not only measured: the working-directory fallback is
    * {@code "."}, which names no filesystem to a reader looking at a disk figure they do not believe.
+   * <p>
+   * The canonicalisation is memoised on the absolute path it was computed from, because it is the expensive half -
+   * it resolves every symlink in the path, and both callers hold this class's monitor while Studio polls them.
+   * The resolution itself is NOT cached: it is a couple of {@code exists()} calls, and caching it would keep
+   * reporting the parent directory after the configured one is finally created.
    */
   private static File diskSpaceDirectory() {
-    final File dir = FileUtils.resolveDiskSpaceDirectory(new ContextConfiguration());
+    final File dir = FileUtils.resolveDiskSpaceDirectory(new ContextConfiguration()).getAbsoluteFile();
+
+    final File[] memo = canonicalDiskSpaceDirectory;
+    if (memo != null && memo[0].equals(dir))
+      return memo[1];
+
+    File canonical;
     try {
-      return dir.getCanonicalFile();
+      canonical = dir.getCanonicalFile();
     } catch (final IOException e) {
-      return dir.getAbsoluteFile();
+      canonical = dir;
     }
+
+    // Racing threads compute the same answer from the same input, so last writer wins costs nothing.
+    canonicalDiskSpaceDirectory = new File[] { dir, canonical };
+    return canonical;
   }
 
   public synchronized void dumpMetrics(final PrintStream out) {

--- a/engine/src/main/java/com/arcadedb/Profiler.java
+++ b/engine/src/main/java/com/arcadedb/Profiler.java
@@ -388,13 +388,20 @@ public class Profiler {
     json.put("deferredRAM", new JSONObject().put("space", pStats.deferredRAMBytes));
     json.put("pageFlushQueueWaits", new JSONObject().put("count", pStats.flushQueueWaits));
 
-    final long freeSpace = new File(".").getFreeSpace();
-    final long totalSpace = new File(".").getTotalSpace();
-    final float freeSpacePerc = freeSpace * 100F / totalSpace;
+    // #7223: the databases' filesystem, not the JVM working directory, and usable rather than free space - the same
+    // measurement #7124 fixed in ServerMonitor. This is the copy that actually reaches an operator, through
+    // GET /api/v1/server and the Studio disk bar.
+    final File diskDir = diskSpaceDirectory();
+    final long freeSpace = diskDir.getUsableSpace();
+    final long totalSpace = diskDir.getTotalSpace();
+    final float freeSpacePerc = totalSpace > 0 ? freeSpace * 100F / totalSpace : 0F;
 
     json.put("diskFreeSpace", new JSONObject().put("space", freeSpace));
     json.put("diskTotalSpace", new JSONObject().put("space", totalSpace));
     json.put("diskFreeSpacePerc", new JSONObject().put("perc", freeSpacePerc));
+    // Which filesystem the three figures above describe. Without it the reader cannot tell a nearly-full data
+    // volume from a nearly-full root filesystem, which is the first thing they need to know.
+    json.put("diskDirectory", new JSONObject().put("value", diskDir.getPath()));
 
     json.put("gcTime", new JSONObject().put("count", getGarbageCollectionTime()));
 
@@ -447,12 +454,35 @@ public class Profiler {
     return json;
   }
 
+  /**
+   * The directory whose filesystem the disk figures describe (issue #7223).
+   * <p>
+   * The profiler has no {@link ContextConfiguration} of its own - it is a JVM-wide singleton that predates any
+   * server - so it reads the process-wide setting through an empty one, which is what
+   * {@link ContextConfiguration#getValueAsString(GlobalConfiguration)} falls back to. That resolves to the same
+   * directory the server's own low-disk warning measures, so the two never describe different filesystems while
+   * reporting the same thing.
+   * <p>
+   * Canonicalised, because the path is REPORTED here and not only measured: the working-directory fallback is
+   * {@code "."}, which names no filesystem to a reader looking at a disk figure they do not believe.
+   */
+  private static File diskSpaceDirectory() {
+    final File dir = FileUtils.resolveDiskSpaceDirectory(new ContextConfiguration());
+    try {
+      return dir.getCanonicalFile();
+    } catch (final IOException e) {
+      return dir.getAbsoluteFile();
+    }
+  }
+
   public synchronized void dumpMetrics(final PrintStream out) {
 
     final StringBuilder buffer = new StringBuilder("\n");
 
-    final long freeSpaceInMB = new File(".").getFreeSpace();
-    final long totalSpaceInMB = new File(".").getTotalSpace();
+    // #7223: same measurement as toJSON() - the databases' filesystem, read as usable rather than free space.
+    final File diskDir = diskSpaceDirectory();
+    final long freeSpaceInMB = diskDir.getUsableSpace();
+    final long totalSpaceInMB = diskDir.getTotalSpace();
 
     try {
       final long[] dbStats = collectDatabaseStats();
@@ -600,9 +630,9 @@ public class Profiler {
         "%n WAL totalFiles=%d pagesWritten=%d bytesWritten=%s".formatted(walTotalFiles, walPagesWritten,
           FileUtils.getSizeAsString(walBytesWritten)));
 
-      buffer.append(
-        "%n FILE-MANAGER FS=%s/%s openFiles=%d maxFilesOpened=%d".formatted(FileUtils.getSizeAsString(freeSpaceInMB),
-          FileUtils.getSizeAsString(totalSpaceInMB), totalOpenFiles, maxOpenFiles));
+      buffer.append("%n FILE-MANAGER FS=%s/%s on '%s' openFiles=%d maxFilesOpened=%d".formatted(
+        FileUtils.getSizeAsString(freeSpaceInMB), FileUtils.getSizeAsString(totalSpaceInMB), diskDir.getPath(),
+        totalOpenFiles, maxOpenFiles));
 
       out.println(buffer);
     } catch (final Exception e) {

--- a/engine/src/main/java/com/arcadedb/Profiler.java
+++ b/engine/src/main/java/com/arcadedb/Profiler.java
@@ -112,6 +112,13 @@ public class Profiler {
    */
   private static volatile File[] canonicalDiskSpaceDirectory;
 
+  /**
+   * The overlay {@link #diskSpaceDirectory()} reads the database directory through. An empty
+   * {@link ContextConfiguration} is a pure proxy for the process-wide settings - it holds nothing and nothing here
+   * writes to it - so one shared instance is what a per-call {@code new} was already asking for.
+   */
+  private static final ContextConfiguration GLOBAL_SETTINGS = new ContextConfiguration();
+
   protected Profiler() {
   }
 
@@ -465,7 +472,7 @@ public class Profiler {
    * The directory whose filesystem the disk figures describe (issue #7223).
    * <p>
    * The profiler has no {@link ContextConfiguration} of its own - it is a JVM-wide singleton that predates any
-   * server - so it reads the process-wide setting through an empty one, which is what
+   * server - so it reads the process-wide setting through {@link #GLOBAL_SETTINGS}, an empty one, which is what
    * {@link ContextConfiguration#getValueAsString(GlobalConfiguration)} falls back to. That resolves to the same
    * directory the server's own low-disk warning measures, so the two never describe different filesystems while
    * reporting the same thing.
@@ -479,7 +486,7 @@ public class Profiler {
    * reporting the parent directory after the configured one is finally created.
    */
   private static File diskSpaceDirectory() {
-    final File dir = FileUtils.resolveDiskSpaceDirectory(new ContextConfiguration()).getAbsoluteFile();
+    final File dir = FileUtils.resolveDiskSpaceDirectory(GLOBAL_SETTINGS).getAbsoluteFile();
 
     final File[] memo = canonicalDiskSpaceDirectory;
     if (memo != null && memo[0].equals(dir))

--- a/engine/src/main/java/com/arcadedb/Profiler.java
+++ b/engine/src/main/java/com/arcadedb/Profiler.java
@@ -109,6 +109,11 @@ public class Profiler {
    * The last {@code {absolute, canonical}} pair {@link #diskSpaceDirectory()} computed, or null before the first
    * call. Volatile rather than synchronized: it is a pure function of its first element, so a reader that misses a
    * write only pays for one more canonicalisation.
+   * <p>
+   * Deliberately safe WITHOUT a lock, rather than safe because of one. Both current readers reach it under this
+   * class's instance monitor - {@link #toJSON()} and {@link #dumpMetrics} are {@code synchronized} and the class is
+   * used as {@link #INSTANCE} - but this field is {@code static}, so a future caller that is neither would still be
+   * correct: the worst a race costs is a duplicated canonicalisation, and the array is published whole.
    */
   private static volatile File[] canonicalDiskSpaceDirectory;
 

--- a/engine/src/main/java/com/arcadedb/utility/FileUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/FileUtils.java
@@ -18,6 +18,8 @@
  */
 package com.arcadedb.utility;
 
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Binary;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.log.LogManager;
@@ -519,5 +521,58 @@ public class FileUtils {
         return Arrays.copyOf(bytes, read);
     }
     return bytes;
+  }
+
+  /**
+   * Returns the directory whose filesystem a disk-space reading must measure, which is the one the databases live
+   * on rather than the one the JVM happens to have been started in.
+   * <p>
+   * Issue #7124 established this for the server's low-disk warning; issue #7223 moved it here because
+   * {@code Profiler} - which is what feeds {@code GET /api/v1/server} and the Studio disk bar, and is therefore the
+   * number an operator actually reads - was still measuring {@code new File(".")}. On the normal container layout
+   * the databases sit on a mounted volume and the process starts in the image's {@code WORKDIR}, so the two are
+   * different filesystems and the reported figure described the wrong one in both directions: a nearly-full data
+   * volume reads as comfortably empty, a small root filesystem makes a large data volume look critical.
+   * <p>
+   * Callers must read the returned directory with {@link File#getUsableSpace()} rather than
+   * {@link File#getFreeSpace()}: the latter ignores per-user quotas and reservations, so it reports space this
+   * process cannot actually write to.
+   * <p>
+   * Two fallbacks, both because a path that describes no filesystem measures 0 usable and 0 total, which a reader
+   * cannot tell apart from a full disk:
+   * <ul>
+   * <li>the configured directory does not necessarily exist yet - at startup it has not been created - so the walk
+   * goes up to the closest existing ancestor, which sits on the filesystem the databases are going to land on;</li>
+   * <li>if that walk bottoms out at the filesystem ROOT, the whole chain is absent and the configuration has said
+   * nothing about where the databases will be. That is what an embedded JVM gets, where nobody sets
+   * {@code arcadedb.server.rootPath} and the default expands to {@code /databases}; measuring {@code /} there would
+   * describe a filesystem chosen by accident, so the working directory is used instead.</li>
+   * </ul>
+   *
+   * @param configuration the configuration to read {@code arcadedb.server.databaseDirectory} from, or {@code null}
+   *                      to measure the working directory without consulting any setting
+   *
+   * @return a directory to measure, never {@code null}
+   */
+  public static File resolveDiskSpaceDirectory(final ContextConfiguration configuration) {
+    if (configuration != null) {
+      try {
+        final String configured = configuration.getValueAsString(GlobalConfiguration.SERVER_DATABASE_DIRECTORY);
+        if (configured != null && !configured.isBlank()) {
+          File dir = new File(configured.trim()).getAbsoluteFile();
+          while (dir != null && !dir.exists())
+            dir = dir.getParentFile();
+
+          if (dir != null && dir.getParentFile() != null)
+            return dir;
+        }
+      } catch (final Exception e) {
+        LogManager.instance()
+            .log(FileUtils.class, Level.FINE, "Cannot resolve the configured database directory, falling back to the "
+                + "working directory", e);
+      }
+    }
+
+    return new File(".");
   }
 }

--- a/engine/src/main/java/com/arcadedb/utility/FileUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/FileUtils.java
@@ -543,10 +543,12 @@ public class FileUtils {
    * <ul>
    * <li>the configured directory does not necessarily exist yet - at startup it has not been created - so the walk
    * goes up to the closest existing ancestor, which sits on the filesystem the databases are going to land on;</li>
-   * <li>if that walk bottoms out at the filesystem ROOT, the whole chain is absent and the configuration has said
+   * <li>if that WALK bottoms out at the filesystem ROOT, the whole chain is absent and the configuration has said
    * nothing about where the databases will be. That is what an embedded JVM gets, where nobody sets
    * {@code arcadedb.server.rootPath} and the default expands to {@code /databases}; measuring {@code /} there would
-   * describe a filesystem chosen by accident, so the working directory is used instead.</li>
+   * describe a filesystem chosen by accident, so the working directory is used instead. The test is on having
+   * walked, not on the answer being the root: a directory configured AS {@code /} and existing is a deliberate
+   * choice and is honoured.</li>
    * </ul>
    *
    * @param configuration the configuration to read {@code arcadedb.server.databaseDirectory} from, or {@code null}
@@ -560,10 +562,13 @@ public class FileUtils {
         final String configured = configuration.getValueAsString(GlobalConfiguration.SERVER_DATABASE_DIRECTORY);
         if (configured != null && !configured.isBlank()) {
           File dir = new File(configured.trim()).getAbsoluteFile();
-          while (dir != null && !dir.exists())
+          boolean walked = false;
+          while (dir != null && !dir.exists()) {
             dir = dir.getParentFile();
+            walked = true;
+          }
 
-          if (dir != null && dir.getParentFile() != null)
+          if (dir != null && !(walked && dir.getParentFile() == null))
             return dir;
         }
       } catch (final Exception e) {

--- a/engine/src/test/java/com/arcadedb/Issue7222StrictBooleanFromConfigurationSourceTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue7222StrictBooleanFromConfigurationSourceTest.java
@@ -132,6 +132,34 @@ class Issue7222StrictBooleanFromConfigurationSourceTest {
     assertThat(BOOLEAN_SETTING_DEFAULTING_TO_TRUE.redactIfHidden("yes")).isEqualTo("'yes'");
   }
 
+  /**
+   * "Keeps the default" has to mean the default the setting would have had, and for a setting that AUTO-SIZES one
+   * that is not its compiled-in {@code defValue}. {@code QUERY_MAX_RANGE_SIZE} scales its cap with the JVM heap
+   * through {@code callbackIfNoSet}, and its {@code defValue} is the unbounded-heap figure - so a refused value
+   * that fell through to {@code defValue} would RAISE the cap on a small-heap JVM, which for a setting whose whole
+   * job is to bound the memory one query can ask for is the wrong direction to move on a typo.
+   */
+  @Test
+  void aRefusedValueTakesTheSameBranchAsAnAbsentOne() {
+    // SERVER_HTTP_IO_THREADS rather than QUERY_MAX_RANGE_SIZE: its auto-sized value is availableProcessors(), which
+    // is never its defValue of 0 on any machine. Sizing QUERY_MAX_RANGE_SIZE off the heap would make this test
+    // silently vacuous on a JVM whose heap happens to land on the compiled-in figure.
+    final GlobalConfiguration autoSized = GlobalConfiguration.SERVER_HTTP_IO_THREADS;
+    try {
+      autoSized.applyConfigurationSource(null, "system property");
+      final int whenAbsent = autoSized.getValueAsInteger();
+
+      // The value the auto-sizing exists to avoid, so a refusal falling through to it is visible here.
+      assertThat(whenAbsent).isNotEqualTo(autoSized.getDefValue());
+
+      autoSized.applyConfigurationSource("not-a-number", "environment variable");
+
+      assertThat(autoSized.getValueAsInteger()).isEqualTo(whenAbsent);
+    } finally {
+      autoSized.reset();
+    }
+  }
+
   /** A value that arrives already typed - a callback's return, a programmatic write - is not text and is stored. */
   @Test
   void anAlreadyTypedValueIsStored() {

--- a/engine/src/test/java/com/arcadedb/Issue7222StrictBooleanFromConfigurationSourceTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue7222StrictBooleanFromConfigurationSourceTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7222.
+ * <p>
+ * {@code arcadedb.serverMetrics.prometheus.requireAuthentication} is documented as having a STRICT parse so that "a
+ * typo cannot silently publish the endpoint unauthenticated". That held on the two administrative writers and not on
+ * the third one - {@link GlobalConfiguration#readConfiguration()}, which feeds every system property and environment
+ * variable through the PERMISSIVE {@code coerce}, where {@code Boolean.parseBoolean} maps everything that is not
+ * {@code "true"} to {@code false} with no error.
+ * <p>
+ * So {@code requireAuthentication=yes} in a Kubernetes env var stored {@code Boolean.FALSE}, the plugin's own strict
+ * check found a value that was already a {@code Boolean} and had nothing left to reject, and {@code /prometheus} was
+ * published unauthenticated while the operator believed they had turned the protection ON. The refusal has to happen
+ * where the text still exists.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7222StrictBooleanFromConfigurationSourceTest {
+
+  private static final GlobalConfiguration BOOLEAN_SETTING_DEFAULTING_TO_TRUE  =
+      GlobalConfiguration.SERVER_METRICS_PROMETHEUS_REQUIRE_AUTHENTICATION;
+  private static final GlobalConfiguration BOOLEAN_SETTING_DEFAULTING_TO_FALSE = GlobalConfiguration.NETWORK_USE_SSL;
+
+  @AfterEach
+  void restoreTheSettings() {
+    BOOLEAN_SETTING_DEFAULTING_TO_TRUE.reset();
+    BOOLEAN_SETTING_DEFAULTING_TO_FALSE.reset();
+    GlobalConfiguration.SERVER_DATABASE_DIRECTORY.reset();
+  }
+
+  @Test
+  void aValueThatIsNeitherTrueNorFalseIsRefusedRatherThanReadAsFalse() {
+    assertThat(BOOLEAN_SETTING_DEFAULTING_TO_TRUE.getDefValue()).isEqualTo(Boolean.TRUE);
+
+    for (final String typo : new String[] { "yes", "1", "on", "TRUE!", "ture", "" }) {
+      assertThat(BOOLEAN_SETTING_DEFAULTING_TO_TRUE.setValueFromConfigurationSource(typo, "system property")).as(
+          "'%s' was accepted", typo).isFalse();
+      assertThat(BOOLEAN_SETTING_DEFAULTING_TO_TRUE.getValueAsBoolean()).as("'%s' turned the setting OFF", typo).isTrue();
+      assertThat(BOOLEAN_SETTING_DEFAULTING_TO_TRUE.isChanged()).as("'%s' was recorded as an explicit choice", typo)
+          .isFalse();
+    }
+  }
+
+  /**
+   * The refusal keeps the DEFAULT rather than forcing {@code true}: what makes this setting fail closed is that its
+   * own default is the safe value, and a general rule that read every unparseable boolean as {@code true} would flip
+   * settings whose safe side is the other one. Refusing to guess is the property that has to hold for all of them.
+   */
+  @Test
+  void aRefusedValueKeepsTheSettingsOwnDefaultInBothDirections() {
+    assertThat(BOOLEAN_SETTING_DEFAULTING_TO_FALSE.getDefValue()).isEqualTo(Boolean.FALSE);
+
+    assertThat(BOOLEAN_SETTING_DEFAULTING_TO_FALSE.setValueFromConfigurationSource("yes", "environment variable"))
+        .isFalse();
+    assertThat(BOOLEAN_SETTING_DEFAULTING_TO_FALSE.getValueAsBoolean()).isFalse();
+  }
+
+  @Test
+  void trueAndFalseAreStillHonouredInEveryCasingAndWithSurroundingSpace() {
+    for (final String text : new String[] { "false", "FALSE", "  False  " }) {
+      assertThat(BOOLEAN_SETTING_DEFAULTING_TO_TRUE.setValueFromConfigurationSource(text, "system property")).isTrue();
+      assertThat(BOOLEAN_SETTING_DEFAULTING_TO_TRUE.getValueAsBoolean()).as("'%s'", text).isFalse();
+    }
+
+    for (final String text : new String[] { "true", "TRUE", " True " }) {
+      assertThat(BOOLEAN_SETTING_DEFAULTING_TO_TRUE.setValueFromConfigurationSource(text, "system property")).isTrue();
+      assertThat(BOOLEAN_SETTING_DEFAULTING_TO_TRUE.getValueAsBoolean()).as("'%s'", text).isTrue();
+    }
+  }
+
+  /**
+   * Only {@code Boolean} settings gain the strict parse. Every other type already refuses what it cannot read, and
+   * the leniency this path needs is about not taking the engine down over one bad value - not about accepting one.
+   */
+  @Test
+  void aNonBooleanSettingIsUnaffected() {
+    assertThat(GlobalConfiguration.SERVER_DATABASE_DIRECTORY.setValueFromConfigurationSource("/mnt/data", "system property"))
+        .isTrue();
+    assertThat(GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString()).isEqualTo("/mnt/data");
+  }
+
+  /**
+   * An unreadable value of a non-Boolean setting must not take the whole engine down: this method runs inside this
+   * class's static initializer, where a throw becomes an {@code ExceptionInInitializerError}. It is reported and the
+   * setting keeps its default, which is the same answer the Boolean arm gives.
+   */
+  @Test
+  void anUnreadableValueOfAnyTypeIsReportedRatherThanThrown() {
+    final int previous = GlobalConfiguration.ASYNC_WORKER_THREADS.getValueAsInteger();
+
+    assertThat(GlobalConfiguration.ASYNC_WORKER_THREADS.setValueFromConfigurationSource("abc", "environment variable"))
+        .isFalse();
+    assertThat(GlobalConfiguration.ASYNC_WORKER_THREADS.getValueAsInteger()).isEqualTo(previous);
+  }
+
+  /** A value that arrives already typed - a callback's return, a programmatic write - is not text and is stored. */
+  @Test
+  void anAlreadyTypedValueIsStored() {
+    assertThat(BOOLEAN_SETTING_DEFAULTING_TO_TRUE.setValueFromConfigurationSource(Boolean.FALSE, "system property"))
+        .isTrue();
+    assertThat(BOOLEAN_SETTING_DEFAULTING_TO_TRUE.getValueAsBoolean()).isFalse();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/Issue7222StrictBooleanFromConfigurationSourceTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue7222StrictBooleanFromConfigurationSourceTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Regression test for issue #7222.
@@ -157,6 +158,29 @@ class Issue7222StrictBooleanFromConfigurationSourceTest {
       assertThat(autoSized.getValueAsInteger()).isEqualTo(whenAbsent);
     } finally {
       autoSized.reset();
+    }
+  }
+
+  /**
+   * The "nothing was chosen" half of a refusal has to survive a throw from INSIDE {@link GlobalConfiguration#setValue}
+   * too, not only from the strict parse that runs before it. {@code setValue} marked the setting explicitly-set
+   * before doing the work and, on failure, rolled back the value but not that flag - so a rejected write left
+   * {@code isChanged()} reporting a setting as configured while it sat at its default. The strict parse catches a bad
+   * Boolean first, so no setting here could reach it; a callback or an {@code allowed} set that throws can.
+   */
+  @Test
+  void aWriteThatWasRolledBackIsNotRecordedAsAChoice() {
+    final GlobalConfiguration withAllowedValues = GlobalConfiguration.BUCKET_REUSE_SPACE_MODE;
+    try {
+      assertThat(withAllowedValues.isChanged()).isFalse();
+
+      assertThatThrownBy(() -> withAllowedValues.setValue("not-an-allowed-value")).isInstanceOf(
+          IllegalArgumentException.class);
+
+      assertThat(withAllowedValues.isChanged()).as("a refused write was recorded as an explicit choice").isFalse();
+      assertThat(withAllowedValues.getValueAsString()).isEqualTo(withAllowedValues.getDefValue());
+    } finally {
+      withAllowedValues.reset();
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/Issue7222StrictBooleanFromConfigurationSourceTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue7222StrictBooleanFromConfigurationSourceTest.java
@@ -117,6 +117,21 @@ class Issue7222StrictBooleanFromConfigurationSourceTest {
     assertThat(GlobalConfiguration.ASYNC_WORKER_THREADS.getValueAsInteger()).isEqualTo(previous);
   }
 
+  /**
+   * The refusal REPORTS the value it refused, which is what makes the warning actionable - and the value is text an
+   * operator typed, so a hidden setting must not put it in a log. No hidden setting is of a type that can fail to
+   * coerce today (they are all {@code String}), which is exactly why the rule has to be pinned now rather than
+   * discovered by the first one that is not.
+   */
+  @Test
+  void aHiddenSettingsValueIsNotWrittenToTheLog() {
+    assertThat(GlobalConfiguration.SERVER_ROOT_PASSWORD.isHidden()).isTrue();
+    assertThat(GlobalConfiguration.SERVER_ROOT_PASSWORD.redactIfHidden("hunter2")).isEqualTo("<hidden>");
+
+    assertThat(BOOLEAN_SETTING_DEFAULTING_TO_TRUE.isHidden()).isFalse();
+    assertThat(BOOLEAN_SETTING_DEFAULTING_TO_TRUE.redactIfHidden("yes")).isEqualTo("'yes'");
+  }
+
   /** A value that arrives already typed - a callback's return, a programmatic write - is not text and is stored. */
   @Test
   void anAlreadyTypedValueIsStored() {

--- a/engine/src/test/java/com/arcadedb/Issue7223ProfilerDiskSpaceTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue7223ProfilerDiskSpaceTest.java
@@ -135,6 +135,20 @@ class Issue7223ProfilerDiskSpaceTest {
         new File(".").getCanonicalFile());
   }
 
+  /**
+   * The fallback above tests having WALKED, not the answer being the root: a directory configured AS the filesystem
+   * root and existing is a deliberate choice, and silently measuring somewhere else instead would be the same class
+   * of defect #7223 is about - reporting a filesystem the operator did not name.
+   */
+  @Test
+  void anExplicitlyConfiguredFilesystemRootIsHonoured() throws Exception {
+    final File root = new File(File.separator);
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, root.getAbsolutePath());
+
+    assertThat(FileUtils.resolveDiskSpaceDirectory(configuration).getCanonicalFile()).isEqualTo(root.getCanonicalFile());
+  }
+
   @Test
   void aBlankOrAbsentConfigurationFallsBackToTheWorkingDirectory() throws Exception {
     final ContextConfiguration blank = new ContextConfiguration();

--- a/engine/src/test/java/com/arcadedb/Issue7223ProfilerDiskSpaceTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue7223ProfilerDiskSpaceTest.java
@@ -62,9 +62,13 @@ class Issue7223ProfilerDiskSpaceTest {
     assertThat(new File(json.getJSONObject("diskDirectory").getString("value")).getCanonicalFile()).isEqualTo(
         databases.getCanonicalFile());
     assertThat(json.getJSONObject("diskTotalSpace").getLong("space")).isEqualTo(databases.getTotalSpace());
+    // Bounded against the TOTAL, which is the only figure of a live filesystem that does not drift between two
+    // readings. Asserting usable <= free instead looks like it pins "usable, not free" and does not: the two are
+    // read moments apart, so an unrelated write between them makes the earlier usable exceed the later free and
+    // the test fails on the filesystem's mood rather than on the code. What getUsableSpace() buys over
+    // getFreeSpace() - quotas and reservations - is not observable from here at all.
     assertThat(json.getJSONObject("diskFreeSpace").getLong("space")).isPositive()
-        // Usable, not free: getFreeSpace() ignores per-user quotas and reservations, so it can only be larger.
-        .isLessThanOrEqualTo(databases.getFreeSpace());
+        .isLessThanOrEqualTo(databases.getTotalSpace());
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/Issue7223ProfilerDiskSpaceTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue7223ProfilerDiskSpaceTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb;
+
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7223: {@code Profiler} kept measuring {@code new File(".").getFreeSpace()} at both of
+ * its sites after #7124 had fixed the identical measurement in {@code ServerMonitor} - and {@code Profiler} is what
+ * feeds {@code GET /api/v1/server} and the Studio disk bar, so the number an operator actually reads described the
+ * filesystem the JVM happened to be started in rather than the one the databases live on.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7223ProfilerDiskSpaceTest {
+
+  @TempDir
+  Path tempDir;
+
+  @AfterEach
+  void restoreTheDatabaseDirectory() {
+    GlobalConfiguration.SERVER_DATABASE_DIRECTORY.reset();
+  }
+
+  @Test
+  void theProfilerMeasuresTheConfiguredDatabaseDirectory() throws Exception {
+    final File databases = tempDir.resolve("mnt").resolve("databases").toFile();
+    assertThat(databases.mkdirs()).isTrue();
+
+    GlobalConfiguration.SERVER_DATABASE_DIRECTORY.setValue(databases.getAbsolutePath());
+
+    final JSONObject json = Profiler.INSTANCE.toJSON();
+
+    assertThat(new File(json.getJSONObject("diskDirectory").getString("value")).getCanonicalFile()).isEqualTo(
+        databases.getCanonicalFile());
+    assertThat(json.getJSONObject("diskTotalSpace").getLong("space")).isEqualTo(databases.getTotalSpace());
+    assertThat(json.getJSONObject("diskFreeSpace").getLong("space")).isPositive()
+        // Usable, not free: getFreeSpace() ignores per-user quotas and reservations, so it can only be larger.
+        .isLessThanOrEqualTo(databases.getFreeSpace());
+  }
+
+  @Test
+  void theTextDumpMeasuresTheSameDirectory() throws Exception {
+    final File databases = tempDir.resolve("dump").toFile();
+    assertThat(databases.mkdirs()).isTrue();
+
+    GlobalConfiguration.SERVER_DATABASE_DIRECTORY.setValue(databases.getAbsolutePath());
+
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    Profiler.INSTANCE.dumpMetrics(new PrintStream(out));
+
+    assertThat(out.toString()).contains(databases.getCanonicalPath());
+  }
+
+  @Test
+  void theReportedPercentageIsConsistentWithTheTwoFigures() {
+    final JSONObject json = Profiler.INSTANCE.toJSON();
+
+    final long free = json.getJSONObject("diskFreeSpace").getLong("space");
+    final long total = json.getJSONObject("diskTotalSpace").getLong("space");
+    final float perc = json.getJSONObject("diskFreeSpacePerc").getFloat("perc");
+
+    assertThat(total).isPositive();
+    assertThat(perc).isEqualTo(free * 100F / total);
+  }
+
+  // ---------------------------------------------------------------- the shared resolver
+
+  @Test
+  void anExistingConfiguredDirectoryIsMeasuredAsItIs() throws Exception {
+    final File databases = tempDir.resolve("volume").resolve("databases").toFile();
+    assertThat(databases.mkdirs()).isTrue();
+
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, databases.getAbsolutePath());
+
+    assertThat(FileUtils.resolveDiskSpaceDirectory(configuration).getCanonicalFile()).isEqualTo(
+        databases.getCanonicalFile());
+  }
+
+  @Test
+  void aNotYetCreatedDirectoryResolvesToItsClosestExistingAncestor() throws Exception {
+    final File volume = tempDir.resolve("volume").toFile();
+    assertThat(volume.mkdirs()).isTrue();
+
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY,
+        volume.getAbsolutePath() + File.separator + "not-created-yet" + File.separator + "databases");
+
+    final File resolved = FileUtils.resolveDiskSpaceDirectory(configuration);
+    assertThat(resolved.getCanonicalFile()).isEqualTo(volume.getCanonicalFile());
+    assertThat(resolved.getTotalSpace()).isPositive();
+  }
+
+  /**
+   * A path whose whole chain is missing walks all the way up to the filesystem root, which is a filesystem chosen
+   * by accident rather than one the configuration named. That is exactly what an embedded JVM produces, where
+   * nobody sets {@code arcadedb.server.rootPath} and the default expands to {@code /databases}.
+   */
+  @Test
+  void aPathThatBottomsOutAtTheFilesystemRootFallsBackToTheWorkingDirectory() throws Exception {
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY,
+        File.separator + "no-such-volume-" + UUID.randomUUID() + File.separator + "databases");
+
+    assertThat(FileUtils.resolveDiskSpaceDirectory(configuration).getCanonicalFile()).isEqualTo(
+        new File(".").getCanonicalFile());
+  }
+
+  @Test
+  void aBlankOrAbsentConfigurationFallsBackToTheWorkingDirectory() throws Exception {
+    final ContextConfiguration blank = new ContextConfiguration();
+    blank.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, "   ");
+
+    assertThat(FileUtils.resolveDiskSpaceDirectory(blank).getCanonicalFile()).isEqualTo(new File(".").getCanonicalFile());
+    assertThat(FileUtils.resolveDiskSpaceDirectory(null).getCanonicalFile()).isEqualTo(new File(".").getCanonicalFile());
+  }
+}

--- a/metrics/src/main/java/com/arcadedb/metrics/prometheus/PrometheusMetricsPlugin.java
+++ b/metrics/src/main/java/com/arcadedb/metrics/prometheus/PrometheusMetricsPlugin.java
@@ -89,12 +89,16 @@ public class PrometheusMetricsPlugin implements ServerPlugin {
    * a throw there becomes an {@code ExceptionInInitializerError} that takes the whole engine down instead of the
    * setting. An authentication switch is worth the extra care at the one site that reads it.
    * <p>
-   * A value that arrives ALREADY a {@link Boolean} is trusted, and that is only sound because the two paths that
-   * store one - {@code SET SERVER SETTING} and the {@code set_server_setting} MCP tool - both go through
-   * {@link GlobalConfiguration#coerceFromAdminCommand(Object)}, which refuses a boolean it cannot read rather than
-   * folding it to {@code false}. Were either to fall back to the permissive {@code coerce}, a typo would reach here
-   * as {@code Boolean.FALSE} with the text that produced it already lost, and no parse at this end could tell it
-   * from a deliberate {@code false}.
+   * A value that arrives ALREADY a {@link Boolean} is trusted, and that is only sound because every path that
+   * stores one applies the strict parse first, where the text still exists: {@code SET SERVER SETTING}, the
+   * {@code set_server_setting} MCP tool and the two SQL/HTTP setting commands through
+   * {@link GlobalConfiguration#coerceFromAdminCommand(Object)}, and - since issue #7222 - a system property or
+   * environment variable through {@link GlobalConfiguration#setValueFromConfigurationSource(Object, String)}. Any
+   * path falling back to the permissive {@code coerce} reopens this: a typo would reach here as
+   * {@code Boolean.FALSE} with the text that produced it already lost, and no parse at this end could tell it from
+   * a deliberate {@code false}. That is exactly what #7222 was - {@code -Darcadedb...requireAuthentication=yes}
+   * stored {@code Boolean.FALSE} and published this endpoint unauthenticated, and the fail-closed reader below had
+   * nothing left to reject.
    *
    * @return {@code true} unless the configured value is unambiguously {@code false}
    */

--- a/metrics/src/test/java/com/arcadedb/metrics/prometheus/Issue7222PrometheusEnvironmentPathTest.java
+++ b/metrics/src/test/java/com/arcadedb/metrics/prometheus/Issue7222PrometheusEnvironmentPathTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.metrics.prometheus;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7222, at the endpoint the defect actually reached.
+ * <p>
+ * #7124 made the plugin fail closed on a value it cannot read, but it can only do that while the TEXT still exists.
+ * The system-property and environment-variable path used the permissive coercion, so
+ * {@code requireAuthentication=yes} was stored as {@code Boolean.FALSE} and arrived here already typed - and a value
+ * that is already a {@code Boolean} is exactly the one the strict guard skips, because a deliberate {@code false} is
+ * indistinguishable from a folded typo. {@code /prometheus} was then published unauthenticated, silently, on the one
+ * configuration path a Kubernetes deployment uses.
+ * <p>
+ * The environment-variable half is what these tests exercise: unlike a system property, an environment variable is
+ * not re-read by {@link ContextConfiguration#getValue(String, Object)}, so nothing downstream can recover the text
+ * and the process-wide value is all the plugin sees. Setting an environment variable is not portable from a test, so
+ * the entry point {@code readConfiguration()} calls is invoked directly - it is the same call with the same argument.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7222PrometheusEnvironmentPathTest {
+
+  private static final GlobalConfiguration SETTING = GlobalConfiguration.SERVER_METRICS_PROMETHEUS_REQUIRE_AUTHENTICATION;
+
+  private String previousSystemProperty;
+
+  /**
+   * The environment path is the one where the raw text is NOT recoverable downstream, so the system property has to
+   * be out of the way: {@link ContextConfiguration#getValue(String, Object)} re-reads it and would answer with the
+   * text instead of the stored value. Other test classes in this module set it and leave it set.
+   */
+  @BeforeEach
+  void hideTheSystemProperty() {
+    previousSystemProperty = System.getProperty(SETTING.getKey());
+    System.clearProperty(SETTING.getKey());
+  }
+
+  @AfterEach
+  void restoreTheSetting() {
+    SETTING.reset();
+    if (previousSystemProperty != null)
+      System.setProperty(SETTING.getKey(), previousSystemProperty);
+  }
+
+  @Test
+  void aTypoInTheEnvironmentDoesNotPublishTheEndpointUnauthenticated() {
+    for (final String typo : new String[] { "yes", "1", "on", "TRUE!", "ture" }) {
+      SETTING.setValueFromConfigurationSource(typo, "environment variable");
+
+      assertThat(PrometheusMetricsPlugin.isAuthenticationRequired(new ContextConfiguration())).as(
+          "'%s' published /prometheus unauthenticated", typo).isTrue();
+    }
+  }
+
+  @Test
+  void aDeliberateFalseFromTheEnvironmentIsStillHonoured() {
+    SETTING.setValueFromConfigurationSource("false", "environment variable");
+
+    assertThat(PrometheusMetricsPlugin.isAuthenticationRequired(new ContextConfiguration())).isFalse();
+  }
+
+  @Test
+  void anExplicitTrueFromTheEnvironmentIsHonoured() {
+    SETTING.setValueFromConfigurationSource("TRUE", "environment variable");
+
+    assertThat(PrometheusMetricsPlugin.isAuthenticationRequired(new ContextConfiguration())).isTrue();
+  }
+}

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
@@ -88,6 +88,12 @@ public class PostgresCatalog {
    * {@link PostgresTypeCatalog}'s {@code typowner}, so the two surfaces cannot drift apart on who owns what.
    */
   static final int OWNER_OID = 10;
+  /**
+   * The schema PostgreSQL's built-in types live in, which is what {@code pg_type.typnamespace} answers here
+   * (issue #7224). It is deliberately NOT the one schema this catalog emulates for the user's own types: a
+   * type row joined to pg_namespace must report the namespace its own typnamespace column names.
+   */
+  private static final String PG_CATALOG_SCHEMA = "pg_catalog";
 
   /** A catalog query whose shape this class will not answer. The caller sends an empty result set. */
   public static final Answer DECLINED = new Answer(new LinkedHashMap<>(), null, false);
@@ -420,21 +426,32 @@ public class PostgresCatalog {
   }
 
   /**
-   * How specific a family is, when a query names relations belonging to more than one. TYPES stays at the
-   * bottom on purpose: pg_type joined to pg_class or pg_attribute is a question about tables or columns that
-   * happens to name the type of each, and answering it with one row per type instead of one row per column
-   * would change what every such query means.
+   * How specific a family is, when a query names relations belonging to more than one. The ladder ranks by what
+   * the other relation DOES to the row set, which is the only thing that decides what the query is about:
+   * <ul>
+   * <li>a relation that CONSTRAINS it outranks the one it is joined to - pg_class or pg_attribute joined to
+   * pg_type is a question about tables or columns that happens to name the type of each, and answering it with
+   * one row per type instead of one row per column would change what every such query means;</li>
+   * <li>a relation that only QUALIFIES it does not - pg_namespace joined to pg_type attaches a schema to each
+   * type and selects nothing, so the query is still about types.</li>
+   * </ul>
+   * Issue #7224: SCHEMAS used to outrank TYPES, so {@code DatabaseMetaData.getTypeInfo()} - pg_type joined to
+   * pg_namespace, which is pure qualification - was answered with the one schema row, whose pg_type columns
+   * {@link Row#complete()} then filled with NULL. The client got one nameless type instead of the type list,
+   * and no error. SCHEMAS therefore sits BELOW TYPES: pg_namespace is the one relation here that can never be
+   * the subject of a query naming anything else, because this catalog models exactly one schema.
    * <p>
-   * So TYPES loses to every ranked family. Against the other rank-0 ones - ROLES, DATABASES, PRIVILEGES,
-   * CHARACTER_SETS, COLLATIONS - it does not lose, it ties, and the FROM order settles it. That is what this
-   * scheme happens to give rather than a considered answer; no client joins pg_type to pg_roles, and if one
-   * ever does it is the tie that needs deciding, not the ranking above it.
+   * TYPES still loses to TABLES, VIEWS and COLUMNS, which is the half of the old ranking that was right. It now
+   * beats the unranked families - ROLES, DATABASES, PRIVILEGES, CHARACTER_SETS, COLLATIONS - rather than tying
+   * with them and letting the FROM order settle it, and that is the same reading: pg_type joined to pg_roles
+   * reads an owner for each type, so it qualifies.
    */
   private static int rank(final Family family) {
     return switch (family) {
       case SCHEMAS -> 1;
-      case TABLES, VIEWS -> 2;
-      case COLUMNS -> 3;
+      case TYPES -> 2;
+      case TABLES, VIEWS -> 3;
+      case COLUMNS -> 4;
       default -> 0;
     };
   }
@@ -872,13 +889,23 @@ public class PostgresCatalog {
    * WHERE (typreceive != 0 OR typsend != 0) AND typtype != 'r' AND typreceive::TEXT != 'array_recv'} - is a
    * shape no regular expression should be asked to read, and the driver rejects the connection outright when
    * the answer has no columns rather than falling back to anything.
+   * <p>
+   * Issue #7224: each row carries the {@code pg_namespace} row of the schema the type lives in, because a type
+   * query that names pg_namespace does so to qualify each type - {@code DatabaseMetaData.getTypeInfo()} joins
+   * it and then filters on {@code n.nspname != 'pg_toast'}. Left to {@link Row#complete()}'s null fill that
+   * predicate would read as UNKNOWN and, TYPES being the family that does not tolerate an unreadable filter,
+   * the whole query would be declined. The schema is pg_catalog rather than the database's own, which is what
+   * {@code pg_type.typnamespace} already says these types are in, so the join column and the joined row agree.
    */
   private static List<Row> typeRows() {
     final List<PostgresType> types = PostgresTypeCatalog.types();
     final List<Row> rows = new ArrayList<>(types.size());
 
-    for (final PostgresType type : types)
-      rows.add(describeType(new Row(), type).complete());
+    for (final PostgresType type : types) {
+      final Row row = describeType(new Row(), type);
+      rows.add(row.with("pg_namespace", "oid", row.of("pg_type").get("typnamespace"), "nspname", PG_CATALOG_SCHEMA,
+          "nspowner", OWNER_OID).complete());
+    }
 
     return rows;
   }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
@@ -190,7 +190,9 @@ public class PostgresCatalog {
 
     // pg_type is both: on its own it is a query about the types this protocol can produce (issue #7178), and
     // joined to pg_attribute it decorates a column row with that column's type. Which of the two a query is
-    // about is decided by rank(): TYPES never outranks anything, so it only wins when nothing else is named.
+    // about is decided by rank(), and by whether the other relation CONSTRAINS the row set or only QUALIFIES it
+    // (issue #7224): TYPES loses to pg_class and pg_attribute, which select the rows, and wins over pg_namespace,
+    // which only names a schema for each type.
     relation("pg_type", Family.TYPES, "oid", "typname", "typnamespace", "typowner", "typlen", "typbyval", "typtype",
         "typcategory", "typispreferred", "typisdefined", "typdelim", "typrelid", "typelem", "typarray", "typinput",
         "typoutput", "typreceive", "typsend", "typmodin", "typmodout", "typanalyze", "typsubscript", "typalign",

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
@@ -89,9 +89,13 @@ public class PostgresCatalog {
    */
   static final int OWNER_OID = 10;
   /**
-   * The schema PostgreSQL's built-in types live in, which is what {@code pg_type.typnamespace} answers here
+   * The schema PostgreSQL's own built-in objects live in, which is what {@code pg_type.typnamespace} answers here
    * (issue #7224). It is deliberately NOT the one schema this catalog emulates for the user's own types: a
    * type row joined to pg_namespace must report the namespace its own typnamespace column names.
+   * <p>
+   * Every place this catalog names that schema uses this constant - the type rows, a column's {@code udt_schema},
+   * and the collation rows - so the answer cannot come out one way on one surface and another way on the next,
+   * which is the failure mode #7224 itself was.
    */
   private static final String PG_CATALOG_SCHEMA = "pg_catalog";
 
@@ -987,7 +991,7 @@ public class PostgresCatalog {
                 type.getName(), "column_name", property.getName(), "ordinal_position", ordinal,//
                 "column_default", defaultValue == null ? null : defaultValue.toString(),//
                 "is_nullable", notNull ? "NO" : "YES", "data_type", pgType.typeName, "udt_catalog", schema,//
-                "udt_schema", "pg_catalog", "udt_name", pgType.typeName, "is_identity", "NO", "is_generated", "NEVER",//
+                "udt_schema", PG_CATALOG_SCHEMA, "udt_name", pgType.typeName, "is_identity", "NO", "is_generated", "NEVER",//
                 "is_updatable", "YES", "numeric_precision_radix", numericPrecisionRadix(pgType));
 
         // The type row a client joins pg_attribute to in order to name the column's type. It describes the
@@ -1040,13 +1044,13 @@ public class PostgresCatalog {
   private static Row characterSetRow(final Context context) {
     return new Row().with("information_schema.character_sets", "character_set_catalog", null, "character_set_schema",
         null, "character_set_name", "UTF8", "character_repertoire", "UCS", "form_of_use", "UTF8",
-        "default_collate_catalog", context.schema(), "default_collate_schema", "pg_catalog", "default_collate_name",
+        "default_collate_catalog", context.schema(), "default_collate_schema", PG_CATALOG_SCHEMA, "default_collate_name",
         "default");
   }
 
   private static Row collationRow(final Context context) {
     return new Row().with("information_schema.collations", "collation_catalog", context.schema(), "collation_schema",
-        "pg_catalog", "collation_name", "default", "pad_attribute", "NO PAD");
+        PG_CATALOG_SCHEMA, "collation_name", "default", "pad_attribute", "NO PAD");
   }
 
   private static List<DocumentType> sortedTypes(final Context context) {

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalogExpression.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalogExpression.java
@@ -160,6 +160,21 @@ abstract class PostgresCatalogExpression {
     }
   }
 
+  /**
+   * An operand this catalog cannot compute, which evaluates to {@link #UNKNOWN} rather than aborting the parse
+   * of the predicate that contains it. Issue #7224: a scalar sub-select used to make the whole WHERE unreadable,
+   * and an unreadable WHERE over pg_type declines the query outright - so {@code DatabaseMetaData.getTypeInfo()},
+   * whose predicate is {@code t.typrelid = 0 OR (SELECT ...)}, lost its readable half along with the subquery.
+   * Reading it as UNKNOWN lets three-valued logic settle it: {@code TRUE OR UNKNOWN} is TRUE, and a predicate
+   * that is still UNKNOWN once the whole tree has been evaluated is declined exactly as it was before.
+   */
+  private static class Unreadable extends PostgresCatalogExpression {
+    @Override
+    Object evaluate(final Resolver resolver) {
+      return UNKNOWN;
+    }
+  }
+
   static class ColumnReference extends PostgresCatalogExpression {
     final String qualifier;
     final String name;
@@ -616,7 +631,11 @@ abstract class PostgresCatalogExpression {
     }
 
     PostgresCatalogToken peek() {
-      return position < tokens.size() ? tokens.get(position) : null;
+      return peek(0);
+    }
+
+    PostgresCatalogToken peek(final int ahead) {
+      return position + ahead < tokens.size() ? tokens.get(position + ahead) : null;
     }
 
     boolean skipKeyword(final String keyword) {
@@ -931,6 +950,10 @@ abstract class PostgresCatalogExpression {
         return null;
 
       if (token.isSymbol("(")) {
+        final PostgresCatalogToken next = peek(1);
+        if (next != null && next.isKeyword("SELECT"))
+          return parseScalarSubquery();
+
         ++position;
         final PostgresCatalogExpression inner = parseExpression();
         if (inner == null || !skipSymbol(")"))
@@ -1091,6 +1114,25 @@ abstract class PostgresCatalogExpression {
         return null;
 
       return new WindowCall(functionName, partitionBy, orderBy, orderByDescending);
+    }
+
+    /**
+     * Skips a parenthesised sub-select and reads it as an operand whose value is unknown (issue #7224). The
+     * tokens are skipped rather than parsed: planning a subquery is well outside what a catalog emulation
+     * should pretend to do, and the point is only to stop one operand from making the whole predicate
+     * unreadable. The scan is iterative, so however deeply the subquery nests it costs no stack, and an
+     * unbalanced tail declines the query as it did before.
+     */
+    private PostgresCatalogExpression parseScalarSubquery() {
+      int open = 0;
+      while (position < tokens.size()) {
+        final PostgresCatalogToken token = tokens.get(position++);
+        if (token.isSymbol("("))
+          ++open;
+        else if (token.isSymbol(")") && --open == 0)
+          return new Unreadable();
+      }
+      return null;
     }
 
     private PostgresCatalogExpression parseCase() {

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue7224GetTypeInfoIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue7224GetTypeInfoIT.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7224 through the PostgreSQL JDBC driver itself.
+ * <p>
+ * {@link DatabaseMetaData#getTypeInfo()} joins pg_type to pg_namespace, which the catalog answered as a question
+ * about SCHEMAS: one fabricated row whose type columns were all NULL. The driver reported a single type with no
+ * name, silently - any tool populating a type picker or validating a column type against the catalog got that.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7224GetTypeInfoIT extends PostgresWireProtocolTestBase {
+
+  @Test
+  void theTypeListIsTheTypeListAndNotOneNamelessRow() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      final List<String> names = new ArrayList<>();
+      try (final ResultSet resultSet = connection.getMetaData().getTypeInfo()) {
+        while (resultSet.next())
+          names.add(resultSet.getString("TYPE_NAME"));
+      }
+
+      assertThat(names).hasSizeGreaterThan(1).doesNotContainNull();
+      // The names PostgreSQL uses, which is what a client resolves an OID against.
+      assertThat(names).contains("int4", "int8", "varchar", "bool");
+    }
+  }
+
+  private Connection openJdbcConnection() throws Exception {
+    Class.forName("org.postgresql.Driver");
+    final Properties properties = new Properties();
+    properties.setProperty("user", "root");
+    properties.setProperty("password", DEFAULT_PASSWORD_FOR_TESTS);
+    properties.setProperty("ssl", "false");
+    properties.setProperty("sslMode", "disable");
+    return DriverManager.getConnection("jdbc:postgresql://localhost:5432/" + getDatabaseName(), properties);
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue7224PgTypeNamespaceJoinTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue7224PgTypeNamespaceJoinTest.java
@@ -120,6 +120,26 @@ class Issue7224PgTypeNamespaceJoinTest {
     assertThat(names(columns.rows, "attname")).contains("id");
   }
 
+  /**
+   * The families that used to TIE with TYPES at rank 0 - ROLES, DATABASES, PRIVILEGES, CHARACTER_SETS, COLLATIONS -
+   * now lose to it, so the FROM order no longer settles them. That is a side effect of the ranking this issue
+   * changed, and it is the same reading: pg_roles joined to pg_type reads an owner for each type, so it qualifies.
+   * The old javadoc admitted the tie was accidental rather than considered, which is precisely why it needs pinning
+   * now that it is neither.
+   */
+  @Test
+  void typesWinsOverTheFamiliesItUsedToTieWith() {
+    for (final String from : new String[] { "pg_type t, pg_roles r", "pg_roles r, pg_type t" }) {
+      final PostgresCatalog.Answer answer = resolve("SELECT t.typname, r.rolname FROM " + from);
+
+      assertThat(answer.rows).as("FROM %s", from).hasSize(PostgresTypeCatalog.types().size());
+      assertThat(names(answer.rows, "typname")).doesNotContainNull();
+    }
+
+    // And pg_roles on its own is still a question about roles: one row, not one per type.
+    assertThat(resolve("SELECT rolname FROM pg_roles").rows).hasSize(1);
+  }
+
   /** And pg_namespace alone is still a question about schemas. */
   @Test
   void pgNamespaceOnItsOwnIsStillASchemaQuery() {

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue7224PgTypeNamespaceJoinTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue7224PgTypeNamespaceJoinTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7224: {@code pg_type} joined to {@code pg_namespace} was answered as a question about
+ * SCHEMAS, because SCHEMAS outranked TYPES in the family ranking. The single fabricated schema row then had every
+ * {@code pg_type} column filled with NULL by {@code Row.complete()}, so the projection validated and the client got
+ * one nameless type instead of the type list - silently, with no error.
+ * <p>
+ * The join is a qualification, not a constraint: {@code pg_namespace} is named purely to attach a schema to each
+ * type, exactly as PostgreSQL's own {@code DatabaseMetaData.getTypeInfo()} writes it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7224PgTypeNamespaceJoinTest {
+  private static final String DATABASE_PATH = "./target/databases/Issue7224PgTypeNamespaceJoinTest";
+  private static final String USER          = "root";
+
+  /** {@code DatabaseMetaData.getTypeInfo()} exactly as pgjdbc writes it. */
+  private static final String JDBC_GET_TYPE_INFO =
+      "SELECT t.typname,t.oid FROM pg_catalog.pg_type t JOIN pg_catalog.pg_namespace n ON (t.typnamespace = n.oid) "
+          + "WHERE n.nspname  != 'pg_toast' AND (t.typrelid = 0 OR (SELECT c.relkind = 'c' FROM pg_catalog.pg_class c "
+          + "WHERE c.oid = t.typrelid))";
+
+  private Database database;
+
+  @BeforeEach
+  void createDatabase() {
+    final DatabaseFactory factory = new DatabaseFactory(DATABASE_PATH);
+    if (factory.exists())
+      factory.open().drop();
+
+    database = factory.create();
+    database.transaction(() -> database.getSchema().createDocumentType("Article").createProperty("id", Type.INTEGER));
+  }
+
+  @AfterEach
+  void dropDatabase() {
+    if (database != null && database.isOpen())
+      database.drop();
+  }
+
+  @Test
+  void getTypeInfoAnswersTheTypeListRatherThanOneNullSchemaRow() {
+    final PostgresCatalog.Answer answer = resolve(JDBC_GET_TYPE_INFO);
+
+    assertThat(answer.rows).as("one fabricated all-NULL row instead of the type list").hasSizeGreaterThan(1);
+    assertThat(answer.rows).allSatisfy(row -> {
+      assertThat(row.get("typname")).isNotNull();
+      assertThat(row.get("oid")).isNotNull();
+    });
+
+    // The same set the dedicated pg_type recogniser answers with, so the two surfaces cannot disagree.
+    assertThat(names(answer.rows, "typname")).containsExactlyInAnyOrderElementsOf(
+        PostgresTypeCatalog.types().stream().map(t -> PostgresTypeCatalog.columnValue(t, "typname")).toList());
+  }
+
+  @Test
+  void aPlainJoinOfTypeAndNamespaceIsAboutTypes() {
+    final PostgresCatalog.Answer answer = resolve(
+        "SELECT t.typname, n.nspname, n.oid, t.typnamespace FROM pg_type t JOIN pg_namespace n ON (t.typnamespace = n.oid)");
+
+    assertThat(answer.rows).hasSize(PostgresTypeCatalog.types().size());
+    assertThat(names(answer.rows, "typname")).doesNotContainNull();
+    // The schema a built-in type lives in is pg_catalog, which is also what pg_type.typnamespace already says -
+    // so the column the query joins ON and the row it joins TO have to agree, or the join it wrote is a lie.
+    assertThat(names(answer.rows, "nspname")).containsOnly("pg_catalog");
+    assertThat(answer.rows).allSatisfy(row -> assertThat(row.get("oid")).isEqualTo(row.get("typnamespace")));
+  }
+
+  /** The FROM order must not decide it: a client is free to name pg_namespace first. */
+  @Test
+  void theFromOrderDoesNotChangeTheAnswer() {
+    final PostgresCatalog.Answer answer = resolve("SELECT t.typname FROM pg_namespace n, pg_type t");
+
+    assertThat(answer.rows).hasSize(PostgresTypeCatalog.types().size());
+    assertThat(names(answer.rows, "typname")).doesNotContainNull();
+  }
+
+  /**
+   * The other half of the ranking must not move: {@code pg_type} joined to {@code pg_class} or {@code pg_attribute}
+   * CONSTRAINS the row set - one row per table or per column - and answering it with one row per type would change
+   * what every JDBC {@code getColumns()} means.
+   */
+  @Test
+  void pgClassAndPgAttributeStillOutrankPgType() {
+    assertThat(names(resolve("SELECT c.relname, t.typname FROM pg_class c, pg_type t").rows, "relname")).containsExactly(
+        "Article");
+
+    final PostgresCatalog.Answer columns = resolve("SELECT a.attname, t.typname FROM pg_attribute a, pg_type t");
+    assertThat(names(columns.rows, "attname")).contains("id");
+  }
+
+  /** And pg_namespace alone is still a question about schemas. */
+  @Test
+  void pgNamespaceOnItsOwnIsStillASchemaQuery() {
+    final PostgresCatalog.Answer answer = resolve("SELECT nspname FROM pg_catalog.pg_namespace");
+
+    assertThat(answer.rows).hasSize(1);
+    assertThat(answer.rows.get(0).get("nspname")).isNotNull();
+  }
+
+  /** A three-way join keeps naming the most specific subject: pg_class still wins over both. */
+  @Test
+  void tablesStillWinWhenNamespaceAndTypeAreBothJoinedToPgClass() {
+    final PostgresCatalog.Answer answer = resolve("SELECT c.relname FROM pg_class c, pg_namespace n, pg_type t");
+
+    assertThat(names(answer.rows, "relname")).containsExactly("Article");
+  }
+
+  /**
+   * A scalar sub-select in the predicate is an operand this catalog cannot compute, not a reason to abandon the
+   * whole predicate: the readable half still constrains, and three-valued logic settles the rest. What it must
+   * NOT do is weaken the pg_type strictness - a predicate whose value is still UNKNOWN once the subquery has
+   * answered UNKNOWN is declined exactly as an unparseable one was.
+   */
+  @Test
+  void aScalarSubqueryIsAnUnknownOperandRatherThanAnUnreadablePredicate() {
+    // typrelid is 0 for every type this protocol produces, so `= 0 OR <unknown>` is TRUE for all of them.
+    assertThat(resolve("SELECT typname FROM pg_type t WHERE t.typrelid = 0 OR (SELECT c.relkind = 'c' FROM pg_class c "
+        + "WHERE c.oid = t.typrelid)").rows).hasSize(PostgresTypeCatalog.types().size());
+
+    // With nothing readable left to decide it, the answer is still a decline rather than "every type".
+    assertThat(PostgresCatalog.resolve("SELECT typname FROM pg_type t WHERE (SELECT c.relkind = 'c' FROM pg_class c "
+        + "WHERE c.oid = t.typrelid)", database, USER)).isSameAs(PostgresCatalog.DECLINED);
+  }
+
+  private PostgresCatalog.Answer resolve(final String query, final Object... parameters) {
+    final PostgresCatalog.Answer answer = PostgresCatalog.resolve(query, database, USER, parameters);
+    assertThat(answer).as("query was not recognised as a catalog query: %s", query).isNotNull();
+    assertThat(answer).as("query was declined: %s", query).isNotSameAs(PostgresCatalog.DECLINED);
+    return answer;
+  }
+
+  private static List<Object> names(final List<Map<String, Object>> rows, final String column) {
+    return rows.stream().map(row -> row.get(column)).toList();
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue7224PgTypeNamespaceJoinTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue7224PgTypeNamespaceJoinTest.java
@@ -129,12 +129,14 @@ class Issue7224PgTypeNamespaceJoinTest {
    */
   @Test
   void typesWinsOverTheFamiliesItUsedToTieWith() {
-    for (final String from : new String[] { "pg_type t, pg_roles r", "pg_roles r, pg_type t" }) {
-      final PostgresCatalog.Answer answer = resolve("SELECT t.typname, r.rolname FROM " + from);
+    final PostgresCatalog.Answer typeFirst = resolve("SELECT t.typname, r.rolname FROM pg_type t, pg_roles r");
+    final PostgresCatalog.Answer rolesFirst = resolve("SELECT t.typname, r.rolname FROM pg_roles r, pg_type t");
 
-      assertThat(answer.rows).as("FROM %s", from).hasSize(PostgresTypeCatalog.types().size());
-      assertThat(names(answer.rows, "typname")).doesNotContainNull();
-    }
+    assertThat(typeFirst.rows).hasSize(PostgresTypeCatalog.types().size());
+    assertThat(names(typeFirst.rows, "typname")).doesNotContainNull();
+    // The two orders have to agree on the ROWS, not merely on how many there are: a ranking regression could keep
+    // the count and the non-null names while answering about a different relation.
+    assertThat(rolesFirst.rows).containsExactlyElementsOf(typeFirst.rows);
 
     // And pg_roles on its own is still a question about roles: one row, not one per type.
     assertThat(resolve("SELECT rolname FROM pg_roles").rows).hasSize(1);

--- a/server/src/main/java/com/arcadedb/server/monitor/ServerMonitor.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/ServerMonitor.java
@@ -19,9 +19,9 @@
 package com.arcadedb.server.monitor;
 
 import com.arcadedb.ContextConfiguration;
-import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.event.ServerEventLog;
+import com.arcadedb.utility.FileUtils;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -149,30 +149,13 @@ public class ServerMonitor {
 	 * normal container and Kubernetes layout - that reports the container filesystem and the warning stays quiet
 	 * while the data volume fills, which is precisely the condition it exists to precede.
 	 * <p>
-	 * The configured directory does not necessarily exist yet: a not-yet-created path reports 0 usable and 0 total
-	 * bytes, which the {@code totalSpace > 0} guard reads as "cannot tell" and the check goes silent. Walking up to
-	 * the closest existing ancestor measures the filesystem the databases are going to land on, which is the number
-	 * the operator needs. The working directory remains the fallback so the check never has nothing to measure.
+	 * Issue #7223 moved the resolution itself into {@link FileUtils#resolveDiskSpaceDirectory(ContextConfiguration)},
+	 * where the engine can reach it: {@code Profiler} - what feeds {@code GET /api/v1/server} and the Studio disk
+	 * bar - carried its own copy of the original defect. One implementation is what keeps the warning an operator
+	 * gets and the number they then go and read describing the same filesystem.
 	 */
 	static File resolveDiskSpaceDirectory(final ContextConfiguration configuration) {
-		if (configuration != null) {
-			try {
-				final String configured = configuration.getValueAsString(GlobalConfiguration.SERVER_DATABASE_DIRECTORY);
-				if (configured != null && !configured.isBlank()) {
-					File dir = new File(configured.trim()).getAbsoluteFile();
-					while (dir != null && !dir.exists())
-						dir = dir.getParentFile();
-
-					if (dir != null)
-						return dir;
-				}
-			}
-			catch (Exception e) {
-				LOGGER.log(Level.FINE, "Cannot resolve the configured database directory, falling back to the working directory", e);
-			}
-		}
-
-		return new File(".");
+		return FileUtils.resolveDiskSpaceDirectory(configuration);
 	}
 
 	private void checkHeapRAM() {

--- a/studio/src/main/resources/static/js/studio-server.js
+++ b/studio/src/main/resources/static/js/studio-server.js
@@ -149,6 +149,10 @@ function displayServerSummary() {
   $("#summDiskUsed").text(globalFormatSpace(diskUsed));
   $("#summDiskTotal").text(globalFormatSpace(diskTotal));
   $("#summDiskBar").css("width", Math.round(diskUsed / diskTotal * 100) + "%");
+  // #7223: the figures above describe the filesystem the databases live on, which on a container is a mounted
+  // volume and not the one the process was started in. Naming it is what makes them readable.
+  var diskDir = (p.diskDirectory && p.diskDirectory.value) || "";
+  $("#summDiskDir").text(diskDir || " ").attr("title", diskDir);
 
   // Read Cache
   var cacheUsed = (p.readCacheUsed && p.readCacheUsed.space) || 0;
@@ -257,7 +261,7 @@ function displayMetrics() {
 
   // Profiler details table (remaining metrics without rate tracking)
   var skipProfiler = { cpuLoad: 1, ramHeapUsed: 1, ramHeapMax: 1, ramOsUsed: 1, ramOsTotal: 1,
-    diskFreeSpace: 1, diskTotalSpace: 1, readCacheUsed: 1, cacheMax: 1, configuration: 1,
+    diskFreeSpace: 1, diskTotalSpace: 1, diskDirectory: 1, readCacheUsed: 1, cacheMax: 1, configuration: 1,
     writeTx: 1, readTx: 1, txRollbacks: 1, queries: 1, concurrentModificationExceptions: 1,
     edgeAppendMerges: 1, txPageSlotMerges: 1, mergesDeclinedByCoverage: 1 };
   var profilerHtml = "";

--- a/studio/src/main/resources/static/js/studio-server.js
+++ b/studio/src/main/resources/static/js/studio-server.js
@@ -120,6 +120,13 @@ function displayServerSettings() {
   });
 }
 
+// #7223: the disk figures on the summary describe the filesystem the DATABASES live on, which on a container is a
+// mounted volume and not the one the process was started in - so the card has to name it. A server that predates the
+// field, or a reading taken before it existed, answers "" rather than "undefined".
+function diskDirectoryOf(profiler) {
+  return (profiler && profiler.diskDirectory && profiler.diskDirectory.value) || "";
+}
+
 function displayServerSummary() {
   var p = serverData.metrics.profiler || {};
   var ev = serverData.metrics.events || {};
@@ -151,8 +158,10 @@ function displayServerSummary() {
   $("#summDiskBar").css("width", Math.round(diskUsed / diskTotal * 100) + "%");
   // #7223: the figures above describe the filesystem the databases live on, which on a container is a mounted
   // volume and not the one the process was started in. Naming it is what makes them readable.
-  var diskDir = (p.diskDirectory && p.diskDirectory.value) || "";
-  $("#summDiskDir").text(diskDir || " ").attr("title", diskDir);
+  var diskDir = diskDirectoryOf(p);
+  // A non-breaking space keeps the line's height when there is nothing to name, so the card does not resize
+  // between refreshes. Written as an escape because an invisible character in source is a trap.
+  $("#summDiskDir").text(diskDir || "\u00a0").attr("title", diskDir);
 
   // Read Cache
   var cacheUsed = (p.readCacheUsed && p.readCacheUsed.space) || 0;

--- a/studio/src/main/resources/static/server.html
+++ b/studio/src/main/resources/static/server.html
@@ -97,13 +97,16 @@
         </div>
         <div class="col-md-2">
           <div class="card">
-            <div class="card-header">OS Disk</div>
+            <div class="card-header">Databases Disk</div>
             <div class="card-body text-center">
               <div class="fs-4" id="summDiskUsed">-</div>
               <div class="text-muted small">of <span id="summDiskTotal">-</span></div>
               <div class="progress mt-2" style="height: 6px;">
                 <div class="progress-bar" id="summDiskBar" role="progressbar" style="width: 0%; background-color: #48C392;"></div>
               </div>
+              <!-- #7223: which filesystem the figures above describe. On a container the databases sit on a mounted
+                   volume while the process starts elsewhere, so "how full is the disk" has more than one answer. -->
+              <div class="text-muted small text-truncate mt-1" id="summDiskDir" title="">&nbsp;</div>
             </div>
           </div>
         </div>

--- a/studio/test/server-disk-directory.test.js
+++ b/studio/test/server-disk-directory.test.js
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+
+// Issue #7223: the disk figures on the server summary describe the filesystem the DATABASES live on, which on a
+// container is a mounted volume and not the one the process was started in. The card therefore has to name it -
+// a figure that does not say which filesystem it is answering about cannot be acted on. Run with:
+//
+//     node --test studio/test/server-disk-directory.test.js
+//
+// displayServerSummary() is extracted from studio-server.js and run against stubs for the globals it touches, so
+// the assertion is on what it hands to each element. Studio has no bundler for application JS.
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const SRC_PATH = path.join(__dirname, "..", "src", "main", "resources", "static", "js", "studio-server.js");
+const src = fs.readFileSync(SRC_PATH, "utf8");
+
+// Pulls one top-level `function name(...) {...}` out of the source by counting braces, as the sibling tests do.
+function extractFn(name) {
+  const start = src.indexOf("function " + name + "(");
+  if (start < 0) throw new Error("function not found in studio-server.js: " + name);
+  let i = src.indexOf("{", start);
+  let depth = 1;
+  i++;
+  while (i < src.length && depth > 0) {
+    const c = src[i];
+    if (c === "{") depth++;
+    else if (c === "}") depth--;
+    i++;
+  }
+  if (depth !== 0) throw new Error("unbalanced braces while extracting " + name + ": reached end of file");
+
+  const source = src.substring(start, i);
+  try {
+    new Function("return (" + source + ")");
+  } catch (e) {
+    throw new Error("the extracted source of " + name + " does not parse: " + e.message);
+  }
+  return source;
+}
+
+// What displayServerSummary() hands to each element, keyed by selector.
+const text = {};
+const attrs = {};
+
+function $(selector) {
+  const node = {
+    text: function (value) {
+      text[selector] = value;
+      return node;
+    },
+    attr: function (name, value) {
+      (attrs[selector] || (attrs[selector] = {}))[name] = value;
+      return node;
+    },
+  };
+  for (const noop of ["html", "show", "hide", "val", "addClass", "removeClass", "css", "empty", "append"])
+    node[noop] = function () {
+      return node;
+    };
+  return node;
+}
+
+function globalFormatDouble(v, decimals) {
+  return Number(v).toFixed(decimals);
+}
+
+function globalFormatSpace(v) {
+  return Number(v) + " b";
+}
+
+// The tail of the function builds the ops chart; none of it is what this test is about, so it gets the smallest
+// stubs that let it run to completion.
+const document = { documentElement: {}, querySelector: () => ({}) };
+const getComputedStyle = () => ({ getPropertyValue: () => "" });
+function ApexCharts() {
+  this.render = function () {};
+  this.destroy = function () {};
+}
+
+var opsPerSecHistory = {};
+var serverChartCommands = null;
+var serverData = {};
+
+eval(extractFn("displayServerSummary"));
+
+function render(profiler) {
+  serverData = { metrics: { profiler: profiler, events: {} } };
+  opsPerSecHistory = {};
+  displayServerSummary();
+}
+
+test("the disk card names the filesystem the figures describe", () => {
+  render({
+    diskFreeSpace: { space: 30 },
+    diskTotalSpace: { space: 100 },
+    diskDirectory: { value: "/mnt/data/databases" },
+  });
+
+  assert.strictEqual(text["#summDiskUsed"], "70 b");
+  assert.strictEqual(text["#summDiskTotal"], "100 b");
+  assert.strictEqual(text["#summDiskDir"], "/mnt/data/databases");
+  // Also as a tooltip, because the element truncates: a long container path is exactly the case that needs naming.
+  assert.strictEqual(attrs["#summDiskDir"].title, "/mnt/data/databases");
+});
+
+test("a server that does not report the directory leaves the card readable", () => {
+  // An older server, or a reading taken before the field existed. The figures still render and the line is blank
+  // rather than showing "undefined".
+  render({ diskFreeSpace: { space: 30 }, diskTotalSpace: { space: 100 } });
+
+  assert.strictEqual(text["#summDiskUsed"], "70 b");
+  assert.strictEqual(text["#summDiskDir"].trim(), "");
+  assert.strictEqual(attrs["#summDiskDir"].title, "");
+});

--- a/studio/test/server-disk-directory.test.js
+++ b/studio/test/server-disk-directory.test.js
@@ -25,8 +25,10 @@
 //
 //     node --test studio/test/server-disk-directory.test.js
 //
-// displayServerSummary() is extracted from studio-server.js and run against stubs for the globals it touches, so
-// the assertion is on what it hands to each element. Studio has no bundler for application JS.
+// The normalization lives in diskDirectoryOf(), a pure function taking the profiler payload, which is where
+// studio/CLAUDE.md asks for the logic worth testing. displayServerSummary() is also exercised, against stubs for the
+// globals it touches, because "the pure function is right" and "the card shows it" are different claims and the
+// wiring between them is exactly what a rename would break. Studio has no bundler for application JS.
 
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
@@ -103,6 +105,7 @@ var opsPerSecHistory = {};
 var serverChartCommands = null;
 var serverData = {};
 
+eval(extractFn("diskDirectoryOf"));
 eval(extractFn("displayServerSummary"));
 
 function render(profiler) {
@@ -110,6 +113,19 @@ function render(profiler) {
   opsPerSecHistory = {};
   displayServerSummary();
 }
+
+test("the reported directory is read off the profiler payload", () => {
+  assert.strictEqual(diskDirectoryOf({ diskDirectory: { value: "/mnt/data/databases" } }), "/mnt/data/databases");
+});
+
+test("a payload without the field answers empty rather than undefined", () => {
+  // An older server, a reading taken before the field existed, or a profiler that could not resolve a directory.
+  // Each has to leave the card blank; "undefined" rendered under a disk bar reads as a broken server.
+  assert.strictEqual(diskDirectoryOf({}), "");
+  assert.strictEqual(diskDirectoryOf({ diskDirectory: {} }), "");
+  assert.strictEqual(diskDirectoryOf(null), "");
+  assert.strictEqual(diskDirectoryOf(undefined), "");
+});
 
 test("the disk card names the filesystem the figures describe", () => {
   render({


### PR DESCRIPTION
Closes #7223, closes #7222, closes #7224.

## #7223 - Profiler measured the wrong filesystem, with the wrong call

`Profiler` still had `new File(".").getFreeSpace()` at both of its sites, which is the exact
measurement #7124 fixed in `ServerMonitor` - and `Profiler` is what feeds `GET /api/v1/server` and
the Studio disk bar, so the number an operator actually reads described the filesystem the JVM
happened to be started in.

- the resolution moved to `FileUtils.resolveDiskSpaceDirectory(ContextConfiguration)`, which
  `ServerMonitor` now delegates to. One implementation, so the warning an operator gets and the
  number they then go and read cannot describe different filesystems.
- both sites read `getUsableSpace()` rather than `getFreeSpace()`, for the reason the `ServerMonitor`
  comment already gave: `getFreeSpace` ignores per-user quotas and reservations.
- **beyond what the issue asked for**, and what the issue's last paragraph points at: the response
  and the Studio card now NAME the directory (`diskDirectory`). On a container "how full is the
  disk" has more than one answer, and a figure that does not say which one it is answering cannot be
  acted on. The Studio card header is `Databases Disk` for the same reason.
- one fallback the shared resolver adds over the `ServerMonitor` original: if the walk up to the
  closest existing ancestor bottoms out at the filesystem ROOT, the whole chain is absent and the
  configuration has said nothing about where the databases will be. That is what an embedded JVM
  gets - nobody sets `arcadedb.server.rootPath`, so the default expands to `/databases` - and
  measuring `/` there would report a filesystem chosen by accident. It falls back to the working
  directory instead.

## #7222 - the strict parse was bypassed by the one path a container uses

The setting's own description promises a strict parse "so a typo cannot silently publish the
endpoint unauthenticated". That held on the four administrative writers and not on the fifth:
`readConfiguration()` fed every system property and environment variable through the permissive
`coerce`, whose Boolean arm is `Boolean.parseBoolean` - `yes`, `1`, `on` and every typo become
`false`, with no error. The value then reached the plugin ALREADY a `Boolean`, which is exactly the
case its own strict guard skips (a deliberate `false` is indistinguishable from a folded typo once
the text is gone), so `requireAuthentication=yes` turned the protection OFF while the operator
believed they had turned it on.

The issue offered two fixes and preferred (1), "have `readConfiguration()` use `coerceFromAdminCommand`
for settings that opt into strict parsing". **A better version of (1) is what landed, differing on two
points:**

- **no opt-in.** A per-setting flag makes the guarantee a property of one setting that the next
  security-relevant Boolean has to remember to ask for, which is the same shape of gap this issue is.
  Every Boolean setting gets the strict parse on entry; nowhere should `-Dfoo=yes` mean `false`.
- **it reports rather than fails startup.** A throw here becomes an `ExceptionInInitializerError` -
  `readConfiguration()` runs inside `GlobalConfiguration`'s static initializer - which takes the whole
  engine down over one mistyped variable. `setValueFromConfigurationSource()` logs a WARNING naming
  the key, the value, its source and what was kept, and drops the setting instead.

A refusal leaves the setting exactly as it was, which from `readConfiguration()` is its compiled-in
default. Reading an unparseable boolean as `true` instead would fail closed for this one setting and
flip every setting whose safe side is the other one; refusing to guess is the property that holds for
all of them, and it is what makes this one fail closed, its default being `true`. As a side effect an
unreadable value of any other type - `arcadedb.asyncWorkerThreads=abc` - is now reported and dropped
rather than killing the JVM at class-init time.

The javadoc that enumerated the writers and named two (the issue is right, and it was four) now names
all five and says which one is which.

## #7224 - pg_type joined to pg_namespace

`DatabaseMetaData.getTypeInfo()` was answered as a question about SCHEMAS, and `Row.complete()` filled
the schema row's `pg_type` columns with NULL, so the projection validated and the driver got one type
with a null name and null OID. Silently.

The issue offered a narrow fix (exclude `pg_namespace` from the relations that outrank TYPES) and a
principled one (weight each relation by whether it can be a lone subject). **The principled one landed,
expressed in the ranking that already exists rather than as a second mechanism beside it:** the ladder
now reads what the other relation DOES to the row set. A relation that CONSTRAINS it outranks the one
it is joined to - `pg_class` and `pg_attribute` joined to `pg_type` are questions about tables and
columns, which is the half of the old ranking that was right. A relation that only QUALIFIES it does
not, and `pg_namespace` is the one relation here that can never be the subject of a query naming
anything else, because this catalog models exactly one schema. It also settles the tie the old javadoc
admitted was accidental: TYPES now beats ROLES/DATABASES/PRIVILEGES/CHARACTER_SETS/COLLATIONS instead
of letting the FROM order decide, which is the same reading (`pg_type` joined to `pg_roles` reads an
owner for each type).

The ranking alone would have turned a fabricated answer into a DECLINE, which is not a fix - the driver
would get an empty result set instead of a wrong one. Two things had to follow:

- **type rows carry a `pg_namespace` row.** `getTypeInfo()` filters on `n.nspname != 'pg_toast'`, which
  against the null fill reads as UNKNOWN - and TYPES is the family that does not tolerate an unreadable
  filter, so the query would be declined. The schema is `pg_catalog`, not the database's own: that is
  what `pg_type.typnamespace` already answers, so the column the query joins ON and the row it joins TO
  agree.
- **a scalar sub-select parses as an UNKNOWN operand** instead of aborting the parse of the predicate
  containing it. `t.typrelid = 0 OR (SELECT ...)` used to lose its readable half along with the
  subquery. Three-valued logic settles it - `TRUE OR UNKNOWN` is TRUE - and this cannot weaken the
  pg_type strictness in either direction: a predicate that is still UNKNOWN once the tree has been
  evaluated is declined exactly as an unparseable one was. Tokens are skipped, not planned, and
  iteratively, so a deeply nested subquery costs no stack.

### Deliberately not done

The issue also suggests hardening `Row.complete()` to reject a projection naming a column the chosen
family does not own. That null fill is load-bearing: the decorating relations (`pg_description`,
`pg_attrdef`, `pg_collation`) are modelled precisely so a LEFT JOIN against them yields the NULLs
PostgreSQL itself would give, and rejecting foreign columns would take out the column list of every
JDBC client. The mis-route it made plausible is closed at the ranking instead.

## Tests

- `Issue7223ProfilerDiskSpaceTest` (engine) - the profiler and the text dump measure and NAME the
  configured directory; the shared resolver's walk-up, blank, null and root-bottomed fallbacks.
- `Issue7222StrictBooleanFromConfigurationSourceTest` (engine) - `yes`/`1`/`on`/`TRUE!`/`ture`/empty
  are refused and the setting is not turned off, in both default directions; `true`/`false` still
  honoured in any casing; a non-Boolean setting unaffected; an unreadable Integer reported not thrown.
- `Issue7222PrometheusEnvironmentPathTest` (metrics) - the same typos at the endpoint the defect
  reached, with the system property cleared so the environment half is what is exercised.
- `Issue7224PgTypeNamespaceJoinTest` (postgresw) - pgjdbc's `getTypeInfo()` SQL verbatim; FROM order
  does not decide it; pg_class/pg_attribute still outrank pg_type; pg_namespace alone is still a
  schema query; the scalar-subquery operand in both directions.
- `Issue7224GetTypeInfoIT` (postgresw) - the same through the PostgreSQL JDBC driver itself.

Full engine unit suite green (14593 tests), postgresw 463, metrics and the server monitor tests green,
studio JS 67. The two `PrometheusMetricsPlugin{Authenticated,NotAuthenticated}Test` failures seen
locally are an unrelated process already listening on port 2480.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid Boolean values from system properties and environment variables are now rejected, preserving secure authentication defaults.
  - PostgreSQL catalog queries, scalar predicates, and JDBC type metadata now return more accurate results.
  - Disk metrics now measure the configured database filesystem instead of the process working directory.
  - Rejected configuration values no longer appear as successfully applied settings.

- **Improvements**
  - Server summaries display the database disk label, usage, and measured directory path.
  - Profiler output identifies the filesystem used for disk measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->