### PR TITLE
fix(#7225): unlearn a peer that has left the Raft configuration

### DIFF
--- a/docs/7225-unlearn-removed-peer-hosts.md
+++ b/docs/7225-unlearn-removed-peer-hosts.md
@@ -222,3 +222,30 @@ rather than by a fresh subagent. Findings:
    `refreshPeerAllowlist()` before any lifecycle branch.
 4. **"`learnedHosts` could drift from its two components"** - not real. `grep -n "pinnedHosts =|memberHosts ="`
    returns exactly the two writers, and both call `republishLearnedHosts()` under the same monitor.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/7251
+
+## Review cycles
+
+### Cycle 1 - 9b0b7547b2
+
+Reviewer: `claude`. No blocking findings; three items applied, none deferred.
+
+1. **`learnPeerHosts` did not exclude `memberHosts` from its dedup, so pinning a live member would defeat
+   unlearning for that host.** Real interaction, unreachable today. Not fixed by refusing the pin - that would
+   make a pin evaporate at the next shrink, which is exactly when the caller wanted it. Instead the contract is
+   now stated on `learnPeerHosts` (a pin beats membership, deliberately), and
+   `aPinnedHostStaysAdmittedEvenWhenMembershipDropsIt` pins it as a test. This is also the interleaving the
+   reviewer noted the suite did not touch.
+2. **The `dropped` log line would have claimed a host stopped being admitted when a pin still admitted it.**
+   Fixed: `dropped.removeAll(pinnedHosts)`, so the one line an operator reads to confirm a revocation cannot
+   lie.
+3. **The `memberHosts.isEmpty()` guard deserved a comment about joint-consensus reachability.** Added, phrased
+   as "defensive, not expected to fire" rather than as an unreachability claim - `RaftConfiguration.getCurrentPeers()`
+   during joint consensus was not exhaustively verified here.
+4. Cosmetic javadoc wording on `getResolvedPeerHostCount()` - applied.
+
+Re-run: `Issue7225AllowlistUnlearnsRemovedPeersTest` 9/9,
+`Issue7132AllowlistLearnsRuntimePeersTest` 9/9 (unmodified), `PeerAddressAllowlistFilterTest` 41/41.

--- a/docs/7225-unlearn-removed-peer-hosts.md
+++ b/docs/7225-unlearn-removed-peer-hosts.md
@@ -1,0 +1,224 @@
+# Issue #7225 - hosts learned from the live Raft configuration are never unlearned
+
+Follow-up to #7132. Two findings, both consequences of #7132 landing.
+
+## Finding ledger
+
+- [x] 1. `learnedHosts` is add-only, so a peer removed from the Raft configuration keeps inbound Raft
+      gRPC access (and a DNS lookup per refresh tick) for the rest of the process lifetime.
+- [x] 2. The startup fail-open log line counts `lastKnownIps`, which learned hosts now share with
+      configured hosts, so it can report a resolved count larger than the configured host count.
+
+Status at PR time: **1 fixed** (replace semantics + sticky pruning), **2 fixed** (the message counts configured
+hosts only). One gap found in the adversarial pass and filed as **#7250**.
+
+## Root cause
+
+`PeerAddressAllowlistFilter.learnPeerHosts` merges into `learnedHosts` (`merged.addAll(added)`) and the
+class has no removal path at all. `RaftHAServer.refreshPeerAllowlist` feeds it the hosts of the live
+Raft configuration on every health-monitor tick, so membership growth is reconciled and membership
+*shrink* is not: the departed host stays in `learnedHosts`, keeps being re-resolved by `doResolve()`,
+and keeps contributing its IPs to `allowedIps`.
+
+The same shared state carries finding 2: `lastKnownIps` is keyed by every host the filter has ever
+resolved - configured *and* learned - while the fail-open message prints it against
+`peerHosts.size()`. On a Kubernetes node with the headless-service seed plus a learned member, the
+message reads "resolved 3/1 hosts".
+
+One host must survive a membership shrink: the Kubernetes headless-service domain seeded by #7132 in
+`installPeerAllowlist`. That is what admits a scale-up pod *before* it is a member, so it cannot be
+treated as just another learned host under replace semantics.
+
+## Completeness
+
+### 1. Invariant
+
+After a reconciliation that reads a committed Raft configuration, the filter's learned host set is
+exactly the hosts of that configuration plus the hosts explicitly pinned at install time; a host that
+has left the configuration contributes no IP to `allowedIps` and no entry to the sticky
+`lastKnownIps`/`lastKnownMs` maps. Separately, the startup fail-open message reports a resolved count
+that counts only configured hosts, so it can never exceed the configured host count.
+
+### 2. Paths found by command
+
+```
+$ grep -rn "learnedHosts *=" ha-raft/src/main ha-raft/src/test
+PeerAddressAllowlistFilter.java:106:  private volatile Set<String> learnedHosts = Collections.emptySet();
+PeerAddressAllowlistFilter.java:270:      learnedHosts = Collections.unmodifiableSet(merged);
+PeerAddressAllowlistFilter.java:451:    return "PeerAddressAllowlistFilter{peerHosts=" ... learnedHosts ...
+```
+
+Exactly one writer: `learnPeerHosts` (line 270). No `unlearn`, `forget`, `remove` or `set` sibling.
+
+```
+$ grep -rn "learnedHosts" ha-raft/src/main | grep -v "learnedHosts *="
+PeerAddressAllowlistFilter.java:218:  isAllowed() reject log line
+PeerAddressAllowlistFilter.java:261:  learnPeerHosts() dedup check
+PeerAddressAllowlistFilter.java:268:  learnPeerHosts() merge
+PeerAddressAllowlistFilter.java:282:  getLearnedHosts()
+PeerAddressAllowlistFilter.java:331:  doResolve() resolution loop
+```
+
+```
+$ grep -rn "learnPeerHosts" --exclude-dir=target .
+RaftHAServer.java:3923:      filter.learnPeerHosts(List.of(serviceDomain));   <- k8s headless-service seed
+RaftHAServer.java:3976:    filter.learnPeerHosts(memberHosts);              <- health monitor tick
+Issue7132AllowlistLearnsRuntimePeersTest.java:70,83,84,85,88,89,108,124   <- tests
+```
+
+Two production callers, and they want different semantics: the first pins, the second reconciles.
+
+```
+$ grep -rn "lastKnownIps\|lastKnownMs" ha-raft/src/main ha-raft/src/test
+PeerAddressAllowlistFilter.java:120,121  declarations
+PeerAddressAllowlistFilter.java:207      fail-open log line: lastKnownIps.size() vs peerHosts.size()
+PeerAddressAllowlistFilter.java:366,367  written per resolved host
+PeerAddressAllowlistFilter.java:374,375  read for sticky retention
+PeerAddressAllowlistFilter.java:380,381  removed when the sticky TTL expires
+```
+
+Line 207 is also the only read of `lastKnownIps` *outside* `doResolve()`'s monitor, i.e. an unsynchronised
+read of a plain `HashMap`. Replacing it with a `volatile int` fixes the count and the race in one move.
+
+```
+$ grep -rn "refreshPeerAllowlist" --exclude-dir=target .
+HealthMonitor.java:91    HealthTarget default no-op
+HealthMonitor.java:271   tick() -> target.refreshPeerAllowlist()   <- runs on EVERY node
+RaftHAServer.java:3960   the implementation
+HealthMonitorTest.java:78 test double
+```
+
+```
+$ grep -rn "removePeer" ha-raft/src/main
+DeletePeerHandler.java:57 -> RaftHAPlugin.removePeer -> RaftHAServer.removePeer -> RaftClusterManager.removePeer
+```
+
+`removePeer` runs `setConfiguration` on the leader; every node - leader included - observes the shrink
+through its own committed configuration, which is what the health-monitor tick already reads.
+
+### 3. Entry-point coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| `HealthMonitor.tick` -> `RaftHAServer.refreshPeerAllowlist` -> membership shrink | yes - replace semantics via `setMemberHosts` | yes - `reconcileAllowlistMembership` shrink test |
+| `RaftHAServer.refreshPeerAllowlist` while the committed configuration is unreadable (#5271 window) | yes - membership left untouched rather than replaced by the declared list | yes - detached-server test |
+| `RaftHAServer.installPeerAllowlist` k8s headless-service seed | yes - pinned, survives every shrink | yes - pin-survives-shrink test |
+| `PeerAddressAllowlistFilter.learnPeerHosts` (pin API) | unchanged, add-only by design | yes - existing #7132 tests, unmodified |
+| `doResolve()` sticky maps for a dropped host | yes - `lastKnownIps`/`lastKnownMs` pruned to tracked hosts | yes - sticky-revival test |
+| `isAllowed` startup fail-open log count | yes - counts configured hosts only | yes - count test |
+| `DELETE /api/v1/cluster/peer/{id}` -> `removePeer` | argued: not a separate write path. It commits a new configuration; the reconciliation is the tick that reads it, at most one tick period later | n/a |
+| An already-established transport from the removed peer | **filed as #7250** - `transportReady` is the only gate the filter has, and nothing closes a live transport | n/a |
+| A departed peer that is ALSO in `arcadedb.ha.serverList` | argued: `serverList` is the declared allowlist and is deliberately not reconciled from membership; removing a declared host is a configuration change | n/a |
+
+No blank rows.
+
+### 5. Reachability
+
+`HealthMonitor.tick()` line 271 calls `target.refreshPeerAllowlist()` unconditionally on every node,
+before any lifecycle-state branch, so the reconciliation runs wherever the health monitor runs - the
+same path #7132 already relies on. `installPeerAllowlist` is called from `buildParameters`, which is on
+the Raft startup path. Neither is behind a new flag; `arcadedb.ha.peerAllowlist.enabled` (default true)
+gates the whole filter exactly as before.
+
+## Changes
+
+`ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java`
+
+- `learnedHosts` is split into two sets with deliberately different lifetimes: `pinnedHosts`, written only by
+  `learnPeerHosts` and never unlearned, and `memberHosts`, replaced wholesale by the new `setMemberHosts`.
+  `learnedHosts` stays as their union, republished under the monitor, so the resolver, `getLearnedHosts()` and
+  the log lines keep working off one consistent volatile read.
+- `setMemberHosts(Collection)` - replace semantics, re-resolves only when the set actually changed, logs at
+  INFO the hosts that left. Configured hosts are skipped on the way in; pinned hosts are untouched.
+- `doResolve()` prunes `lastKnownIps`/`lastKnownMs` down to the tracked hosts, so a departed peer's sticky
+  last-known-good IPs cannot readmit it later.
+- The startup fail-open message now reports `resolvedPeerHosts` (configured hosts covered by the last
+  resolution) instead of `lastKnownIps.size()`. That fixes the count and removes the message's unsynchronised
+  read of a plain `HashMap`.
+- The reject message names the members and the pinned hosts separately, since "learned" now covers both.
+
+`ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java`
+
+- `refreshPeerAllowlist()` delegates to the new package-private `reconcileAllowlistMembership(Collection)` and
+  feeds it `getCommittedPeersOrNull()` rather than `getLivePeers()`. `getLivePeers()` substitutes the DECLARED
+  server list when the division cannot be read (#5271), and under replace semantics that would unlearn every
+  runtime-joined peer for the whole restart window - the #7132 regression in a new shape. `null` means "no
+  membership this tick" and leaves the membership alone; so does a peer list that reduces to no usable host.
+- `installPeerAllowlist`'s headless-service seed is documented as a pin.
+
+## Tests
+
+`ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7225AllowlistUnlearnsRemovedPeersTest.java`, 8 tests:
+
+| Test | Entry point it drives |
+|---|---|
+| `aHostThatLeftTheConfigurationIsUnlearnedAndItsIpsAreRejected` | `setMemberHosts` shrink |
+| `thePinnedHeadlessServiceDomainSurvivesAMembershipShrink` | the k8s seed under a shrink |
+| `reconcilingTheSameMembershipIsANoOp` | idempotence, order-independence, configured-host exclusion |
+| `aDroppedHostLosesItsStickyLastKnownIps` | `lastKnownIps`/`lastKnownMs` pruning |
+| `theResolvedHostCountNeverExceedsTheConfiguredHostCount` | the fail-open log count (finding 2) |
+| `reconcilingFromTheCommittedConfigurationUnlearnsARemovedPeer` | `RaftHAServer.reconcileAllowlistMembership` |
+| `anUnreadableMembershipLeavesTheLearnedHostsAlone` | the `getCommittedPeersOrNull()` null case |
+| `aMembershipThatCarriesNoUsableHostIsIgnored` | the degenerate-membership guard |
+
+### The tests were proved able to fail
+
+Three falsification runs against deliberately reverted behaviour, each restored afterwards:
+
+1. `setMemberHosts` merging instead of replacing + the sticky prune removed + the old `lastKnownIps.size()`
+   count: **6 of 8 failed** (the two that survived pin the `RaftHAServer` policy, which that revert did not
+   touch).
+2. `refreshPeerAllowlist` reading `getLivePeers()` instead of `getCommittedPeersOrNull()`:
+   `anUnreadableMembershipLeavesTheLearnedHostsAlone` failed.
+3. The `memberHosts.isEmpty()` guard removed: `aMembershipThatCarriesNoUsableHostIsIgnored` failed.
+
+### Results
+
+- `mvn -o -pl ha-raft test -Dtest=Issue7225AllowlistUnlearnsRemovedPeersTest` - 8/8 green.
+- `mvn -o -pl ha-raft test -DexcludedGroups=benchmark,vector,slow` - **389 tests, 0 failures, 0 errors**.
+  One surefire fork crash on `LeaveClusterTest` in that run is environmental, not a regression: another agent's
+  server was holding port 2480 (`lsof -nP -iTCP:2480 -sTCP:LISTEN` showed a foreign java process), and
+  `LeaveClusterTest` run on its own is green (2/2).
+
+## Impact
+
+A peer removed from the cluster - by `DELETE /api/v1/cluster/peer/{id}` or a StatefulSet scale-down - now
+loses inbound Raft gRPC access on every surviving node within one health-monitor tick instead of at the next
+process restart, and stops costing a DNS lookup per tick. Nothing changes for a cluster that only grows: the
+scale-up path of #7132 is exercised by its own tests, which are unmodified and still green.
+
+## Residual risk
+
+- **A departed peer that is also declared in `arcadedb.ha.serverList` keeps its access.** By design:
+  `serverList` is the operator's declared allowlist, and narrowing it is a configuration change. Removing such
+  a peer from the group does not remove it from the configuration.
+- **The revocation is not instantaneous.** It lands on the next health-monitor tick of each node, and each node
+  ticks independently, so there is a bounded window in which some nodes still admit the departed peer.
+- **The Kubernetes headless-service domain still admits every pod backing the service**, including a pod that
+  was removed from the Raft group but is still running and still published by the service. That is inherent to
+  the #7132 seed: the same property is what admits a scale-up pod before it joins. On a scale-down the pod is
+  deleted and leaves the service's A records, which is the ordinary case.
+- **An already-established gRPC transport from the removed peer is not closed.** `transportReady` is the only
+  gate a `ServerTransportFilter` has; the fix revokes the ability to reconnect, not an open connection. Filed
+  as **#7250**.
+- **A removed peer keeps no sticky retention.** Pruning `lastKnownIps` means a peer removed and re-added
+  inside the sticky window, while its DNS is simultaneously down, is not readmitted from its pre-removal IPs.
+  That is the intended direction for a revocation path, but it is a behaviour change for a churn-heavy
+  cluster.
+- Unchanged and still true: the filter provides no peer identity and is not a substitute for mTLS (#3890).
+
+## Adversarial pass
+
+No `Task` tool was available in this environment, so the pass was run by re-reading the diff against the tree
+rather than by a fresh subagent. Findings:
+
+1. **Established transports are never closed** - real, out of scope, filed as **#7250** (evidence: the
+   `transportTerminated`/`ServerTransportFilter` grep above; the filter's only gate is `transportReady`).
+2. **The Kubernetes headless-service pin still admits a removed-but-running pod** - real, and deliberate: that
+   pin is what admits a scale-up pod before it is a member, and a scale-down deletes the pod, which removes it
+   from the service's A records. Argued in Residual risk rather than filed.
+3. **"The health monitor may not run on every node"** - not real. `RaftHAServer` line 1042 calls
+   `healthMonitor.start()` unconditionally on the startup path, and `HealthMonitor.tick()` line 271 calls
+   `refreshPeerAllowlist()` before any lifecycle branch.
+4. **"`learnedHosts` could drift from its two components"** - not real. `grep -n "pinnedHosts =|memberHosts ="`
+   returns exactly the two writers, and both call `republishLearnedHosts()` under the same monitor.

--- a/docs/7225-unlearn-removed-peer-hosts.md
+++ b/docs/7225-unlearn-removed-peer-hosts.md
@@ -289,3 +289,29 @@ of the field section - so EVERY field in this class already violated the rule, a
 ones a diff touches. Moved the interface to the bottom of the class, which clears all three and stops the
 next field added to this file inheriting the same report. No semantic change; the allowlist tests, the #7132
 tests and `Issue3890RaftParametersPublicationTest` are green after it.
+
+### Cycle 4 - 47e4830991
+
+Reviewer: `claude`. "Nothing here blocks merging." Codacy went green on this SHA. Two nits:
+
+1. **The local `memberHosts` in `RaftHAServer.reconcileAllowlistMembership` shadows the *concept* of
+   `PeerAddressAllowlistFilter.memberHosts`** (different classes, so no real collision - a readability nit
+   given how much vocabulary the two now share). Applied: renamed to `committedHosts`, with a comment saying
+   why the obvious name was avoided.
+2. **The tracking doc is long for a contained fix.** The reviewer withdrew this itself - it matches the
+   convention of `docs/6989-*.md` and `docs/7122-*.md`. No change.
+
+The review also re-raised, without finding a concrete failure mode, whether Ratis joint consensus could make
+`getCurrentPeers()` reduce to zero usable hosts. Unchanged from cycle 2: the guard is commented as defensive
+rather than as an unreachability claim, and it now logs at WARNING so it cannot fire unnoticed.
+
+## Final state
+
+`max-cycles-reached` - the loop ran its full 4 cycles rather than exiting early. No blocking feedback remains:
+cycle 4's review states nothing blocks merging, CodeRabbit reported no actionable comments, and Codacy passes.
+
+No `review-deferred-*.md` file was produced: every actionable item in every cycle was applied in the cycle
+that raised it.
+
+**The final commit is unreviewed** - it carries cycle 4's variable rename and this doc update, and no bot has
+seen it. Merge remains the developer's call.

--- a/docs/7225-unlearn-removed-peer-hosts.md
+++ b/docs/7225-unlearn-removed-peer-hosts.md
@@ -266,3 +266,26 @@ Reviewer: `claude`. No blocking findings; two items applied, none deferred.
 
 Re-run: `Issue7225AllowlistUnlearnsRemovedPeersTest` 9/9, `Issue7132AllowlistLearnsRuntimePeersTest` 9/9,
 `PeerAddressAllowlistFilterTest` 41/41, `HealthMonitorTest` 29/29.
+
+### Cycle 3 - fad2d2706e
+
+The `claude` comment on this SHA was the single word `test` - a degenerate bot run carrying no review
+content, not an approval and not a finding. CodeRabbit reported "no actionable comments were generated".
+
+The one thing on the PR that WAS actionable was the red `Codacy Static Code Analysis` check, which the same
+check passes on comparable merged PRs (#7246, #7212, #7210). Its three findings, read from the Codacy API:
+
+```
+$ curl -s 'https://app.codacy.com/api/v3/analysis/organizations/gh/ArcadeData/repositories/arcadedb/pull-requests/7251/issues'
+PMD_category_java_codestyle_FieldDeclarationsShouldBeAtStartOfClass x3
+  PeerAddressAllowlistFilter.java:121  private volatile Set<String> pinnedHosts
+  PeerAddressAllowlistFilter.java:124  private volatile Set<String> memberHosts
+  PeerAddressAllowlistFilter.java:154  private volatile int         resolvedPeerHosts
+```
+
+All three are the same rule, and the cause is structural rather than anything about the new fields: the
+`HostResolver` nested interface was declared before the field block, and PMD counts a nested type as the end
+of the field section - so EVERY field in this class already violated the rule, and Codacy reports only the
+ones a diff touches. Moved the interface to the bottom of the class, which clears all three and stops the
+next field added to this file inheriting the same report. No semantic change; the allowlist tests, the #7132
+tests and `Issue3890RaftParametersPublicationTest` are green after it.

--- a/docs/7225-unlearn-removed-peer-hosts.md
+++ b/docs/7225-unlearn-removed-peer-hosts.md
@@ -249,3 +249,20 @@ Reviewer: `claude`. No blocking findings; three items applied, none deferred.
 
 Re-run: `Issue7225AllowlistUnlearnsRemovedPeersTest` 9/9,
 `Issue7132AllowlistLearnsRuntimePeersTest` 9/9 (unmodified), `PeerAddressAllowlistFilterTest` 41/41.
+
+### Cycle 2 - 735788b509
+
+Reviewer: `claude`. No blocking findings; two items applied, none deferred.
+
+1. **`HealthMonitor.HealthTarget.refreshPeerAllowlist()`'s default-method javadoc had drifted** - it still
+   described only the #4696 DNS reconciliation while the `RaftHAServer` override describes membership. Updated
+   to name all three behaviours (#4696, #7132, #7225).
+2. **The degenerate-membership guard logged at FINE.** Bumped to WARNING, matching the precedent a few lines
+   above it: the `getCommittedPeersOrNull()` catch was deliberately raised from FINE to WARNING so a genuine
+   bug could not hide behind a silent degradation, and this guard skipping a reconciliation is the same shape
+   of hiding place. The message now also reports how many peers the configuration carried. The expected case -
+   an unreadable membership during a #5271 restart window - returns before this line, so an ordinary restart
+   logs nothing here.
+
+Re-run: `Issue7225AllowlistUnlearnsRemovedPeersTest` 9/9, `Issue7132AllowlistLearnsRuntimePeersTest` 9/9,
+`PeerAddressAllowlistFilterTest` 41/41, `HealthMonitorTest` 29/29.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/HealthMonitor.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/HealthMonitor.java
@@ -84,9 +84,11 @@ public final class HealthMonitor {
     }
 
     /**
-     * Proactively reconciles the inbound Raft gRPC peer allowlist with current DNS so a peer that
-     * restarted with a new pod IP is admitted without first being rejected (issue #4696). No-op when
-     * the allowlist is disabled; the filter itself throttles the DNS re-resolution.
+     * Reconciles the inbound Raft gRPC peer allowlist with cluster membership and with current DNS. A peer
+     * that restarted with a new pod IP is admitted without first being rejected (issue #4696), a peer that
+     * joined at runtime is admitted at all (issue #7132), and a peer removed from the Raft configuration is
+     * unlearned instead of keeping its access for the life of the process (issue #7225). No-op when the
+     * allowlist is disabled; the filter itself throttles the DNS re-resolution.
      */
     default void refreshPeerAllowlist() {
     }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java
@@ -102,12 +102,6 @@ import java.util.logging.Level;
  */
 final class PeerAddressAllowlistFilter extends ServerTransportFilter {
 
-  /** Pluggable host resolver so tests can drive resolution deterministically without real DNS. */
-  @FunctionalInterface
-  interface HostResolver {
-    InetAddress[] resolve(String host) throws UnknownHostException;
-  }
-
   // Minimum spacing between miss-triggered re-resolutions. Bounds DNS load under a connection flood
   // (at startup or from a non-peer) while letting the allowlist converge within ~1s.
   private static final long        MISS_RESOLVE_FLOOR_MS = 1_000L;
@@ -582,5 +576,17 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
   public String toString() {
     return "PeerAddressAllowlistFilter{peerHosts=" + peerHosts + ", pinnedHosts=" + pinnedHosts + ", memberHosts="
         + memberHosts + ", allowed=" + allowedIps.get() + "}";
+  }
+
+  /**
+   * Pluggable host resolver so tests can drive resolution deterministically without real DNS.
+   * <p>
+   * Declared last rather than first so it does not sit between the class header and the fields: PMD's
+   * {@code FieldDeclarationsShouldBeAtStartOfClass} counts a nested type as the start of the method section,
+   * so every field declared after it is reported, and Codacy reports the ones a diff happens to touch.
+   */
+  @FunctionalInterface
+  interface HostResolver {
+    InetAddress[] resolve(String host) throws UnknownHostException;
   }
 }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java
@@ -73,13 +73,28 @@ import java.util.logging.Level;
  * <p>
  * The set of hosts is NOT frozen at boot (issue #7132). The hosts declared in {@code serverList} are the
  * <i>configured</i> ones and are the only ones the quorum and completeness latches above count, but a
- * caller may {@link #learnPeerHosts add} more at runtime, and {@code RaftHAServer} does so on every health
- * monitor tick from the live Raft configuration. Without that, a peer that joined after this node started -
- * through {@code addPeer}, or through the Kubernetes StatefulSet scale-up auto-join of issue #4836 - was
- * rejected forever by every node that had already latched {@code everQuorumResolved}: the two features are
+ * caller may add more at runtime, and {@code RaftHAServer} does so on every health monitor tick from the
+ * live Raft configuration. Without that, a peer that joined after this node started - through
+ * {@code addPeer}, or through the Kubernetes StatefulSet scale-up auto-join of issue #4836 - was rejected
+ * forever by every node that had already latched {@code everQuorumResolved}: the two features are
  * individually correct and were jointly broken, because nothing reconciled them. Learned hosts resolve
  * exactly like configured ones but are best-effort: a name that does not resolve contributes nothing,
  * is logged at FINE rather than WARNING, and never holds the latches back.
+ * <p>
+ * Runtime hosts arrive through two APIs with deliberately different lifetimes (issue #7225), because the
+ * first version of #7132 had only the first and a host once learned was never unlearned - so a peer removed
+ * from the cluster kept inbound Raft access, and a DNS lookup per refresh tick, for the rest of the process
+ * lifetime:
+ * <ul>
+ *   <li>{@link #learnPeerHosts} <b>pins</b> a host for the life of the filter. Its one production caller
+ *       seeds the Kubernetes headless-service domain, which is what admits a scale-up pod <i>before</i> it
+ *       is a member and therefore must survive every membership shrink.</li>
+ *   <li>{@link #setMemberHosts} <b>replaces</b> the membership-derived hosts wholesale with the hosts of the
+ *       live Raft configuration, so a departed peer's IPs leave {@code allowedIps} - and its sticky
+ *       last-known-good entries leave the retention maps - on the next reconciliation.</li>
+ * </ul>
+ * Neither ever shadows a configured host: {@code serverList} is configuration, not membership, and removing
+ * a host from it is a configuration change rather than something a Raft configuration commit can do.
  * <p>
  * This is NOT a substitute for mTLS: it does not authenticate peer identity and does not
  * encrypt the traffic. See GitHub issue #3890. The bounded startup fail-open is an acceptable
@@ -100,9 +115,15 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
   // Hosts declared in arcadedb.ha.serverList. Immutable, and the ONLY ones the quorum/completeness
   // latches below count: they describe the configured cluster, which is what #4828 reasoned about.
   private final List<String>                 peerHosts;
-  // Hosts learned after construction (issue #7132): the members of the live Raft configuration, plus - on
-  // Kubernetes - the headless service domain behind arcadedb.ha.k8sSuffix, which resolves to every pod of
-  // the StatefulSet. Copy-on-write so isAllowed()'s hot path never synchronises against a learner.
+  // Hosts pinned after construction and never unlearned (issue #7132): on Kubernetes, the headless service
+  // domain behind arcadedb.ha.k8sSuffix, which resolves to every pod of the StatefulSet including one that
+  // is not Ready yet. Deliberately outside the membership reconciliation below.
+  private volatile Set<String>               pinnedHosts  = Collections.emptySet();
+  // Hosts of the live Raft configuration, REPLACED wholesale on every reconciliation (issue #7225) so a peer
+  // removed from the cluster stops being resolved and stops being admitted.
+  private volatile Set<String>               memberHosts  = Collections.emptySet();
+  // pinnedHosts | memberHosts, republished whenever either changes. Copy-on-write so isAllowed()'s hot path
+  // never synchronises against a learner, and one volatile read so a resolution sees a consistent union.
   private volatile Set<String>               learnedHosts = Collections.emptySet();
   // Number of declared peer hosts that must resolve before the startup fail-open ends: a Raft
   // majority (floor(n/2)+1). Enough peers to form the cluster, so a single permanently-down peer
@@ -126,6 +147,11 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
   // Latches true the first time a quorum of peer hosts is covered; gates the fail-open grace so the
   // window ends as soon as a Raft majority is known, even if a peer is permanently down (issue #4828).
   private volatile boolean                   everQuorumResolved;
+  // How many CONFIGURED hosts the last resolution covered. Reported by the startup fail-open message, which
+  // used to count lastKnownIps - a map keyed by configured AND learned hosts, so the message could claim more
+  // resolved hosts than there are configured ones (issue #7225). Also removes that message's unsynchronised
+  // read of a plain HashMap.
+  private volatile int                       resolvedPeerHosts;
 
   PeerAddressAllowlistFilter(final List<String> peerHosts, final long refreshIntervalMs) {
     this(peerHosts, refreshIntervalMs,
@@ -204,7 +230,7 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
       LogManager.instance().log(this, Level.WARNING,
           "Accepting Raft gRPC connection from %s during startup grace: peer allowlist below quorum "
               + "(resolved %d/%d hosts, quorum=%d, allowed=%s). Will enforce once a quorum of peers resolves or after %dms.",
-          ip, lastKnownIps.size(), peerHosts.size(), resolveQuorum, allowedIps.get(), startupGraceMs);
+          ip, resolvedPeerHosts, peerHosts.size(), resolveQuorum, allowedIps.get(), startupGraceMs);
       return true;
     }
 
@@ -212,10 +238,11 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
     // looking at a peer that will not join sees nothing at all in ITS log (issue #7132).
     LogManager.instance().log(this, Level.WARNING,
         "Rejecting Raft gRPC connection from %s: the address is not in the cluster peer allowlist "
-            + "(allowed=%s, configured hosts=%s, learned from the live Raft configuration=%s). If this is a "
-            + "legitimate peer, add it to 'arcadedb.ha.serverList' or check that its hostname resolves from "
-            + "this node; 'arcadedb.ha.peerAllowlist.enabled=false' disables the check entirely.",
-        ip, allowedIps.get(), peerHosts, learnedHosts);
+            + "(allowed=%s, configured hosts=%s, members of the live Raft configuration=%s, pinned hosts=%s). "
+            + "If this is a legitimate peer, add it to 'arcadedb.ha.serverList' or check that its hostname "
+            + "resolves from this node; 'arcadedb.ha.peerAllowlist.enabled=false' disables the check entirely. "
+            + "A peer removed from the Raft configuration is expected to appear here.",
+        ip, allowedIps.get(), peerHosts, memberHosts, pinnedHosts);
     return false;
   }
 
@@ -235,18 +262,19 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
   }
 
   /**
-   * Adds hosts discovered after construction to the allowlist and re-resolves immediately when any of them
-   * is new (issue #7132). The caller is {@code RaftHAServer.refreshPeerAllowlist}, which passes the hosts of
-   * the live Raft configuration on every health monitor tick, and {@code installPeerAllowlist}, which seeds
-   * the Kubernetes headless service domain. Idempotent: a tick that discovers nothing new costs one set
-   * comparison and does not touch DNS.
+   * Pins hosts discovered after construction to the allowlist and re-resolves immediately when any of them is
+   * new (issue #7132). A pinned host is never unlearned: the one production caller is
+   * {@code RaftHAServer.installPeerAllowlist}, which seeds the Kubernetes headless service domain, and that
+   * domain is precisely how a scale-up pod is admitted BEFORE it is a member of the Raft configuration - so it
+   * cannot be subject to the membership reconciliation in {@link #setMemberHosts}. Idempotent: a call that
+   * pins nothing new costs one set comparison and does not touch DNS.
    * <p>
    * Learned hosts do not count towards {@link #isQuorumResolved()} or {@link #isEverCompletelyResolved()}:
    * those gates describe the CONFIGURED cluster (issue #4828), and a name that does not resolve yet must not
    * hold the fail-open window open, nor - once it does resolve - retroactively widen the quorum a returning
    * peer has to clear.
    *
-   * @return true when at least one host was not already known, i.e. when a re-resolution was performed
+   * @return true when at least one host was not already pinned, i.e. when a re-resolution was performed
    */
   boolean learnPeerHosts(final Collection<String> hosts) {
     if (hosts == null || hosts.isEmpty())
@@ -255,31 +283,109 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
     final Set<String> added = new HashSet<>();
     synchronized (this) {
       for (final String host : hosts) {
-        if (host == null || host.isBlank())
-          continue;
-        final String trimmed = host.trim();
-        if (peerHosts.contains(trimmed) || learnedHosts.contains(trimmed))
+        final String trimmed = normalize(host);
+        if (trimmed == null || peerHosts.contains(trimmed) || pinnedHosts.contains(trimmed))
           continue;
         added.add(trimmed);
       }
       if (added.isEmpty())
         return false;
 
-      final Set<String> merged = new HashSet<>(learnedHosts);
+      final Set<String> merged = new HashSet<>(pinnedHosts);
       merged.addAll(added);
-      learnedHosts = Collections.unmodifiableSet(merged);
+      pinnedHosts = Collections.unmodifiableSet(merged);
+      republishLearnedHosts();
       // Unconditional, NOT resolveIfStale: a newly learned host is exactly the case the refresh floors were
       // written to throttle away, and the connection it is meant to admit is usually already being retried.
       doResolve();
     }
     LogManager.instance().log(this, Level.FINE,
-        "Raft gRPC peer allowlist learned %d new host(s): %s", added.size(), added);
+        "Raft gRPC peer allowlist pinned %d new host(s): %s", added.size(), added);
     return true;
   }
 
-  /** The hosts learned after construction. Exposed for testing. */
+  /**
+   * Replaces the membership-derived hosts with {@code hosts}, the hosts of the live Raft configuration, and
+   * re-resolves when the set actually changed (issue #7225). Replace, not merge: the first version of the
+   * #7132 reconciliation only ever added, so a peer removed from the cluster - by
+   * {@code DELETE /api/v1/cluster/peer/{id}} or a StatefulSet scale-down - kept its IPs in the allowlist and
+   * kept costing a DNS lookup on every refresh tick until the process restarted.
+   * <p>
+   * Two kinds of host are deliberately not touched here. Configured hosts are skipped on the way in, because
+   * {@code arcadedb.ha.serverList} is configuration rather than membership. Pinned hosts
+   * ({@link #learnPeerHosts}) survive every shrink, because the Kubernetes headless-service domain is what
+   * admits a pod that is not a member yet.
+   * <p>
+   * An empty collection means "the membership is empty", and clears every membership-derived host. Deciding
+   * that an unreadable or degenerate membership must NOT be applied is the caller's job - see
+   * {@code RaftHAServer.reconcileAllowlistMembership}, which skips the call rather than passing nothing.
+   *
+   * @return true when the membership-derived host set changed, i.e. when a re-resolution was performed
+   */
+  boolean setMemberHosts(final Collection<String> hosts) {
+    final Set<String> current = new HashSet<>();
+    if (hosts != null)
+      for (final String host : hosts) {
+        final String trimmed = normalize(host);
+        if (trimmed == null || peerHosts.contains(trimmed))
+          continue;
+        current.add(trimmed);
+      }
+
+    final Set<String> dropped;
+    synchronized (this) {
+      if (memberHosts.equals(current))
+        return false;
+
+      dropped = new HashSet<>(memberHosts);
+      dropped.removeAll(current);
+      memberHosts = Collections.unmodifiableSet(current);
+      republishLearnedHosts();
+      // Unconditional for the same reason learnPeerHosts is: this is a membership change, not the periodic
+      // DNS churn the refresh floors exist to throttle. doResolve() rebuilds the allowed set from the tracked
+      // hosts, which is what actually evicts a departed peer's addresses.
+      doResolve();
+    }
+    if (!dropped.isEmpty())
+      LogManager.instance().log(this, Level.INFO,
+          "Raft gRPC peer allowlist no longer admits %d host(s) that left the Raft configuration: %s",
+          dropped.size(), dropped);
+    return true;
+  }
+
+  /** Republishes the union the resolver walks. Callers hold this object's monitor. */
+  private void republishLearnedHosts() {
+    final Set<String> union = new HashSet<>(pinnedHosts);
+    union.addAll(memberHosts);
+    learnedHosts = Collections.unmodifiableSet(union);
+  }
+
+  /** Trimmed host, or null when there is nothing usable to resolve. */
+  private static String normalize(final String host) {
+    if (host == null)
+      return null;
+    final String trimmed = host.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+
+  /** The hosts learned after construction, pinned and membership-derived alike. Exposed for testing. */
   Set<String> getLearnedHosts() {
     return learnedHosts;
+  }
+
+  /** The hosts pinned by {@link #learnPeerHosts}, which no membership change unlearns. Exposed for testing. */
+  Set<String> getPinnedHosts() {
+    return pinnedHosts;
+  }
+
+  /** The hosts of the last reconciled Raft configuration. Exposed for testing. */
+  Set<String> getMemberHosts() {
+    return memberHosts;
+  }
+
+  /** How many CONFIGURED hosts the last resolution covered; never more than the configured total. Testing. */
+  int getResolvedPeerHostCount() {
+    return resolvedPeerHosts;
   }
 
   /** Triggers an immediate DNS re-resolution. Exposed for testing. */
@@ -322,17 +428,27 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
 
   private synchronized void doResolve() {
     final long now = clock.getAsLong();
+    final Set<String> learned = learnedHosts; // one read: pinned and member hosts change under this monitor
     final Set<String> effective = new HashSet<>(LoopbackHosts.IPS);
     int covered = 0;
     for (final String host : peerHosts)
       if (resolveHostInto(host, now, effective, true))
         covered++;
     // Learned hosts widen the allowlist but never the gates: see learnPeerHosts.
-    for (final String host : learnedHosts)
+    for (final String host : learned)
       resolveHostInto(host, now, effective, false);
+
+    // Forget the sticky retention of hosts nothing tracks any more (issue #7225). A peer removed from the
+    // Raft configuration must not keep last-known-good IPs on standby: they would readmit it the moment
+    // anything re-learned the name, from an entry that outlived the membership that created it.
+    final Set<String> tracked = new HashSet<>(peerHosts);
+    tracked.addAll(learned);
+    lastKnownIps.keySet().retainAll(tracked);
+    lastKnownMs.keySet().retainAll(tracked);
 
     allowedIps.set(Collections.unmodifiableSet(effective));
     lastResolveMs = now;
+    resolvedPeerHosts = covered;
     if (covered >= resolveQuorum)
       everQuorumResolved = true;
     if (covered == peerHosts.size())
@@ -448,7 +564,7 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
 
   @Override
   public String toString() {
-    return "PeerAddressAllowlistFilter{peerHosts=" + peerHosts + ", learnedHosts=" + learnedHosts + ", allowed="
-        + allowedIps.get() + "}";
+    return "PeerAddressAllowlistFilter{peerHosts=" + peerHosts + ", pinnedHosts=" + pinnedHosts + ", memberHosts="
+        + memberHosts + ", allowed=" + allowedIps.get() + "}";
   }
 }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java
@@ -269,6 +269,15 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
    * cannot be subject to the membership reconciliation in {@link #setMemberHosts}. Idempotent: a call that
    * pins nothing new costs one set comparison and does not touch DNS.
    * <p>
+   * <b>A pin beats membership, deliberately.</b> Pinning a host that is also a current member keeps it
+   * admitted after that member leaves, which is the one way to defeat the unlearning this class exists to do.
+   * The alternative - silently refusing to pin a host that happens to be a member today - is worse: the pin
+   * would then evaporate at the next shrink, which is exactly when the caller wanted it. So the contract is
+   * that a pin is permanent, and a caller that does not want permanence calls {@link #setMemberHosts}
+   * instead. Nothing in the tree pins a peer hostname: {@code grep -rn "learnPeerHosts" --exclude-dir=target}
+   * finds one production caller, {@code RaftHAServer.installPeerAllowlist}, and it pins the static Kubernetes
+   * headless-service domain.
+   * <p>
    * Learned hosts do not count towards {@link #isQuorumResolved()} or {@link #isEverCompletelyResolved()}:
    * those gates describe the CONFIGURED cluster (issue #4828), and a name that does not resolve yet must not
    * hold the fail-open window open, nor - once it does resolve - retroactively widen the quorum a returning
@@ -337,8 +346,12 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
       if (memberHosts.equals(current))
         return false;
 
+      // What actually stopped being admitted, which is not the same as what left the membership: a host that
+      // is also pinned stays in the allowlist, and reporting it as dropped would be a lie in the one log line
+      // an operator reads to confirm a revocation landed.
       dropped = new HashSet<>(memberHosts);
       dropped.removeAll(current);
+      dropped.removeAll(pinnedHosts);
       memberHosts = Collections.unmodifiableSet(current);
       republishLearnedHosts();
       // Unconditional for the same reason learnPeerHosts is: this is a membership change, not the periodic
@@ -383,7 +396,10 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
     return memberHosts;
   }
 
-  /** How many CONFIGURED hosts the last resolution covered; never more than the configured total. Testing. */
+  /**
+   * How many CONFIGURED hosts the last resolution covered; never more than the configured total. Exposed for
+   * testing.
+   */
   int getResolvedPeerHostCount() {
     return resolvedPeerHosts;
   }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -3918,6 +3918,8 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     // records of every pod backing it, at any replica count and without an ordinal to guess, and it covers a
     // pod that is not Ready yet because the service that publishes it sets publishNotReadyAddresses (which
     // the shipped manifest documents as required, since a pod is Ready only once it has joined).
+    // learnPeerHosts PINS it: it is the one host that has to outlive a membership shrink, because admitting a
+    // pod that is not a member yet is its entire purpose (issue #7225).
     final String serviceDomain = headlessServiceDomain(k8sDnsSuffix);
     if (serviceDomain != null)
       filter.learnPeerHosts(List.of(serviceDomain));
@@ -3950,11 +3952,12 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   }
 
   /**
-   * Proactively reconciles the inbound Raft gRPC peer allowlist with current DNS (issue #4696).
-   * Invoked from the health monitor tick on every node so a peer that restarted with a new pod IP is
-   * admitted without first having to be rejected on an inbound connection - which a leader with a
-   * wedged outbound appender channel may never receive. No-op when the allowlist is disabled. The
-   * filter throttles the actual DNS re-resolution to its configured refresh interval.
+   * Proactively reconciles the inbound Raft gRPC peer allowlist with cluster membership and with current DNS
+   * (issues #4696, #7132, #7225). Invoked from the health monitor tick on every node so a peer that restarted
+   * with a new pod IP is admitted without first having to be rejected on an inbound connection - which a
+   * leader with a wedged outbound appender channel may never receive - and so a peer removed from the group
+   * loses its access without waiting for a process restart. No-op when the allowlist is disabled. The filter
+   * throttles the actual DNS re-resolution to its configured refresh interval.
    */
   @Override
   public void refreshPeerAllowlist() {
@@ -3962,20 +3965,46 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     if (filter == null)
       return;
 
-    // Reconcile the allowlist with cluster MEMBERSHIP, not with the boot-time configuration (issue #7132).
-    // getLivePeers() reads the committed Raft configuration - the same authority the cluster status endpoint
-    // uses - so a peer added at runtime (addPeer, the Kubernetes auto-join) is admitted from here on instead
-    // of being rejected forever by every node that had already latched everQuorumResolved. A tick that finds
-    // nothing new is a set comparison and does not touch DNS.
-    final List<String> memberHosts = new ArrayList<>();
-    for (final RaftPeer peer : getLivePeers()) {
+    reconcileAllowlistMembership(getCommittedPeersOrNull());
+
+    filter.proactiveRefresh();
+  }
+
+  /**
+   * Makes the allowlist's membership-derived hosts equal the hosts of {@code committedPeers} (issue #7225).
+   * Package-private so a test can drive a membership change without a running Ratis division.
+   * <p>
+   * Replace, not merge: #7132 taught the allowlist to learn a peer that joined at runtime, but nothing ever
+   * unlearned one, so a peer removed by {@code DELETE /api/v1/cluster/peer/&#123;id&#125;} or by a StatefulSet
+   * scale-down kept inbound Raft gRPC access - and a DNS lookup per tick - until the process restarted.
+   * <p>
+   * The input is {@link #getCommittedPeersOrNull()} rather than {@link #getLivePeers()} exactly because the
+   * two differ on the case replace semantics is sensitive to: {@code getLivePeers()} substitutes the DECLARED
+   * server list when the division cannot be read (before startup, and throughout an in-place restart - issue
+   * #5271), and replacing membership with the declared list would unlearn every runtime-joined peer every time
+   * that window opens. {@code null} means "no membership information this tick", which is not the same as "no
+   * members", and is the same distinction {@code RaftClusterStatusExporter.everCommitted} draws (issue #7136).
+   * A peer list that reduces to no usable host is treated the same way: a committed configuration always
+   * carries at least this node, so an empty one is a read that went wrong rather than an empty cluster.
+   */
+  void reconcileAllowlistMembership(final Collection<RaftPeer> committedPeers) {
+    final PeerAddressAllowlistFilter filter = allowlistFilter;
+    if (filter == null || committedPeers == null)
+      return;
+
+    final List<String> memberHosts = new ArrayList<>(committedPeers.size());
+    for (final RaftPeer peer : committedPeers) {
       final String host = allowlistHostOf(peer.getAddress());
       if (host != null)
         memberHosts.add(host);
     }
-    filter.learnPeerHosts(memberHosts);
+    if (memberHosts.isEmpty()) {
+      LogManager.instance().log(this, Level.FINE,
+          "The Raft configuration carried no usable peer host this tick; keeping the current peer allowlist membership");
+      return;
+    }
 
-    filter.proactiveRefresh();
+    filter.setMemberHosts(memberHosts);
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -3998,6 +3998,10 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
       if (host != null)
         memberHosts.add(host);
     }
+    // Defensive, and not expected to fire: a committed configuration carries at least the local node, and
+    // allowlistHostOf only returns null for an address with no host part at all. It is here so that a peer
+    // list this method cannot reduce to a single host - whatever produced it - can never be mistaken for an
+    // empty cluster and wipe the membership the previous tick learned.
     if (memberHosts.isEmpty()) {
       LogManager.instance().log(this, Level.FINE,
           "The Raft configuration carried no usable peer host this tick; keeping the current peer allowlist membership");

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -3992,11 +3992,13 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     if (filter == null || committedPeers == null)
       return;
 
-    final List<String> memberHosts = new ArrayList<>(committedPeers.size());
+    // committedHosts, not memberHosts: PeerAddressAllowlistFilter has a field by the latter name, and the two
+    // classes' vocabulary overlaps enough now that reusing it here reads like the same thing.
+    final List<String> committedHosts = new ArrayList<>(committedPeers.size());
     for (final RaftPeer peer : committedPeers) {
       final String host = allowlistHostOf(peer.getAddress());
       if (host != null)
-        memberHosts.add(host);
+        committedHosts.add(host);
     }
     // Defensive, and not expected to fire: a committed configuration carries at least the local node, and
     // allowlistHostOf only returns null for an address with no host part at all. It is here so that a peer
@@ -4006,14 +4008,14 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     // silently skipping the reconciliation is how a genuine bug in address parsing or in the membership read
     // would hide, and the unreadable-membership case - the one that IS expected - returns above without
     // reaching this line, so an ordinary #5271 restart window does not log here at all.
-    if (memberHosts.isEmpty()) {
+    if (committedHosts.isEmpty()) {
       LogManager.instance().log(this, Level.WARNING,
           "The Raft configuration carried %d peer(s) but no usable host this tick; keeping the current peer "
               + "allowlist membership rather than treating it as an empty cluster", committedPeers.size());
       return;
     }
 
-    filter.setMemberHosts(memberHosts);
+    filter.setMemberHosts(committedHosts);
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -4002,9 +4002,14 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     // allowlistHostOf only returns null for an address with no host part at all. It is here so that a peer
     // list this method cannot reduce to a single host - whatever produced it - can never be mistaken for an
     // empty cluster and wipe the membership the previous tick learned.
+    // WARNING rather than FINE, matching the getCommittedPeersOrNull catch this method reads from: the guard
+    // silently skipping the reconciliation is how a genuine bug in address parsing or in the membership read
+    // would hide, and the unreadable-membership case - the one that IS expected - returns above without
+    // reaching this line, so an ordinary #5271 restart window does not log here at all.
     if (memberHosts.isEmpty()) {
-      LogManager.instance().log(this, Level.FINE,
-          "The Raft configuration carried no usable peer host this tick; keeping the current peer allowlist membership");
+      LogManager.instance().log(this, Level.WARNING,
+          "The Raft configuration carried %d peer(s) but no usable host this tick; keeping the current peer "
+              + "allowlist membership rather than treating it as an empty cluster", committedPeers.size());
       return;
     }
 

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7225AllowlistUnlearnsRemovedPeersTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7225AllowlistUnlearnsRemovedPeersTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for issue #7225, a follow-up to #7132: the allowlist learned hosts from the live Raft
+ * configuration but never unlearned them, so a peer deliberately removed from the cluster kept inbound
+ * access to the Raft gRPC port - and a steady DNS lookup per refresh tick - until the process restarted.
+ * <p>
+ * Reconciliation is now replace-semantics ({@code setMemberHosts}) rather than a merge, with two hosts
+ * deliberately exempt: the Kubernetes headless-service domain pinned at install time (#7132), which is what
+ * admits a scale-up pod <i>before</i> it is a member, and everything declared in
+ * {@code arcadedb.ha.serverList}, which is configuration and not membership.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue7225AllowlistUnlearnsRemovedPeersTest {
+
+  // ---------------------------------------------------------------------------
+  // PeerAddressAllowlistFilter: replace semantics
+  // ---------------------------------------------------------------------------
+
+  /** Finding 1: a peer removed from the Raft configuration loses its Raft gRPC access on the next tick. */
+  @Test
+  void aHostThatLeftTheConfigurationIsUnlearnedAndItsIpsAreRejected() {
+    final AtomicLong clock = new AtomicLong(0);
+    final PeerAddressAllowlistFilterTest.FakeResolver dns = new PeerAddressAllowlistFilterTest.FakeResolver();
+    dns.table.put("arcadedb-0", List.of("10.1.13.1"));
+    dns.table.put("arcadedb-3", List.of("10.1.13.4"));
+
+    final PeerAddressAllowlistFilter f = new PeerAddressAllowlistFilter(List.of("arcadedb-0"), 30_000L, 0L,
+        300_000L, clock::get, dns);
+
+    // Scale-up: pod 3 joins, the tick feeds the new membership in, and it is admitted.
+    assertThat(f.setMemberHosts(List.of("arcadedb-0", "arcadedb-3"))).isTrue();
+    assertThat(f.getLearnedHosts()).containsExactly("arcadedb-3");
+    assertThat(f.isAllowed("10.1.13.4")).isTrue();
+
+    // Scale-down: pod 3 is removed from the group. The next tick reports the smaller membership.
+    assertThat(f.setMemberHosts(List.of("arcadedb-0"))).isTrue();
+    assertThat(f.getLearnedHosts()).isEmpty();
+    assertThat(f.getAllowedIps()).doesNotContain("10.1.13.4");
+    assertThat(f.isAllowed("10.1.13.4")).as("a removed peer must not keep Raft gRPC access").isFalse();
+    assertThat(f.isAllowed("10.1.13.1")).as("the surviving configured peer is untouched").isTrue();
+  }
+
+  /**
+   * The Kubernetes headless-service domain seeded by #7132 is how a scale-up pod is admitted BEFORE it is a
+   * member, so replace semantics has to retain it explicitly rather than treat it as a learned host.
+   */
+  @Test
+  void thePinnedHeadlessServiceDomainSurvivesAMembershipShrink() {
+    final AtomicLong clock = new AtomicLong(0);
+    final PeerAddressAllowlistFilterTest.FakeResolver dns = new PeerAddressAllowlistFilterTest.FakeResolver();
+    dns.table.put("arcadedb-0", List.of("10.1.13.1"));
+    dns.table.put("arcadedb.myns.svc.cluster.local", List.of("10.1.13.1", "10.1.13.2"));
+    dns.table.put("arcadedb-1", List.of("10.1.13.2"));
+
+    final PeerAddressAllowlistFilter f = new PeerAddressAllowlistFilter(List.of("arcadedb-0"), 30_000L, 0L,
+        300_000L, clock::get, dns);
+    f.learnPeerHosts(List.of("arcadedb.myns.svc.cluster.local"));
+
+    f.setMemberHosts(List.of("arcadedb-0", "arcadedb-1"));
+    assertThat(f.getLearnedHosts()).containsExactlyInAnyOrder("arcadedb.myns.svc.cluster.local", "arcadedb-1");
+
+    f.setMemberHosts(List.of("arcadedb-0"));
+    assertThat(f.getLearnedHosts()).containsExactly("arcadedb.myns.svc.cluster.local");
+    assertThat(f.getPinnedHosts()).containsExactly("arcadedb.myns.svc.cluster.local");
+    assertThat(f.getMemberHosts()).isEmpty();
+  }
+
+  /** Reconciling to the same membership must not touch DNS: the tick runs on every node, forever. */
+  @Test
+  void reconcilingTheSameMembershipIsANoOp() {
+    final AtomicLong clock = new AtomicLong(0);
+    final PeerAddressAllowlistFilterTest.FakeResolver dns = new PeerAddressAllowlistFilterTest.FakeResolver();
+    dns.table.put("peerA", List.of("10.0.0.1"));
+    dns.table.put("peerB", List.of("10.0.0.2"));
+    final PeerAddressAllowlistFilter f = new PeerAddressAllowlistFilter(List.of("peerA"), 30_000L, 0L, 300_000L,
+        clock::get, dns);
+
+    assertThat(f.setMemberHosts(List.of("peerA", "peerB"))).isTrue();
+    assertThat(f.setMemberHosts(List.of("peerB", "peerA"))).as("order is irrelevant").isFalse();
+    assertThat(f.setMemberHosts(List.of("peerA"))).isTrue();
+    assertThat(f.setMemberHosts(List.of())).as("a configured host is never a learned host").isFalse();
+  }
+
+  /**
+   * The sticky last-known-good IPs must be pruned along with the host. Otherwise a departed peer whose name
+   * no longer resolves is readmitted the moment anything re-learns it, from a retention entry that outlived
+   * the membership it belonged to.
+   */
+  @Test
+  void aDroppedHostLosesItsStickyLastKnownIps() {
+    final AtomicLong clock = new AtomicLong(0);
+    final PeerAddressAllowlistFilterTest.FakeResolver dns = new PeerAddressAllowlistFilterTest.FakeResolver();
+    dns.table.put("peerA", List.of("10.0.0.1"));
+    dns.table.put("gone", List.of("10.0.0.9"));
+    final PeerAddressAllowlistFilter f = new PeerAddressAllowlistFilter(List.of("peerA"), 30_000L, 0L, 300_000L,
+        clock::get, dns);
+
+    f.setMemberHosts(List.of("gone"));
+    assertThat(f.getAllowedIps()).contains("10.0.0.9");
+
+    f.setMemberHosts(List.of());
+    assertThat(f.getAllowedIps()).doesNotContain("10.0.0.9");
+
+    // The peer is gone from DNS too, as a decommissioned pod is. Re-learning the name must resolve nothing:
+    // its pre-removal IPs are no longer retained on its behalf.
+    dns.table.remove("gone");
+    f.setMemberHosts(List.of("gone"));
+    assertThat(f.getAllowedIps()).as("a sticky entry must not outlive the membership that created it")
+        .doesNotContain("10.0.0.9");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Finding 2: the startup fail-open log line counts configured hosts only
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void theResolvedHostCountNeverExceedsTheConfiguredHostCount() {
+    final AtomicLong clock = new AtomicLong(0);
+    final PeerAddressAllowlistFilterTest.FakeResolver dns = new PeerAddressAllowlistFilterTest.FakeResolver();
+    dns.table.put("peerA", List.of("10.0.0.1"));
+    dns.table.put("learned-1", List.of("10.0.0.11"));
+    dns.table.put("learned-2", List.of("10.0.0.12"));
+    // peerB and peerC are not Ready yet, so the filter is still below quorum and still failing open.
+    final PeerAddressAllowlistFilter f = new PeerAddressAllowlistFilter(List.of("peerA", "peerB", "peerC"),
+        30_000L, 60_000L, 300_000L, clock::get, dns);
+
+    f.learnPeerHosts(List.of("learned-1"));
+    f.setMemberHosts(List.of("learned-2"));
+
+    assertThat(f.isQuorumResolved()).isFalse();
+    assertThat(f.getResolvedPeerHostCount())
+        .as("the count an operator reads against the configured total must count configured hosts only")
+        .isEqualTo(1);
+    assertThat(f.getResolvedPeerHostCount()).isLessThanOrEqualTo(3);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Wiring in RaftHAServer
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void reconcilingFromTheCommittedConfigurationUnlearnsARemovedPeer() {
+    final ContextConfiguration config = kubernetesConfiguration();
+    final RaftHAServer server = detachedServer(config);
+    server.buildParameters(config);
+    final PeerAddressAllowlistFilter filter = server.allowlistFilterForTest();
+
+    server.reconcileAllowlistMembership(List.of(peer("arcadedb-0"), peer("arcadedb-1")));
+    assertThat(filter.getLearnedHosts())
+        .containsExactlyInAnyOrder("arcadedb.myns.svc.cluster.local", "arcadedb-1.arcadedb.myns.svc.cluster.local");
+
+    server.reconcileAllowlistMembership(List.of(peer("arcadedb-0")));
+    assertThat(filter.getLearnedHosts()).as("the removed peer is unlearned, the seeded service domain is not")
+        .containsExactly("arcadedb.myns.svc.cluster.local");
+  }
+
+  /**
+   * {@code getCommittedPeersOrNull()} returns null while the division cannot be read (issue #5271), and
+   * {@code getLivePeers()} substitutes the DECLARED server list there. Replacing membership with the declared
+   * list would unlearn every runtime-joined peer on every restart window - exactly the #7132 regression.
+   */
+  @Test
+  void anUnreadableMembershipLeavesTheLearnedHostsAlone() {
+    final ContextConfiguration config = kubernetesConfiguration();
+    final RaftHAServer server = detachedServer(config); // Ratis server never started: membership is unreadable
+    server.buildParameters(config);
+    final PeerAddressAllowlistFilter filter = server.allowlistFilterForTest();
+
+    server.reconcileAllowlistMembership(List.of(peer("arcadedb-0"), peer("arcadedb-1")));
+    assertThat(filter.getMemberHosts()).contains("arcadedb-1.arcadedb.myns.svc.cluster.local");
+
+    assertThat(server.getCommittedPeersOrNull()).isNull();
+    server.refreshPeerAllowlist();
+
+    assertThat(filter.getMemberHosts()).as("no membership information is not the same as no members")
+        .contains("arcadedb-1.arcadedb.myns.svc.cluster.local");
+  }
+
+  /** A committed configuration always carries this node; a peer list that reduces to nothing is not membership. */
+  @Test
+  void aMembershipThatCarriesNoUsableHostIsIgnored() {
+    final ContextConfiguration config = kubernetesConfiguration();
+    final RaftHAServer server = detachedServer(config);
+    server.buildParameters(config);
+    final PeerAddressAllowlistFilter filter = server.allowlistFilterForTest();
+
+    server.reconcileAllowlistMembership(List.of(peer("arcadedb-1")));
+    assertThat(filter.getMemberHosts()).contains("arcadedb-1.arcadedb.myns.svc.cluster.local");
+
+    server.reconcileAllowlistMembership(List.of());
+    assertThat(filter.getMemberHosts()).contains("arcadedb-1.arcadedb.myns.svc.cluster.local");
+  }
+
+  private static RaftPeer peer(final String podName) {
+    return RaftPeer.newBuilder().setId(RaftPeerId.valueOf(podName))
+        .setAddress(podName + ".arcadedb.myns.svc.cluster.local:2434").build();
+  }
+
+  private static ContextConfiguration kubernetesConfiguration() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_SERVER_LIST, "arcadedb-0:2434:2480");
+    config.setValue(GlobalConfiguration.HA_K8S, true);
+    config.setValue(GlobalConfiguration.HA_K8S_DNS_SUFFIX, ".arcadedb.myns.svc.cluster.local");
+    return config;
+  }
+
+  /** A {@link RaftHAServer} whose constructor has run but whose Ratis server was never started. */
+  private static RaftHAServer detachedServer(final ContextConfiguration config) {
+    final ArcadeDBServer arcadeServer = mock(ArcadeDBServer.class);
+    when(arcadeServer.getServerName()).thenReturn("arcadedb-0");
+    return new RaftHAServer(arcadeServer, config);
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7225AllowlistUnlearnsRemovedPeersTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7225AllowlistUnlearnsRemovedPeersTest.java
@@ -143,6 +143,33 @@ class Issue7225AllowlistUnlearnsRemovedPeersTest {
         .doesNotContain("10.0.0.9");
   }
 
+  /**
+   * Pinning and membership can name the same host, and the contract is that the pin wins: it keeps the host
+   * admitted after the member leaves. Refusing the pin instead would make it evaporate at the next shrink,
+   * which is exactly when the caller wanted it. Nothing in the tree pins a peer hostname today - the one
+   * production caller pins the static Kubernetes headless-service domain - so this pins the contract rather
+   * than a live scenario, and it is the interaction the rest of the suite does not touch.
+   */
+  @Test
+  void aPinnedHostStaysAdmittedEvenWhenMembershipDropsIt() {
+    final AtomicLong clock = new AtomicLong(0);
+    final PeerAddressAllowlistFilterTest.FakeResolver dns = new PeerAddressAllowlistFilterTest.FakeResolver();
+    dns.table.put("peerA", List.of("10.0.0.1"));
+    dns.table.put("both", List.of("10.0.0.7"));
+    final PeerAddressAllowlistFilter f = new PeerAddressAllowlistFilter(List.of("peerA"), 30_000L, 0L, 300_000L,
+        clock::get, dns);
+
+    f.setMemberHosts(List.of("both"));
+    assertThat(f.learnPeerHosts(List.of("both"))).as("a pin is accepted even for a host that is a member").isTrue();
+    assertThat(f.getPinnedHosts()).containsExactly("both");
+    assertThat(f.getMemberHosts()).containsExactly("both");
+
+    f.setMemberHosts(List.of());
+    assertThat(f.getMemberHosts()).isEmpty();
+    assertThat(f.getPinnedHosts()).as("a pin outlives the membership that shared its name").containsExactly("both");
+    assertThat(f.isAllowed("10.0.0.7")).isTrue();
+  }
+
   // ---------------------------------------------------------------------------
   // Finding 2: the startup fail-open log line counts configured hosts only
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #7225

## Summary

#7132 taught the Raft gRPC allowlist to learn hosts from the live Raft configuration, which is what makes
Kubernetes scale-up work. The reconciliation ran in one direction only - `learnPeerHosts` merged
(`merged.addAll(added)`) and the class had no removal path at all - so a peer removed by
`DELETE /api/v1/cluster/peer/{id}` or by a StatefulSet scale-down kept inbound access to the Raft port, and
kept costing a DNS lookup on every refresh tick, for the rest of the process lifetime. `learnedHosts` is now
two sets with deliberately different lifetimes: `learnPeerHosts` **pins** a host for the life of the filter,
which is exactly what the Kubernetes headless-service seed needs (it admits a scale-up pod *before* that pod
is a member), while the new `setMemberHosts` **replaces** the membership-derived hosts wholesale, so a
departed peer's IPs leave `allowedIps` and its sticky last-known-good entries leave the retention maps on the
next health-monitor tick. `RaftHAServer` feeds that reconciliation from `getCommittedPeersOrNull()` rather
than `getLivePeers()`, because the two differ on precisely the case replace semantics is sensitive to:
`getLivePeers()` substitutes the DECLARED server list when the division cannot be read (#5271), and replacing
membership with the declared list would unlearn every runtime-joined peer for the whole restart window - the
#7132 regression in a new shape. The second, smaller finding is fixed with the same shared state: the startup
fail-open message counted `lastKnownIps`, a map keyed by configured *and* learned hosts, so it could report
more resolved hosts than there are configured ones; it now reports the configured hosts the last resolution
covered, which also removes that message's unsynchronised read of a plain `HashMap`.

## Test plan

- [ ] `mvn -o -pl ha-raft -am -DskipTests install` then
      `mvn -o -pl ha-raft test -Dtest=Issue7225AllowlistUnlearnsRemovedPeersTest` - 8 tests green.
- [ ] `mvn -o -pl ha-raft test -DexcludedGroups=benchmark,vector,slow` - 389 tests, 0 failures, 0 errors.
      (`LeaveClusterTest` crashed a surefire fork in one local run while another agent's server held port
      2480; run on its own it is green 2/2.)
- [ ] The #7132 tests are unmodified and still green - `learnPeerHosts` keeps its add-only contract.
- [ ] Manual, on a cluster: `DELETE /api/v1/cluster/peer/{id}`, then watch each surviving node log
      `Raft gRPC peer allowlist no longer admits 1 host(s) that left the Raft configuration: [...]` within one
      health-monitor tick, and confirm a new connection from that host is rejected.

### The tests were proved able to fail

Three falsification runs against deliberately reverted behaviour, each restored afterwards:

1. `setMemberHosts` merging instead of replacing, the sticky prune removed, the old `lastKnownIps.size()`
   count restored: **6 of 8 failed** (the two survivors pin the `RaftHAServer` policy, which that revert did
   not touch).
2. `refreshPeerAllowlist` reading `getLivePeers()` instead of `getCommittedPeersOrNull()`:
   `anUnreadableMembershipLeavesTheLearnedHostsAlone` failed.
3. The `memberHosts.isEmpty()` guard removed: `aMembershipThatCarriesNoUsableHostIsIgnored` failed.

## Coverage

| Entry point | Status |
|---|---|
| `HealthMonitor.tick` -> `refreshPeerAllowlist` -> membership shrink | fixed, tested |
| `refreshPeerAllowlist` while the committed configuration is unreadable (#5271) | fixed - membership left alone rather than replaced by the declared list; tested |
| `installPeerAllowlist` Kubernetes headless-service seed | fixed - pinned, survives every shrink; tested |
| `learnPeerHosts` (the pin API) | unchanged by design; existing #7132 tests unmodified and green |
| `doResolve()` sticky maps for a dropped host | fixed - `lastKnownIps`/`lastKnownMs` pruned to tracked hosts; tested |
| `isAllowed` startup fail-open log count | fixed - counts configured hosts only; tested |
| `DELETE /api/v1/cluster/peer/{id}` -> `removePeer` | argued: not a separate write path. It commits a new configuration; the reconciliation is the tick that reads it, at most one tick later |
| A departed peer that is ALSO in `arcadedb.ha.serverList` | argued: `serverList` is the operator's declared allowlist, and narrowing it is a configuration change, not something a Raft commit can do |

### Known gaps

- **#7250** - unlearning a removed peer does not close its **already-established** Raft gRPC transport.
  `ServerTransportFilter.transportReady` is the only gate the filter has, nothing overrides
  `transportTerminated`, and nothing asks Ratis to close a live transport. This PR revokes the ability to
  reconnect, not an open connection. Found in the adversarial pass on this branch and filed before opening it.
- **Argued, not filed:** on Kubernetes the pinned headless-service domain still resolves to every pod backing
  the service, so a peer removed from the Raft group but still Running and still published keeps access. That
  is inherent to the #7132 seed - the same property is what admits a scale-up pod before it joins - and a
  scale-down deletes the pod, which removes it from the service's A records.
- **Behaviour change worth knowing:** pruning `lastKnownIps` means a peer removed and re-added inside the
  sticky window, while its DNS is simultaneously down, is no longer readmitted from its pre-removal IPs. That
  is the intended direction for a revocation path.

Blast radius is unchanged from what the issue described: the filter provides no peer identity and is
explicitly not a substitute for mTLS (#3890), and gRPC authorization on the Raft port applies independently.
This is defence-in-depth revocation, not authentication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqxCPL284Ptg3FmjWo3goZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed Raft peers are now removed from the active allowlist without requiring a server restart.
  * Stale DNS addresses for removed peers are no longer retained.
  * Startup fail-open reporting now counts only configured hosts and provides clearer host details.
  * Membership information is preserved when configuration data is temporarily unavailable or empty.
  * Kubernetes headless-service connectivity remains available during membership changes.

* **Documentation**
  * Added detailed documentation covering the issue, behavior, testing, impact, and known limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->