### PR TITLE
fix(#7265): an empty DATETIME value means "not set" instead of aborting the import

### DIFF
--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -1318,7 +1318,13 @@ public class GraphImporter implements AutoCloseable {
       }
     case DATETIME: {
       final String v = record.get(pd.attribute);
-      if (v == null)
+      // Empty means "not set", as it does in the RecordReader defaults above: getInt/getLong/
+      // getDouble answer 0 and getFloatArray/getList answer null for an empty value, so a blank
+      // cell in an optional datetime column must not abort the import either. null is already this
+      // branch's "not set" answer and both call sites drop it, so returning it needs nothing else.
+      // A value that is present but not whitespace-free is still a data error: isEmpty(), not
+      // isBlank(), is what every accessor above tests (#7265)
+      if (v == null || v.isEmpty())
         return null;
       // DateUtils.getFormatter(), not DateTimeFormatter.ofPattern(): the latter binds the JVM default locale, so the
       // same file imported on two machines would parse a textual month/day name differently, or not at all (#7144)

--- a/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterEmptyDatetimeTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterEmptyDatetimeTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.integration.importer.graph.CsvRowSource;
+import com.arcadedb.integration.importer.graph.GraphImporter;
+import com.arcadedb.integration.importer.graph.JsonlRowSource;
+import com.arcadedb.integration.importer.graph.XmlRowSource;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.utility.FileUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * An empty value on a DATETIME property means "not set", exactly as it does for every other property
+ * type {@code GraphImporter.readProperty} dispatches on, and never aborts the import (issue #7265).
+ * <p>
+ * A nullable timestamp with blank cells is the normal shape of an optional date exported from almost
+ * any system, so every source that can hand {@code readProperty} a non-null empty string gets its
+ * own case: {@code JsonlRowSource} and {@code XmlRowSource} return it verbatim, while
+ * {@code CsvRowSource} already maps it to {@code null} and is pinned here so it stays that way.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class GraphImporterEmptyDatetimeTest {
+
+  private static final String DB_PATH   = "target/databases/graph-importer-empty-datetime-test";
+  private static final String DATA_PATH = "target/test-data/graph-importer-empty-datetime";
+
+  private Database database;
+  private File     dataDir;
+
+  @BeforeEach
+  void setup() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    FileUtils.deleteRecursively(new File(DATA_PATH));
+    dataDir = new File(DATA_PATH);
+    dataDir.mkdirs();
+    database = new DatabaseFactory(DB_PATH).create();
+  }
+
+  @AfterEach
+  void cleanup() {
+    if (database != null) {
+      // An import that aborts mid-row leaves the batch's transaction open, and the instance is not
+      // released until it is rolled back - which would turn one real failure here into a cascade of
+      // "already in use" errors in every later test of the class.
+      if (database.isTransactionActive())
+        database.rollback();
+      if (database.isOpen())
+        database.drop();
+      database = null;
+    }
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    FileUtils.deleteRecursively(new File(DATA_PATH));
+  }
+
+  private String write(final String fileName, final String... lines) throws Exception {
+    final File f = new File(dataDir, fileName);
+    Files.write(f.toPath(), String.join("\n", lines).getBytes(StandardCharsets.UTF_8));
+    return f.getAbsolutePath();
+  }
+
+  /**
+   * The vertex path with a JSONL source: {@code JsonlRecordReader.get} returns the empty string
+   * verbatim for an explicit {@code ""}, so this is the shape that reaches {@code LocalDateTime.parse("")}.
+   */
+  @Test
+  void emptyJsonlDatetimeLeavesTheVertexPropertyUnset() throws Exception {
+    final String vertices = write("empty-datetime-vertices.jsonl",
+        "{\"id\": \"1\", \"name\": \"alice\", \"deletedAt\": \"\"}",
+        "{\"id\": \"2\", \"name\": \"bob\",   \"deletedAt\": \"2026-01-05 10:00:00\"}",
+        "{\"id\": \"3\", \"name\": \"carol\"}");
+
+    database.transaction(() -> database.getSchema().createVertexType("User"));
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("User", new JsonlRowSource(vertices), v -> {
+          v.id("id");
+          v.property("name", "name");
+          v.datetimeProperty("deletedAt", "deletedAt");
+        })
+        .build()) {
+
+      importer.run();
+      assertThat(importer.getVertexCount()).isEqualTo(3);
+    }
+
+    assertThat(deletedAtOf("alice")).isNull();
+    assertThat(deletedAtOf("bob")).isEqualTo(LocalDateTime.of(2026, 1, 5, 10, 0, 0));
+    // an absent attribute already worked and must keep working
+    assertThat(deletedAtOf("carol")).isNull();
+  }
+
+  /**
+   * The vertex path with an XML attribute source, and with an explicit datetime format: the empty
+   * check has to happen before the formatter is chosen, or a custom format fails the same way.
+   */
+  @Test
+  void emptyXmlDatetimeAttributeLeavesTheVertexPropertyUnset() throws Exception {
+    final String vertices = write("empty-datetime-vertices.xml",
+        "<users>",
+        "  <row Id=\"1\" Name=\"alice\" DeletedAt=\"\" />",
+        "  <row Id=\"2\" Name=\"bob\" DeletedAt=\"05/01/2026 10:00:00\" />",
+        "</users>");
+
+    database.transaction(() -> database.getSchema().createVertexType("User"));
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("User", new XmlRowSource(vertices), v -> {
+          v.id("Id");
+          v.property("name", "Name");
+          v.datetimeProperty("deletedAt", "DeletedAt", "dd/MM/yyyy HH:mm:ss");
+        })
+        .build()) {
+
+      importer.run();
+      assertThat(importer.getVertexCount()).isEqualTo(2);
+    }
+
+    assertThat(deletedAtOf("alice")).isNull();
+    assertThat(deletedAtOf("bob")).isEqualTo(LocalDateTime.of(2026, 1, 5, 10, 0, 0));
+  }
+
+  /**
+   * {@code CsvRowSource.get} already maps an empty cell to {@code null}, so the issue's own CSV
+   * repro never reached the parse. Pinned so the CSV source cannot start returning {@code ""}
+   * without this failing.
+   */
+  @Test
+  void emptyCsvDatetimeCellLeavesTheVertexPropertyUnset() throws Exception {
+    final String vertices = write("empty-datetime-vertices.csv",
+        "id,name,deletedAt",
+        "1,alice,",
+        "2,bob,2026-01-05 10:00:00");
+
+    database.transaction(() -> database.getSchema().createVertexType("User"));
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("User", new CsvRowSource(vertices), v -> {
+          v.id("id");
+          v.property("name", "name");
+          v.datetimeProperty("deletedAt", "deletedAt");
+        })
+        .build()) {
+
+      importer.run();
+      assertThat(importer.getVertexCount()).isEqualTo(2);
+    }
+
+    assertThat(deletedAtOf("alice")).isNull();
+    assertThat(deletedAtOf("bob")).isEqualTo(LocalDateTime.of(2026, 1, 5, 10, 0, 0));
+  }
+
+  /**
+   * The edge-source path: DATETIME falls into {@code processEdgeSource}'s default branch, which
+   * routes it through the same {@code readProperty} the vertex pass uses and then drops a
+   * {@code null} in {@code EdgeCollector.appendProperties}.
+   */
+  @Test
+  void emptyEdgeSourceDatetimeLeavesTheEdgePropertyUnset() throws Exception {
+    final String vertices = write("empty-datetime-edge-vertices.jsonl",
+        "{\"id\": \"1\", \"name\": \"alice\"}",
+        "{\"id\": \"2\", \"name\": \"bob\"}");
+    final String edges = write("empty-datetime-edges.jsonl",
+        "{\"from\": \"1\", \"to\": \"2\", \"kind\": \"blank\",  \"since\": \"\"}",
+        "{\"from\": \"2\", \"to\": \"1\", \"kind\": \"filled\", \"since\": \"2026-01-05 10:00:00\"}");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("User");
+      database.getSchema().createEdgeType("Knows");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("User", new JsonlRowSource(vertices), v -> {
+          v.id("id");
+          v.property("name", "name");
+        })
+        .edgeSource("Knows", new JsonlRowSource(edges), e -> {
+          e.from("from", "User");
+          e.to("to", "User");
+          e.property("kind", "kind");
+          e.datetimeProperty("since", "since");
+        })
+        .build()) {
+
+      importer.run();
+      assertThat(importer.getEdgeCount()).isEqualTo(2);
+    }
+
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("sql", "SELECT FROM Knows WHERE kind = 'blank'")) {
+        assertThat(rs.hasNext()).isTrue();
+        final Edge e = rs.next().getEdge().get();
+        assertThat(e.has("since")).isFalse();
+      }
+      try (final ResultSet rs = database.query("sql", "SELECT FROM Knows WHERE kind = 'filled'")) {
+        assertThat(rs.hasNext()).isTrue();
+        final Edge e = rs.next().getEdge().get();
+        assertThat(e.getLocalDateTime("since")).isEqualTo(LocalDateTime.of(2026, 1, 5, 10, 0, 0));
+      }
+    });
+  }
+
+  /**
+   * Empty means "not set"; a value that is present but not a datetime is still a data error, and
+   * still names the property and the source attribute.
+   */
+  @Test
+  void aMalformedDatetimeIsStillReported() throws Exception {
+    final String vertices = write("malformed-datetime-vertices.jsonl",
+        "{\"id\": \"1\", \"name\": \"alice\", \"deletedAt\": \"not-a-date\"}");
+
+    database.transaction(() -> database.getSchema().createVertexType("User"));
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("User", new JsonlRowSource(vertices), v -> {
+          v.id("id");
+          v.property("name", "name");
+          v.datetimeProperty("deletedAt", "deletedAt");
+        })
+        .build()) {
+
+      assertThatThrownBy(importer::run)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("deletedAt")
+          .hasMessageContaining("declared as a datetime");
+    }
+  }
+
+  private LocalDateTime deletedAtOf(final String name) {
+    final LocalDateTime[] result = new LocalDateTime[1];
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("sql", "SELECT FROM User WHERE name = ?", name)) {
+        assertThat(rs.hasNext()).isTrue();
+        final Vertex v = rs.next().getVertex().get();
+        result[0] = v.has("deletedAt") ? v.getLocalDateTime("deletedAt") : null;
+      }
+    });
+    return result[0];
+  }
+}


