### PR TITLE
fix(ha): propagate exhausted step-down failures to phase-2 recovery

### DIFF
--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterLeadershipResponses.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterLeadershipResponses.java
@@ -46,4 +46,18 @@ final class ClusterLeadershipResponses {
   static ExecutionResponse notTheLeader(final NotTheLeaderRefusalException e) {
     return new ExecutionResponse(409, new JSONObject().put("error", e.getMessage()).toString());
   }
+
+  /**
+   * 503 Service Unavailable: this node IS the leader and every leadership transfer it tried failed, so it is
+   * still the leader and the step-down did not happen (issue #7127). Retry-worthy as issued - a peer that was
+   * lagging, unreachable or mid-restart when the transfers ran can be eligible moments later - which is the
+   * same reading {@code AbstractServerHttpHandler} gives 503 for a {@code NeedRetryException}.
+   * <p>
+   * Without this arm the exception reaches the central mapper, which has no case for a Raft type it cannot
+   * reference, and answers a generic 500 "Internal error": indistinguishable from a bug, and read by clients
+   * and load balancers as do-not-retry.
+   */
+  static ExecutionResponse stepDownFailed(final ReplicationException e) {
+    return new ExecutionResponse(503, new JSONObject().put("error", e.getMessage()).toString());
+  }
 }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostStepDownHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostStepDownHandler.java
@@ -51,6 +51,13 @@ public class PostStepDownHandler extends AbstractServerHttpHandler {
       // Service across every ready endpoint does. 409 names the leader so the caller can reissue there,
       // instead of a 200 for an effect that landed on another node (issue #7134).
       return ClusterLeadershipResponses.notTheLeader(e);
+    } catch (final ReplicationException e) {
+      // This node is still the leader and every transfer failed, so nothing stepped down (issue #7127). Before
+      // stepDown() reported that terminal case at all, this endpoint answered 200 "Leadership step-down
+      // initiated" for it. 503 - not the generic 500 the central mapper would give a Raft type it cannot
+      // reference - because the condition is transient by construction and the same request can succeed as
+      // issued once a peer catches up or comes back.
+      return ClusterLeadershipResponses.stepDownFailed(e);
     }
     return new ExecutionResponse(200,
         new JSONObject().put("result", "Leadership step-down initiated").toString());

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -2761,7 +2761,8 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * than only in the handler.
    *
    * @throws NotTheLeaderRefusalException when this node is not the leader, whether that is already true on
