### PR TITLE
feat(#7219): negotiate peer capabilities so a schema delta is never written to a peer that cannot read it

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1908,12 +1908,19 @@ public enum GlobalConfiguration {
       the next change against; on a multi-MB schema that is tens of MB of heap per database, released as soon as \
       the setting goes back off. \
       \
-      OFF BY DEFAULT, and it must stay off during a rolling upgrade. A node running a version that predates \
-      the delta section of SCHEMA_ENTRY cannot see it - it stops decoding after the sections it knows - and \
-      would apply an empty schema change and diverge SILENTLY. Reading a delta needs no configuration, so \
-      upgrade every node first, then turn this on: from that point every peer understands what the leader \
-      emits. Turning it back off is safe at any time.""",
-      Boolean.class, false),
+      ON BY DEFAULT since issue #7219, and safe there because the leader no longer takes the operator's word \
+      for it. A node running a version that predates the delta section of SCHEMA_ENTRY cannot see it - it stops \
+      decoding after the sections it knows - and would apply an empty schema change and diverge SILENTLY. The \
+      leader therefore asks every peer in its Raft configuration, over POST /api/v1/cluster/capabilities, \
+      whether it can decode one, and ships the whole document unless every peer has said yes: a peer that is \
+      unknown, unreachable, running a build without that endpoint, or whose answer has gone stale all count as \
+      no. A rolling upgrade needs no sequencing - deltas start by themselves once the last node is up. \
+      \
+      What this setting is FOR, now that it is not a safety interlock: turning deltas off is the way to give \
+      back the per-database schema document the leader holds to diff against, and the way to force whole \
+      documents while diagnosing a schema divergence. Turning it off is safe at any time; turning it back on \
+      costs one whole-document entry per database to re-prime the diff base.""",
+      Boolean.class, true),
 
   HA_BOOTSTRAP_FROM_LOCAL_DATABASE("arcadedb.ha.bootstrapFromLocalDatabase", SCOPE.SERVER,
       """

--- a/ha-raft/CLAUDE.md
+++ b/ha-raft/CLAUDE.md
@@ -85,3 +85,23 @@ Two constraints that are easy to miss:
 `SCHEMA_ENTRY` is **excluded**, not merely exempt, and the distinction matters: its optional sections are unframed and positional, so a decoder that has consumed the file maps reads whatever comes next as the #4382 WAL section's count. Append a frame to one and it is not skipped - the magic is read as that count and the entry is rejected as corrupt. Extend `SCHEMA_ENTRY` by adding another section to its own mechanism in `decodeSchemaEntry`, exactly as #5443 and #4416 did.
 
 The same issue moved decode failures off the node-halt path: a `RaftLogEntryDecodeException` naming a database quarantines that one database and resyncs it, and only a failure with no database name still halts the node. An *unknown type* is a different failure and still halts - skipping a committed mutation nobody can read is a silent divergence (#4798).
+
+## A new optional wire-format section needs a capability, not a setting
+
+`SCHEMA_ENTRY` is the one entry type that can be extended with unframed trailing sections (see above), and #6989 used that to append a schema delta. That is safe to *read* on any build that has the decoder, and unsafe to *write* to any build that does not: a peer that predates the section stops decoding before it, sees an entry with an empty `schemaJson`, applies nothing, logs nothing, and diverges. The divergence surfaces much later, as a WAL version gap or a `checkDatabase`.
+
+The first answer was a setting - `arcadedb.ha.schemaDelta`, off by default, with "upgrade every node first, then turn it on" in its javadoc. That is an operator instruction enforced by nothing, which is #7219.
+
+**Do not add another one.** Since #7219 a node publishes what it can decode at `POST /api/v1/cluster/capabilities`, the leader polls every peer in its Raft configuration every `PeerCapabilityRegistry.REFRESH_PERIOD_MS`, and an optional section is written only when every peer has answered that it understands it. To add a section:
+
+1. add a token to `PeerCapabilities` (permanent spelling - renaming one makes every older peer read as incapable, which is safe but silently turns the feature off cluster-wide) and put it in `PeerCapabilities.LOCAL`;
+2. gate the *emission* on `RaftHAServer.peersMissingCapability(token).isEmpty()`, the way `RaftReplicatedDatabase.schemaDeltaEnabled()` does;
+3. leave decoding unconditional, so the upgrade stays a one-way ratchet - every node reads the section before any node writes one.
+
+Three things about that mechanism that are easy to get wrong:
+
+- **A 404 is the answer, not an error.** A peer running a build with no capability route replies 404, which `PeerCapabilityQuery` raises as an `IOException` exactly like an unreachable peer, and the refresh *forgets* that peer. Forgetting rather than keeping matters: the peer may have been replaced by an older build, and believing its last answer until the TTL expires would be believing it for a reason that has gone away. Every unknown - never probed, unreachable, ambiguous address, stale - is a "no".
+- **It cannot ride the Raft log.** The obvious design, a `PEER_CAPABILITIES_ENTRY` every node applies, halts every not-yet-upgraded peer: an unrecognised type byte is a deliberate `triggerCriticalHalt()` in `ArcadeStateMachine.applyTransaction` (#4798), not a skip. HTTP is the module's other node-to-node transport for exactly this reason.
+- **The answer is bound to the peer that gave it.** `PeerDialAddress` withholds an address that identifies no single peer, and `PeerCapabilityQuery.parse` independently refuses an advertisement whose `peerId` is not the peer being probed. On a cluster that declares no `http` ports, several peers derive onto one address (#6202, #6267), and crediting one peer's answer to another is how a capability gets believed for a node that never claimed it.
+
+The cost of getting it wrong is asymmetric and worth restating: withholding a section that a peer could actually have read costs one larger Raft entry. Writing one a peer cannot read costs a silent schema divergence. Every arm of `PeerCapabilityRegistry` is written to fail the cheap way.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/GetClusterHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/GetClusterHandler.java
@@ -83,6 +83,11 @@ public class GetClusterHandler extends AbstractServerHttpHandler {
     final RaftPeerId localPeerId = raftHAServer.getLocalPeerId();
     response.put("localPeerId", localPeerId.toString());
 
+    // What THIS node can decode (issue #7219). Published next to the peer list below, which carries the same
+    // field per peer on the leader, so "which node is holding the cluster back" is one diff rather than a poll
+    // of every node in turn.
+    response.put("capabilities", capabilitiesArray(raftHAServer.getAdvertisedCapabilities()));
+
     // Local Raft lifecycle state (division-aware, issue #5271): a node whose group member is CLOSED
     // or EXCEPTION cannot vote or accept a leader's contact - surfacing it here is the only way an
     // operator can see that the cluster is running without failover margin.
@@ -177,6 +182,17 @@ public class GetClusterHandler extends AbstractServerHttpHandler {
       // A peer outside the configuration is not a follower: the leader does not replicate to it and it cannot
       // vote. Naming that state in the role keeps a consumer that only reads roles from mistaking it for one.
       peerJson.put("role", peerIsLeader ? "LEADER" : inConfiguration ? "FOLLOWER" : ROLE_NOT_IN_CONFIGURATION);
+
+      // Only the leader polls for capabilities, so only the leader has an answer to report; a follower simply
+      // omits the field rather than reporting an empty set that would read as "this peer can decode nothing".
+      final PeerCapabilityRegistry.Advertisement advertisement =
+          raftHAServer.getPeerCapabilityRegistry().freshAdvertisementOf(peerId);
+      if (advertisement != null) {
+        peerJson.put("capabilities", capabilitiesArray(advertisement.capabilities()));
+        if (!advertisement.version().isEmpty())
+          peerJson.put("version", advertisement.version());
+      } else if (peerIsLeader)
+        peerJson.put("capabilities", capabilitiesArray(raftHAServer.getAdvertisedCapabilities()));
 
       final HAReplicationStatsProvider.FollowerSample health = followerHealth.get(peerId);
       if (!peerIsLeader && health != null) {
@@ -283,6 +299,14 @@ public class GetClusterHandler extends AbstractServerHttpHandler {
         .put("divergedDatabases", ClusterAlerts.namesArray(ClusterAlerts.visible(state.divergedDatabases(), visibleDatabases)))
         .put("snapshotAppliedFloor", state.snapshotAppliedFloor())
         .put("databaseAppliedFloors", ClusterAlerts.visibleFloors(state.databaseAppliedFloors(), visibleDatabases));
+  }
+
+  /** A capability set as a stable, sorted JSON array, so two peers' documents can be diffed by eye. */
+  private static JSONArray capabilitiesArray(final Set<String> capabilities) {
+    final JSONArray array = new JSONArray();
+    for (final String capability : new TreeSet<>(capabilities))
+      array.put(capability);
+    return array;
   }
 
   private static boolean isPresenceRequested(final HttpServerExchange exchange) {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerCapabilities.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerCapabilities.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import java.util.Set;
+
+/**
+ * The vocabulary of wire-format capabilities one cluster node advertises to another, and the set THIS build
+ * advertises (issue #7219).
+ * <p>
+ * A Raft log entry carries no version field - the type byte is the whole envelope (see the module's
+ * {@code CLAUDE.md}) - so a leader cannot tell from the protocol whether a follower understands an optional
+ * section it is about to write. Before this existed, the answer was an operator instruction: "upgrade every node
+ * first, then turn {@code arcadedb.ha.schemaDelta} on". Get the order wrong and a pre-delta follower applied an
+ * empty schema change and diverged with no signal.
+ * <p>
+ * A capability is a short, stable token. It names what a receiver can DECODE, never what it prefers or what it is
+ * configured to do: the question the leader asks is "would this peer understand the bytes I am about to write",
+ * and a peer that can read a section must advertise it whether or not it would ever produce one.
+ * <p>
+ * <b>Tokens are permanent.</b> A token that has shipped keeps its exact spelling for as long as any supported
+ * version might advertise it; renaming one makes every older peer read as incapable, which is safe but silently
+ * turns the feature off across a whole cluster.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class PeerCapabilities {
+
+  /**
+   * This node decodes the trailing schema-delta section of {@code SCHEMA_ENTRY} (issue #6989).
+   * <p>
+   * Decoding it has been unconditional since the section existed, so advertising this token is a statement about
+   * the BUILD and not about {@code arcadedb.ha.schemaDelta}: a node with the setting off still decodes a delta
+   * happily, and must say so, or a cluster could never turn the feature on one node at a time.
+   */
+  public static final String SCHEMA_DELTA = "schema-delta";
+
+  /**
+   * Everything this build can decode. Immutable, and deliberately a whitelist written out by hand rather than
+   * derived from anything: a capability is a promise about the wire format, and the only thing that can make it
+   * true is a human having checked that the decoder is present.
+   */
+  public static final Set<String> LOCAL = Set.of(SCHEMA_DELTA);
+
+  private PeerCapabilities() {
+    // utility class
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerCapabilityQuery.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerCapabilityQuery.java
@@ -19,6 +19,7 @@
 package com.arcadedb.server.ha.raft;
 
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
@@ -31,6 +32,8 @@ import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
 
 /**
  * Asks one peer what wire-format sections it can decode, by calling its
@@ -38,7 +41,10 @@ import java.util.Set;
  * <p>
  * Transport, authentication and endpoint selection are {@link LeaderDatabaseQuery}'s, because this is the same
  * kind of call: the {@code X-ArcadeDB-Cluster-Token} + {@code X-ArcadeDB-Forwarded-User} pair every peer-to-peer
- * cluster RPC uses, and the peer's HTTPS endpoint preferred when {@code arcadedb.ssl.enabled} is set.
+ * cluster RPC uses, the peer's HTTPS endpoint preferred when {@code arcadedb.ssl.enabled} is set, and the same
+ * one-time warning when that preference cannot be honoured and the token goes over plain HTTP instead. That
+ * warning carries more weight here than at its origin: this query repeats for as long as the node leads, so the
+ * fallback is a standing condition rather than one request.
  * <p>
  * <b>A node that predates this route answers 404</b>, which arrives here as an {@link IOException} exactly like an
  * unreachable peer. That is the whole discriminator: no separate version comparison is needed, and none would be
@@ -61,6 +67,9 @@ public final class PeerCapabilityQuery {
   private static final HttpClient HTTP = HttpClient.newBuilder()
       .connectTimeout(Duration.ofSeconds(5))
       .build();
+
+  /** One-time warning that SSL is enabled but the probe fell back to plain HTTP for lack of an HTTPS address. */
+  private static final AtomicBoolean PLAIN_HTTP_FALLBACK_WARNED = new AtomicBoolean(false);
 
   private PeerCapabilityQuery() {
   }
@@ -87,6 +96,17 @@ public final class PeerCapabilityQuery {
     final String url = chooseUrl(httpAddr, httpsAddr, useSSL);
     if (url == null)
       throw new IOException("no peer address available for a capability query");
+    if (useSSL && !url.startsWith("https://") && PLAIN_HTTP_FALLBACK_WARNED.compareAndSet(false, true))
+      // The same one-time warning LeaderDatabaseQuery emits on the same fallback, and it matters MORE here: that
+      // query runs at a join or on an operator's request, while this one repeats every
+      // PeerCapabilityRegistry.REFRESH_PERIOD_MS for as long as the node leads. On a cluster that enables SSL but
+      // declares no 'https' ports, the cluster token would otherwise go out in clear text on this RPC
+      // indefinitely with nothing in the log to point at it. Named for the peer that first hit it, because the
+      // remedy is per-peer configuration; one line, because the cause is a configuration fact and not an event.
+      LogManager.instance().log(PeerCapabilityQuery.class, Level.WARNING,
+          "SSL is enabled but no HTTPS address is known for peer '%s'; its capability query - and the cluster "
+              + "token it carries - go over plain HTTP. Declare each node's 'https' port in %s.",
+          expectedPeerId, GlobalConfiguration.HA_SERVER_LIST.getKey());
 
     final HttpRequest.Builder builder = HttpRequest.newBuilder()
         .uri(URI.create(url))

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerCapabilityQuery.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerCapabilityQuery.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Asks one peer what wire-format sections it can decode, by calling its
+ * {@code POST /api/v1/cluster/capabilities} RPC (issue #7219).
+ * <p>
+ * Transport, authentication and endpoint selection are {@link LeaderDatabaseQuery}'s, because this is the same
+ * kind of call: the {@code X-ArcadeDB-Cluster-Token} + {@code X-ArcadeDB-Forwarded-User} pair every peer-to-peer
+ * cluster RPC uses, and the peer's HTTPS endpoint preferred when {@code arcadedb.ssl.enabled} is set.
+ * <p>
+ * <b>A node that predates this route answers 404</b>, which arrives here as an {@link IOException} exactly like an
+ * unreachable peer. That is the whole discriminator: no separate version comparison is needed, and none would be
+ * safe - a version string tells you what a build calls itself, not what its decoder actually handles.
+ * <p>
+ * <b>The answer is bound to the peer that gave it.</b> {@link #parse} refuses an advertisement whose {@code peerId}
+ * is not the one being probed. With no {@code http} port declared in {@code arcadedb.ha.serverList} a peer's
+ * endpoint is DERIVED, and on such a cluster several peers collapse onto one address (issues #6202, #6267); the
+ * dial is already guarded by {@link PeerDialAddress}, and this is the second half of the same guard - the guard
+ * withholds an address that identifies no single peer, this refuses an answer that came back from the wrong one.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class PeerCapabilityQuery {
+
+  /** What a peer says about itself. {@code version} is operator-facing only; nothing decides on it. */
+  public record Advertisement(String peerId, String version, Set<String> capabilities) {
+  }
+
+  private static final HttpClient HTTP = HttpClient.newBuilder()
+      .connectTimeout(Duration.ofSeconds(5))
+      .build();
+
+  private PeerCapabilityQuery() {
+  }
+
+  /**
+   * Synchronously asks {@code expectedPeerId} what it can decode.
+   *
+   * @param expectedPeerId the peer this address is believed to name; an answer from any other peer is refused.
+   * @param httpAddr       the peer plain-HTTP address ({@code host:port}).
+   * @param httpsAddr      the peer HTTPS address ({@code host:port}), or {@code null} when none is known.
+   * @param clusterToken   the inter-node cluster token, may be {@code null}/blank if not configured.
+   * @param timeoutMs      per-request timeout in milliseconds.
+   * @param server         the local server, used to read {@code arcadedb.ssl.enabled} and build the trust context.
+   *
+   * @throws IOException          on transport error, a non-200 response (which is what a peer without this route
+   *                              answers), or an advertisement that names another peer.
+   * @throws InterruptedException if the calling thread is interrupted while waiting.
+   */
+  public static Advertisement fetch(final String expectedPeerId, final String httpAddr, final String httpsAddr,
+      final String clusterToken, final long timeoutMs, final ArcadeDBServer server)
+      throws IOException, InterruptedException {
+
+    final boolean useSSL = server != null && server.getConfiguration().getValueAsBoolean(GlobalConfiguration.NETWORK_USE_SSL);
+    final String url = chooseUrl(httpAddr, httpsAddr, useSSL);
+    if (url == null)
+      throw new IOException("no peer address available for a capability query");
+
+    final HttpRequest.Builder builder = HttpRequest.newBuilder()
+        .uri(URI.create(url))
+        .timeout(Duration.ofMillis(timeoutMs))
+        .header("Content-Type", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString("{}"));
+    if (clusterToken != null && !clusterToken.isBlank())
+      builder.header("X-ArcadeDB-Cluster-Token", clusterToken);
+    builder.header("X-ArcadeDB-Forwarded-User", RaftHAServer.FORWARDED_ROOT_USER);
+    final HttpRequest request = builder.build();
+
+    if (url.startsWith("https://")) {
+      // A dedicated client carrying the cluster trust context, closed after the call - same reasoning as
+      // LeaderDatabaseQuery. This runs once per peer per refresh period, not on a hot path.
+      try (final HttpClient client = HttpClient.newBuilder()
+          .connectTimeout(Duration.ofSeconds(5))
+          .sslContext(SnapshotInstaller.buildSSLContext(server))
+          .build()) {
+        return parse(expectedPeerId, client.send(request, HttpResponse.BodyHandlers.ofString()), url);
+      }
+    }
+    return parse(expectedPeerId, HTTP.send(request, HttpResponse.BodyHandlers.ofString()), url);
+  }
+
+  /**
+   * Picks the endpoint URL. Prefers HTTPS when SSL is enabled and an HTTPS address is available; otherwise plain
+   * HTTP. {@code null} when no usable address was provided. Package-private and pure for unit testing.
+   */
+  static String chooseUrl(final String httpAddr, final String httpsAddr, final boolean useSSL) {
+    if (useSSL && httpsAddr != null)
+      return "https://" + httpsAddr + "/api/v1/cluster/capabilities";
+    if (httpAddr != null)
+      return "http://" + httpAddr + "/api/v1/cluster/capabilities";
+    return null;
+  }
+
+  private static Advertisement parse(final String expectedPeerId, final HttpResponse<String> response, final String url)
+      throws IOException {
+    if (response.statusCode() != 200)
+      throw new IOException("capability query to " + url + " returned HTTP " + response.statusCode());
+    return parse(expectedPeerId, response.body(), url);
+  }
+
+  /**
+   * Reads one advertisement document, refusing one that names a peer other than {@code expectedPeerId}.
+   * Package-private and pure for unit testing.
+   */
+  // @VisibleForTesting
+  static Advertisement parse(final String expectedPeerId, final String body, final String url) throws IOException {
+    final JSONObject json = new JSONObject(body);
+    final String peerId = json.getString("peerId", "");
+    if (!peerId.equals(expectedPeerId))
+      throw new IOException("capability query to " + url + " for peer '" + expectedPeerId
+          + "' was answered by peer '" + peerId + "'; the address does not identify the peer it was meant for "
+          + "(declare each node's 'http' port explicitly in " + GlobalConfiguration.HA_SERVER_LIST.getKey() + ")");
+
+    final Set<String> capabilities = new LinkedHashSet<>();
+    final JSONArray array = json.has("capabilities") ? json.getJSONArray("capabilities") : new JSONArray();
+    for (int i = 0; i < array.length(); i++)
+      capabilities.add(array.getString(i));
+
+    return new Advertisement(peerId, json.getString("version", ""), capabilities);
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerCapabilityRegistry.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerCapabilityRegistry.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
+
+/**
+ * What the leader knows about each peer's decoding capabilities, and how long it is entitled to keep believing it
+ * (issue #7219).
+ * <p>
+ * A pure cache: something else does the asking ({@link RaftHAServer#refreshPeerCapabilities} over
+ * {@link PeerCapabilityQuery}), and this holds the answers with the timestamp at which each was observed. Keeping
+ * the two apart is what lets every arm of the decision be pinned without a cluster - the arms that matter here
+ * are the ones that are invisible when they misfire, exactly like {@code RaftReplicatedDatabase.baseIsUsable}.
+ *
+ * <h2>Every unknown is a "no"</h2>
+ *
+ * {@link #peersMissing} treats these as identical, because the consequence of getting any of them wrong is the
+ * same silent divergence:
+ * <ul>
+ *   <li>a peer never probed (just added to the configuration, or its address is ambiguous so
+ *       {@link PeerDialAddress} refuses to dial it at all);</li>
+ *   <li>a peer whose probe failed - unreachable, or running a build with no capability route, which answers a
+ *       non-200 and is the discriminator this whole mechanism turns on;</li>
+ *   <li>a peer whose last answer is older than {@link #ttlMs}.</li>
+ * </ul>
+ *
+ * <h2>Why the answer expires</h2>
+ *
+ * A capability is a property of the build a peer is CURRENTLY running, and that can go backwards: an operator
+ * rolling back one pod puts an older build behind an id whose advertisement the leader already believes. The TTL
+ * bounds how long that window lasts - the leader stops shipping deltas to it within {@link #ttlMs} of the last
+ * successful probe - and it is why an advertisement is never cached indefinitely even though a peer's build
+ * changes only on restart.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class PeerCapabilityRegistry {
+
+  /** How often the leader re-asks every peer in its configuration. */
+  static final long REFRESH_PERIOD_MS = 5_000L;
+
+  /**
+   * Per-peer probe timeout. Short on purpose: the fan-out is sequential on one scheduled thread, so the whole
+   * round costs at most {@code peers x this}, and a peer that cannot answer in two seconds is reported unknown -
+   * which only ever costs a whole-document schema entry.
+   */
+  static final long PROBE_TIMEOUT_MS = 2_000L;
+
+  /**
+   * How long an advertisement is believed. Four refresh periods, so a peer has to miss several rounds - a GC
+   * pause, a brief network blip - before the leader gives up on it, while a genuine downgrade stops being
+   * believed within twenty seconds.
+   */
+  static final long ADVERTISEMENT_TTL_MS = 4 * REFRESH_PERIOD_MS;
+
+  /** One peer's last successful answer. */
+  public record Advertisement(Set<String> capabilities, String version, long observedAtMs) {
+  }
+
+  private final ConcurrentHashMap<String, Advertisement> advertisements = new ConcurrentHashMap<>();
+  private final long                                     ttlMs;
+
+  // Injectable clock for deterministic tests; defaults to the wall clock. Volatile because a test thread writes
+  // it while the capability-refresh thread reads it (consistent with ClusterMonitor's clock).
+  private volatile LongSupplier clock = System::currentTimeMillis;
+
+  public PeerCapabilityRegistry() {
+    this(ADVERTISEMENT_TTL_MS);
+  }
+
+  // @VisibleForTesting
+  PeerCapabilityRegistry(final long ttlMs) {
+    this.ttlMs = ttlMs;
+  }
+
+  // @VisibleForTesting
+  void setClock(final LongSupplier clock) {
+    this.clock = clock;
+  }
+
+  /**
+   * Records what {@code peerId} just answered. The capability set is copied and frozen, so a caller reusing its
+   * parsing buffer cannot mutate a recorded answer.
+   */
+  public void record(final String peerId, final Set<String> capabilities, final String version) {
+    advertisements.put(peerId, new Advertisement(Set.copyOf(capabilities), version, clock.getAsLong()));
+  }
+
+  /**
+   * Drops what was known about {@code peerId}, so it counts as incapable from the next question on. Called when a
+   * probe fails: a peer that stopped answering may have been replaced by an older build, and continuing to
+   * believe its last answer until the TTL runs out would be believing it for the wrong reason.
+   */
+  public void forget(final String peerId) {
+    advertisements.remove(peerId);
+  }
+
+  /**
+   * Forgets every peer outside {@code peerIds}, so a cluster that has removed and re-added peers over a long
+   * uptime does not accumulate their advertisements for the life of the leader.
+   */
+  public void retainOnly(final Collection<String> peerIds) {
+    advertisements.keySet().retainAll(new LinkedHashSet<>(peerIds));
+  }
+
+  /** {@code peerId}'s last answer if it is still within the TTL, {@code null} when unknown or expired. */
+  public Advertisement freshAdvertisementOf(final String peerId) {
+    final Advertisement advertisement = advertisements.get(peerId);
+    if (advertisement == null)
+      return null;
+    return clock.getAsLong() - advertisement.observedAtMs() <= ttlMs ? advertisement : null;
+  }
+
+  /**
+   * The peers of {@code peerIds} that have NOT proved they support {@code capability}, in the order given, so the
+   * caller can both decide and say which peer decided it. Empty means every peer is covered - including the
+   * vacuous case of a cluster with no other peer, where there is nobody left who could fail to understand the
+   * bytes.
+   */
+  public List<String> peersMissing(final Collection<String> peerIds, final String capability) {
+    final List<String> missing = new ArrayList<>();
+    for (final String peerId : peerIds) {
+      final Advertisement advertisement = freshAdvertisementOf(peerId);
+      if (advertisement == null || !advertisement.capabilities().contains(capability))
+        missing.add(peerId);
+    }
+    return missing.isEmpty() ? Collections.emptyList() : missing;
+  }
+
+  /** Whether every peer of {@code peerIds} has proved it supports {@code capability}. */
+  public boolean allPeersSupport(final Collection<String> peerIds, final String capability) {
+    return peersMissing(peerIds, capability).isEmpty();
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostCapabilitiesHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostCapabilitiesHandler.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.Constants;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.http.HttpServer;
+import com.arcadedb.server.http.handler.AbstractServerHttpHandler;
+import com.arcadedb.server.http.handler.ExecutionResponse;
+import com.arcadedb.server.security.ServerSecurityUser;
+import io.undertow.server.HttpServerExchange;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * {@code POST /api/v1/cluster/capabilities} - peer-to-peer capability advertisement RPC (issue #7219).
+ * <p>
+ * Answers what wire-format sections THIS node can decode, so a leader can decide whether it may write an optional
+ * section rather than leaving that to an operator's rolling-upgrade discipline. The response shape is:
+ * <pre>
+ *   {
+ *     "peerId": "arcadedb0",
+ *     "version": "26.9.1",
+ *     "capabilities": ["schema-delta"]
+ *   }
+ * </pre>
+ * <p>
+ * <b>The absence of this route is itself the answer.</b> A node running a build that predates it replies 404, which
+ * the caller reads as "cannot decode anything optional" - so no negotiation, no handshake and no version parsing is
+ * needed to be safe against a peer that has never heard of the mechanism.
+ * <p>
+ * {@code capabilities} is sorted so two nodes running the same build return byte-identical documents, which makes a
+ * diff between two peers' answers readable by eye. {@code version} is reported for the operator and for support
+ * logs; nothing decides on it, because a version string says what a build calls itself rather than what its decoder
+ * handles.
+ * <p>
+ * Authentication is inherited from {@link AbstractServerHttpHandler}: the {@code X-ArcadeDB-Cluster-Token} +
+ * {@code X-ArcadeDB-Forwarded-User} pair every other peer-to-peer cluster RPC uses. Root-only for the same reason
+ * {@link PostBootstrapStateHandler} is - it answers a whole-cluster question no single tenant can act on - and it is
+ * cheap by construction: it reads two in-memory constants and opens nothing.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class PostCapabilitiesHandler extends AbstractServerHttpHandler {
+
+  private final RaftHAPlugin plugin;
+
+  public PostCapabilitiesHandler(final HttpServer httpServer, final RaftHAPlugin plugin) {
+    super(httpServer);
+    this.plugin = plugin;
+  }
+
+  @Override
+  public ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user,
+      final JSONObject payload) {
+    checkRootUser(user);
+
+    final RaftHAServer raftHAServer = plugin.getRaftHAServer();
+    if (raftHAServer == null)
+      return new ExecutionResponse(400, new JSONObject().put("error", "Raft HA is not enabled").toString());
+
+    return new ExecutionResponse(200,
+        advertisement(raftHAServer.getLocalPeerId().toString(), raftHAServer.getAdvertisedCapabilities()).toString());
+  }
+
+  /**
+   * The advertisement document for {@code peerId}. Package-private and pure so the shape this contract depends on -
+   * the peer id a caller matches against, and the capability array - can be pinned without an HTTP server.
+   */
+  // @VisibleForTesting
+  static JSONObject advertisement(final String peerId, final Set<String> capabilities) {
+    final JSONArray array = new JSONArray();
+    for (final String capability : new TreeSet<>(capabilities))
+      array.put(capability);
+
+    return new JSONObject()
+        .put("peerId", peerId)
+        .put("version", Constants.getVersion())
+        .put("capabilities", array);
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -241,6 +241,10 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
     // Issue #4147: pre-bootstrap state RPC, used by the bootstrap leader at first cluster
     // formation to collect each peer's (fingerprint, lastTxId) per database.
     routes.addExactPath("/api/v1/cluster/bootstrap-state", new PostBootstrapStateHandler(httpServer, this));
+    // Issue #7219: peer-capability advertisement RPC, polled by the leader so it can decide for itself whether
+    // an optional wire-format section is safe to write. A node predating this route answers 404, and that 404 is
+    // the answer - see PostCapabilitiesHandler.
+    routes.addExactPath("/api/v1/cluster/capabilities", new PostCapabilitiesHandler(httpServer, this));
     LogManager.instance().log(this, Level.INFO, "Raft cluster management endpoints registered");
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -79,8 +79,10 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -200,6 +202,23 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   private volatile RaftTransactionBroker     transactionBroker;
   private          RaftClusterStatusExporter statusExporter;
   private          ScheduledExecutorService  lagMonitorExecutor;
+  // Peer-capability discovery (issue #7219). Leader-only: a follower writes no optional wire-format section,
+  // so it has no question to ask. Refreshed on its OWN scheduled thread rather than the lag monitor's, because
+  // a probe round is a sequential HTTP fan-out that can take peers x PROBE_TIMEOUT_MS, and replica
+  // classification must not be delayed by an unreachable peer's connect timeout - the same reasoning that keeps
+  // channelRecoveryExecutor off the resync executor below.
+  private          ScheduledExecutorService  capabilityMonitorExecutor;
+  private final    PeerCapabilityRegistry    peerCapabilities = new PeerCapabilityRegistry();
+  // What THIS node tells its peers it can decode. A field rather than PeerCapabilities.LOCAL read directly, so an
+  // integration test can stand a node up that behaves like a build predating a section - which is the only way to
+  // exercise a mixed-version cluster inside one JVM.
+  private volatile Set<String>               advertisedCapabilities = PeerCapabilities.LOCAL;
+  // Last capability set logged per peer, so the refresh reports a CHANGE (first observation, a peer losing a
+  // capability, an advertisement expiring) instead of a line per peer per five seconds.
+  private final    Map<String, Set<String>>  lastLoggedCapabilities = new ConcurrentHashMap<>();
+  // Sentinel stored in lastLoggedCapabilities for a peer whose last probe FAILED, so a repeated failure is
+  // distinguishable from a first one by identity. Not a capability set anyone reads - only ever compared with ==.
+  private static final Set<String>           PROBE_FAILED = Set.of("<probe-failed>");
   // Runs leader-driven stalled-replica resyncs off the lag-monitor thread (issue #4728). One worker is
   // enough since at most one resync fires per replica per stall streak; a small bounded queue with a
   // caller-runs policy degrades to running on the lag-monitor thread under the (unlikely) burst.
@@ -3846,6 +3865,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
       return t;
     });
     lagMonitorExecutor.scheduleAtFixedRate(statusExporter::checkReplicaLag, 5, 5, TimeUnit.SECONDS);
+    startCapabilityMonitor();
   }
 
   /**
@@ -3856,6 +3876,166 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
       lagMonitorExecutor.shutdownNow();
       lagMonitorExecutor = null;
     }
+    stopCapabilityMonitor();
+  }
+
+  /**
+   * Starts the leader-side peer-capability refresh (issue #7219).
+   * <p>
+   * The first round runs with NO initial delay, because until it lands every peer reads as incapable and the
+   * leader ships whole schema documents: correct, but it is the state the whole mechanism exists to leave, and a
+   * leader that has just been elected is precisely when a burst of DDL tends to arrive.
+   */
+  private void startCapabilityMonitor() {
+    if (capabilityMonitorExecutor != null)
+      return;
+    // A fresh term says nothing about what the peers can decode - a build does not change because an election
+    // happened - but the advertisements were observed under the previous leadership and their timestamps are
+    // what the TTL is measured against, so they are re-asked immediately rather than inherited silently.
+    lastLoggedCapabilities.clear();
+    capabilityMonitorExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+      final Thread t = new Thread(r, "arcadedb-raft-capability-monitor");
+      t.setDaemon(true);
+      return t;
+    });
+    capabilityMonitorExecutor.scheduleWithFixedDelay(this::refreshPeerCapabilities, 0,
+        PeerCapabilityRegistry.REFRESH_PERIOD_MS, TimeUnit.MILLISECONDS);
+  }
+
+  /** Stops the peer-capability refresh. Called when this node loses leadership. */
+  private void stopCapabilityMonitor() {
+    if (capabilityMonitorExecutor != null) {
+      capabilityMonitorExecutor.shutdownNow();
+      capabilityMonitorExecutor = null;
+    }
+  }
+
+  /**
+   * Asks every peer in the current Raft configuration what it can decode, and records the answers (issue #7219).
+   * <p>
+   * Sequential on the capability-monitor thread with a short per-peer timeout, so one unreachable peer costs the
+   * round {@link PeerCapabilityRegistry#PROBE_TIMEOUT_MS} and nothing else - {@code scheduleWithFixedDelay} (not
+   * {@code AtFixedRate}) keeps a slow round from queueing the next one behind it.
+   * <p>
+   * <b>Every failure forgets rather than keeps.</b> A peer that stopped answering may have been replaced by an
+   * older build, so continuing to believe its last answer until the TTL expires would be believing it for a
+   * reason that no longer holds.
+   */
+  // @VisibleForTesting
+  void refreshPeerCapabilities() {
+    try {
+      final List<RaftPeer> peers = configuredPeers();
+      final List<String> peerIds = new ArrayList<>(peers.size());
+      for (final RaftPeer peer : peers)
+        peerIds.add(peer.getId().toString());
+      // Bound the map by the live configuration: a long-lived leader of a cluster that has added and removed
+      // peers must not accumulate their advertisements for its whole uptime.
+      peerCapabilities.retainOnly(peerIds);
+
+      final String clusterToken = getClusterToken();
+      for (final RaftPeer peer : peers) {
+        final RaftPeerId peerId = peer.getId();
+        if (peerId.equals(localPeerId))
+          continue;
+
+        // The guarded address, not the best-effort one (issues #6202, #6267): an address that resolves to the
+        // wrong node would answer for a node that was never asked. PeerCapabilityQuery re-checks the peer id in
+        // the reply, so the two halves of the guard are independent.
+        final PeerDialAddress dial = PeerDialAddress.resolve(this, peerId, "peer");
+        if (dial.refused()) {
+          forgetPeerCapabilities(peerId.toString(), dial.refusal());
+          continue;
+        }
+
+        try {
+          final PeerCapabilityQuery.Advertisement advertisement = PeerCapabilityQuery.fetch(peerId.toString(),
+              dial.httpAddress(), dial.httpsAddress(), clusterToken, PeerCapabilityRegistry.PROBE_TIMEOUT_MS,
+              arcadeServer);
+          recordPeerCapabilities(peerId.toString(), advertisement);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+          forgetPeerCapabilities(peerId.toString(), "the capability query was interrupted");
+          return;
+        } catch (final Exception e) {
+          // A peer running a build without the capability route answers 404 and lands here, which is exactly the
+          // discriminator this mechanism turns on - so this arm is the NORMAL one during a rolling upgrade, not
+          // an error. forgetPeerCapabilities logs it once per change rather than once per round.
+          forgetPeerCapabilities(peerId.toString(), e.getMessage());
+        }
+      }
+    } catch (final Exception e) {
+      // Never let the scheduled task die: scheduleWithFixedDelay cancels the schedule on an escaped throwable,
+      // and a cancelled refresh is a leader that silently stops re-checking its peers.
+      LogManager.instance().log(this, Level.WARNING, "Peer-capability refresh round failed: %s", e.getMessage());
+    }
+  }
+
+  private void recordPeerCapabilities(final String peerId, final PeerCapabilityQuery.Advertisement advertisement) {
+    peerCapabilities.record(peerId, advertisement.capabilities(), advertisement.version());
+    final Set<String> previous = lastLoggedCapabilities.put(peerId, Set.copyOf(advertisement.capabilities()));
+    if (!advertisement.capabilities().equals(previous))
+      LogManager.instance().log(this, Level.INFO,
+          "Peer '%s' (version %s) advertises the cluster capabilities %s", peerId, advertisement.version(),
+          new TreeSet<>(advertisement.capabilities()));
+  }
+
+  private void forgetPeerCapabilities(final String peerId, final String reason) {
+    peerCapabilities.forget(peerId);
+    // Reported on the TRANSITION into the failed state and not once per refresh period: a peer that is
+    // permanently on an older build is the steady state of a half-finished rolling upgrade, and a line every five
+    // seconds about it would be noise. It is reported the FIRST time as well as on a regression from a known-good
+    // answer, because "no peer ever answered" and "a peer stopped answering" are both things an operator who has
+    // noticed their entries are not shrinking needs told - and the first of the two is otherwise completely
+    // silent, which is the failure mode this whole issue is about.
+    if (lastLoggedCapabilities.put(peerId, PROBE_FAILED) != PROBE_FAILED)
+      LogManager.instance().log(this, Level.WARNING,
+          "Peer '%s' does not advertise any cluster capability (%s); optional wire-format sections will not be "
+              + "written to this cluster until it answers again", peerId, reason);
+  }
+
+  /** The peer-capability cache this leader decides on (issue #7219). */
+  public PeerCapabilityRegistry getPeerCapabilityRegistry() {
+    return peerCapabilities;
+  }
+
+  /**
+   * Whether EVERY peer in the current Raft configuration has proved it can decode {@code capability}
+   * (issue #7219). False whenever any peer is unknown, unreachable, stale or explicitly without it, which is what
+   * makes an optional wire-format section safe to write without an operator sequencing the upgrade by hand.
+   */
+  public boolean allPeersSupport(final String capability) {
+    return peersMissingCapability(capability).isEmpty();
+  }
+
+  /**
+   * The peers of the current Raft configuration that have NOT proved they can decode {@code capability}, in
+   * configuration order (issue #7219). Empty means every peer is covered, so the section may be written.
+   * <p>
+   * The list rather than a boolean, because the peer that withholds the answer is the only actionable thing an
+   * operator can be told: "deltas are off" sends them to the setting, "peer arcadedb2 does not advertise
+   * schema-delta" sends them to the node that has not been upgraded.
+   */
+  public List<String> peersMissingCapability(final String capability) {
+    final List<String> peerIds = new ArrayList<>();
+    for (final RaftPeer peer : configuredPeers())
+      if (!peer.getId().equals(localPeerId))
+        peerIds.add(peer.getId().toString());
+    return peerCapabilities.peersMissing(peerIds, capability);
+  }
+
+  /** What this node tells its peers it can decode. */
+  public Set<String> getAdvertisedCapabilities() {
+    return advertisedCapabilities;
+  }
+
+  /**
+   * Overrides what this node advertises, so an integration test can stand up a node that behaves like a build
+   * predating a wire-format section. There is no other way to build a mixed-version cluster inside one JVM, and
+   * the mixed-version case is the one this mechanism exists for.
+   */
+  // @VisibleForTesting
+  void setAdvertisedCapabilities(final Set<String> capabilities) {
+    this.advertisedCapabilities = Set.copyOf(capabilities);
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
@@ -496,11 +496,13 @@ public final class RaftLogEntryCodec {
    *                    rule as every section before it. That makes it invisible to a node running an older
    *                    codec - which stops after the slices - and such a node would therefore see a
    *                    {@code SCHEMA_ENTRY} with an EMPTY schema JSON and apply NOTHING, diverging silently.
-   *                    <b>That is why emitting a delta is gated on {@code arcadedb.ha.schemaDelta}, which is
-   *                    off by default</b>: the leader keeps shipping whole documents until an operator turns
-   *                    deltas on, which is safe only once every peer understands them. Decoding is
+   *                    <b>That is why the leader asks before it emits one</b>: since issue #7219 it polls every
+   *                    peer in its Raft configuration over {@code POST /api/v1/cluster/capabilities} and ships
+   *                    the whole document unless all of them advertise {@link PeerCapabilities#SCHEMA_DELTA}. A
+   *                    node predating that endpoint answers 404, which is the answer. Decoding stays
    *                    unconditional, so the upgrade is a one-way ratchet - every node can read a delta before
-   *                    any node is allowed to write one.
+   *                    any node is allowed to write one - and {@code arcadedb.ha.schemaDelta} is now a kill
+   *                    switch on top of that rather than the interlock itself.
    */
   public static ByteString encodeSchemaEntry(final String databaseName, final String schemaJson,
       final Map<Integer, String> filesToAdd, final Map<Integer, String> filesToRemove,
@@ -980,6 +982,23 @@ public final class RaftLogEntryCodec {
       final byte[] raw = CompressionFactory.getDefault().decompress(compressed, uncompressedLen);
       schemaDelta = new SchemaDelta.Payload(baseVersion, new String(raw, StandardCharsets.UTF_8));
     }
+
+    // Nothing is written after the delta section by any producer in this codec, so bytes left here belong to a
+    // section a NEWER node added. Refusing beats accepting (issue #7219): every other section of this entry has
+    // already been read, so accepting would apply a change this node can only see part of - and the part it
+    // cannot see is, by construction, the part that carries meaning. A refusal is a RaftLogEntryDecodeException
+    // naming this database, which quarantines and resyncs that one database (#7138) - loud, scoped and
+    // self-healing, where the alternative is a schema that quietly stopped matching the leader's.
+    //
+    // A node predating the section it does not understand cannot be given this check retroactively, which is why
+    // it is only the backstop: the guarantee is peer-capability negotiation on the LEADER, which does not write a
+    // section until every peer has advertised it. This is what catches the release that forgets to declare one.
+    if (dis.available() > 0)
+      throw new IllegalStateException("SCHEMA_ENTRY for database '" + databaseName + "' carries " + dis.available()
+          + " trailing bytes after every section this version knows about; they belong to a section written by a "
+          + "newer node. Refusing the entry rather than applying the part that could be read. Whoever added that "
+          + "section must gate emitting it on a PeerCapabilities token (issue #7219), so a leader never writes it "
+          + "to a peer that cannot read it");
 
     return new DecodedEntry(RaftLogEntryType.SCHEMA_ENTRY, databaseName, null, null,
         schemaJson, filesToAdd, filesToRemove, walEntries, bucketDeltas, null, false, null, -1L, sealedFileBlobs,

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -220,8 +220,9 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * version-based guard would refuse every delta. It is carried in the payload for diagnostics only.
    * <p>
    * <b>Cost:</b> one parsed schema document retained per replicated database, which for the multi-MB schema this
-   * issue is about is tens of MB of heap. That is why it is held only while {@code arcadedb.ha.schemaDelta} is
-   * on - see {@link #rememberReplicatedSchema} - and why the base is kept parsed rather than as text: a diff
+   * issue is about is tens of MB of heap. That is why it is held only while a delta could actually ship - the
+   * setting on AND every peer advertising the capability, issue #7219; see {@link #rememberReplicatedSchema} -
+   * and why the base is kept parsed rather than as text: a diff
    * against text would have to re-parse it on every DDL, which is one of the very costs the delta exists to
    * avoid.
    */
@@ -238,6 +239,16 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    */
   private final        AtomicLong                                        schemaDeltasShipped      = new AtomicLong();
   private final        AtomicLong                                        schemaDocumentsShipped   = new AtomicLong();
+
+  /** Throttle window for the "deltas are on but withheld" report (issue #7219), per database. */
+  private static final long                                              SCHEMA_DELTA_WITHHELD_LOG_THROTTLE_MS = 5 * 60_000L;
+
+  /**
+   * When {@link #logSchemaDeltaWithheld} last reported that a peer is holding deltas back. Plain volatile rather
+   * than an atomic: a duplicate line costs nothing and the schema-replication path should not take a lock for a
+   * diagnostic.
+   */
+  private volatile     long                                              lastSchemaDeltaWithheldLog = 0L;
 
   /**
    * Memoized unreferenced-file count behind the (file modification count, schema version) gate (issue #6168).
@@ -2847,9 +2858,9 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * <p>
    * Null is returned - and the whole document shipped - whenever any of these is true:
    * <ul>
-   *   <li>{@code arcadedb.ha.schemaDelta} is off (the default). A node running a version that predates the
-   *       delta section cannot see it, so emitting one is only safe once every peer understands it; see
-   *       {@link GlobalConfiguration#HA_SCHEMA_DELTA}.</li>
+   *   <li>{@code arcadedb.ha.schemaDelta} is off, or some peer in the Raft configuration has not proved it can
+   *       decode a delta - unknown, unreachable, stale, or running a build that predates the section (issue
+   *       #7219). See {@link #schemaDeltaEnabled()}; both halves of that answer land in this one arm.</li>
    *   <li>Nothing has been shipped yet in this instance's lifetime, so there is no base to diff against.</li>
    *   <li>The Raft term moved since the cache was filled, so another node has been leader in between and what
    *       the followers hold is whatever IT shipped - see {@link #lastReplicatedSchema}. An unknown term
@@ -2920,14 +2931,65 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   }
 
   /**
-   * Whether this cluster wants schema deltas. Read off the SERVER's configuration, like every other
-   * {@code SCOPE.SERVER} setting this class consults ({@code HA_QUORUM_TIMEOUT},
-   * {@code HA_FORWARD_LEADER_WAIT_TIMEOUT_MS}): the per-database {@code ContextConfiguration} does not carry
-   * what a server-scoped setting was set to, so reading it there silently answers "default" - which for this
-   * setting means the feature never engages at all, and nothing fails.
+   * Whether this cluster may ship schema deltas right now: the setting allows it AND every peer in the Raft
+   * configuration has proved it can decode one (issue #7219).
+   * <p>
+   * The setting is read off the SERVER's configuration, like every other {@code SCOPE.SERVER} setting this class
+   * consults ({@code HA_QUORUM_TIMEOUT}, {@code HA_FORWARD_LEADER_WAIT_TIMEOUT_MS}): the per-database
+   * {@code ContextConfiguration} does not carry what a server-scoped setting was set to, so reading it there
+   * silently answers "default".
+   * <p>
+   * <b>The capability half is what makes the setting safe to default to on.</b> A delta rides an optional trailing
+   * section of {@code SCHEMA_ENTRY}; a node predating that section stops decoding before it, sees an entry with an
+   * empty {@code schemaJson}, applies nothing and diverges with no error. Until #7219 nothing could tell the leader
+   * that such a peer was in the cluster, so the setting carried an operator instruction ("upgrade every node
+   * first") that nothing enforced. Now the leader asks - {@link RaftHAServer#peersMissingCapability} - and any peer
+   * that is unknown, unreachable, stale or explicitly without the capability sends the whole document instead.
+   * <p>
+   * Read on every schema change rather than cached, so a peer that stops answering stops receiving deltas from the
+   * next DDL on, and one that finishes upgrading starts receiving them without a leader restart.
    */
   private boolean schemaDeltaEnabled() {
-    return server != null && server.getConfiguration().getValueAsBoolean(GlobalConfiguration.HA_SCHEMA_DELTA);
+    if (server == null || !server.getConfiguration().getValueAsBoolean(GlobalConfiguration.HA_SCHEMA_DELTA))
+      return false;
+
+    final RaftHAServer raft = raftHAServer;
+    if (raft == null)
+      // No Raft server to ask, so nothing has proved it can decode a delta. The same answer the capability
+      // registry gives for an unknown peer, for the same reason.
+      return false;
+
+    final List<String> missing = raft.peersMissingCapability(PeerCapabilities.SCHEMA_DELTA);
+    if (missing.isEmpty())
+      return true;
+
+    logSchemaDeltaWithheld(missing);
+    return false;
+  }
+
+  /**
+   * Reports, at most once per {@link #SCHEMA_DELTA_WITHHELD_LOG_THROTTLE_MS} per database, that deltas are
+   * configured but withheld and WHICH peers withheld them.
+   * <p>
+   * The whole failure mode this replaces was silent, and a mechanism that silently declines to engage is only
+   * marginally better than one that silently diverges: an operator who has turned the setting on and sees no
+   * change in entry sizes needs to be told that peer {@code arcadedb2} has not answered, not left to infer it.
+   * Throttled because the alternative is a line per DDL, and a bulk migration is thousands of them.
+   */
+  private void logSchemaDeltaWithheld(final List<String> peersMissingTheCapability) {
+    final long now = System.currentTimeMillis();
+    final long last = lastSchemaDeltaWithheldLog;
+    if (now - last < SCHEMA_DELTA_WITHHELD_LOG_THROTTLE_MS)
+      return;
+    // Racy by design: two DDL threads crossing the window at the same instant cost one duplicate line, which is
+    // a far better trade than a lock on the schema-replication path.
+    lastSchemaDeltaWithheldLog = now;
+    LogManager.instance().log(this, Level.INFO,
+        "Schema changes on database '%s' are shipping as whole documents even though %s is on: peer(s) %s have not "
+            + "advertised the '%s' capability, so a delta could not be decoded there (issue #7219). Upgrade or "
+            + "restore contact with those peers and deltas resume by themselves.",
+        getName(), GlobalConfiguration.HA_SCHEMA_DELTA.getKey(), peersMissingTheCapability,
+        PeerCapabilities.SCHEMA_DELTA);
   }
 
   /** The Raft term this node is in, or {@code -1} when it cannot be read (no server, division restarting). */
@@ -2960,10 +3022,15 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
           "Schema delta base for database '%s' updated outside a file recording session; the session is what "
               + "serializes the two writers, so this cache can now be torn (issue #6989)", getName());
 
-    // Only retained when deltas are actually wanted: the document is the size of the schema, and a cluster
-    // running the default configuration would otherwise pay several MB per replicated database for a base
-    // nothing will ever diff against. Turning the setting on at runtime costs one more whole-document entry -
-    // the base is null until then, which is already one of the fallback arms.
+    // Only retained when deltas can actually ship: the document is the size of the schema, and a cluster that
+    // cannot use it would otherwise pay several MB per replicated database for a base nothing will ever diff
+    // against. Deliberately the SAME predicate the emission gate uses (issue #7219), so a cluster holding a base
+    // is exactly a cluster that could ship a delta from it - a peer that has not advertised the capability
+    // releases the base too, rather than leaving the leader paying for a diff it may not send.
+    //
+    // The cost of the predicate flipping back to true - the setting turned on at runtime, or the last peer
+    // finishing its upgrade - is one more whole-document entry, because the base is null until then, which is
+    // already one of the fallback arms.
     final boolean wanted = schemaDeltaEnabled();
     lastReplicatedSchema = wanted ? fullSchema : null;
     lastReplicatedSchemaTerm = wanted ? currentRaftTerm() : -1L;

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7219CapabilityAdvertisementTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7219CapabilityAdvertisementTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7219: the advertisement document is a wire contract between two nodes that may be running different
+ * builds, so its shape - and the identity check the reader makes on it - are pinned here rather than left to an
+ * integration test that only ever exercises two identical nodes.
+ */
+class Issue7219CapabilityAdvertisementTest {
+
+  private static final String URL = "http://localhost:2480/api/v1/cluster/capabilities";
+
+  @Test
+  void thisBuildAdvertisesThatItDecodesSchemaDeltas() {
+    // The decoder has been unconditional since #6989, so this build must say so - otherwise a cluster of nodes
+    // that can all read a delta would never agree to write one.
+    assertThat(PeerCapabilities.LOCAL).contains(PeerCapabilities.SCHEMA_DELTA);
+  }
+
+  @Test
+  void theAdvertisementNamesThePeerItsVersionAndItsCapabilities() {
+    final JSONObject document = PostCapabilitiesHandler.advertisement("arcadedb0", Set.of(PeerCapabilities.SCHEMA_DELTA));
+
+    assertThat(document.getString("peerId")).isEqualTo("arcadedb0");
+    assertThat(document.getString("version", "")).isNotEmpty();
+    assertThat(document.getJSONArray("capabilities").toList()).containsExactly(PeerCapabilities.SCHEMA_DELTA);
+  }
+
+  @Test
+  void capabilitiesAreSortedSoTwoPeersDocumentsCanBeDiffed() {
+    final Set<String> unsorted = new LinkedHashSet<>();
+    unsorted.add("zeta");
+    unsorted.add("alpha");
+    unsorted.add("mu");
+
+    assertThat(PostCapabilitiesHandler.advertisement("arcadedb0", unsorted).getJSONArray("capabilities").toList())
+        .containsExactly("alpha", "mu", "zeta");
+  }
+
+  @Test
+  void anAdvertisementIsReadBackFromItsOwnDocument() throws IOException {
+    final String body = PostCapabilitiesHandler.advertisement("arcadedb1", Set.of(PeerCapabilities.SCHEMA_DELTA))
+        .toString();
+
+    final PeerCapabilityQuery.Advertisement parsed = PeerCapabilityQuery.parse("arcadedb1", body, URL);
+
+    assertThat(parsed.peerId()).isEqualTo("arcadedb1");
+    assertThat(parsed.capabilities()).containsExactly(PeerCapabilities.SCHEMA_DELTA);
+  }
+
+  @Test
+  void anAdvertisementFromAnotherPeerIsRejected() {
+    // With no 'http' port declared in arcadedb.ha.serverList a peer's endpoint is DERIVED, and several peers can
+    // collapse onto one address (#6202, #6267). PeerDialAddress withholds such an address, and this is the
+    // independent second half of that guard: an answer that came back from the wrong node must not be recorded
+    // against the node that was asked, or the leader would credit a capability to a peer that never claimed it.
+    final String body = PostCapabilitiesHandler.advertisement("arcadedb0", Set.of(PeerCapabilities.SCHEMA_DELTA))
+        .toString();
+
+    assertThatThrownBy(() -> PeerCapabilityQuery.parse("arcadedb1", body, URL))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("arcadedb1")
+        .hasMessageContaining("arcadedb0");
+  }
+
+  @Test
+  void anAdvertisementWithNoCapabilityArrayIsEmptyRatherThanAFailure() throws IOException {
+    // Forward compatibility in the other direction: a future build may answer with fields this one does not know
+    // about, and it must read as "nothing advertised" rather than throwing, which is a strictly safer answer.
+    final PeerCapabilityQuery.Advertisement parsed =
+        PeerCapabilityQuery.parse("arcadedb1", "{\"peerId\":\"arcadedb1\",\"somethingNew\":42}", URL);
+
+    assertThat(parsed.capabilities()).isEmpty();
+    assertThat(parsed.version()).isEmpty();
+  }
+
+  @Test
+  void theEndpointIsPreferredOverHttpsOnlyWhenSslIsOn() {
+    assertThat(PeerCapabilityQuery.chooseUrl("h:1", "h:2", false)).isEqualTo("http://h:1/api/v1/cluster/capabilities");
+    assertThat(PeerCapabilityQuery.chooseUrl("h:1", "h:2", true)).isEqualTo("https://h:2/api/v1/cluster/capabilities");
+    // SSL on but no HTTPS address resolved: fall back to the listener that is always there, exactly as
+    // LeaderDatabaseQuery does, rather than refusing to ask at all.
+    assertThat(PeerCapabilityQuery.chooseUrl("h:1", null, true)).isEqualTo("http://h:1/api/v1/cluster/capabilities");
+    assertThat(PeerCapabilityQuery.chooseUrl(null, null, false)).isNull();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7219MixedVersionSchemaDeltaIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7219MixedVersionSchemaDeltaIT.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.function.ToLongFunction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7219: a mixed-version cluster, covered by a test rather than by an operator instruction.
+ * <p>
+ * #7211 gave {@code SCHEMA_ENTRY} an optional trailing schema-delta section. A node whose build predates it stops
+ * decoding before the section, sees an entry with an EMPTY {@code schemaJson}, applies nothing, reports nothing,
+ * and diverges. The only thing standing between a cluster and that outcome was {@code arcadedb.ha.schemaDelta}
+ * being off by default plus an operator upgrading every node before turning it on - an instruction nothing
+ * enforced. This test is the enforcement.
+ * <p>
+ * <b>How a mixed-version cluster is built inside one JVM.</b> Every node here runs the same classes, so "old
+ * build" is simulated at the one place a build's identity actually enters the protocol:
+ * {@link RaftHAServer#setAdvertisedCapabilities} makes a node answer the capability RPC exactly as a build with no
+ * delta decoder would - it says it cannot decode one. That is a faithful stand-in for the case that matters,
+ * because the leader's decision consults nothing else: not a version string, not a build number, only what the
+ * peer said it can decode. The one case it does NOT reproduce is a peer with no capability route at all, which
+ * answers 404; that arm is covered by {@code Issue7219PeerCapabilityRegistryTest} (a failed probe forgets the
+ * peer, and a forgotten peer blocks the capability), because standing up a second, older jar is not something a
+ * single-JVM test can do.
+ * <p>
+ * Note what this class does NOT configure: {@code arcadedb.ha.schemaDelta}. Deltas ship here on the default,
+ * which is the third acceptance point of the issue.
+ */
+@Tag("slow")
+class Issue7219MixedVersionSchemaDeltaIT extends BaseRaftHATest {
+
+  private static final int SEED_TYPES  = 60;
+  private static final int DDL_CHANGES = 8;
+
+  /** How long the leader is given to notice a peer's advertisement change (a few refresh rounds). */
+  private static final long CAPABILITY_CONVERGENCE_TIMEOUT_MS = 30_000L;
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    config.setValue(GlobalConfiguration.HA_QUORUM, "majority");
+    // arcadedb.ha.schemaDelta is deliberately NOT set: since #7219 it defaults to on, and the negotiation below
+    // is what makes that safe. A test that turned it on by hand could not tell the two apart.
+  }
+
+  @Override
+  protected int getServerCount() {
+    return 2;
+  }
+
+  @Test
+  void aPeerThatCannotDecodeADeltaKeepsGettingWholeDocuments() throws InterruptedException {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+    final int replicaIndex = leaderIndex == 0 ? 1 : 0;
+
+    // The replica now behaves like a node whose build predates the delta section.
+    raftServerOf(replicaIndex).setAdvertisedCapabilities(Set.of());
+    awaitObservedIncapablePeer(leaderIndex, peerIdForIndex(replicaIndex));
+
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+    requireAPristineDatabase(leaderDb, "MixedSeed_0");
+    seedSchema(leaderDb, "MixedSeed_");
+
+    final long deltasBefore = schemaDeltasShipped();
+    final long documentsBefore = schemaDocumentsShipped();
+
+    for (int i = 0; i < DDL_CHANGES; i++) {
+      final int typeIndex = i;
+      leaderDb.transaction(() -> leaderDb.getSchema().getType("MixedSeed_" + typeIndex)
+          .createProperty("added_" + typeIndex, Type.INTEGER));
+    }
+
+    assertThat(schemaDeltasShipped() - deltasBefore)
+        .as("not one DDL may go out as a delta while a peer has not advertised that it can decode one - that "
+            + "entry would apply nothing on the peer and diverge silently")
+        .isZero();
+    assertThat(schemaDocumentsShipped() - documentsBefore)
+        .as("every DDL fell back to the whole document")
+        .isGreaterThanOrEqualTo(DDL_CHANGES);
+
+    // The fallback is not just quiet, it is correct: the peer that could not read a delta still has the schema.
+    assertClusterConsistency();
+    final Schema replicaSchema = getServerDatabase(replicaIndex, getDatabaseName()).getSchema();
+    for (int i = 0; i < DDL_CHANGES; i++)
+      assertThat(replicaSchema.getType("MixedSeed_" + i).existsProperty("added_" + i))
+          .as("DDL %d reached the peer that cannot decode deltas", i)
+          .isTrue();
+  }
+
+  @Test
+  void deltasResumeByThemselvesOnceEveryPeerAdvertisesTheCapability() throws InterruptedException {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+    final int replicaIndex = leaderIndex == 0 ? 1 : 0;
+
+    // Start the cluster in the mixed-version state, then "finish the rolling upgrade" mid-test. No leader
+    // restart, no setting change, no operator step: the point of the issue is that the cluster works this out.
+    raftServerOf(replicaIndex).setAdvertisedCapabilities(Set.of());
+    awaitObservedIncapablePeer(leaderIndex, peerIdForIndex(replicaIndex));
+
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+    requireAPristineDatabase(leaderDb, "UpgradeSeed_0");
+    seedSchema(leaderDb, "UpgradeSeed_");
+
+    raftServerOf(replicaIndex).setAdvertisedCapabilities(PeerCapabilities.LOCAL);
+    awaitObservedCapablePeer(leaderIndex, peerIdForIndex(replicaIndex));
+
+    // The first change after the upgrade re-primes the diff base and is a whole document BY DESIGN, and asserting
+    // that is the second half of the fix: rememberReplicatedSchema releases the base through the very same
+    // predicate the emission gate reads, so a cluster that cannot ship a delta is also not paying to hold the
+    // multi-MB document it would have diffed against. If the two ever drift apart this assertion is what says so.
+    final long documentsBeforePrimer = schemaDocumentsShipped();
+    final long deltasBeforePrimer = schemaDeltasShipped();
+    leaderDb.transaction(() -> leaderDb.getSchema().getType("UpgradeSeed_0").createProperty("primer", Type.STRING));
+    assertThat(schemaDocumentsShipped() - documentsBeforePrimer)
+        .as("the base was released while deltas were withheld, so the first change after the upgrade re-primes it")
+        .isGreaterThan(0);
+    assertThat(schemaDeltasShipped() - deltasBeforePrimer)
+        .as("and it cannot have been a delta - there was nothing to diff against")
+        .isZero();
+
+    final long deltasBefore = schemaDeltasShipped();
+    for (int i = 1; i <= DDL_CHANGES; i++) {
+      final int typeIndex = i;
+      leaderDb.transaction(() -> leaderDb.getSchema().getType("UpgradeSeed_" + typeIndex)
+          .createProperty("added_" + typeIndex, Type.INTEGER));
+    }
+
+    assertThat(schemaDeltasShipped() - deltasBefore)
+        .as("with every peer advertising the capability the leader ships deltas again, without anyone touching "
+            + GlobalConfiguration.HA_SCHEMA_DELTA.getKey())
+        .isGreaterThanOrEqualTo(DDL_CHANGES - 1);
+
+    assertClusterConsistency();
+    final Schema replicaSchema = getServerDatabase(replicaIndex, getDatabaseName()).getSchema();
+    for (int i = 1; i <= DDL_CHANGES; i++)
+      assertThat(replicaSchema.getType("UpgradeSeed_" + i).existsProperty("added_" + i))
+          .as("the property added by delta %d reached the replica", i)
+          .isTrue();
+  }
+
+  private RaftHAServer raftServerOf(final int serverIndex) {
+    final RaftHAPlugin plugin = getRaftPlugin(serverIndex);
+    assertThat(plugin).as("server %d runs the Raft HA plugin", serverIndex).isNotNull();
+    assertThat(plugin.getRaftHAServer()).as("server %d has started its Raft server", serverIndex).isNotNull();
+    return plugin.getRaftHAServer();
+  }
+
+  /**
+   * Waits until the leader has actually ASKED {@code peerId} and been told it cannot decode a delta.
+   * <p>
+   * Deliberately not "until the leader reports the peer as missing the capability": a peer the leader has never
+   * successfully probed reports exactly the same way, so a run in which the capability RPC was broken end to end
+   * would satisfy that weaker condition instantly - and the whole-document assertions that follow would then pass
+   * for the wrong reason, proving nothing about negotiation. Waiting for a recorded, empty advertisement means
+   * the probe demonstrably worked and the answer it carried is the one the test planted.
+   */
+  private void awaitObservedIncapablePeer(final int leaderIndex, final String peerId) throws InterruptedException {
+    awaitObservedCapabilities(leaderIndex, peerId,
+        capabilities -> capabilities != null && !capabilities.contains(PeerCapabilities.SCHEMA_DELTA),
+        "the leader must probe peer '" + peerId + "' and be told it cannot decode " + PeerCapabilities.SCHEMA_DELTA);
+  }
+
+  /** Waits until the leader has been told by {@code peerId} that it CAN decode a delta, and agrees. */
+  private void awaitObservedCapablePeer(final int leaderIndex, final String peerId) throws InterruptedException {
+    awaitObservedCapabilities(leaderIndex, peerId,
+        capabilities -> capabilities != null && capabilities.contains(PeerCapabilities.SCHEMA_DELTA),
+        "the leader must probe peer '" + peerId + "' and be told it can decode " + PeerCapabilities.SCHEMA_DELTA);
+    assertThat(raftServerOf(leaderIndex).peersMissingCapability(PeerCapabilities.SCHEMA_DELTA))
+        .as("and with that answer in hand the leader must consider the whole cluster covered")
+        .isEmpty();
+  }
+
+  private void awaitObservedCapabilities(final int leaderIndex, final String peerId,
+      final Predicate<Set<String>> settled, final String what) throws InterruptedException {
+    final RaftHAServer leader = raftServerOf(leaderIndex);
+    final long deadline = System.currentTimeMillis() + CAPABILITY_CONVERGENCE_TIMEOUT_MS;
+    Set<String> observed = observedCapabilities(leader, peerId);
+    while (!settled.test(observed) && leader.isLeader() && System.currentTimeMillis() < deadline) {
+      Thread.sleep(200);
+      observed = observedCapabilities(leader, peerId);
+    }
+    // Only the leader polls for capabilities, so a node that lost leadership mid-test stops refreshing and its
+    // advertisements go stale - which would otherwise read here as "the negotiation is broken" and cost the next
+    // reader half an hour. This test pins one leader (its DDL has to run there) so an election is a failed
+    // PRECONDITION, and it says so rather than timing out silently.
+    assertThat(leader.isLeader())
+        .as("this test pins the leader it elected at the start; %s lost leadership mid-test, so the capability "
+            + "refresh it drives stopped", leader.getLocalPeerId())
+        .isTrue();
+    // A wall-clock bound used as a hang detector, not as a latency assertion: the refresh runs every
+    // PeerCapabilityRegistry.REFRESH_PERIOD_MS, so a budget of several rounds only ever fires when the leader
+    // stopped asking altogether.
+    assertThat(settled.test(observed))
+        .as(what + " (leader is %s, last observed advertisement: %s)", leader.getLocalPeerId(), observed)
+        .isTrue();
+  }
+
+  private static Set<String> observedCapabilities(final RaftHAServer leader, final String peerId) {
+    final PeerCapabilityRegistry.Advertisement advertisement =
+        leader.getPeerCapabilityRegistry().freshAdvertisementOf(peerId);
+    return advertisement != null ? advertisement.capabilities() : null;
+  }
+
+  private void seedSchema(final Database leaderDb, final String prefix) {
+    leaderDb.transaction(() -> {
+      final Schema schema = leaderDb.getSchema();
+      for (int i = 0; i < SEED_TYPES; i++) {
+        final DocumentType type = schema.createVertexType(prefix + i);
+        type.createProperty("id_" + i, Type.STRING);
+        type.createProperty("name_" + i, Type.STRING);
+        type.createProperty("payload_" + i, Type.STRING);
+      }
+    });
+  }
+
+  /** Same guard as {@code Issue6989SchemaDeltaReplicationIT}: the counters are only readable from a clean base. */
+  private void requireAPristineDatabase(final Database leaderDb, final String firstSeededType) {
+    assertThat(leaderDb.getSchema().existsType(firstSeededType))
+        .as("this test seeds its own schema and needs a pristine database; remove the leftover "
+            + "ha-raft/target/databases* directories an aborted run left behind")
+        .isFalse();
+  }
+
+  /** The leader can move between tests, so ask every node rather than guessing which one shipped. */
+  private long schemaDeltasShipped() {
+    return sumOverNodes(RaftReplicatedDatabase::getSchemaDeltasShipped);
+  }
+
+  private long schemaDocumentsShipped() {
+    return sumOverNodes(RaftReplicatedDatabase::getSchemaDocumentsShipped);
+  }
+
+  private long sumOverNodes(final ToLongFunction<RaftReplicatedDatabase> counter) {
+    long total = 0;
+    for (int i = 0; i < getServerCount(); i++) {
+      final DatabaseInternal wrapped =
+          ((DatabaseInternal) getServerDatabase(i, getDatabaseName())).getWrappedDatabaseInstance();
+      if (wrapped instanceof final RaftReplicatedDatabase raft)
+        total += counter.applyAsLong(raft);
+    }
+    return total;
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7219PeerCapabilityRegistryTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7219PeerCapabilityRegistryTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7219: the leader may write an optional wire-format section only when EVERY peer has proved it can
+ * decode it. This pins the arms of that decision.
+ * <p>
+ * The arms are pinned here rather than in the cluster, for the same reason
+ * {@code RaftReplicatedDatabase.baseIsUsable} is: every one of them fails SILENTLY. A registry that answers
+ * "capable" for a peer it has never heard of does not break replication - it makes the leader write a section the
+ * peer cannot read, which shows up later as a schema that quietly stopped matching. Nothing in an integration
+ * test goes red on that.
+ */
+class Issue7219PeerCapabilityRegistryTest {
+
+  private static final String CAP   = PeerCapabilities.SCHEMA_DELTA;
+  private static final String PEER1 = "arcadedb1";
+  private static final String PEER2 = "arcadedb2";
+
+  private final AtomicLong             now      = new AtomicLong(1_000_000L);
+  private final PeerCapabilityRegistry registry = newRegistry();
+
+  private PeerCapabilityRegistry newRegistry() {
+    final PeerCapabilityRegistry created = new PeerCapabilityRegistry(PeerCapabilityRegistry.ADVERTISEMENT_TTL_MS);
+    created.setClock(now::get);
+    return created;
+  }
+
+  @Test
+  void aClusterWithNoOtherPeerIsCapable() {
+    // A single-node cluster has nobody who could fail to understand the bytes. Vacuously true, and it has to be
+    // true or a one-node deployment would never use any optional section.
+    assertThat(registry.allPeersSupport(List.of(), CAP)).isTrue();
+    assertThat(registry.peersMissing(List.of(), CAP)).isEmpty();
+  }
+
+  @Test
+  void anUnknownPeerBlocksTheCapability() {
+    // Never probed: a peer just added to the configuration, or one whose address PeerDialAddress refuses to
+    // hand out because it identifies no single node (#6202). Both arrive here as "no entry".
+    assertThat(registry.allPeersSupport(List.of(PEER1), CAP)).isFalse();
+    assertThat(registry.peersMissing(List.of(PEER1), CAP)).containsExactly(PEER1);
+  }
+
+  @Test
+  void aPeerThatAdvertisedTheCapabilityIsCapable() {
+    registry.record(PEER1, Set.of(CAP), "26.10.1");
+
+    assertThat(registry.allPeersSupport(List.of(PEER1), CAP)).isTrue();
+    assertThat(registry.freshAdvertisementOf(PEER1).version()).isEqualTo("26.10.1");
+  }
+
+  @Test
+  void aPeerThatAnsweredWithoutTheCapabilityBlocksIt() {
+    // A build that HAS the capability endpoint but does not decode this particular section - the shape every
+    // future capability will arrive in, and the one a version comparison would get wrong.
+    registry.record(PEER1, Set.of("some-other-capability"), "26.10.1");
+
+    assertThat(registry.allPeersSupport(List.of(PEER1), CAP)).isFalse();
+    assertThat(registry.peersMissing(List.of(PEER1), CAP)).containsExactly(PEER1);
+  }
+
+  @Test
+  void oneIncapablePeerBlocksTheWholeCluster() {
+    registry.record(PEER1, Set.of(CAP), "26.10.1");
+
+    assertThat(registry.allPeersSupport(List.of(PEER1, PEER2), CAP))
+        .as("PEER2 has never answered, so the cluster is not covered even though PEER1 is")
+        .isFalse();
+    assertThat(registry.peersMissing(List.of(PEER1, PEER2), CAP)).containsExactly(PEER2);
+  }
+
+  @Test
+  void anExpiredAdvertisementBlocksTheCapability() {
+    registry.record(PEER1, Set.of(CAP), "26.10.1");
+    assertThat(registry.allPeersSupport(List.of(PEER1), CAP)).isTrue();
+
+    // Still inside the window: several missed refresh rounds are absorbed on purpose, so a GC pause on one peer
+    // does not cost the whole cluster its deltas.
+    now.addAndGet(PeerCapabilityRegistry.ADVERTISEMENT_TTL_MS);
+    assertThat(registry.allPeersSupport(List.of(PEER1), CAP))
+        .as("an answer exactly at the TTL boundary is still believed")
+        .isTrue();
+
+    // Past it: a peer rolled back to an older build sits behind the same id, and this is the bound on how long
+    // the leader keeps writing sections it can no longer read.
+    now.addAndGet(1L);
+    assertThat(registry.allPeersSupport(List.of(PEER1), CAP)).isFalse();
+    assertThat(registry.freshAdvertisementOf(PEER1)).isNull();
+  }
+
+  @Test
+  void aPeerThatLostTheCapabilityBlocksItAgain() {
+    registry.record(PEER1, Set.of(CAP), "26.10.1");
+    assertThat(registry.allPeersSupport(List.of(PEER1), CAP)).isTrue();
+
+    // What a failed probe does - a 404 from a build without the route, or an unreachable peer. Forgetting rather
+    // than keeping matters: the peer may have been replaced by an older build, and believing its last answer
+    // until the TTL ran out would be believing it for a reason that no longer holds.
+    registry.forget(PEER1);
+
+    assertThat(registry.allPeersSupport(List.of(PEER1), CAP)).isFalse();
+  }
+
+  @Test
+  void aPeerOutsideTheConfigurationDoesNotBlock() {
+    registry.record(PEER1, Set.of(CAP), "26.10.1");
+
+    // PEER2 was never asked about, because the question is only ever about the peers the leader replicates to.
+    assertThat(registry.allPeersSupport(List.of(PEER1), CAP)).isTrue();
+  }
+
+  @Test
+  void retainOnlyDropsPeersNoLongerInTheConfiguration() {
+    registry.record(PEER1, Set.of(CAP), "26.10.1");
+    registry.record(PEER2, Set.of(CAP), "26.10.1");
+
+    registry.retainOnly(List.of(PEER1));
+
+    assertThat(registry.freshAdvertisementOf(PEER1)).isNotNull();
+    assertThat(registry.freshAdvertisementOf(PEER2))
+        .as("a peer the configuration dropped must not keep an advertisement for the leader's whole uptime")
+        .isNull();
+  }
+
+  @Test
+  void aRecordedCapabilitySetCannotBeMutatedByItsCaller() {
+    // The refresh loop parses into its own set; a recorded answer that shared that set could change under the
+    // gate between two DDLs.
+    final Set<String> parsed = new java.util.LinkedHashSet<>(Set.of(CAP));
+    registry.record(PEER1, parsed, "26.10.1");
+    parsed.clear();
+
+    assertThat(registry.allPeersSupport(List.of(PEER1), CAP)).isTrue();
+  }
+
+  @Test
+  void everyMissingPeerIsNamed() {
+    // peersMissing is not just a boolean in disguise: it is what the operator log names, and "which node is
+    // holding the cluster back" is the only actionable half of the answer.
+    registry.record(PEER1, Set.of(CAP), "26.10.1");
+
+    assertThat(registry.peersMissing(List.of(PEER1, PEER2, "arcadedb3"), CAP))
+        .containsExactly(PEER2, "arcadedb3");
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7219SchemaEntryTrailingSectionTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7219SchemaEntryTrailingSectionTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7219, the receiver-side backstop: a {@code SCHEMA_ENTRY} carrying a section this version does not know
+ * about is refused rather than half-applied.
+ * <p>
+ * Peer-capability negotiation is the guarantee - a leader does not write an optional section until every peer has
+ * advertised that it decodes it. This is what catches the release that adds a section and forgets to declare a
+ * capability for it. It cannot help a node that predates the section (nothing can, retroactively), which is
+ * exactly why the leader-side gate is the primary mechanism and this is only the second line.
+ * <p>
+ * The refusal is a decode failure naming the database, so it quarantines and resyncs that one database (#7138)
+ * instead of halting the node - loud and recoverable, where accepting the entry would be silent and permanent.
+ */
+class Issue7219SchemaEntryTrailingSectionTest {
+
+  private static final String DB = "mydb";
+
+  @Test
+  void anEntryWithNoTrailingSectionStillDecodes() {
+    // The control: everything this version writes must keep decoding, or the check below is just breakage.
+    final ByteString entry = RaftLogEntryCodec.encodeSchemaEntry(DB, "{\"schemaVersion\":7}",
+        Map.of(3, "one.bucket"), Collections.emptyMap());
+
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(entry);
+
+    assertThat(decoded.type()).isEqualTo(RaftLogEntryType.SCHEMA_ENTRY);
+    assertThat(decoded.schemaJson()).isEqualTo("{\"schemaVersion\":7}");
+    assertThat(decoded.schemaDelta()).isNull();
+  }
+
+  @Test
+  void aDeltaBearingEntryStillDecodes() {
+    final ByteString entry = RaftLogEntryCodec.encodeSchemaEntry(DB, "", Collections.emptyMap(),
+        Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), false,
+        Collections.emptyList(), new SchemaDelta.Payload(41L, "{\"types\":{}}"));
+
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(entry);
+
+    assertThat(decoded.schemaDelta()).isNotNull();
+    assertThat(decoded.schemaDelta().baseVersion()).isEqualTo(41L);
+  }
+
+  @Test
+  void aSectionAppendedAfterTheDeltaIsRefusedRatherThanIgnored() {
+    // What a newer node adding a section would produce. Before #7219 these bytes were dropped on the floor and
+    // the entry applied as if the section were not there - the silent half-apply this issue is about.
+    final ByteString entry = RaftLogEntryCodec.encodeSchemaEntry(DB, "", Collections.emptyMap(),
+        Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), false,
+        Collections.emptyList(), new SchemaDelta.Payload(41L, "{\"types\":{}}"));
+
+    final ByteString withFutureSection = entry.concat(ByteString.copyFrom(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }));
+
+    assertThatThrownBy(() -> RaftLogEntryCodec.decode(withFutureSection))
+        .isInstanceOf(RaftLogEntryDecodeException.class)
+        .hasMessageContaining(DB)
+        .hasMessageContaining("trailing bytes")
+        .hasMessageContaining("7219");
+  }
+
+  @Test
+  void theRefusalNamesTheDatabaseSoItQuarantinesRatherThanHaltingTheNode() {
+    // The database name is what routes a decode failure to a per-database quarantine instead of a node-wide halt
+    // (#7138). A refusal that lost it would take the whole node down for one unreadable entry.
+    final ByteString entry = RaftLogEntryCodec.encodeSchemaEntry(DB, "", Collections.emptyMap(),
+        Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), false,
+        Collections.emptyList(), new SchemaDelta.Payload(41L, "{\"types\":{}}"))
+        .concat(ByteString.copyFrom(new byte[] { 9, 9, 9, 9 }));
+
+    assertThatThrownBy(() -> RaftLogEntryCodec.decode(entry))
+        .asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.throwable(RaftLogEntryDecodeException.class))
+        .extracting(RaftLogEntryDecodeException::getDatabaseName)
+        .isEqualTo(DB);
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/PluginApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/PluginApiSpec.java
@@ -67,7 +67,7 @@ public class PluginApiSpec implements OpenApiContributor {
       "/api/v1/cluster", "/api/v1/cluster/peer", "/api/v1/cluster/peer/{peerId}",
       "/api/v1/cluster/leader", "/api/v1/cluster/stepdown", "/api/v1/cluster/leave",
       "/api/v1/cluster/verify/{database}", "/api/v1/cluster/resync/{database}",
-      "/api/v1/cluster/bootstrap-state",
+      "/api/v1/cluster/bootstrap-state", "/api/v1/cluster/capabilities",
       "/api/v1/ha/snapshot/{database}", "/api/v1/ha/snapshot/{database}/checksums");
 
   /**
@@ -94,6 +94,7 @@ public class PluginApiSpec implements OpenApiContributor {
     openAPI.getPaths().addPathItem("/api/v1/cluster/verify/{database}", createVerifyPath());
     openAPI.getPaths().addPathItem("/api/v1/cluster/resync/{database}", createResyncPath());
     openAPI.getPaths().addPathItem("/api/v1/cluster/bootstrap-state", createBootstrapStatePath());
+    openAPI.getPaths().addPathItem("/api/v1/cluster/capabilities", createCapabilitiesPath());
     openAPI.getPaths().addPathItem("/api/v1/ha/snapshot/{database}", createSnapshotPath());
     openAPI.getPaths().addPathItem("/api/v1/ha/snapshot/{database}/checksums", createChecksumsPath());
 
@@ -103,6 +104,7 @@ public class PluginApiSpec implements OpenApiContributor {
     openAPI.getComponents().addSchemas("ClusterActionResponse", createClusterActionResponseSchema());
     openAPI.getComponents().addSchemas("VerifyDatabaseResponse", createVerifyResponseSchema());
     openAPI.getComponents().addSchemas("BootstrapStateResponse", createBootstrapStateResponseSchema());
+    openAPI.getComponents().addSchemas("PeerCapabilitiesResponse", createPeerCapabilitiesResponseSchema());
   }
 
   private PathItem createScrapePath() {
@@ -305,6 +307,30 @@ public class PluginApiSpec implements OpenApiContributor {
     return pathItem;
   }
 
+  private PathItem createCapabilitiesPath() {
+    final Operation post = SpecBuilders.operation("getClusterPeerCapabilities", "Cluster",
+        "Report the wire-format capabilities of this peer",
+        """
+            Reports the optional replication wire-format sections this node can DECODE, as short stable \
+            tokens. The leader polls it on every peer of its Raft configuration and writes an optional \
+            section only when every peer has advertised it, so a rolling upgrade needs no ordering by \
+            hand (issue #7219).
+
+            A node running a release without this route answers 404, and the caller reads that as 'this \
+            peer can decode nothing optional' - which is why the route is safe to add and why no version \
+            comparison takes part in the decision.
+
+            Restricted to the root user; peers satisfy this by forwarding as root with the cluster \
+            token. """ + RAFT_REQUIRED);
+    post.setResponses(SpecBuilders.standardResponses("200",
+        SpecBuilders.jsonResponse("Peer capabilities", "PeerCapabilitiesResponse"),
+        "400", "401", "403", "500"));
+
+    final PathItem pathItem = new PathItem();
+    pathItem.setPost(post);
+    return pathItem;
+  }
+
   private PathItem createSnapshotPath() {
     final Operation get = SpecBuilders.operation("downloadDatabaseSnapshot", "Cluster",
         "Download a database snapshot",
@@ -404,6 +430,13 @@ public class PluginApiSpec implements OpenApiContributor {
         "Mean replication round-trip time. Absent when no sample exists."));
     peer.addProperty("replicationRttP99Ms", SpecBuilders.integer(
         "99th percentile replication round-trip time. Absent when no sample exists."));
+    peer.addProperty("capabilities", SpecBuilders.arrayOf(SpecBuilders.string("Capability token"),
+        "Optional wire-format sections this peer can decode, as last observed by the leader (issue #7219). "
+            + "Absent on a follower, which does not poll, and on the leader for a peer it has not reached: an "
+            + "absent array means 'not known', which the leader treats exactly like 'cannot decode'."));
+    peer.addProperty("version", SpecBuilders.string(
+        "Server version this peer reported alongside its capabilities. Absent when the leader has no fresh "
+            + "answer from it."));
 
     final Schema<Object> database = SpecBuilders.object("One database's cluster state");
     database.addProperty("name", SpecBuilders.string("Database name"));
@@ -422,6 +455,8 @@ public class PluginApiSpec implements OpenApiContributor {
     schema.addProperty("implementation", SpecBuilders.string("Always 'raft'"));
     schema.addProperty("clusterName", SpecBuilders.string("Configured cluster name"));
     schema.addProperty("localPeerId", SpecBuilders.string("This server's peer identifier"));
+    schema.addProperty("capabilities", SpecBuilders.arrayOf(SpecBuilders.string("Capability token"),
+        "Optional wire-format sections THIS node can decode, sorted (issue #7219)"));
     schema.addProperty("raftState", SpecBuilders.string("Raft lifecycle state"));
     schema.addProperty("isLeader", SpecBuilders.bool("True when this server is the leader"));
     schema.addProperty("leaderReady", SpecBuilders.bool(
@@ -546,6 +581,18 @@ public class PluginApiSpec implements OpenApiContributor {
     final Schema<Object> schema = SpecBuilders.object("Per-database bootstrap state of one peer");
     schema.addProperty("databases", SpecBuilders.arrayOf(database, "Databases on this peer"));
     schema.addProperty("peerId", SpecBuilders.string("Peer that reported the state"));
+    return schema;
+  }
+
+  private Schema<?> createPeerCapabilitiesResponseSchema() {
+    final Schema<Object> schema = SpecBuilders.object("The wire-format sections one peer can decode");
+    schema.addProperty("peerId", SpecBuilders.string(
+        "Peer that answered. A caller must check this against the peer it meant to ask: on a cluster that "
+            + "declares no explicit 'http' ports several peers can resolve to one address."));
+    schema.addProperty("version", SpecBuilders.string("Server version of the answering peer, for operators; "
+        + "nothing decides on it"));
+    schema.addProperty("capabilities", SpecBuilders.arrayOf(SpecBuilders.string("Capability token"),
+        "Capability tokens this peer can decode, sorted"));
     return schema;
   }
 }

--- a/server/src/test/java/com/arcadedb/server/http/OpenApiSpecGenerationIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/OpenApiSpecGenerationIT.java
@@ -461,7 +461,7 @@ class OpenApiSpecGenerationIT extends BaseGraphServerTest {
       "GET /api/v1/cluster", "POST /api/v1/cluster/peer", "DELETE /api/v1/cluster/peer/{peerId}",
       "POST /api/v1/cluster/leader", "POST /api/v1/cluster/stepdown", "POST /api/v1/cluster/leave",
       "POST /api/v1/cluster/verify/{database}", "POST /api/v1/cluster/resync/{database}",
-      "POST /api/v1/cluster/bootstrap-state",
+      "POST /api/v1/cluster/bootstrap-state", "POST /api/v1/cluster/capabilities",
       "GET /api/v1/ha/snapshot/{database}", "GET /api/v1/ha/snapshot/{database}/checksums");
 
   private static final List<String> EXPECTED_OPERATIONS =

--- a/server/src/test/java/com/arcadedb/server/http/OpenApiSpecGenerationIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/OpenApiSpecGenerationIT.java
@@ -489,14 +489,14 @@ class OpenApiSpecGenerationIT extends BaseGraphServerTest {
   }
 
   @Test
-  void specDocumentsExactlyTheExpectedSixtyFourOperations() throws Exception {
+  void specDocumentsExactlyTheExpectedSixtyFiveOperations() throws Exception {
     final OpenAPI openAPI = new OpenAPIV3Parser().readContents(getOpenApiSpec()).getOpenAPI();
     final List<String> declared = declaredOperations(openAPI);
 
     assertThat(EXPECTED_OPERATIONS)
         .as("the inventory itself must hold no duplicate")
         .doesNotHaveDuplicates()
-        .hasSize(64);
+        .hasSize(65);
 
     assertThat(declared)
         .as("operations missing from the specification")
@@ -563,7 +563,7 @@ class OpenApiSpecGenerationIT extends BaseGraphServerTest {
         .as("client generators derive a method name per operationId, so a collision breaks codegen")
         .doesNotHaveDuplicates()
         .doesNotContainNull()
-        .hasSize(64);
+        .hasSize(65);
   }
 
   @Test

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/PluginApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/PluginApiSpecTest.java
@@ -44,7 +44,7 @@ class PluginApiSpecTest {
   }
 
   @Test
-  void allTwelvePluginOperationsAreDeclared() {
+  void allThirteenPluginOperationsAreDeclared() {
     assertThat(openAPI.getPaths().keySet()).containsExactlyInAnyOrder(
         "/prometheus",
         "/api/v1/cluster",
@@ -56,12 +56,13 @@ class PluginApiSpecTest {
         "/api/v1/cluster/verify/{database}",
         "/api/v1/cluster/resync/{database}",
         "/api/v1/cluster/bootstrap-state",
+        "/api/v1/cluster/capabilities",
         "/api/v1/ha/snapshot/{database}",
         "/api/v1/ha/snapshot/{database}/checksums");
 
     final long operations = openAPI.getPaths().values().stream()
         .mapToLong(item -> item.readOperations().size()).sum();
-    assertThat(operations).isEqualTo(12);
+    assertThat(operations).isEqualTo(13);
   }
 
   @Test
@@ -116,18 +117,18 @@ class PluginApiSpecTest {
   void clusterStatusSchemaCarriesTheLeadershipAndPeerFields() {
     final Schema<?> schema = openAPI.getComponents().getSchemas().get("ClusterStatus");
     assertThat(schema.getProperties().keySet()).containsExactlyInAnyOrder(
-        "implementation", "clusterName", "localPeerId", "raftState", "isLeader", "leaderReady",
+        "implementation", "clusterName", "localPeerId", "capabilities", "raftState", "isLeader", "leaderReady",
         "leaderId", "leaderHttpAddress", "electionCount", "lastElectionTime", "uptime",
         "peers", "databases", "databasePresence", "alerts");
 
-    // Pinned to the exact set (not .contains(...)): GetClusterHandler writes exactly these 14 fields
+    // Pinned to the exact set (not .contains(...)): GetClusterHandler writes exactly these 16 fields
     // per peer, no more, no fewer.
     final Schema<?> peersProperty = schema.getProperties().get("peers");
     final Schema<?> peerItemSchema = peersProperty.getItems();
     assertThat(peerItemSchema.getProperties().keySet()).containsExactlyInAnyOrder(
         "id", "address", "httpAddress", "httpAddressAmbiguous", "role", "matchIndex", "nextIndex",
         "replicationLag", "lastContactMs", "replicaStatus", "laggingForMs", "lagging", "replicationRttMs",
-        "replicationRttP99Ms");
+        "replicationRttP99Ms", "capabilities", "version");
   }
 
   @Test


### PR DESCRIPTION
Closes #7219

## Summary

#7211 (for #6989) gave `SCHEMA_ENTRY` an optional trailing schema-delta section. A node running a build that predates the section stops decoding before it, sees an entry with an EMPTY `schemaJson`, applies nothing, reports nothing, and diverges - caught only much later by WAL-version-gap detection or an explicit `checkDatabase`. The only thing standing between a cluster and that outcome was `arcadedb.ha.schemaDelta` being off by default, plus an operator upgrading every node before turning it on: an instruction enforced by nothing.

A node now advertises the wire-format sections it can DECODE at `POST /api/v1/cluster/capabilities`. The leader polls every peer of its Raft configuration every 5s and writes a delta only when all of them have advertised `schema-delta`; unknown, unreachable, stale and explicitly-incapable all count as "no", and the leader falls back to the whole document exactly as it already does for a moved term or an unprofitable delta. **A build without the route answers 404, and that 404 is the answer** - no version comparison takes part in the decision, because a version string says what a build calls itself rather than what its decoder handles. `arcadedb.ha.schemaDelta` therefore now defaults to `true` and is a kill switch (and a way to release the leader's diff base) rather than the safety interlock itself.

## Why not a Raft log entry

The obvious design - every node proposes a `PEER_CAPABILITIES_ENTRY` that all nodes apply - is unusable, and the module says so:

```java
// ArcadeStateMachine.applyTransaction
if (decoded.type() == null) {
  // A committed entry whose leading type byte is unrecognised [...] is NOT safe to skip.
  triggerCriticalHalt();
```

A new `RaftLogEntryType` id **is** that case (#4798), so advertising over the log would permanently halt every not-yet-upgraded peer - a far worse failure than the one being fixed. `EXTENSION_MAGIC` framing (#7138) does not help either: it is explicitly excluded for `SCHEMA_ENTRY`, and a new *type* is not an extension of an existing one. That leaves the module's other node-to-node transport, the cluster HTTP RPCs, which is what `bootstrap-state`, `resync`, `verify` and snapshot download already use.

## Receiver-side backstop

`decodeSchemaEntry` now refuses a `SCHEMA_ENTRY` carrying bytes after every section this version knows about, instead of dropping them. That is the release which adds a section and forgets to declare a capability for it. The refusal is a `RaftLogEntryDecodeException` naming the database, so it quarantines and resyncs that one database (#7138) rather than halting the node - loud, scoped and self-healing, where accepting the entry is silent and permanent. It cannot help a node that predates a section (nothing can, retroactively), which is why the leader-side gate is the primary mechanism.

## Test plan

- [ ] `mvn -o -pl ha-raft -am -DskipITs=false -Dit.test='Issue7219MixedVersionSchemaDeltaIT' verify` - the mixed-version cluster. One node is made to answer the capability RPC as a build with no delta decoder would; the leader must ship whole documents for every DDL and the follower must still end up with the right schema. Then the "upgrade" completes mid-test and deltas resume with no restart and no setting change.
- [ ] `mvn -o -pl ha-raft -am test` - `Issue7219PeerCapabilityRegistryTest` (11), `Issue7219CapabilityAdvertisementTest` (7), `Issue7219SchemaEntryTrailingSectionTest` (4).
- [ ] `mvn -o -pl ha-raft -am -DskipITs=false -Dit.test='Issue6989SchemaDeltaReplicationIT' verify` - the pre-existing delta IT now depends on the negotiation converging before it can see a delta, and still passes.
- [ ] `mvn -o -pl server -am -Dtest='PluginApiSpecTest,ApiSpecPathConstantsTest,*OpenApi*Test' test` - the new route and the two new `ClusterStatus` fields.
- [ ] Manual: start a 2-node cluster, `curl -u root:… -XPOST http://host:2480/api/v1/cluster/capabilities`, then `GET /api/v1/cluster` on the leader and check each peer's `capabilities`.

Results in this branch: `ha-raft` unit suite **389 tests, 0 failures**; `Issue7219MixedVersionSchemaDeltaIT` 2/2; `Issue6989SchemaDelta*` 50 unit + 2 IT green; `server` OpenAPI 28 green; `engine` configuration tests green after the default flip.

One environmental failure, **not caused by this change**: `LeaveClusterTest` crashes its fork with `java.net.BindException: Address already in use` because another process held port 2480 on this machine (`lsof -nP -iTCP:2480 -sTCP:LISTEN` showed two unrelated JVMs). The suite reports `Tests run: 389, Failures: 0, Errors: 0` before the fork dies. This is the hazard `CLAUDE.md` documents under "Server tests bind fixed ports".

## Coverage

The invariant: **a `SCHEMA_ENTRY` carrying a schema delta is emitted only when the leader holds positive, unexpired, identity-checked evidence that every peer in the current Raft configuration decodes the delta section.**

There is exactly one delta producer and one base-retention reader, verified by grep, and both now go through the same predicate:

```
$ grep -rn "schemaDeltaFor" --include='*.java' . | grep -v javadoc
  RaftReplicatedDatabase.java:1818   schemaDelta = fullSchema != null ? schemaDeltaFor(fullSchema) : null;
  RaftReplicatedDatabase.java:2862   private SchemaDelta.Payload schemaDeltaFor(...)
$ grep -rn "schemaDeltaEnabled" --include='*.java' . | grep -v src/test
  RaftReplicatedDatabase.java:2866   schemaDeltaFor           -> baseIsUsable(...)
  RaftReplicatedDatabase.java:2967   rememberReplicatedSchema -> whether to retain the diff base
```

| Entry point | Covered by fix? | Covered by a test? |
|---|---|---|
| `recordFileChanges` → `schemaDeltaFor` → `baseIsUsable(enabled, …)` - the only delta producer | yes, `enabled` = setting AND negotiated | `Issue7219MixedVersionSchemaDeltaIT` |
| `rememberReplicatedSchema` → whether to hold the diff base | yes, same predicate, so a cluster that cannot ship a delta does not pay to hold the document | `Issue7219MixedVersionSchemaDeltaIT` asserts the first DDL after the upgrade is a whole document, which is only true if the base was released |
| `runWithCompactionReplication` → `replicateSchema` | argued: always passes the whole document, never reaches `schemaDeltaFor` | n/a |
| `RaftTransactionBroker.splitSchemaEntry` (instalments) | argued: re-encodes the payload `schemaDeltaFor` already decided | n/a |
| Peer never probed / unreachable | yes - no entry recorded → incapable | `Issue7219PeerCapabilityRegistryTest.anUnknownPeerBlocksTheCapability` |
| Peer on a build with no capability route (non-200) | yes - the probe throws and the peer is forgotten | `…aPeerThatLostTheCapabilityBlocksItAgain` + the IT |
| Peer with an ambiguous address (`PeerDialAddress` refuses) | yes - never probed → incapable | same state as "unknown" |
| Peer downgraded under a running leader | yes - TTL expiry, bounded at 20s | `…anExpiredAdvertisementBlocksTheCapability` |
| Probe answered by the WRONG node (#6267) | yes - the reply's `peerId` must match the peer probed | `Issue7219CapabilityAdvertisementTest.anAdvertisementFromAnotherPeerIsRejected` |
| Peer removed from the configuration | yes - iteration is over the live configuration only | `…aPeerOutsideTheConfigurationDoesNotBlock`, `…retainOnlyDropsPeers…` |
| Single-node cluster | yes - vacuously capable | `…aClusterWithNoOtherPeerIsCapable` |
| A future section appended after the delta | yes - refused rather than half-applied | `Issue7219SchemaEntryTrailingSectionTest` |

### Known gaps

- **#7255** - negotiation governs what the leader writes *from now on*; delta entries already committed stay in the Raft log, and a node restarted onto (or joining on) an older build replays them with a decoder that cannot see the section. Out of scope here because making the *history* safe is a receiver-side mechanism, not a leader-side emission gate.
- **#7256** - on a cluster whose peers collapse onto one derived HTTP address (#6202, #6267), `PeerDialAddress` refuses to dial, so the probe never runs, every peer reads as incapable, and schema deltas become unreachable there. Fails the safe way, but it makes #6989's benefit unavailable on that deployment shape.

Also worth knowing, argued rather than filed: a permanently dead peer in the configuration stops the whole cluster shipping deltas. That is correct rather than a gap - it still has to apply those entries when it returns.

## Notes for review

- **Three existing tests were modified.** All three are mirrors whose entire purpose is to be updated when a route or a field is added (`PluginApiSpecTest` asserts the peer field set "no more, no fewer"; `OpenApiSpecGenerationIT` duplicates the path list). No assertion was weakened and none was deleted.
- **`ha-raft/CLAUDE.md`** gains a section telling whoever adds the next optional wire-format section to declare a capability rather than another setting, with the three things that are easy to get wrong.
- **The default flip is visible behaviour**: a cluster that never touched `arcadedb.ha.schemaDelta` starts shipping deltas once every node is on this release. The user-facing docs for that setting will want the same correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqxCPL284Ptg3FmjWo3goZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - High-availability clusters now automatically verify peer compatibility before replicating schema deltas.
  - Incompatible, unreachable, or outdated peers receive complete schema documents instead, supporting safer rolling upgrades.
  - Cluster status now displays node versions and supported capabilities.
  - Added a capabilities API endpoint and corresponding OpenAPI documentation.

- **Bug Fixes**
  - Unknown schema-entry sections are now rejected safely and isolated to the affected database.

- **Configuration**
  - Schema-delta replication is enabled by default, with an option to disable it when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->