### PR DESCRIPTION
Closes #7265

`GraphImporter.readProperty()`'s DATETIME branch guarded its value against `null` but not against
the empty string, so an empty cell in an optional datetime column reached `LocalDateTime.parse("")`,
threw, and ended the whole import from inside the per-row visitor. It was the only guard in the file
that tested `null` without also testing empty. The branch now reads `if (v == null || v.isEmpty())`;
`null` is already its "not set" answer and both call sites drop a `null` rather than storing it, so
returning it for an empty value needs nothing else. A value that is present but malformed is
unchanged: still reported by `badValue`, still naming the property and the source attribute.

## Test plan

- [ ] `mvn -o -pl integration test -Dtest=GraphImporterEmptyDatetimeTest` — 5 tests. Three of them
      (JSONL vertex, XML vertex, JSONL edge source) fail on `main` with
      `Property '<p>' is declared as a datetime but attribute '<a>' does not hold one (Text '' could
      not be parsed at index 0)` and pass with this change.
- [ ] `mvn -o -pl integration verify -DexcludedGroups=benchmark,vector,slow` — 241 tests, 0 failures,
      9 skipped.
- [ ] `mvn -o -pl integration verify -DskipITs=false -DexcludedGroups=benchmark,vector,slow` — 123
      failsafe tests, 0 failures.