-   *                                       entry or becomes true while the candidates are being tried
+   *                                       entry or becomes true during leadership transfer
+   * @throws ReplicationException when all leadership transfers fail and this node is still the leader
    */
   public void stepDown() {
     if (!isLeader())
@@ -2774,11 +2775,8 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
         transferLeadership(peer.getId().toString(), 10_000);
         return;
       } catch (final NotTheLeaderRefusalException notLeader) {
-        // Leadership moved between the guard above and this attempt. Every remaining candidate refuses
-        // identically, so walking the list logs the same thing N times and then falls through to "no other peer
-        // available for leadership transfer" - and stepDown() would RETURN NORMALLY, which the HTTP handler
-        // reports as 200 for a step-down that never happened. Propagate instead: the caller is told, with the
-        // new leader's name, that there was nothing here to step down from (issue #7134).
+        // Leadership moved between the guard above and this attempt. Propagate the refusal so callers stop
+        // retrying a step-down that is already moot, and the HTTP handler reports 409 (issue #7134).
         throw notLeader;
       } catch (final Exception e) {
         LogManager.instance().log(this, Level.SEVERE,
@@ -2794,8 +2792,12 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     if (transferLeadership(10_000L))
       return;
 
-    LogManager.instance().log(this, Level.SEVERE,
-        "Cannot step down: no other peer available for leadership transfer");
+    // The no-target API also returns false if leadership was lost before the transfer (issue #4809).
+    // Keep that distinct from an exhausted transfer failure so phase-2 recovery does not retry or stop a follower.
+    if (!isLeader())
+      throw new NotTheLeaderRefusalException("Refusing to step down", getLeaderId());
+
+    throw new ReplicationException("Cannot step down: no other peer available for leadership transfer");
   }
 
   /**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7127StepDownFailureTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7127StepDownFailureTest.java
@@ -134,7 +134,12 @@ class Issue7127StepDownFailureTest {
     assertThat(raft.fallbackAttempts).as("all three real step-down attempts must be exhausted").isEqualTo(3);
     assertThat(raft.targetedAttempts).isEqualTo(6);
     if (stopOnFailure) {
-      assertThat(stopped.await(10, TimeUnit.SECONDS)).as("emergency server stop must be reached").isTrue();
+      // recoverLeadershipAfterPhase2Failure() runs server.stop() on its own daemon thread, so the latch is the
+      // only completion signal available here. The bound is a HANG DETECTOR, not a latency claim - it separates
+      // "the emergency-stop branch was reached" from "it was never reached at all", and the work behind it is a
+      // single call on a mock. Generous on purpose: a wider bound cannot turn a passing run red, while a tight
+      // one turns a full-suite stop-the-world pause into a false failure (see CLAUDE.md on wall-clock bounds).
+      assertThat(stopped.await(60, TimeUnit.SECONDS)).as("emergency server stop must be reached").isTrue();
       verify(server).stop();
     } else
       verify(server, never()).stop();

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7127StepDownFailureTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7127StepDownFailureTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.exception.TransactionCommittedRemotelyException;
+import com.arcadedb.server.ArcadeDBServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #7127: exercise the real step-down loop, including recovery through a real database commit.
+ * Only the replication/leadership-transfer boundary and process stop are simulated, so failures are
+ * deterministic without waiting for a cluster's network timeouts.
+ */
+class Issue7127StepDownFailureTest {
+  private final ContextConfiguration config = configuration();
+  private final ArcadeDBServer server = mock(ArcadeDBServer.class);
+  private final CountDownLatch stopped = new CountDownLatch(1);
+  private ControlledTransfers raft;
+
+  @BeforeEach
+  void setUp() {
+    when(server.getServerName()).thenReturn("ArcadeDB_0");
+    when(server.getConfiguration()).thenReturn(config);
+    doAnswer(invocation -> {
+      stopped.countDown();
+      return null;
+    }).when(server).stop();
+    raft = new ControlledTransfers(server, config);
+  }
+
+  @AfterEach
+  void tearDown() {
+    RaftReplicatedDatabase.TEST_PHASE2_COMMIT_FAULT = null;
+    raft.stop();
+  }
+
+  @Test
+  void exhaustedTransfersMustNotReportSuccessfulStepDown() {
+    assertThatThrownBy(raft::stepDown)
+        .as("a leader that could not transfer leadership must report failure to phase-2 recovery")
+        .isInstanceOf(ReplicationException.class)
+        .hasMessageContaining("Cannot step down");
+    assertThat(raft.targetedAttempts).isEqualTo(2);
+    assertThat(raft.fallbackAttempts).isEqualTo(1);
+  }
+
+  @Test
+  void leadershipLostDuringFallbackMustNotBeReportedAsTransferFailure() {
+    raft.loseLeadershipOnFallbackAttempt = 1;
+
+    assertThatThrownBy(raft::stepDown)
+        .as("phase-2 recovery must stop retrying when this node is already a follower")
+        .isInstanceOf(NotTheLeaderRefusalException.class);
+    assertThat(raft.targetedAttempts).isEqualTo(2);
+    assertThat(raft.fallbackAttempts).isEqualTo(1);
+  }
+
+  @Test
+  void noEligibleCandidatesAndFailedFallbackMustReportFailure() {
+    raft.stop();
+    config.setValue(GlobalConfiguration.HA_SERVER_LIST, "localhost:2434:2480");
+    raft = new ControlledTransfers(server, config);
+
+    assertThatThrownBy(raft::stepDown).isInstanceOf(ReplicationException.class);
+    assertThat(raft.targetedAttempts).isZero();
+    assertThat(raft.fallbackAttempts).isEqualTo(1);
+  }
+
+  @Test
+  void successfulTargetedTransferMustNotTryTheFallback() {
+    raft.targetedTransferSucceeds = true;
+
+    assertThatCode(raft::stepDown).doesNotThrowAnyException();
+    assertThat(raft.targetedAttempts).isEqualTo(1);
+    assertThat(raft.fallbackAttempts).isZero();
+  }
+
+  @Test
+  void successfulFallbackMustNotReportFailure() {
+    raft.successfulFallbackAttempt = 1;
+
+    assertThatCode(raft::stepDown).doesNotThrowAnyException();
+    assertThat(raft.targetedAttempts).isEqualTo(2);
+    assertThat(raft.fallbackAttempts).isEqualTo(1);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = { true, false })
+  void phase2FailureRetriesRealStepDownAndHonorsStopSetting(final boolean stopOnFailure) throws InterruptedException {
+    config.setValue(GlobalConfiguration.HA_STOP_SERVER_ON_REPLICATION_FAILURE, stopOnFailure);
+
+    commitWithPhase2Failure();
+
+    assertThat(raft.fallbackAttempts).as("all three real step-down attempts must be exhausted").isEqualTo(3);
+    assertThat(raft.targetedAttempts).isEqualTo(6);
+    if (stopOnFailure) {
+      assertThat(stopped.await(10, TimeUnit.SECONDS)).as("emergency server stop must be reached").isTrue();
+      verify(server).stop();
+    } else
+      verify(server, never()).stop();
+  }
+
+  @Test
+  void phase2RecoveryStopsRetryingAfterSuccessfulTransfer() {
+    config.setValue(GlobalConfiguration.HA_STOP_SERVER_ON_REPLICATION_FAILURE, true);
+    raft.successfulFallbackAttempt = 2;
+
+    commitWithPhase2Failure();
+
+    assertThat(raft.fallbackAttempts).isEqualTo(2);
+    assertThat(raft.targetedAttempts).isEqualTo(4);
+    verify(server, never()).stop();
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = { 1, 3 })
+  void phase2RecoveryMustNotStopANodeThatLostLeadership(final int demotionAttempt) {
+    config.setValue(GlobalConfiguration.HA_STOP_SERVER_ON_REPLICATION_FAILURE, true);
+    raft.loseLeadershipOnFallbackAttempt = demotionAttempt;
+
+    commitWithPhase2Failure();
+
+    assertThat(raft.fallbackAttempts).isEqualTo(demotionAttempt);
+    assertThat(raft.targetedAttempts).isEqualTo(2 * demotionAttempt);
+    assertThat(raft.isLeader()).isFalse();
+    verify(server, never()).stop();
+  }
+
+  private void commitWithPhase2Failure() {
+    final String path = "target/databases/issue7127-" + UUID.randomUUID();
+    final LocalDatabase local = (LocalDatabase) new DatabaseFactory(path).create();
+    try {
+      local.getSchema().createDocumentType("Item", 1);
+      local.transaction(() -> local.newDocument("Item").set("value", 0).save());
+
+      final RaftReplicatedDatabase database = new RaftReplicatedDatabase(server, local, raft);
+      database.begin();
+      final MutableDocument document = database.iterateType("Item", false).next().asDocument().modify();
+      document.set("value", 1).save();
+
+      final IllegalStateException fault = new IllegalStateException("simulated local phase-2 apply failure");
+      RaftReplicatedDatabase.TEST_PHASE2_COMMIT_FAULT = dbName -> {
+        throw fault;
+      };
+      assertThatThrownBy(database::commit)
+          .isInstanceOf(TransactionCommittedRemotelyException.class)
+          .hasMessageContaining("Do NOT retry")
+          .hasCause(fault);
+      verify(raft.broker).replicateTransaction(anyString(), any(), any());
+    } finally {
+      RaftReplicatedDatabase.TEST_PHASE2_COMMIT_FAULT = null;
+      local.setWrappedDatabaseInstance(local);
+      local.rollbackAllNested();
+      local.drop();
+    }
+  }
+
+  private static ContextConfiguration configuration() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_SERVER_LIST, "localhost:2434:2480,localhost:2435:2481,localhost:2436:2482");
+    return config;
+  }
+
+  private static class ControlledTransfers extends RaftHAServer {
+    private final RaftTransactionBroker broker = mock(RaftTransactionBroker.class);
+    private int targetedAttempts;
+    private int fallbackAttempts;
+    private boolean leader = true;
+    private boolean targetedTransferSucceeds;
+    private int successfulFallbackAttempt = Integer.MAX_VALUE;
+    private int loseLeadershipOnFallbackAttempt = Integer.MAX_VALUE;
+
+    private ControlledTransfers(final ArcadeDBServer server, final ContextConfiguration config) {
+      super(server, config);
+      when(broker.replicateTransaction(anyString(), any(), any())).thenReturn(1L);
+    }
+
+    @Override
+    public RaftTransactionBroker getTransactionBroker() {
+      return broker;
+    }
+
+    @Override
+    public boolean isLeader() {
+      return leader;
+    }
+
+    @Override
+    public void transferLeadership(final String targetPeerId, final long timeoutMs) {
+      targetedAttempts++;
+      if (targetedTransferSucceeds) {
+        leader = false;
+        return;
+      }
+      throw new ReplicationException("Transfer timed out: " + targetPeerId);
+    }
+
+    @Override
+    public boolean transferLeadership(final long timeoutMs) {
+      fallbackAttempts++;
+      if (fallbackAttempts == successfulFallbackAttempt) {
+        leader = false;
+        return true;
+      }
+      if (fallbackAttempts == loseLeadershipOnFallbackAttempt)
+        leader = false;
+      return false;
+    }
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/PostStepDownHandlerFailureTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/PostStepDownHandlerFailureTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.http.handler.ExecutionResponse;
+import com.arcadedb.server.security.ServerSecurityUser;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #7127 follow-up: {@code stepDown()} gained a terminal {@link ReplicationException}, so
+ * {@code POST /api/v1/cluster/stepdown} gained a failure mode it had never seen. Before, that case returned
+ * normally and the endpoint answered 200 "Leadership step-down initiated" for a step-down that never happened.
+ * <p>
+ * The exception must not be left to {@code AbstractServerHttpHandler}'s central mapper: that mapper lives in the
+ * server module, which must not depend on this Raft type, so it has no arm for it and would answer a generic
+ * 500 "Internal error" - indistinguishable from a bug, and read by clients and load balancers as do-not-retry.
+ * The three terminal outcomes of the endpoint are asserted together here so a future change cannot move one of
+ * them without the others being looked at.
+ *
+ * @see PostStepDownHandler
+ */
+class PostStepDownHandlerFailureTest {
+
+  private final RaftHAServer raftHAServer = mock(RaftHAServer.class);
+  private final PostStepDownHandler handler = new PostStepDownHandler(null, pluginReturning(raftHAServer));
+
+  @Test
+  void exhaustedTransfersAnswer503RatherThanTheGeneric500() {
+    doThrow(new ReplicationException("Cannot step down: no other peer available for leadership transfer"))
+        .when(raftHAServer).stepDown();
+
+    final ExecutionResponse response = handler.execute(null, rootUser(), new JSONObject());
+
+    assertThat(response.getCode())
+        .as("a leader that could not hand off is retryable as issued, not an internal error")
+        .isEqualTo(503);
+    assertThat(new JSONObject(response.getResponse()).getString("error", null))
+        .contains("no other peer available for leadership transfer");
+  }
+
+  @Test
+  void aRefusalStillAnswers409() {
+    doThrow(new NotTheLeaderRefusalException("Refusing to step down", RaftPeerId.valueOf("ArcadeDB_1")))
+        .when(raftHAServer).stepDown();
+
+    final ExecutionResponse response = handler.execute(null, rootUser(), new JSONObject());
+
+    assertThat(response.getCode()).isEqualTo(409);
+    assertThat(new JSONObject(response.getResponse()).getString("error", null)).contains("ArcadeDB_1");
+  }
+
+  @Test
+  void aSuccessfulStepDownStillAnswers200() {
+    final ExecutionResponse response = handler.execute(null, rootUser(), new JSONObject());
+
+    assertThat(response.getCode()).isEqualTo(200);
+    assertThat(new JSONObject(response.getResponse()).getString("result", null))
+        .isEqualTo("Leadership step-down initiated");
+  }
+
+  private static RaftHAPlugin pluginReturning(final RaftHAServer raftHAServer) {
+    final RaftHAPlugin plugin = mock(RaftHAPlugin.class);
+    when(plugin.getRaftHAServer()).thenReturn(raftHAServer);
+    return plugin;
+  }
+
+  private static ServerSecurityUser rootUser() {
+    final ServerSecurityUser user = mock(ServerSecurityUser.class);
+    when(user.getName()).thenReturn("root");
+    return user;
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Make `RaftHAServer.stepDown()` throw the existing `ReplicationException` when every targeted transfer and the no-target fallback fail while this node remains the leader.

If leadership was lost during the fallback, propagate `NotTheLeaderRefusalException` instead. This preserves the existing recovery behavior from #7134: stop retrying a step-down that is already moot, without escalating to an emergency server stop.

The public `void stepDown()` signature and the no-target transfer's boolean contract are unchanged.

## Motivation

The terminal failure path previously logged an error and returned normally. `recoverLeadershipAfterPhase2Failure()` interpreted that return as success, so it stopped after the first attempt and never reached its configured emergency-stop policy.

Surfacing the terminal failure makes the existing three-attempt retry loop and `HA_STOP_SERVER_ON_REPLICATION_FAILURE` branch effective without changing that policy.

## Related issues

Fixes #7127.

Preserves the follower-refusal and no-target transfer contracts covered by #7134 and #4809.

## Additional Notes

Added 10 deterministic regression cases. They exercise the real step-down loop and, for phase-2 recovery, a real local database through `RaftReplicatedDatabase.commit()` and the existing phase-2 fault hook. Only replication confirmation, leadership-transfer outcomes, and process stop are simulated.

Coverage includes:

- Exhausted targeted transfers and a failed no-target fallback.
- No eligible candidate and a failed fallback.
- Successful targeted and no-target transfers.
- Leadership lost during the fallback.
- Three real step-down attempts after local phase-2 failure, with emergency stop enabled and disabled.
- Recovery stopping after a later successful transfer or after leadership is lost, including on the final retry.
- Preservation of `TransactionCommittedRemotelyException` and its do-not-retry contract.

Validation on Windows with Temurin Java 21 and Maven 3.9.16:

- Against the old terminal behavior, 7 of the 10 new cases fail, including an expected retry count of 3 versus an actual count of 1.
- With the fix, all 69 selected regression tests pass.
- All 3 selected three-node integration tests pass: `Issue4740Phase2ReconcileIT` and `Issue4809NoTargetTransferLeadershipIT`.
- `git diff --check` passes.

Reproduction command (with Java 21 configured):

```shell
mvn -B -ntp -pl ha-raft -am verify -DskipITs=false \
  -Dtest=Issue7127StepDownFailureTest,Issue7134StepDownRetryStopsOnRefusalTest,Issue7134TargetedTransferRequiresLeaderTest,RaftHAServerStepDownTargetTest,Issue5064ApplyLocallyAfterMajorityCommitTest,Issue5407Phase2TicketLifecycleTest,Issue5410AbandonedPhase2TicketTest,Issue6848LocalOriginHandshakeTest,ArcadeStateMachinePendingPhase2SnapshotTest,Issue5018Phase2ConflictMessageTest \
  -Dit.test=Issue4740Phase2ReconcileIT,Issue4809NoTargetTransferLeadershipIT \
  -Dsurefire.failIfNoSpecifiedTests=false -Dfailsafe.failIfNoSpecifiedTests=false
```

The full multi-module test suite and a full `mvn clean package` were not run.

The integration run also logged an Integer/Long conversion exception for `arcadedb.dumpMetricsEvery` from the unchanged `GlobalConfiguration.resetAll()` / `BaseGraphServerTest` setup/teardown path. It did not produce a test failure, and this patch does not modify that unrelated path.

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting when leadership is lost during a server step-down.
  - Step-down attempts now distinguish between leadership loss and exhausted transfer attempts.
  - Replication failures during step-down now trigger the appropriate retry or server-stop behavior.
  - Failed step-down transfers now return a clear Service Unavailable response instead of a generic error.
  - Successful step-downs and leadership refusals continue to return their appropriate status responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->