### PR TITLE
fix(#7264): a failed vertex source resolves its own transaction and reports the rows that committed

### DIFF
--- a/docs/7264-graphimporter-tx-leak-zero-count.md
+++ b/docs/7264-graphimporter-tx-leak-zero-count.md
@@ -1,0 +1,244 @@
+# #7264 - A failure inside GraphImporter's row loop leaks a nested transaction and reports 0 vertices
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/7264
+Branch: `fix/7264-graphimporter-tx-leak-zero-count`
+Type: bug (labels `bug`, `importer`; milestone 26.10.1)
+
+## Finding ledger
+
+- [x] 1. A throw inside `processVertexSource`'s row loop skips `database.commit()` and leaves the
+      transaction the method pushed on the caller's stack - fixed here, 2 regression tests
+- [x] 2. The same throw skips `ts.count` / `totalVertices`, so `getVertexCount()` reports 0 for a
+      source whose intermediate commits made rows durable - fixed here, 1 regression test
+- [x] 3. Same shape of defect in four other importer entry points - filed as
+      [#7272](https://github.com/ArcadeData/arcadedb/issues/7272)
+
+## Analysis
+
+`GraphImporter.processVertexSource` (`integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java`)
+opened a transaction before the row loop, committed every 50,000 rows inside it, committed once
+after it, and then assigned the per-type counters. No `try`, no `finally`, and `run()` has no
+`catch` either.
+
+Two consequences, both verified by a test that failed before the fix:
+
+1. **Nested transaction left behind.** `LocalDatabase.begin()` pushes a *nested*
+   `TransactionContext` when one is already active
+   (`engine/src/main/java/com/arcadedb/database/LocalDatabase.java:627-644`); `commit()` pops it
+   through `popIfNotLastTransaction()` (`:655-674`). A caller that held its own transaction got it
+   shadowed: the caller's next `commit()` popped and committed the importer's abandoned rows and
+   left the caller's own work uncommitted and still open.
+   Checked and ruled out: `GraphBatch.close()`, which runs on the way out of the failed
+   try-with-resources in `run()`, does **not** resolve the leak. Its `flush()` returns immediately
+   (`edgeCount == 0` during the vertex pass) and `batchUpdateVertexHeadChunks()` is skipped because
+   `preAllocateEdgeChunks` writes the head chunk straight onto the vertex
+   (`GraphBatch#getOrCreateOutEdgeChunk`) instead of populating `deferredOutHead`.
+
+2. **Zero reported for a partial import.** `ts.count` and `totalVertices` were assigned after the
+   final commit, so a failure left them at 0 while the intermediate commits had already made
+   whole multiples of 50,000 rows durable. `getVertexCount()` is public, so an operator or a caller
+   that catches the exception reads 0 and concludes nothing was written.
+
+One correction to the fix sketch in the issue body:
+
+- the sketch assigns `ts.count = count[0]` in the `finally`. `count[0]` is the number of rows
+  **read**, which after a rollback overstates what is on the disk by up to 50,000. The fix tracks
+  the count at the last successful commit separately and reports that.
+- the sketch catches `RuntimeException`. `RecordSource.forEach` and `RecordVisitor.visit` are both
+  declared `throws Exception`, and the issue itself lists "an `IOException` from the reader" as a
+  reachable throw site, so the catch has to be `Exception`.
+- a bare `database.rollback()` is not safe on its own: it pops whatever transaction is on top of
+  the stack, so firing it after this method's own transaction has already been committed and popped
+  would roll back the **caller's**. The fix tracks whether the pushed transaction is still current.
+
+## Invariant
+
+`processVertexSource` never returns or throws with the transaction it pushed still on the
+transaction stack, and after a failure `getVertexCount()` reports the number of vertices durably
+committed rather than zero.
+
+## Completeness
+
+### Ways to violate the invariant (commands and output)
+
+Transaction sites inside `GraphImporter`:
+
+```
+$ grep -n "database\.begin()\|database\.commit()\|database\.rollback()" \
+    integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+976:    database.begin();
+1042:        database.commit();
+1043:        database.begin();
+1046:    database.commit();
+```
+
+All four are inside `processVertexSource`. The class's three other units of work:
+
+```
+$ grep -n "public void run()\|private void process\|private void flushEdgeType" \
+    integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+780:  public void run() throws Exception {
+941:  private void processVertexSource(final GraphBatch batch, final VertexSourceDef vsd) throws Exception {
+1160:  private void processEdgeSource(final EdgeSourceDef esd, final int sourceIndex) throws Exception {
+1231:  private void flushEdgeType(final EdgeCollector ec) {
+```
+
+Readers of the count the fix repairs:
+
+```
+$ grep -n "totalVertices" .../graph/GraphImporter.java
+105:  private long totalVertices;
+809:  ... "  Topology: %,d vertices, %,d edge refs", totalVertices, ...
+820:        totalVertices, totalEdges, ...
+911:    return totalVertices;          # getVertexCount()
+1051:    totalVertices += ts.count;
+```
+
+Same-shape siblings across the importer package (`database.begin()` before a row loop with periodic
+commits):
+
+```
+$ grep -rn "database\.begin()\|database\.commit()\|database\.rollback()" \
+    integration/src/main/java/com/arcadedb/integration/importer/
+... format/JsonlImporterFormat.java:140,171,172,187,188,203,212,909,910,923,924
+... format/JSONImporterFormat.java:152,160,190,227,230,245,248
+... format/CSVImporterFormat.java:196,198,209,216,283,301,302,305,449,451,462,468,590,602,603,613
+... format/RDFImporterFormat.java:51,81,82,86
+... Neo4jImporter.java:341,385,386,403,642,669
+... OrientDBImporter.java:491,506,507,510
+... AbstractImporter.java:112,139,148,156,161
+```
+
+### Coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| `processVertexSource` row loop throws, no caller transaction | yes | yes - `aFailedVertexSourceLeavesNoTransactionActive` |
+| `processVertexSource` row loop throws, caller holds a transaction | yes | yes - `aFailedVertexSourceGivesTheCallerItsOwnTransactionBack` |
+| `processVertexSource` throws after an intermediate commit (report) | yes | yes - `aFailureAfterAnIntermediateCommitReportsTheRowsThatCommitted` |
+| `processVertexSource`'s own `database.commit()` throws | yes | **argued** - `LocalDatabase.commit()` pops the transaction in a `finally` (`:655-674`), so it is off the stack whether it succeeds or throws. The fix clears the "still mine" flag *before* the call, so the catch does not then roll back the caller's. Driving a commit failure needs fault injection the importer has no hook for |
+| `processEdgeSource` | **argued** - opens no transaction; the grep above shows every `begin()` in the class is inside `processVertexSource`, and the method only fills in-memory buffers | n/a |
+| `flushEdgeType` | **argued** - delegates to `GraphBatch`, which owns its transactions and is closed by try-with-resources | n/a |
+| `run()`'s `GraphBatch` close after a failed vertex source | yes, by consequence - the transaction is rolled back before `close()` runs | exercised by all three tests (the batch is closed on the exceptional path) |
+| `RDFImporterFormat.parse` | **filed** - [#7272](https://github.com/ArcadeData/arcadedb/issues/7272) | no |
+| `CSVImporterFormat.loadEdges` | **filed** - [#7272](https://github.com/ArcadeData/arcadedb/issues/7272) | no |
+| `OrientDBImporter.updateDocumentLinks` | **filed** - [#7272](https://github.com/ArcadeData/arcadedb/issues/7272) | no |
+| `Neo4jImporter.readFile` | **filed** - [#7272](https://github.com/ArcadeData/arcadedb/issues/7272) | no |
+| `JsonlImporterFormat` | **argued** - the mirror case (touching a transaction it does not own), already tracked by #6561 | n/a |
+| `CSVImporterFormat.loadDocuments` / `loadVertices`, `JSONImporterFormat` | **argued** - both already roll back on the failure path (`rollbackIfOwned`, and `JSONImporterFormat:160/190/230`) | pre-existing tests |
+
+### Reachability
+
+`GraphImporter.processVertexSource` runs on every `GraphImporter.run()`, which is the only way to
+use the class - `run()` is called by `GraphImporter.main`, by the JSON-config path
+(`GraphImporter.fromJSON`) and by the existing tests. `getVertexCount()` is public and is the value
+`main` prints. No flag gates the changed lines: the `try`/`catch`/`finally` wraps the loop
+unconditionally, and the intermediate-commit branch is the same one that was already there, now
+reading the extracted `COMMIT_EVERY_ROWS` constant.
+
+### Residual risk
+
+- A failure past an intermediate commit still leaves a **partial** graph. That is inherent to
+  committing periodically; the fix makes the size of the partial import visible (`getVertexCount()`
+  plus a `WARNING` naming the committed rows and the rolled-back ones) instead of hiding it behind
+  a zero. It does not resume, truncate or otherwise repair the import.
+- `ts.buckets` / `ts.positions` are trimmed and kept at their full read length while `ts.count`
+  reports only the committed prefix. Nothing reads them after a failure - the exception propagates
+  out of `run()` before pass 2, and `close()` clears `typeStates` - so the two are never compared;
+  truncating them would cost a copy on the success path for no reader.
+- The four sibling entry points listed above are untouched and tracked by #7272.
+
+## Changes
+
+`integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java`
+
+- extracted the literal `50_000` commit cadence into `COMMIT_EVERY_ROWS`, documented as the reason a
+  failed import is partial rather than atomic;
+- `processVertexSource` wraps the row loop and the final commit in `try` / `catch (Exception)` /
+  `finally`:
+  - `committed[0]` tracks the row count at the last successful commit;
+  - `txOpen[0]` tracks whether the transaction this method pushed is still current, cleared *before*
+    each `commit()` because `LocalDatabase.commit()` pops in a `finally`;
+  - the catch logs a `WARNING` naming the committed and the rolled-back row counts when anything had
+    been committed, and rethrows the original exception unwrapped (existing tests assert on those
+    messages and types);
+  - the `finally` rolls back when the pushed transaction is still current - in the `finally` rather
+    than the `catch` so an `Error` resolves it too - and assigns `ts.buckets`, `ts.positions`,
+    `ts.count = committed[0]` and `totalVertices` on every exit.
+
+`integration/src/test/java/com/arcadedb/integration/importer/GraphImporterFailedSourceTest.java` (new)
+
+- three tests, one per fixed row of the coverage table, driven through the public `RecordSource`
+  extension point so the failing row can be placed exactly (an `intProperty` fed non-numeric text,
+  which throws from `readProperty` - one of the throw sites the issue names).
+
+## Adversarial pass
+
+No `Task` tool was available in this session, so the Phase 1.5 subagent could not be spawned. The
+pass was run inline instead, reading the diff against the issue body as the reporter would. What it
+turned up:
+
+- **Real, fixed here.** The rollback sat in `catch (Exception)`, so an `Error` - and
+  `OutOfMemoryError` is the one a 200k-row import can realistically raise - would have run the
+  counter `finally` and still left the transaction on the stack, which is the exact defect the issue
+  reports. Moved into the `finally`, guarded by the same `txOpen[0]` flag. The three tests still
+  pass; none of them can reach an `Error`, so this one row of the table rests on the guard being the
+  same guard the tested paths use rather than on a test of its own.
+- **Real, out of scope, filed.** Four other importer row loops have the same shape -
+  [#7272](https://github.com/ArcadeData/arcadedb/issues/7272).
+- **Considered, not real.** `totalVertices += ts.count` in a `finally` double-counting a type
+  imported by two sources: `validateEdgeTargets` refuses a type declared by more than one vertex
+  source (`GraphImporter.java:850-863`), and each call builds its own `TypeState`.
+- **Considered, not real.** A `database.begin()` that itself throws (either the one before the loop
+  or the one after an intermediate commit) skipping the rollback: `txOpen[0]` is false at both
+  points, and nothing this method opened is on the stack, so there is nothing to roll back.
+- **Considered, not real.** The `finally` masking the original exception if `rollback()` throws:
+  `LocalDatabase.rollback()` swallows `TransactionException` (`:677-690`), and any other failure
+  there would have replaced the exception from a `catch` block just the same.
+
+## Test results
+
+All three tests fail on the unfixed tree and pass on the fixed one.
+
+Before the fix:
+
+```
+Tests run: 3, Failures: 3, Errors: 0, Skipped: 0
+  aFailedVertexSourceLeavesNoTransactionActive:116
+    [the transaction processVertexSource opened must be resolved before the failure propagates]
+    Expecting value to be false but was true
+  aFailedVertexSourceGivesTheCallerItsOwnTransactionBack:151
+    [one commit for the one transaction the caller opened must leave nothing active]
+    Expecting value to be false but was true
+  aFailureAfterAnIntermediateCommitReportsTheRowsThatCommitted:181
+    [the report must name the rows the intermediate commit made durable, not zero]
+    expected: 50000L but was: 0L
+```
+
+After the fix:
+
+- `mvn -o -pl integration test -Dtest=GraphImporterFailedSourceTest` - 3/3 pass (2.0 s; the 50,010
+  row case runs in ~1.1 s, so no `@Tag("slow")`)
+- `mvn -o -pl integration test` - `Tests run: 240, Failures: 0, Errors: 0, Skipped: 9`
+- `mvn -o -pl integration verify -DskipITs=false -DskipTests=true` -
+  `Tests run: 123, Failures: 0, Errors: 0, Skipped: 0` (includes `CSVImporterIT`, `Neo4jImporterIT`,
+  `JsonLImporterIT`, `OrientDBImporterIT`)
+
+## Impact
+
+Behaviour changes only on the failure path of a vertex source:
+
+- the transaction the importer pushed is rolled back instead of left active, so a caller keeps its
+  own transaction and the rows the importer abandoned are no longer committed by the caller's next
+  `commit()`;
+- `getVertexCount()` and the per-type `TypeState` report the durable prefix instead of zero;
+- a new `WARNING` line is logged when the failed source had already committed rows.
+
+The success path is unchanged: `committed[0] == count[0]` after the final commit, so `ts.count` and
+`totalVertices` carry the same values as before.
+
+## Recommendations
+
+- Resolve #7272 so the other four importer row loops behave the same way.
+- A resumable import (skip the first N rows of a source) would turn the partial state this fix now
+  reports into something an operator can act on directly. Out of scope here.

--- a/docs/7264-graphimporter-tx-leak-zero-count.md
+++ b/docs/7264-graphimporter-tx-leak-zero-count.md
@@ -147,6 +147,9 @@ reading the extracted `COMMIT_EVERY_ROWS` constant.
   out of `run()` before pass 2, and `close()` clears `typeStates` - so the two are never compared;
   truncating them would cost a copy on the success path for no reader.
 - The four sibling entry points listed above are untouched and tracked by #7272.
+- A `rollback()` that fails is reported at `SEVERE` and swallowed, so a repeated failure there is
+  visible only by reading the log. Giving the importer metrics would be the place to surface it
+  (review cycle 3, observation 3); out of scope here.
 
 ## Changes
 
@@ -192,9 +195,12 @@ turned up:
 - **Considered, not real.** A `database.begin()` that itself throws (either the one before the loop
   or the one after an intermediate commit) skipping the rollback: `txOpen[0]` is false at both
   points, and nothing this method opened is on the stack, so there is nothing to roll back.
-- **Considered, not real.** The `finally` masking the original exception if `rollback()` throws:
-  `LocalDatabase.rollback()` swallows `TransactionException` (`:677-690`), and any other failure
-  there would have replaced the exception from a `catch` block just the same.
+- **Considered, argued at first, then fixed in review cycle 2.** The `finally` masking the original
+  exception if `rollback()` throws. `LocalDatabase.rollback()` already swallows
+  `TransactionException` (`:677-690`), which is what made this look survivable - but a throw there
+  would also have skipped the counter assignment after it, which is this issue's own "reports 0
+  vertices" symptom re-entering through the code that fixes it. The rollback now reports a failure
+  at `SEVERE` and swallows it.
 
 ## Test results
 
@@ -236,6 +242,29 @@ Behaviour changes only on the failure path of a vertex source:
 
 The success path is unchanged: `committed[0] == count[0]` after the final commit, so `ts.count` and
 `totalVertices` carry the same values as before.
+
+## PR and review cycles
+
+PR: https://github.com/ArcadeData/arcadedb/pull/7273
+
+- **cycle 1** - `0f4c9a30` - the fix, the three tests and this doc. Review: no blocking findings; one
+  request for a one-line confirmation that skipping the `WARNING` when nothing had been committed is
+  deliberate, and a note that `ts.buckets`/`ts.positions` outlive the committed count on the failure
+  path. Both answered with comments at the two lines in question (`dcbe91ee`).
+- **cycle 2** - `dcbe91ee` - review found a real off-by-one: the `WARNING` described
+  `count[0] - committed[0]` as "rows read since the last commit", but `count[0]` is incremented only
+  after a row becomes a vertex, so the failing row was not in it. The message now speaks in the terms
+  the counters actually hold. The same review flagged, as non-blocking residual risk, that the
+  rollback in the `finally` could replace the propagating exception; acted on rather than deferred,
+  because a throw there would also skip the counter assignment and re-create this issue's own
+  symptom. Both fixed in `31515737`.
+- **cycle 3** - `31515737` - clean. Its two observations (a comment on the `committed[0] > 0` guard,
+  a comment at `ts.buckets = bk.trim()`) were already in the tree from cycle 1; the review appears to
+  have read them only in the cycle-1 commit message. No changes applied, no deferred items.
+
+Final state: **clean-approval** after 3 of the 4 allowed cycles.
+
+Merge is the developer's; this branch was never merged or closed by the workflow.
 
 ## Recommendations
 

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -1080,9 +1080,9 @@ public class GraphImporter implements AutoCloseable {
       // own says everything there is to say
       if (committed[0] > 0)
         LogManager.instance().log(this, Level.WARNING,
-            "  %-12s failed after reading %,d rows: the import is PARTIAL - %,d vertices an earlier batch commit "
-                + "made durable stay on the disk, the %,d rows read since it were rolled back. Resume the source "
-                + "after the committed rows, or empty the type before running it again",
+            "  %-12s failed after importing %,d rows: the import is PARTIAL - %,d of them an earlier batch commit "
+                + "made durable and they stay on the disk, the other %,d were rolled back along with the row that "
+                + "failed. Resume the source after the committed rows, or empty the type before running it again",
             vc.typeName, count[0], committed[0], count[0] - committed[0]);
       throw e;
     } finally {
@@ -1091,7 +1091,17 @@ public class GraphImporter implements AutoCloseable {
       // every path that already committed, which is what keeps this from rolling back the caller's
       if (txOpen[0]) {
         txOpen[0] = false;
-        database.rollback();
+        try {
+          database.rollback();
+        } catch (final Exception rollbackFailure) {
+          // A throw here would replace the exception on its way out with one about the cleanup, and
+          // would skip the counter assignment below - which is this issue's own symptom, reached
+          // through the code that fixes it. Reported and swallowed instead: the caller keeps the
+          // failure it can act on, and this line says the transaction may still be pushed
+          LogManager.instance().log(this, Level.SEVERE,
+              "  %-12s could not roll back after the import failed: the transaction it opened may still be on the "
+                  + "stack", rollbackFailure, vc.typeName);
+        }
       }
 
       // The counters are assigned whatever happened: the number of vertices actually on the disk is

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -95,6 +95,14 @@ public class GraphImporter implements AutoCloseable {
    */
   static final long NOT_CANONICAL_LONG = Long.MIN_VALUE;
 
+  /**
+   * Rows the vertex pass buffers before committing. The commit is what bounds the transaction's
+   * memory on a large source, and it is also what makes a failed import PARTIAL rather than atomic:
+   * everything up to the last multiple of this stays on the disk when a later row throws, which is
+   * why {@link #processVertexSource} reports the committed count rather than the count read.
+   */
+  private static final int COMMIT_EVERY_ROWS = 50_000;
+
   private final Database                            database;
   private final List<VertexSourceDef>               vertexSources;
   private final List<EdgeSourceDef>                 edgeSources;
@@ -973,82 +981,124 @@ public class GraphImporter implements AutoCloseable {
       deferredSelf.add(new DeferredSelfEdges());
 
     final int[] count = {0};
+
+    // Rows an intermediate commit already made durable. Counted apart from count[0] because a
+    // failure rolls back the transaction in flight: what the report owes the operator is the number
+    // of vertices that survived, which is what decides whether to resume, truncate or start over
+    final int[] committed = {0};
+
+    // Whether the transaction opened below is still the current one. database.rollback() pops
+    // whatever transaction is on top of the stack, and this one nests inside the caller's when the
+    // caller holds one (see LocalDatabase#begin()), so rolling back after it has already been
+    // committed and popped would discard the CALLER's transaction instead of this method's
+    final boolean[] txOpen = {false};
+
     database.begin();
+    txOpen[0] = true;
 
     final String filterAttr = vc.filterAttribute;
     final String filterVal = vc.filterValue;
 
-    vsd.source.forEach(record -> {
-      if (limit > 0 && count[0] >= limit)
-        return;
-
-      // Apply row filter (e.g. PostTypeId=1 for questions only)
-      if (filterAttr != null) {
-        final String v = record.get(filterAttr);
-        if (v == null || !v.equals(filterVal))
+    try {
+      vsd.source.forEach(record -> {
+        if (limit > 0 && count[0] >= limit)
           return;
-      }
 
-      // The raw text is the key: an identity is whatever the source wrote, so reading it as an int
-      // would reject a string key and truncate one wider than an int. Read once - deduplication
-      // looks the same key up that registration then stores
-      final String id = vc.idAttribute != null ? identity(record, vc.idAttribute) : null;
-      final String nameId = vc.nameIdAttribute != null ? identity(record, vc.nameIdAttribute) : null;
-
-      // Deduplication: skip if this id/nameId was already imported
-      if (vc.deduplicate && (ts.idToIdx.get(id) >= 0 || ts.nameToIdx.get(nameId) >= 0))
-        return;
-
-      final int idx = count[0];
-      ts.idToIdx.put(id, idx);
-      ts.nameToIdx.put(nameId, idx);
-
-      // Build vertex properties
-      propBuf.clear();
-      for (final PropDef pd : vc.properties) {
-        final Object val = readProperty(record, pd);
-        if (val != null) {
-          propBuf.add(pd.name);
-          propBuf.add(val);
+        // Apply row filter (e.g. PostTypeId=1 for questions only)
+        if (filterAttr != null) {
+          final String v = record.get(filterAttr);
+          if (v == null || !v.equals(filterVal))
+            return;
         }
-      }
 
-      final MutableVertex v = batch.createVertex(vc.typeName, propBuf.toArray());
-      bk.add(v.getIdentity().getBucketId());
-      ps.add(v.getIdentity().getPosition());
+        // The raw text is the key: an identity is whatever the source wrote, so reading it as an int
+        // would reject a string key and truncate one wider than an int. Read once - deduplication
+        // looks the same key up that registration then stores
+        final String id = vc.idAttribute != null ? identity(record, vc.idAttribute) : null;
+        final String nameId = vc.nameIdAttribute != null ? identity(record, vc.nameIdAttribute) : null;
 
-      // Collect edges
-      for (final EdgeDef ed : resolvedEdges)
-        collectEdge(record, ed, vc.typeName, idx);
+        // Deduplication: skip if this id/nameId was already imported
+        if (vc.deduplicate && (ts.idToIdx.get(id) >= 0 || ts.nameToIdx.get(nameId) >= 0))
+          return;
 
-      // Collect deferred (self-referencing) edges: this row's index is already final, only the
-      // target key has to wait for the rest of the file
-      for (int i = 0; i < deferredEdgeDefs.size(); i++) {
-        final EdgeDef ed = deferredEdgeDefs.get(i);
-        final String fieldVal = ed.isSplit ? record.get(ed.fkAttribute) : identity(record, ed.fkAttribute);
-        if (fieldVal == null)
-          continue;
-        final DeferredSelfEdges deferred = deferredSelf.get(i);
-        if (ed.isSplit)
-          collectSplitKeys(fieldVal, ed.delimiter.charAt(0), deferred, idx);
-        else {
-          deferred.srcIdx.add(idx);
-          deferred.targetKeys.add(fieldVal);
+        final int idx = count[0];
+        ts.idToIdx.put(id, idx);
+        ts.nameToIdx.put(nameId, idx);
+
+        // Build vertex properties
+        propBuf.clear();
+        for (final PropDef pd : vc.properties) {
+          final Object val = readProperty(record, pd);
+          if (val != null) {
+            propBuf.add(pd.name);
+            propBuf.add(val);
+          }
         }
+
+        final MutableVertex v = batch.createVertex(vc.typeName, propBuf.toArray());
+        bk.add(v.getIdentity().getBucketId());
+        ps.add(v.getIdentity().getPosition());
+
+        // Collect edges
+        for (final EdgeDef ed : resolvedEdges)
+          collectEdge(record, ed, vc.typeName, idx);
+
+        // Collect deferred (self-referencing) edges: this row's index is already final, only the
+        // target key has to wait for the rest of the file
+        for (int i = 0; i < deferredEdgeDefs.size(); i++) {
+          final EdgeDef ed = deferredEdgeDefs.get(i);
+          final String fieldVal = ed.isSplit ? record.get(ed.fkAttribute) : identity(record, ed.fkAttribute);
+          if (fieldVal == null)
+            continue;
+          final DeferredSelfEdges deferred = deferredSelf.get(i);
+          if (ed.isSplit)
+            collectSplitKeys(fieldVal, ed.delimiter.charAt(0), deferred, idx);
+          else {
+            deferred.srcIdx.add(idx);
+            deferred.targetKeys.add(fieldVal);
+          }
+        }
+
+        count[0]++;
+        if (count[0] % COMMIT_EVERY_ROWS == 0) {
+          // Cleared before the call, not after: LocalDatabase#commit() pops the transaction in a
+          // finally, so a commit that throws still leaves this method's transaction off the stack
+          txOpen[0] = false;
+          database.commit();
+          committed[0] = count[0];
+          database.begin();
+          txOpen[0] = true;
+        }
+      });
+
+      txOpen[0] = false;
+      database.commit();
+      committed[0] = count[0];
+    } catch (final Exception e) {
+      if (committed[0] > 0)
+        LogManager.instance().log(this, Level.WARNING,
+            "  %-12s failed after reading %,d rows: the import is PARTIAL - %,d vertices an earlier batch commit "
+                + "made durable stay on the disk, the %,d rows read since it were rolled back. Resume the source "
+                + "after the committed rows, or empty the type before running it again",
+            vc.typeName, count[0], committed[0], count[0] - committed[0]);
+      throw e;
+    } finally {
+      // In the finally rather than in the catch so that an Error - an OutOfMemoryError is the one a
+      // large import can realistically raise - resolves the transaction too. txOpen[0] is false on
+      // every path that already committed, which is what keeps this from rolling back the caller's
+      if (txOpen[0]) {
+        txOpen[0] = false;
+        database.rollback();
       }
 
-      count[0]++;
-      if (count[0] % 50_000 == 0) {
-        database.commit();
-        database.begin();
-      }
-    });
-    database.commit();
-
-    ts.buckets = bk.trim();
-    ts.positions = ps.trim();
-    ts.count = count[0];
-    totalVertices += ts.count;
+      // The counters are assigned whatever happened: the number of vertices actually on the disk is
+      // most valuable precisely when the import failed, and leaving it at zero reads as "nothing was
+      // written" for a source that committed hundreds of thousands of rows
+      ts.buckets = bk.trim();
+      ts.positions = ps.trim();
+      ts.count = committed[0];
+      totalVertices += ts.count;
+    }
 
     // Resolve deferred self-referencing edges (srcType == dstType == thisType)
     for (int i = 0; i < deferredEdgeDefs.size(); i++) {

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -1075,6 +1075,9 @@ public class GraphImporter implements AutoCloseable {
       database.commit();
       committed[0] = count[0];
     } catch (final Exception e) {
+      // Only when something was committed: below the first COMMIT_EVERY_ROWS the rollback takes the
+      // whole source with it, so there is no partial import to warn about and the exception on its
+      // own says everything there is to say
       if (committed[0] > 0)
         LogManager.instance().log(this, Level.WARNING,
             "  %-12s failed after reading %,d rows: the import is PARTIAL - %,d vertices an earlier batch commit "
@@ -1093,7 +1096,13 @@ public class GraphImporter implements AutoCloseable {
 
       // The counters are assigned whatever happened: the number of vertices actually on the disk is
       // most valuable precisely when the import failed, and leaving it at zero reads as "nothing was
-      // written" for a source that committed hundreds of thousands of rows
+      // written" for a source that committed hundreds of thousands of rows.
+      //
+      // On the failure path the two arrays hold every row READ while ts.count names only the
+      // committed prefix, so the tail addresses records the rollback took away. Nothing reads them
+      // there: run() has no per-source catch, so the failure aborts the import before pass 2 and
+      // before the deferred self-edge resolution below, and close() clears typeStates. Give run() a
+      // continue-on-error mode and this has to become a trim to committed[0] on the failure path
       ts.buckets = bk.trim();
       ts.positions = ps.trim();
       ts.count = committed[0];

--- a/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterFailedSourceTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterFailedSourceTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.integration.importer.graph.GraphImporter;
+import com.arcadedb.utility.FileUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A row that cannot be read aborts the vertex pass from inside the row loop. What the importer owes
+ * the caller at that point is the subject of issue #7264: the transaction it opened has to be
+ * resolved rather than left on the caller's stack, and the count it reports has to be the number of
+ * vertices that actually reached the disk rather than zero.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class GraphImporterFailedSourceTest {
+
+  private static final String DB_PATH = "target/databases/graph-importer-failed-source-test";
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    database = new DatabaseFactory(DB_PATH).create();
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Row");
+      database.getSchema().createVertexType("Marker");
+    });
+  }
+
+  @AfterEach
+  void cleanup() {
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollbackAllNested();
+      if (database.isOpen())
+        database.drop();
+      database = null;
+    }
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  /**
+   * Rows held in memory rather than in a file: the intermediate commit fires every 50,000 rows, and
+   * placing a failure just past one needs that many rows without writing them to disk first.
+   * {@code score} is declared as an integer, so the row at {@code badRow} throws from
+   * {@code readProperty} - one of the throw sites the issue lists, reached the way a malformed
+   * source reaches it.
+   */
+  private static GraphImporter.RecordSource rows(final int total, final int badRow) {
+    return visitor -> {
+      for (int i = 0; i < total; i++) {
+        final int row = i;
+        visitor.visit(attribute -> switch (attribute) {
+          case "id" -> String.valueOf(row);
+          case "score" -> row == badRow ? "not-a-number" : String.valueOf(row);
+          default -> null;
+        });
+      }
+    };
+  }
+
+  private long countOf(final String typeName) {
+    return database.query("sql", "select count(*) as c from " + typeName).next().<Long>getProperty("c");
+  }
+
+  /**
+   * No caller transaction: the one the importer pushed is the only one there is, and a failure must
+   * not leave it active for whatever runs next on this thread.
+   */
+  @Test
+  void aFailedVertexSourceLeavesNoTransactionActive() throws Exception {
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Row", rows(10, 5), v -> {
+          v.id("id");
+          v.intProperty("score", "score");
+        })
+        .build()) {
+
+      assertThatThrownBy(importer::run)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("score");
+    }
+
+    assertThat(database.isTransactionActive())
+        .as("the transaction processVertexSource opened must be resolved before the failure propagates")
+        .isFalse();
+    assertThat(countOf("Row"))
+        .as("nothing was committed before the failure, so the rolled-back rows must not be on disk")
+        .isZero();
+  }
+
+  /**
+   * The case the issue reports: the caller already holds a transaction, so {@code database.begin()}
+   * pushes a nested one. Leaving it there shadows the caller's - the caller's next {@code commit()}
+   * pops the importer's instead, committing rows the importer had abandoned and leaving the
+   * caller's own work uncommitted and still open.
+   */
+  @Test
+  void aFailedVertexSourceGivesTheCallerItsOwnTransactionBack() throws Exception {
+    database.begin();
+    database.newVertex("Marker").set("name", "caller").save();
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Row", rows(10, 5), v -> {
+          v.id("id");
+          v.intProperty("score", "score");
+        })
+        .build()) {
+
+      assertThatThrownBy(importer::run)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("score");
+    }
+
+    // The caller commits the transaction it opened, unaware that the importer failed inside one of
+    // its own. That commit has to land on the caller's work
+    database.commit();
+
+    assertThat(database.isTransactionActive())
+        .as("one commit for the one transaction the caller opened must leave nothing active")
+        .isFalse();
+    assertThat(countOf("Marker"))
+        .as("the caller's own record must be what its commit made durable")
+        .isEqualTo(1);
+    assertThat(countOf("Row"))
+        .as("the importer's abandoned rows must not ride out on the caller's commit")
+        .isZero();
+  }
+
+  /**
+   * Past the first intermediate commit the partial import is durable whatever happens next, and the
+   * number the operator reads is what decides whether to resume, truncate or start over. Reporting
+   * zero for 50,000 rows that are on the disk turns a partial import into the wrong decision.
+   */
+  @Test
+  void aFailureAfterAnIntermediateCommitReportsTheRowsThatCommitted() throws Exception {
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Row", rows(50_010, 50_005), v -> {
+          v.id("id");
+          v.intProperty("score", "score");
+        })
+        .build()) {
+
+      assertThatThrownBy(importer::run)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("score");
+
+      assertThat(importer.getVertexCount())
+          .as("the report must name the rows the intermediate commit made durable, not zero")
+          .isEqualTo(50_000);
+    }
+
+    assertThat(database.isTransactionActive()).isFalse();
+    assertThat(countOf("Row"))
+        .as("the reported count must be the count the database actually holds")
+        .isEqualTo(50_000);
+  }
+}


### PR DESCRIPTION
Closes #7264

`GraphImporter.processVertexSource` opened a transaction before the row loop, committed every
50,000 rows inside it, committed once after it and then assigned the per-type counters, with no
`try`/`finally` and no `catch` in `run()`. Anything thrown from inside the loop skipped both the
final commit and the bookkeeping, so the importer left a **nested** transaction on the caller's
stack (`LocalDatabase.begin()` pushes rather than reuses, and `commit()` pops through
`popIfNotLastTransaction()`) and reported **0 vertices** for a source whose intermediate commits had
already made whole multiples of 50,000 rows durable - which is what turns a recoverable partial
import into a wrong decision about whether to resume, truncate or start over. The row loop and the
final commit are now wrapped: the transaction the method pushed is rolled back on the way out, and
the counters are assigned in a `finally` from the row count at the last successful commit, so
`getVertexCount()` names the durable prefix and a `WARNING` says how many rows committed and how
many were rolled back.

Three details differ from the fix sketched in the issue, each for a reason:

- **The count reported is the committed count, not `count[0]`.** `count[0]` is rows *read*, which
  after a rollback overstates what is on the disk by up to 50,000.
- **The catch is `Exception`, not `RuntimeException`.** `RecordSource.forEach` and
  `RecordVisitor.visit` are both declared `throws Exception`, and the issue itself names an
  `IOException` from the reader as a reachable throw site.
- **The rollback is guarded and lives in the `finally`.** `database.rollback()` pops whatever
  transaction is on top of the stack, so firing it after this method's own has already been
  committed and popped would roll back the **caller's**. A flag tracks whether the pushed
  transaction is still current, cleared *before* each `commit()` because `LocalDatabase.commit()`
  pops in a `finally` whether it succeeds or throws. It sits in the `finally` rather than the
  `catch` so an `Error` - `OutOfMemoryError` being the one a large import can realistically raise -
  resolves the transaction too.

The literal `50_000` cadence is extracted into `COMMIT_EVERY_ROWS`, documented as the reason a
failed import is partial rather than atomic.

## Test plan

- [ ] `mvn -o -pl integration test -Dtest=GraphImporterFailedSourceTest` - 3/3 pass in ~2 s. Each of
      the three fails on the tree without the fix, with the assertion that names the defect
      ("Expecting value to be false but was true" for the leak, `expected: 50000L but was: 0L` for
      the report).
- [ ] `mvn -o -pl integration test` - `Tests run: 240, Failures: 0, Errors: 0, Skipped: 9`.
- [ ] `mvn -o -pl integration verify -DskipITs=false -DskipTests=true` -
      `Tests run: 123, Failures: 0, Errors: 0, Skipped: 0`, covering `CSVImporterIT`,
      `Neo4jImporterIT`, `JsonLImporterIT` and `OrientDBImporterIT`.
- [ ] Manual read of the new `WARNING` on the 50,010-row case:
      `Row failed after importing 50,005 rows: the import is PARTIAL - 50,000 of them an earlier
      batch commit made durable and they stay on the disk, the other 5 were rolled back along with
      the row that failed.`

## Coverage

| Entry point | Fixed | Test |
|---|---|---|
| `processVertexSource` row loop throws, no caller transaction | yes | `aFailedVertexSourceLeavesNoTransactionActive` |
| `processVertexSource` row loop throws, caller holds a transaction | yes | `aFailedVertexSourceGivesTheCallerItsOwnTransactionBack` |
| `processVertexSource` throws after an intermediate commit (the report) | yes | `aFailureAfterAnIntermediateCommitReportsTheRowsThatCommitted` |
| `run()`'s `GraphBatch` close after a failed vertex source | yes, by consequence - the transaction is resolved before `close()` runs | all three (the batch closes on the exceptional path) |
| `processVertexSource`'s own `commit()` throws | yes | argued - `LocalDatabase.commit()` pops in a `finally`, so the transaction is off the stack either way and the flag is cleared before the call. Driving a commit failure needs fault injection the importer has no hook for |
| `processEdgeSource` | n/a | argued - opens no transaction (every `begin()` in the class is inside `processVertexSource`); it only fills in-memory buffers |
| `flushEdgeType` | n/a | argued - delegates to `GraphBatch`, which owns its transactions and is closed by try-with-resources |
| `CSVImporterFormat.loadDocuments`/`loadVertices`, `JSONImporterFormat` | n/a | argued - both already roll back on the failure path (`rollbackIfOwned`) |

**Known gaps**

- The same shape of defect - `begin()` before a row loop with periodic commits and no `finally` - in
  `RDFImporterFormat.parse`, `CSVImporterFormat.loadEdges`, `OrientDBImporter.updateDocumentLinks`
  and `Neo4jImporter.readFile`. Each is a different class with its own commit cadence and its own
  notion of a partial import, so each needs its own test rather than sharing these. Filed as
  **#7272**.
- `JsonlImporterFormat` is the mirror case (touching a transaction it does not own) and is already
  tracked by **#6561**.
- A failure past an intermediate commit still leaves a partial graph. That is inherent to committing
  periodically; this PR makes the size of the partial import visible instead of hiding it behind a
  zero. It does not resume or repair the import.

Two review cycles changed the code after the first push: the `WARNING` was undercounting the
rolled-back rows by one (`count[0]` is incremented only after a row becomes a vertex, so the failing
row was not in it), and the rollback in the `finally` was unguarded - a throw there would have
replaced the propagating exception *and* skipped the counter assignment, re-creating this issue's own
"reports 0 vertices" symptom through the code that fixes it. It now reports at `SEVERE` and swallows.

Tracking notes, including the completeness sweep with its grep output, the adversarial pass and the
per-cycle review history, are in `docs/7264-graphimporter-tx-leak-zero-count.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuuFV2rsSfiK4yvr6i91uz