## Coverage

The invariant: **an empty attribute value can never abort a graph import — for every property type
in `readProperty`'s switch, and on both the vertex and the edge-source path, it means the property
is not set.** (About *empty*, not *blank*; see the last row.)

`grep -n "v == null)" GraphImporter.java` returns exactly one hit, `:1321`, the DATETIME branch.
Every other guard in the file already pairs `null` with `isEmpty()` — `:710` `getInt`, `:715`
`getLong`, `:720` `getDouble`, `:738` `getFloatArray`, `:751` `getList`, `:1077`, `:1132`, `:1141`,
`:1598`, `:1614`. `grep -n "readProperty"` returns exactly two call sites, `:1009` and `:1209`, both
of which drop a `null` (`:1009` directly, `:1209` via `appendProperties:1513`).

| Entry point | Covered by fix? | Covered by a test? |
|---|---|---|
| Vertex DATETIME, empty value — JSONL source (`:1009`) | yes | yes — `emptyJsonlDatetimeLeavesTheVertexPropertyUnset` |
| Vertex DATETIME, empty value — XML attribute source, explicit `datetimeFormat` | yes | yes — `emptyXmlDatetimeAttributeLeavesTheVertexPropertyUnset` |
| Edge-source DATETIME, empty value (`processEdgeSource` default branch → `:1209`) | yes | yes — `emptyEdgeSourceDatetimeLeavesTheEdgePropertyUnset` |
| Vertex DATETIME, empty value — CSV source | already immune: `CsvRecordReader.get` maps `""` to `null` (`CsvRowSource.java:98-101`), so the issue's own CSV repro never reached the parse | yes — `emptyCsvDatetimeCellLeavesTheVertexPropertyUnset` pins it |
| Caller-supplied `RecordReader` returning `""` (the interface is public) | yes — the fix is in `readProperty`, which every source funnels through | covered transitively by the four above |
| Present-but-malformed datetime | unchanged, still reported | yes — `aMalformedDatetimeIsStillReported` |
| Blank on a *mandatory* property (the reporter's open question) | argued, no code change — omitting the property is what lets the schema report it: `DocumentValidator:75` rejects the record with `"<prop> is mandatory, but not found on record: ..."`, naming the property, which is the schema-level report the issue asked for | n/a |
| `Neo4jImporter` DATETIME parse (`:311`, `:607`) — the only sibling hits for `LocalDateTime.parse`/`DateTimeParseException` in `integration/src/main` | argued — both catch sites are already non-fatal (falls back to `Type.STRING`; logs, counts an error and keeps the string), so neither can abort an import | n/a |
| Whitespace-only value (`" "`) | **no, by design** — `isEmpty()`, not `isBlank()`, is what all five sibling accessors test, so `" "` is a malformed value for every type in this file rather than an absent one. Widening DATETIME alone would make it the outlier in the other direction | n/a |

### Known gaps

- **#7269** — `JsonlRecordReader` overrides `getInt`/`getLong`/`getDouble`/`getFloatArray`/`getList`
  (`JsonlRowSource.java:88-120`) and none of the overrides carries the empty guard the
  `RecordReader` defaults have, because `json.isNull()` is false for an explicit `""`. So an empty
  JSONL value still aborts an import for `int:`/`long:`/`double:`/`vector:`/`list:` properties — the
  same defect shape as this issue, one level down. Found by the adversarial pass on this patch and
  deliberately left out: different file, different property types, needs tests of its own.
  `CsvRowSource` and `XmlRowSource` are unaffected.

### Reachability

`readProperty` is `private static` with the two live call sites above, on the only path
`GraphImporter.run()` has; no flag gates them. All five tests drive the real `GraphImporter` against
real files and a real database, so the changed line executes in production shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuuFV2rsSfiK4yvr6i91uz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty DATETIME values are now treated as unset during data imports instead of aborting the import.
  * Valid datetime values continue to be parsed correctly across supported import formats and edge data.
  * Invalid non-empty datetime values still report an appropriate error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->