### PR TITLE
fix(#7266): the importer config, the disk card and the second-pass rebuild guard each do what they say

### DIFF
--- a/docs/7266-three-small-defects.md
+++ b/docs/7266-three-small-defects.md
@@ -1,0 +1,296 @@
+# Issue #7266 - three small defects with the same shape
+
+<https://github.com/ArcadeData/arcadedb/issues/7266>
+
+Three unrelated defects, filed together. The shape they share: a guard or a figure added or
+corrected recently, whose new form does not do what its own comment or contract says.
+
+## Finding ledger
+
+- [x] 1. JSON importer config crashes with `ArrayIndexOutOfBoundsException` before the new
+      `checkEdgeSourceEndpoint` validation can report the mistake - **fixed**, on both endpoints and
+      on the `"filter"` sibling of the same shape in the same parser
+- [x] 2. Studio's "Databases Disk" card counts the filesystem's root-reserved blocks as used -
+      **fixed**, the server now reports `diskUsedSpace` and the card renders it
+- [x] 3. The second-pass full-rebuild guard in `LocalSchema.loadIncremental` is unreachable -
+      **fixed for the bloom filter** (the half that was actually broken), made explicit rather than
+      accidental for the compacted index, and deliberately left off for the dictionary with the
+      reason stated in both places the contract is written down
+
+## Analysis
+
+### 1. `GraphImporter` JSON edge endpoint parse
+
+`integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java:352-355`
+splits `"from"` / `"to"` on `:` and indexes `[1]` unconditionally. A value that forgot the
+`:VertexType` half - the exact mistake `checkEdgeSourceEndpoint` (`:892-906`, added by
+`2a3cb60ef`) was written to describe - throws
+`ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1` inside the
+`b.edgeSource(...)` consumer, which `Builder.edgeSource` runs eagerly (`:459-465`), i.e. before
+`build()` ever reaches the validation.
+
+Two further mis-shapes of the same value are silently accepted rather than reported:
+`"a:b:c"` drops `:c`, and an empty half yields an empty attribute or vertex type.
+
+**Sibling of the same shape, same file, same parser:** `:306`
+`vj.getString("filter").split("=", 2)` then `parts[1]`. A filter written without `=` throws the
+same `ArrayIndexOutOfBoundsException` from the same JSON entry point.
+
+### 2. Studio "Databases Disk" used figure
+
+`#7223` moved the profiler's free-space reading to `File.getUsableSpace()`, which excludes the
+blocks the filesystem reserves for root. `total` stayed `File.getTotalSpace()`, which counts
+them. Studio derives `used = total - free`
+(`studio/src/main/resources/static/js/studio-server.js:153-155`), so the reservation - 5% of an
+ext4 by default - is charged to the databases. On a 100 GB volume holding 1 GB of databases the
+card reports roughly 6 GB used, a constant offset an operator watching for growth reads as data.
+
+`java.io.File`, precisely:
+
+| reading | counts root-reserved blocks as |
+|---|---|
+| `getTotalSpace()` | part of the total |
+| `getFreeSpace()` | free |
+| `getUsableSpace()` | neither free nor available to this JVM |
+
+So `total - usable` overstates used by the reservation, while `total - free` is what `df` calls
+Used. The fix reports the allocated figure from the server, derived from the two readings that
+describe the same thing, and leaves `diskFreeSpace` (usable) alone - that one is the right
+reading for "how much room is left", which is what the low-space warning and the percentage use.
+
+`ServerMonitor.checkDiskSpace()` (`server/.../monitor/ServerMonitor.java:118-142`) reads the same
+pair but only ever reports *available* space and a percentage of it. It computes no "used"
+figure, so it carries none of this defect.
+
+### 3. `LocalSchema.loadIncremental` second pass
+
+`engine/src/main/java/com/arcadedb/schema/LocalSchema.java:419-436`. The loop reads:
+
+```java
+final Component current = getFileByIdIfExists(fileId);
+if (current == null || !(current.getMainComponent() instanceof IndexInternal))
+  continue;                                     // <- short-circuits here
+...
+if (NON_INCREMENTAL_COMPONENT_EXTENSIONS.contains(file.getFileExtension()))
+  return false;                                 // <- never reached for .bfidx
+```
+
+What each owner of a non-incremental extension answers from `getMainComponent()`:
+
+| extension | component | `getMainComponent()` | second-pass guard reached? |
+|---|---|---|---|
+| `dict` | `Dictionary extends PaginatedComponent` | `this` | no |
+| `uctidx` / `nuctidx` | `LSMTreeIndexCompacted extends LSMTreeIndexAbstract` | `mainIndex`, wired by `LSMTreeIndexMutable.onAfterLoad` (`:134-137`) | yes, but only because of that wiring |
+| `bfidx` | `LSMTreeIndexBloomFilter extends PaginatedComponent` | `this` | **no** |
+
+So the issue's claim is half right, and the half that is right is the one that matters: a touched
+**bloom filter** never forces the rebuild, and its in-RAM `directory` (`LSMTreeIndexBloomFilter:133`,
+filled once by `loadDirectory()` through `attachBloomFilters()` and re-read by no load hook) is
+left describing the file as it was before this entry appended to it. A touched **compacted index**
+does fall back today, but only as a side effect of `mainIndex` having been wired by its mutable
+index - nothing in the guard says so, and a compacted component built by the factory starts with
+`mainIndex == null` (`LSMTreeIndex.java:112,124`).
+
+**The dictionary must NOT be added to the second-pass fallback.** `walTouchedFileIds`
+(`ha-raft/.../ArcadeStateMachine.java:2292-2311`) is every file id the entry's WAL wrote a page
+into, and a DDL entry that adds a type or property name writes dictionary pages. Making `dict`
+force the rebuild from `touchedFileIds` would send every name-adding DDL entry back to the full
+`load()` - which is exactly the O(entries x total files) cost issue #6988 removed. The second
+pass's own comment already states why a touched dictionary needs nothing here
+(`TransactionManager.applyChanges` reloads it). So the two passes need two sets, and the comments
+have to say so rather than claiming one set covers both.
+
+Severity, per the issue's own triage note: a stale bloom-filter directory is a *performance*
+regression, not a wrong answer. `mightContain` validates each directory entry against the series'
+page count and fingerprint before trusting it (`LSMTreeIndexBloomFilter:264-266`) and answers
+`true` - "search this series" - for everything it does not recognise, so a stale directory can
+only cost skipped optimisations, never hide a row.
+
+## Completeness
+
+### Invariants
+
+1. A malformed `"from"`, `"to"` or `"filter"` value in a JSON importer config raises an
+   `IllegalArgumentException` naming the offending value; it can never raise
+   `ArrayIndexOutOfBoundsException`.
+2. The "used" figure the Studio disk card renders is derived from two readings that count the
+   filesystem's root-reserved blocks the same way, so the reservation is never charged to the
+   databases.
+3. `loadIncremental` refuses - returning `false`, having changed nothing - for a touched
+   compacted index or bloom filter, regardless of what that component answers from
+   `getMainComponent()`.
+
+### Enumeration
+
+Commands run in the worktree, with their output.
+
+```
+$ grep -rn "split(" --include='*.java' integration/src/main/java/com/arcadedb/integration/importer/graph/
+GraphImporter.java:306:        final String[] parts = vj.getString("filter").split("=", 2);
+GraphImporter.java:352:      final String[] fromParts = ej.getString("from").split(":");
+GraphImporter.java:354:      final String[] toParts = ej.getString("to").split(":");
+CsvRowSource.java:91:    return line.split(String.valueOf(delimiter), -1);      # split(...,-1), never indexed blind
+```
+
+```
+$ grep -rn "fromJSON(database\|fromJSON(db\|parseEdgeSource(\|parseVertexSource(" --include='*.java' integration/src server/src console/src package/src
+GraphImporter.java:148:      try (final GraphImporter importer = fromJSON(database, config, baseDir)) {    # main()
+GraphImporter.java:269:    return fromJSON(database, new JSONObject(json), baseDir);                      # String overload
+GraphImporter.java:283:        parseVertexSource(b, vertices.getJSONObject(i), baseDir);
+GraphImporter.java:290:        parseEdgeSource(b, edgeSources.getJSONObject(i), baseDir);
+(+ 6 test call sites; no other production caller in server/, console/ or package/)
+```
+
+Both public `fromJSON` overloads and `main()` funnel through the same two private parsers, so
+one fix at the parse site covers every entry point into the JSON config.
+
+```
+$ grep -rn "diskFreeSpace\|diskTotalSpace\|diskUsedSpace" --include='*.js' --include='*.html' --include='*.java' --include='*.py' --include='*.ts' . | grep -v test
+studio/src/main/resources/static/js/studio-server.js:153,154,273
+engine/src/main/java/com/arcadedb/Profiler.java:421,422,423
+```
+
+Exactly one producer (`Profiler.toJSON`) and one consumer (`displayServerSummary`, plus the
+skip-list at `:273` that keeps the card's own fields out of the details table). No other client -
+no Python or JS binding, no HTTP handler - derives a used figure from the pair.
+
+```
+$ grep -rn -A3 "public Object getMainComponent" --include='*.java' engine/src/main/java/
+HashIndexBucket:213 -> mainIndex          LSMTreeIndexAbstract:289 -> mainIndex
+LSMTreeIndexBloomFilter:168 -> this       SparseSegmentComponent:126 -> this
+LSMVectorIndexCompacted:107 -> mainIndex  LSMVectorIndexMutable:78 -> mainIndex
+LSMVectorIndexGraphFile:99 -> mainIndex   Component:50 -> this
+```
+
+The two overrides answering `this` are the bloom filter and the sparse-vector segment. Only the
+bloom filter's extension is in `NON_INCREMENTAL_COMPONENT_EXTENSIONS`; `SparseSegmentComponent`
+is not, and never was, so it is out of this issue's scope and unchanged by this fix.
+
+```
+$ grep -rn "loadIncremental" --include='*.java' .
+ha-raft/.../ArcadeStateMachine.java:2352      # the only production caller
+engine/.../LocalSchema.java:385               # the definition
+engine/src/test/.../Issue6988IncrementalSchemaLoadTest.java  # 9 call sites
+```
+
+### Coverage table
+
+| # | Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|---|
+| 1 | `GraphImporter.fromJSON(db, JSONObject, dir)` -> `parseEdgeSource` -> `"from"` malformed | yes | yes - `Issue7266ImporterConfigValidationTest#aFromEndpointMissingItsVertexTypeIsReported` |
+| 1 | ... -> `"to"` malformed | yes | yes - `#aToEndpointMissingItsVertexTypeIsReported` |
+| 1 | ... -> `"from"` with more than one colon / an empty half | yes | yes - `#anEndpointWithTheWrongNumberOfPartsIsReported` |
+| 1 | `GraphImporter.fromJSON(db, String, dir)` (String overload -> same parser) | yes | yes - `#theStringOverloadReportsItToo` |
+| 1 | `parseVertexSource` -> `"filter"` without `=` (sibling) | yes | yes - `#aFilterWithoutAnEqualsIsReported` |
+| 1 | `parseEdgeSource` -> `"from"` / `"to"` key ABSENT (found by the adversarial pass) | yes | yes - `#anAbsentEndpointKeyIsReportedAsTheMissingEndpointItIs` |
+| 1 | `GraphImporter.main()` | yes, via `fromJSON` | argued: `main()` is a two-line wrapper over `createSchemaFromConfig` + `fromJSON`; it adds no parsing of its own (`GraphImporter.java:127-157`) |
+| 1 | a well-formed config still parses | n/a | yes - `#aWellFormedConfigStillParses` |
+| 2 | `Profiler.toJSON()` -> `diskUsedSpace` | yes | yes - `Issue7266ProfilerDiskUsedSpaceTest` |
+| 2 | Studio card -> `displayServerSummary` with a server that reports `diskUsedSpace` | yes | yes - `studio/test/server-disk-used.test.js` |
+| 2 | Studio card -> a server that does not report it (older build) | yes, falls back to the old difference | yes - same file |
+| 2 | `ServerMonitor.checkDiskSpace()` | not applicable | argued: it reports available space and its percentage only, and computes no used figure (`ServerMonitor.java:126-136`) |
+| 3 | `loadIncremental` second pass, touched `.bfidx` | yes | yes - `Issue7266IncrementalSchemaSecondPassTest#aTouchedBloomFilterForcesTheFullRebuild` |
+| 3 | `loadIncremental` second pass, touched `.uctidx`/`.nuctidx` | yes (made explicit; previously implicit) | yes - `#aTouchedCompactedIndexForcesTheFullRebuild` |
+| 3 | `loadIncremental` second pass, touched `dict` | deliberately NOT changed | argued + pinned: `#aTouchedDictionaryStaysIncremental` proves it stays incremental, because forcing it would undo #6988 (see Analysis) |
+| 3 | `loadIncremental` first pass, unregistered non-incremental file | unchanged | pre-existing: `Issue6988IncrementalSchemaLoadTest#anUnregisteredDictionaryCompactedIndexOrBloomFilterForcesTheFullRebuild` |
+
+No row is blank, so no follow-up issue is filed for this change.
+
+### Reachability
+
+- **1.** `GraphImporter.fromJSON` is public API and the entry point `GraphImporter.main()` uses;
+  the new checks sit on the only two parsers both overloads and `main()` reach.
+- **2.** `Profiler.toJSON()` backs `GET /api/v1/server`, which is what Studio's summary polls -
+  the path #7223 named as "the copy that actually reaches an operator". The Studio JS is served
+  as-is (no bundler for application JS), so editing the file changes the page.
+- **3.** `arcadedb.ha.schemaIncrementalApply` defaults to **true**
+  (`GlobalConfiguration.java:1637-1641`, pinned by
+  `Issue6988SchemaIncrementalApplySettingTest:44`), so
+  `loadIncremental` runs on every cluster on this build, and `ArcadeStateMachine` is its only
+  production caller.
+
+### Residual risk
+
+- Finding 3 leaves a touched **dictionary** on the incremental path, on purpose. That is not a
+  regression - it is today's behaviour and the second pass's own comment already argues for it -
+  but it does mean `NON_INCREMENTAL_COMPONENT_EXTENSIONS` and the new touched-file set differ by
+  one entry, which is now stated in both places rather than implied.
+- Finding 3 does not change the first pass at all, and does not touch
+  `SparseSegmentComponent`, whose extension was never in the set.
+- Finding 2 changes what the card renders, not what any alert fires on: the low-space warning and
+  `diskFreeSpacePerc` still read usable space, which is the right reading for "room left".
+- A Studio talking to a server older than this change keeps the old, overstated figure. There is
+  no way to derive the right one from a payload that does not carry it, and the fallback is what
+  keeps the card rendering at all.
+
+## Changes
+
+| File | Finding | What changed |
+|---|---|---|
+| `integration/.../importer/graph/GraphImporter.java` | 1 | new `splitEdgeSourceEndpoint()` raises an `IllegalArgumentException` naming the edge source, the endpoint and the offending value; the `"filter"` parse gets the same guard |
+| `engine/src/main/java/com/arcadedb/Profiler.java` | 2 | `toJSON()` adds `diskUsedSpace`, derived as `getTotalSpace() - getFreeSpace()`; `diskFreeSpace` still reports usable space |
+| `studio/.../js/studio-server.js` | 2 | the card renders `diskUsedSpace` when the server reports it, falls back to the old difference when it does not, and the new field joins the card's siblings in `skipProfiler` |
+| `engine/src/main/java/com/arcadedb/schema/LocalSchema.java` | 3 | new `NON_INCREMENTAL_TOUCHED_COMPONENT_EXTENSIONS`, checked before the `instanceof IndexInternal` narrowing; the class javadoc, the `@param` and the `attachBloomFilters` skip comment now name which set governs which pass |
+
+## Test results
+
+Every run used an isolated local Maven repository (`-Dmaven.repo.local=$WORKTREE/.m2repo`),
+because other agents were building overlapping modules at the same time.
+
+| Suite | Result |
+|---|---|
+| `Issue7266ImporterConfigValidationTest` (new) | 5 of 6 failed with the reported `ArrayIndexOutOfBoundsException` before the fix; 6/6 green after |
+| `Issue7266ProfilerDiskUsedSpaceTest` (new) | 3 tests, 1 skipped on APFS - `theReservedBlocksAreNotChargedToTheDatabases` needs a filesystem that reserves blocks, and says so instead of passing for the wrong reason |
+| `studio/test/server-disk-used.test.js` (new) | 5/5; reverting the JS line turns 3 of them red, which is the proof they can fail |
+| `Issue7266IncrementalSchemaSecondPassTest` (new) | `aTouchedBloomFilterForcesTheFullRebuild` failed before the fix ("Expecting value to be false but was true"); 3/3 green after |
+| `integration`: `GraphImporter*`, `StackOverflowImporterConfigTest`, `UberTripsImportTest` | 67 run, 0 failures (6 skipped - the StackOverflow fixture needs a data dump that is not in the repo) |
+| `engine`: `Issue7223*`, `Issue6988*`, `ProfilerTest`, `SchemaTest`, `LSMTreeIndexTest`, `Issue5662*`, `Issue5119*`, `Issue5120*` | 94 run, 0 failures |
+| `studio`: full `node scripts/run-tests.js` | 76/76 |
+| `ha-raft`: `Issue6988SchemaIncrementalApplySettingTest`, `Issue6988FullRebuildFallbackIT`, `Issue6988IncrementalSchemaApplyIT` | 6/6 - the run that proves the second-pass change did not send the common DDL path back to the full rebuild |
+| `engine,integration,ha-raft,server -am install -DskipTests` | BUILD SUCCESS |
+
+### A note on what the profiler test can and cannot prove
+
+`theUsedFigureIsDerivedFromTheUnallocatedReadingNotTheUsableOne` pins the formula against the
+same directory's own readings, but on a filesystem that reserves nothing - APFS, tmpfs - the two
+formulas produce the same number and the assertion cannot separate them. The second test says so
+explicitly with an `assumeTrue` rather than passing quietly. The decisive numeric case for the
+arithmetic lives in the JS test, where the numbers are synthetic and a 5% reservation is modelled
+directly.
+
+## Adversarial pass
+
+The orchestrator asks for a subagent that has not been persuaded by the author's reasoning. No
+`Task` tool is available in this harness, so no independent agent could be spawned; the pass was
+run by the same agent reading only the diff, which is weaker and is recorded as such. Findings:
+
+1. **Real, in scope, fixed here.** An edge source config with **no** `"from"` key at all - which
+   is literally what the message `checkEdgeSourceEndpoint` gives ("declares no 'from' endpoint")
+   describes - was still not covered: `JSONObject.getString(name)` throws a `JSONException`
+   naming the key and nothing else (`JSONObject.java:234-241`), so the first version of this fix
+   only helped a key that was present and malformed. The endpoints are now read with a `null`
+   default and an absent one is reported by the same helper. New test:
+   `#anAbsentEndpointKeyIsReportedAsTheMissingEndpointItIs`, and the coverage table gained a row.
+2. **Real, out of scope, argued rather than filed.** The `existsFile` check in the second pass
+   now runs before the `instanceof` narrowing, so a touched file whose component is registered but
+   whose file the `FileManager` no longer holds sends the caller to the full rebuild where it used
+   to be skipped for a non-index component. Reachable only from an inconsistent state, and the
+   full rebuild is the fallback, so it is strictly the safer of the two: a retired file id already
+   makes `loadIncremental` refuse at its first guard (`removedFileIds` non-empty), and a file
+   retired by an earlier entry leaves neither a component nor a `FileManager` entry, so
+   `getFileByIdIfExists` answers null and the loop continues as before.
+3. **Not real.** "A `dict` extension could belong to a component that IS an `IndexInternal`, so
+   dropping the dictionary from the touched set loses a case the old code caught."
+   `Dictionary.DICT_EXT` is `"dict"` and `TimeSeriesTagDictionary.DICT_EXT` is `"tstd"`
+   (`Dictionary.java:72`, `TimeSeriesTagDictionary.java:98`), so `"dict"` has exactly one owner,
+   and `Dictionary extends PaginatedComponent` inherits `Component.getMainComponent()`, which
+   answers `this`. No case is lost.
+4. **Not real.** "The extra `getFreeSpace()` call costs a syscall on every Studio poll."
+   `toJSON()` already makes two `statfs`-class calls at the same site and is called at the poll
+   interval, not per request served. One more is not measurable against the JSON the same method
+   builds.
+5. **Argued, deliberately not fixed.** `vj.getString("type")` and the other required keys in the
+   same parsers throw a bare `JSONException` when absent. That is pre-existing and general to the
+   config format, and no recently-added validation is being bypassed by it - which is what makes
+   finding 1 a defect rather than a wish. Widening the fix to every key would be a different
+   change.

--- a/docs/7266-three-small-defects.md
+++ b/docs/7266-three-small-defects.md
@@ -325,3 +325,29 @@ Not actioned, with the reason: the reviewer noted the tracking doc "reads more l
 working log than user-facing documentation" and then answered itself - `docs/6989-*.md`,
 `docs/7122-*.md` and `docs/7225-*.md` are the same shape, so this follows the repo's convention.
 No deferred items.
+
+### Cycle 2 - `9d0c308`
+
+Nothing blocking again, and the bot re-verified the cycle-1 answers rather than taking them on
+faith - it traced `String.split(":")`'s trailing-empty semantics for every malformed shape the test
+enumerates, and checked the filter comparison against `CsvRowSource` itself to confirm `attr=` is
+genuinely unmatchable on CSV and meaningful on the other two. Three minor points:
+
+1. **Test weight** - `Issue7266IncrementalSchemaSecondPassTest` inserted 10,000 records and forced a
+   compaction per test, and the reviewer asked whether that earned `@Tag("slow")`. Measured rather
+   than assumed: the class ran in **1.56 s**. Rather than tag a class that is not slow, the fixture
+   was sized down to the smallest that still produces a multi-page compacted series with a bloom
+   filter over it - 2,000 records, **1.10 s** for the whole class - and the constant now carries a
+   javadoc saying what the number is for. It stays in the default lane, which is the honest answer:
+   `@Tag("slow")` is for classes that genuinely cost seconds, and tagging a fast one dilutes the
+   lane.
+2. **The filter asymmetry was documented where only an internals reader would find it** - an inline
+   comment in `parseVertexSource` and a test. `Builder.filter(String, String)` is the method a config
+   author actually reads, and it said nothing. Its javadoc now states which sources can match an
+   empty value and which cannot, and that an empty attribute is refused.
+3. **Whether `docs/<issue>-*.md` is the right long-term home** for a per-issue working log. The
+   reviewer noted it matches the existing precedent and framed it as a repo-wide convention question
+   rather than something for this PR. Left alone deliberately: changing where these live is not this
+   branch's business, and doing it here would bury the fix.
+
+No deferred items in either cycle.

--- a/docs/7266-three-small-defects.md
+++ b/docs/7266-three-small-defects.md
@@ -351,3 +351,40 @@ genuinely unmatchable on CSV and meaningful on the other two. Three minor points
    branch's business, and doing it here would bury the fix.
 
 No deferred items in either cycle.
+
+### Cycle 3 - `c91dee2` - clean approval
+
+No actionable items. The bot re-derived the three load-bearing facts from the source rather than
+from this branch's claims: that every malformed endpoint shape lands in the `parts.length != 2`
+branch before any indexing, so the new guard cannot throw the exception it exists to prevent; that
+`JSONObject.getString(name, default)` routes both an absent key and an explicit JSON null through
+the guarded path; and that `LSMTreeIndexBloomFilter.getMainComponent()` answers `this` while
+`LSMTreeIndexCompacted` answers its `mainIndex` only after `onAfterLoad` wired it - which is exactly
+the reading that makes the old ordering let a touched `.bfidx` through. It also confirmed the
+"returns false implies nothing modified" contract still holds, since every early return happens
+before `toReplace` or `registerLoadedComponent` are touched.
+
+Three observations, none requiring a change:
+
+- the extra `getFreeSpace()` syscall - "negligible at the polling interval this runs at, not worth
+  restructuring";
+- the `existsFile` reordering - "the reasoning holds up", and the case is only reachable when the
+  `FileManager` already disagrees with the schema's registered components. The full `engine` and
+  `ha-raft` suites passing is the evidence that nothing depended on the narrower ordering;
+- the tracking-doc convention - raised for the third time and each time framed as a repo-wide
+  question rather than something this branch should settle.
+
+## Final state
+
+**clean-approval** after 3 review cycles. Every finding fixed, every coverage row accounted for, no
+follow-up issue needed and none filed, no deferred items.
+
+| Cycle | Head | Outcome |
+|---|---|---|
+| 1 | `5926c3d` | 2 actionable: document the deliberate filter asymmetry, surface the `existsFile` behaviour change in the PR body. Both applied. |
+| 2 | `9d0c308` | 2 actionable: size the schema fixture down rather than tag it slow (measured 1.56 s -> 1.10 s), document the asymmetry on `Builder.filter`. Both applied. |
+| 3 | `c91dee2` | No actionable items. Clean approval. |
+
+PR: <https://github.com/ArcadeData/arcadedb/pull/7274>
+
+Merge is the developer's.

--- a/docs/7266-three-small-defects.md
+++ b/docs/7266-three-small-defects.md
@@ -182,6 +182,7 @@ engine/src/test/.../Issue6988IncrementalSchemaLoadTest.java  # 9 call sites
 | 1 | ... -> `"from"` with more than one colon / an empty half | yes | yes - `#anEndpointWithTheWrongNumberOfPartsIsReported` |
 | 1 | `GraphImporter.fromJSON(db, String, dir)` (String overload -> same parser) | yes | yes - `#theStringOverloadReportsItToo` |
 | 1 | `parseVertexSource` -> `"filter"` without `=` (sibling) | yes | yes - `#aFilterWithoutAnEqualsIsReported` |
+| 1 | `parseVertexSource` -> `"filter"` with an empty VALUE (`"attr="`) | deliberately accepted | yes - `#aFilterWithAnEmptyValueIsAccepted` pins the asymmetry |
 | 1 | `parseEdgeSource` -> `"from"` / `"to"` key ABSENT (found by the adversarial pass) | yes | yes - `#anAbsentEndpointKeyIsReportedAsTheMissingEndpointItIs` |
 | 1 | `GraphImporter.main()` | yes, via `fromJSON` | argued: `main()` is a two-line wrapper over `createSchemaFromConfig` + `fromJSON`; it adds no parsing of its own (`GraphImporter.java:127-157`) |
 | 1 | a well-formed config still parses | n/a | yes - `#aWellFormedConfigStillParses` |
@@ -294,3 +295,33 @@ run by the same agent reading only the diff, which is weaker and is recorded as 
    config format, and no recently-added validation is being bypassed by it - which is what makes
    finding 1 a defect rather than a wish. Widening the fix to every key would be a different
    change.
+
+## Review cycles
+
+### Cycle 1 - `5926c3d` (PR #7274)
+
+The `claude` bot reviewed and raised nothing blocking. It independently confirmed three things this
+branch relies on: that `split(":")` on `":"` collapses to a zero-length array so `parts.length != 2`
+short-circuits before any indexing (the new guard cannot itself throw the exception it exists to
+catch), that `getString(name, default)` reaches the default through `isNull()` for an absent key as
+well as a null value, and that the new extension set names the right constants. Two points were
+actionable:
+
+1. **The `"filter"` guard checks an empty half on the attribute only, while the endpoint guard
+   checks both sides** - an asymmetry between two guards added in the same commit "for the same
+   shape" of bug. The reviewer asked for either a comment confirming it is deliberate or an
+   alignment of the two. It IS deliberate, and the evidence decides it: `"attr="` selects rows whose
+   attribute is empty, and two of the three record sources can answer that - `XmlRowSource:142-144`
+   returns the raw attribute value, `JsonlRowSource:75-85` returns `""` for an explicit empty
+   string - while only `CsvRowSource:98-101` folds empty to null. Rejecting it would refuse a config
+   that is meaningful on two of three sources. Added the comment naming those three sites, plus
+   `#aFilterWithAnEmptyValueIsAccepted` so the asymmetry stays deliberate rather than drifting.
+2. **The `existsFile` reordering changes behaviour for a touched non-index component** whose file
+   the `FileManager` has lost. Already argued in the adversarial pass above; the reviewer asked for
+   it to be visible in the PR description rather than only here, which is right - it is the kind of
+   thing a reader of the PR should not have to find in a doc. Added to the PR body.
+
+Not actioned, with the reason: the reviewer noted the tracking doc "reads more like an internal
+working log than user-facing documentation" and then answered itself - `docs/6989-*.md`,
+`docs/7122-*.md` and `docs/7225-*.md` are the same shape, so this follows the repo's convention.
+No deferred items.

--- a/engine/src/main/java/com/arcadedb/Profiler.java
+++ b/engine/src/main/java/com/arcadedb/Profiler.java
@@ -418,7 +418,18 @@ public class Profiler {
     final long totalSpace = diskDir.getTotalSpace();
     final float freeSpacePerc = totalSpace > 0 ? freeSpace * 100F / totalSpace : 0F;
 
+    // #7266: how much of the volume is ALLOCATED, reported rather than left to the reader to subtract. The three
+    // File readings do not agree on what the blocks a filesystem reserves for root are: getTotalSpace() counts them
+    // in the total, getFreeSpace() counts them as free, and getUsableSpace() counts them as neither. So
+    // `total - usable` - which is what the Studio card computed - charges that reservation, 5% of an ext4 by
+    // default, to the databases: a 100 GB volume holding 1 GB reported around 6 GB used, a constant offset an
+    // operator watching the card for growth reads as data. `total - free` is the pair that describes the same
+    // thing, and is what df calls Used. diskFreeSpace stays usable space on purpose: "how much room is left" is a
+    // different question, and the answer to it is the one this process can actually write into.
+    final long usedSpace = Math.max(0L, totalSpace - diskDir.getFreeSpace());
+
     json.put("diskFreeSpace", new JSONObject().put("space", freeSpace));
+    json.put("diskUsedSpace", new JSONObject().put("space", usedSpace));
     json.put("diskTotalSpace", new JSONObject().put("space", totalSpace));
     json.put("diskFreeSpacePerc", new JSONObject().put("perc", freeSpacePerc));
     // Which filesystem the three figures above describe. Without it the reader cannot tell a nearly-full data

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -109,7 +109,7 @@ public class LocalSchema implements Schema {
       "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9");
 
   /**
-   * Components whose load has a side effect on ANOTHER component, so they cannot be added to an already-loaded
+   * Components whose load has a side effect on ANOTHER component, so they cannot be ADDED to an already-loaded
    * schema in isolation (issue #6988):
    * <ul>
    *   <li>the dictionary is what every component resolves property names through;</li>
@@ -119,9 +119,34 @@ public class LocalSchema implements Schema {
    * </ul>
    * An entry carrying one of these falls back to the full rebuild, where every component is re-instantiated and
    * every claim is re-established in one pass.
+   * <p>
+   * This set governs the FIRST pass of {@link #loadIncremental} only - files with no component yet. A file that
+   * already has one and was merely written into is a different question, and
+   * {@link #NON_INCREMENTAL_TOUCHED_COMPONENT_EXTENSIONS} answers it.
    */
   private static final Set<String> NON_INCREMENTAL_COMPONENT_EXTENSIONS = Set.of(//
       Dictionary.DICT_EXT, //
+      LSMTreeIndexCompacted.UNIQUE_INDEX_EXT, //
+      LSMTreeIndexCompacted.NOTUNIQUE_INDEX_EXT, //
+      LSMTreeIndexBloomFilter.FILE_EXT);
+
+  /**
+   * Components whose already-registered instance cannot be refreshed in isolation when an entry writes pages INTO
+   * it, so the second pass of {@link #loadIncremental} hands the caller back to the full rebuild (issue #7266).
+   * <ul>
+   *   <li>a compacted index is claimed by the mutable index holding it as its sub-index, so handing the file id a
+   *       new instance would leave that claim pointing at the old one;</li>
+   *   <li>a bloom filter reads its directory into RAM once, in {@code loadDirectory()} by way of
+   *       {@link #attachBloomFilters}, and no load hook re-reads it - so pages appended to the file leave the
+   *       in-RAM directory describing the file as it was before the entry.</li>
+   * </ul>
+   * <b>Deliberately NOT the same set as {@link #NON_INCREMENTAL_COMPONENT_EXTENSIONS}: the dictionary is absent.</b>
+   * A dictionary that ARRIVES has to be adopted by the full load, but a dictionary merely written into needs
+   * nothing here - {@code TransactionManager.applyChanges} reloads it itself - and every DDL entry that adds a type
+   * or a property name writes dictionary pages. Refusing on those would send the common case straight back to the
+   * O(total files) rebuild issue #6988 removed, which is the cost this whole method exists to avoid.
+   */
+  private static final Set<String> NON_INCREMENTAL_TOUCHED_COMPONENT_EXTENSIONS = Set.of(//
       LSMTreeIndexCompacted.UNIQUE_INDEX_EXT, //
       LSMTreeIndexCompacted.NOTUNIQUE_INDEX_EXT, //
       LSMTreeIndexBloomFilter.FILE_EXT);
@@ -376,8 +401,9 @@ public class LocalSchema implements Schema {
    * @param mode           open mode for the newly instantiated components
    * @param removedFileIds file ids retired by this entry; any removal forces the full rebuild (see below)
    * @param touchedFileIds file ids this entry wrote pages into; an already-registered index component among them is
-   *                       rebuilt from its file rather than refreshed in place (see the second pass). May be
-   *                       {@code null}
+   *                       rebuilt from its file rather than refreshed in place (see the second pass), and one
+   *                       carrying a {@link #NON_INCREMENTAL_TOUCHED_COMPONENT_EXTENSIONS} extension forces the
+   *                       full rebuild instead. May be {@code null}
    *
    * @return {@code true} when the schema was refreshed incrementally, {@code false} when the caller must fall back
    * to {@link #load(ComponentFile.MODE, boolean)}. When {@code false} is returned nothing has been modified.
@@ -420,17 +446,25 @@ public class LocalSchema implements Schema {
     if (touchedFileIds != null)
       for (final Integer fileId : touchedFileIds) {
         final Component current = getFileByIdIfExists(fileId);
-        if (current == null || !(current.getMainComponent() instanceof IndexInternal))
+        if (current == null)
           continue;
 
         if (!database.getFileManager().existsFile(fileId))
           return false;
 
         final ComponentFile file = database.getFileManager().getFile(fileId);
-        // A compacted index is claimed by the mutable index holding it as its sub-index, so handing the file id a
-        // new instance would leave that claim pointing at the old one. Only the full rebuild re-establishes it.
-        if (NON_INCREMENTAL_COMPONENT_EXTENSIONS.contains(file.getFileExtension()))
+
+        // Issue #7266: the extension check comes BEFORE the instanceof narrowing below, and not after it as it
+        // used to. Neither component this set names answers an IndexInternal from getMainComponent() by its own
+        // construction - a bloom filter answers ITSELF, and a compacted index answers the mutable index only once
+        // that mutable's onAfterLoad() wired the field, which a factory-built instance starts with null - so the
+        // narrowing dropped a touched bloom filter out of the loop before the guard could refuse the entry, and
+        // left the compacted index refusing by accident rather than by rule.
+        if (NON_INCREMENTAL_TOUCHED_COMPONENT_EXTENSIONS.contains(file.getFileExtension()))
           return false;
+
+        if (!(current.getMainComponent() instanceof IndexInternal))
+          continue;
 
         toReplace.add(file);
       }
@@ -478,8 +512,8 @@ public class LocalSchema implements Schema {
       component.onAfterSchemaLoad();
 
     // attachBloomFilters() is not called: it acts only on LSMTreeIndexCompacted, and a compacted index can never be
-    // in `loaded` - NON_INCREMENTAL_COMPONENT_EXTENSIONS refuses the entry instead, in both passes above. Relaxing
-    // that set means restoring the call.
+    // in `loaded` - the entry is refused instead, by NON_INCREMENTAL_COMPONENT_EXTENSIONS in the first pass and by
+    // NON_INCREMENTAL_TOUCHED_COMPONENT_EXTENSIONS in the second. Relaxing either set means restoring the call.
     //
     // sweepOrphanCompactedIndexFiles() is deliberately NOT run here either. It proves a compacted file is an orphan
     // by observing that no mutable index claimed it during the load - a proof that only holds when EVERY mutable

--- a/engine/src/test/java/com/arcadedb/Issue7266ProfilerDiskUsedSpaceTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue7266ProfilerDiskUsedSpaceTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb;
+
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Regression test for finding 2 of issue #7266.
+ * <p>
+ * #7223 moved the profiler's free-space reading to {@code File.getUsableSpace()}, which excludes the blocks the
+ * filesystem reserves for root, while the total stayed {@code getTotalSpace()}, which counts them. The Studio card
+ * derived used as {@code total - free}, so the reservation - 5% of an ext4 by default - was charged to the
+ * databases: on a 100 GB volume holding 1 GB the card reported roughly 6 GB used, a constant offset an operator
+ * watching for growth reads as data. The server now reports the allocated figure itself, derived from the two
+ * readings that count the reserved blocks the same way.
+ */
+class Issue7266ProfilerDiskUsedSpaceTest {
+
+  /**
+   * The three {@code File} readings are taken microseconds apart inside one {@code toJSON()}, so an unrelated write
+   * landing between them moves either by a few blocks. The bound carries a page-cluster of slack, which is orders
+   * of magnitude smaller than the reservation this fix is about and far larger than any such drift.
+   */
+  private static final long DRIFT_SLACK = 16L * 1024 * 1024;
+
+  @TempDir
+  Path tempDir;
+
+  @AfterEach
+  void restoreTheDatabaseDirectory() {
+    GlobalConfiguration.SERVER_DATABASE_DIRECTORY.reset();
+  }
+
+  @Test
+  void theUsedFigureIsDerivedFromTheUnallocatedReadingNotTheUsableOne() {
+    final File databases = tempDir.resolve("databases").toFile();
+    assertThat(databases.mkdirs()).isTrue();
+    GlobalConfiguration.SERVER_DATABASE_DIRECTORY.setValue(databases.getAbsolutePath());
+
+    final JSONObject json = Profiler.INSTANCE.toJSON();
+
+    final long used = json.getJSONObject("diskUsedSpace").getLong("space");
+    final long total = json.getJSONObject("diskTotalSpace").getLong("space");
+
+    assertThat(total).isPositive();
+    assertThat(used).as("the allocated part of a volume is neither negative nor larger than the volume")
+        .isBetween(0L, total);
+
+    // The positive claim: used is total minus the UNALLOCATED reading, the one that counts the reserved blocks as
+    // free exactly as getTotalSpace() counts them as total.
+    assertThat(used).as("used must be derived from getFreeSpace(), which describes the same blocks as getTotalSpace()")
+        .isCloseTo(databases.getTotalSpace() - databases.getFreeSpace(), within(DRIFT_SLACK));
+  }
+
+  /**
+   * The regression guard proper, and it can only be observed on a filesystem that actually reserves blocks - ext4
+   * does, APFS and tmpfs need not. Where the reservation is smaller than the reading drift there is nothing to
+   * separate the two formulas by, so the test says so rather than passing for the wrong reason.
+   */
+  @Test
+  void theReservedBlocksAreNotChargedToTheDatabases() {
+    final File databases = tempDir.resolve("reserved").toFile();
+    assertThat(databases.mkdirs()).isTrue();
+    GlobalConfiguration.SERVER_DATABASE_DIRECTORY.setValue(databases.getAbsolutePath());
+
+    final long reserved = databases.getFreeSpace() - databases.getUsableSpace();
+    assumeTrue(reserved > DRIFT_SLACK,
+        "this filesystem reserves no blocks for root, so the two formulas cannot be told apart here");
+
+    final JSONObject json = Profiler.INSTANCE.toJSON();
+
+    final long used = json.getJSONObject("diskUsedSpace").getLong("space");
+    final long total = json.getJSONObject("diskTotalSpace").getLong("space");
+    final long usable = json.getJSONObject("diskFreeSpace").getLong("space");
+
+    assertThat(used).as("the figure the card used to compute charged the root reservation to the databases")
+        .isLessThan(total - usable);
+  }
+
+  /**
+   * The reading the low-space warning and the percentage are built on is unchanged: "how much room is left" is a
+   * different question from "how much is allocated", and its answer is still the space this process can write into.
+   */
+  @Test
+  void theFreeFigureStillReportsUsableSpace() {
+    final File databases = tempDir.resolve("free").toFile();
+    assertThat(databases.mkdirs()).isTrue();
+    GlobalConfiguration.SERVER_DATABASE_DIRECTORY.setValue(databases.getAbsolutePath());
+
+    final JSONObject json = Profiler.INSTANCE.toJSON();
+
+    final long usable = json.getJSONObject("diskFreeSpace").getLong("space");
+    final long total = json.getJSONObject("diskTotalSpace").getLong("space");
+
+    assertThat(usable).isPositive().isLessThanOrEqualTo(total);
+    assertThat(json.getJSONObject("diskFreeSpacePerc").getFloat("perc")).isEqualTo(usable * 100F / total);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/Issue7266IncrementalSchemaSecondPassTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue7266IncrementalSchemaSecondPassTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.Component;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.engine.Dictionary;
+import com.arcadedb.index.lsm.LSMTreeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndexBloomFilter;
+import com.arcadedb.index.lsm.LSMTreeIndexCompacted;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for finding 3 of issue #7266.
+ * <p>
+ * {@link LocalSchema#loadIncremental} decides in two passes, and its second one - the files this entry wrote pages
+ * into - narrowed on {@code getMainComponent() instanceof IndexInternal} BEFORE consulting the extension set that
+ * names the components which cannot be refreshed in isolation. A bloom filter answers ITSELF from
+ * {@code getMainComponent()} and is not an index, so a touched {@code .bfidx} short-circuited out of the loop and
+ * never reached the guard: the entry stayed on the incremental path with the filter's in-RAM directory still
+ * describing the file as it was before the entry appended to it. The class javadoc and the {@code attachBloomFilters}
+ * skip comment both claimed the fallback happened "in both passes", so the guard a reader relies on to know when a
+ * rebuild is forced said one thing and did another.
+ * <p>
+ * The dictionary is the deliberate exception, and the last test pins it: every DDL entry that adds a type or a
+ * property name writes dictionary pages, so those file ids arrive in {@code touchedFileIds} on the common path.
+ * Sending them to the full rebuild would undo issue #6988 - which is the whole reason this method exists - and the
+ * second pass's own comment already argues the dictionary needs nothing here.
+ */
+class Issue7266IncrementalSchemaSecondPassTest extends TestHelper {
+
+  private static final String TYPE_NAME = "Issue7266Indexed";
+  private static final int    RECORDS   = 10_000;
+
+  @Override
+  protected void beginTest() {
+    // A small index page size is what makes the compacted output span several pages, i.e. a real series with a real
+    // bloom filter over it - the same fixture shape Issue5662IndexCursorFollowUpsTest uses. Without it the whole
+    // index fits one page and the compactor has nothing to write.
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
+
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(1).create();
+      type.createProperty("value", Integer.class);
+      database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "value" }).withType(Schema.INDEX_TYPE.LSM_TREE)
+          .withUnique(true).withPageSize(1024).create();
+    });
+
+    database.transaction(() -> {
+      for (int i = 0; i < RECORDS; i++)
+        database.newDocument(TYPE_NAME).set("value", i).save();
+    });
+
+    compactTheIndex();
+  }
+
+  /**
+   * The defect as reported: a touched bloom filter is not an {@code IndexInternal}, so the narrowing dropped it
+   * before the extension check could refuse the entry.
+   */
+  @Test
+  void aTouchedBloomFilterForcesTheFullRebuild() throws Exception {
+    final LocalSchema schema = schema();
+    final int filterFileId = fileIdOfRegistered(schema, LSMTreeIndexBloomFilter.class);
+    assertThat(filterFileId)
+        .as("the fixture must produce a bloom filter component, otherwise this test asserts nothing")
+        .isNotNegative();
+
+    final Map<Integer, Component> before = componentsByFileId(schema);
+
+    assertThat(schema.loadIncremental(ComponentFile.MODE.READ_WRITE, Set.of(), Set.of(filterFileId)))
+        .as("an entry writing pages into a bloom filter cannot be expressed incrementally")
+        .isFalse();
+
+    // A refusal must be a no-op, so the caller's fallback runs over consistent state.
+    assertThat(componentsByFileId(schema)).isEqualTo(before);
+  }
+
+  /**
+   * A touched compacted index refuses today too, but only as a side effect: its {@code getMainComponent()} answers
+   * the mutable index that {@code LSMTreeIndexMutable.onAfterLoad} wired into it, and a compacted component the
+   * factory builds starts with that field null. Nothing in the guard said so, so this pins the refusal itself
+   * rather than the accident that produced it.
+   */
+  @Test
+  void aTouchedCompactedIndexForcesTheFullRebuild() throws Exception {
+    final LocalSchema schema = schema();
+    final int compactedFileId = fileIdOfRegistered(schema, LSMTreeIndexCompacted.class);
+    assertThat(compactedFileId)
+        .as("the fixture must produce a compacted index component, otherwise this test asserts nothing")
+        .isNotNegative();
+
+    final Map<Integer, Component> before = componentsByFileId(schema);
+
+    assertThat(schema.loadIncremental(ComponentFile.MODE.READ_WRITE, Set.of(), Set.of(compactedFileId)))
+        .as("an entry writing pages into a compacted index cannot be expressed incrementally")
+        .isFalse();
+
+    assertThat(componentsByFileId(schema)).isEqualTo(before);
+  }
+
+  /**
+   * The other half of the contract, and the one a wholesale "check the extension first" fix would have broken: a
+   * touched dictionary stays on the incremental path. Every DDL entry that adds a name writes dictionary pages, so
+   * refusing here would send the common case back to the O(total files) rebuild #6988 removed.
+   */
+  @Test
+  void aTouchedDictionaryStaysIncremental() throws Exception {
+    final LocalSchema schema = schema();
+    final int dictionaryFileId = fileIdOfRegistered(schema, Dictionary.class);
+    assertThat(dictionaryFileId).as("every database has a dictionary").isNotNegative();
+
+    final Map<Integer, Component> before = componentsByFileId(schema);
+
+    assertThat(schema.loadIncremental(ComponentFile.MODE.READ_WRITE, Set.of(), Set.of(dictionaryFileId)))
+        .as("a DDL entry writing new names into the dictionary is the common case and must stay incremental")
+        .isTrue();
+
+    for (final Map.Entry<Integer, Component> entry : before.entrySet())
+      assertThat(schema.getFileByIdIfExists(entry.getKey()))
+          .as("component for file %d must not be re-instantiated for a dictionary write", entry.getKey())
+          .isSameAs(entry.getValue());
+  }
+
+  private void compactTheIndex() {
+    final LSMTreeIndex index = (LSMTreeIndex) database.getSchema().getType(TYPE_NAME).getAllIndexes(false).iterator()
+        .next().getIndexesOnBuckets()[0];
+    try {
+      if (index.scheduleCompaction())
+        index.compact();
+    } catch (final Exception e) {
+      throw new IllegalStateException("cannot compact the fixture index", e);
+    }
+  }
+
+  /** The file id of the first registered component of the given class, or -1 when the fixture produced none. */
+  private int fileIdOfRegistered(final LocalSchema schema, final Class<? extends Component> componentClass) {
+    for (final ComponentFile file : ((DatabaseInternal) database).getFileManager().getFiles()) {
+      if (file == null)
+        continue;
+      final Component component = schema.getFileByIdIfExists(file.getFileId());
+      if (componentClass.isInstance(component))
+        return component.getFileId();
+    }
+    return -1;
+  }
+
+  private LocalSchema schema() {
+    return ((DatabaseInternal) database).getSchema().getEmbedded();
+  }
+
+  private Map<Integer, Component> componentsByFileId(final LocalSchema schema) {
+    final Map<Integer, Component> result = new HashMap<>();
+    for (final ComponentFile file : ((DatabaseInternal) database).getFileManager().getFiles()) {
+      if (file == null)
+        continue;
+      final Component component = schema.getFileByIdIfExists(file.getFileId());
+      if (component != null)
+        result.put(file.getFileId(), component);
+    }
+    return result;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/Issue7266IncrementalSchemaSecondPassTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue7266IncrementalSchemaSecondPassTest.java
@@ -55,7 +55,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 class Issue7266IncrementalSchemaSecondPassTest extends TestHelper {
 
   private static final String TYPE_NAME = "Issue7266Indexed";
-  private static final int    RECORDS   = 10_000;
+  /**
+   * Enough keys, at the 1024-byte index page size below, for the compaction to write a multi-page series with a
+   * bloom filter over it - which is what these tests need - and no more. Sized down from 10,000 after a review
+   * asked whether the class had earned {@code @Tag("slow")}: at this size the whole class runs in about a second,
+   * so it belongs in the default lane.
+   */
+  private static final int    RECORDS   = 2_000;
 
   @Override
   protected void beginTest() {

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -631,6 +631,12 @@ public class GraphImporter implements AutoCloseable {
      * Filter rows: only rows where the attribute equals the given value are imported.
      * Enables splitting one file into multiple vertex types (e.g. Posts.xml → Question + Answer).
      * Format: {@code filter("PostTypeId", "1")} or in JSON: {@code "filter": "PostTypeId=1"}.
+     * <p>
+     * An EMPTY value is accepted and selects the rows whose attribute is empty - {@code "filter": "PostTypeId="}
+     * in JSON. Which rows those are depends on the source: {@link XmlRowSource} hands back the raw attribute value
+     * and {@link JsonlRowSource} an explicit empty string, so both can match, while {@link CsvRowSource} reads an
+     * empty cell as absent, where such a filter selects nothing. An empty ATTRIBUTE is refused, because there is
+     * no row it could ever test.
      */
     public void filter(final String attribute, final String value) {
       this.filterAttribute = attribute;

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -307,6 +307,13 @@ public class GraphImporter implements AutoCloseable {
         final String[] parts = spec.split("=", 2);
         // Issue #7266: the same unguarded [1] the edge endpoints carried. A filter written without its '=' is a
         // configuration mistake, and it has to read as one rather than as an array index out of bounds.
+        //
+        // The EMPTY HALF is checked on the attribute only, deliberately, and not on both sides as
+        // splitEdgeSourceEndpoint checks them: "attr=" filters for rows whose attribute IS empty, which two of the
+        // three record sources can actually answer - XmlRowSource returns the raw attribute value, so attr="" is a
+        // match, and JsonlRowSource returns "" for an explicit empty string. Only CsvRowSource folds empty to null
+        // (CsvRowSource:98-101), where such a filter selects nothing. Rejecting it here would refuse a config that
+        // is meaningful for the other two.
         if (parts.length != 2 || parts[0].isEmpty())
           throw new IllegalArgumentException("Vertex source '" + typeName + "' declares its filter as '" + spec
               + "': the form is \"filter\": \"attribute=value\", naming the attribute to test and the value that "

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -303,7 +303,14 @@ public class GraphImporter implements AutoCloseable {
       if (vj.has("nameId"))
         v.idByName(vj.getString("nameId"));
       if (vj.has("filter")) {
-        final String[] parts = vj.getString("filter").split("=", 2);
+        final String spec = vj.getString("filter");
+        final String[] parts = spec.split("=", 2);
+        // Issue #7266: the same unguarded [1] the edge endpoints carried. A filter written without its '=' is a
+        // configuration mistake, and it has to read as one rather than as an array index out of bounds.
+        if (parts.length != 2 || parts[0].isEmpty())
+          throw new IllegalArgumentException("Vertex source '" + typeName + "' declares its filter as '" + spec
+              + "': the form is \"filter\": \"attribute=value\", naming the attribute to test and the value that "
+              + "selects the rows to import");
         v.filter(parts[0], parts[1]);
       }
       if (vj.getBoolean("deduplicate", false))
@@ -349,9 +356,9 @@ public class GraphImporter implements AutoCloseable {
 
     b.edgeSource(edgeType, source, e -> {
       // "from": "PostId:Post" → attribute:vertexType
-      final String[] fromParts = ej.getString("from").split(":");
+      final String[] fromParts = splitEdgeSourceEndpoint(edgeType, "from", ej.getString("from", null));
       e.from(fromParts[0], fromParts[1]);
-      final String[] toParts = ej.getString("to").split(":");
+      final String[] toParts = splitEdgeSourceEndpoint(edgeType, "to", ej.getString("to", null));
       e.to(toParts[0], toParts[1]);
 
       if (ej.has("properties")) {
@@ -360,6 +367,35 @@ public class GraphImporter implements AutoCloseable {
           parsePropertySpec(e, propName, props.getString(propName));
       }
     });
+  }
+
+  /**
+   * Splits an edge source's {@code "from"} / {@code "to"} value, whose form is {@code attribute:VertexType}.
+   * <p>
+   * Issue #7266: this used to be a bare {@code split(":")} followed by {@code [1]}. A value that forgot the
+   * {@code :VertexType} half - precisely the mistake {@link #checkEdgeSourceEndpoint} was added to describe in a
+   * sentence - answered one element and threw {@code ArrayIndexOutOfBoundsException} here, inside the consumer
+   * {@link Builder#edgeSource} runs eagerly, so the validation never got the chance to report it. The two other
+   * mis-shapes were worse than a crash because they were silent: a third colon was dropped on the floor, and an
+   * empty half became an attribute or a vertex type that matches nothing, row after row.
+   * <p>
+   * An ABSENT key is the same mistake one step earlier, and reaches the reader the same way {@code
+   * checkEdgeSourceEndpoint} phrases it: {@code getString(key)} throws a {@code JSONException} naming the key and
+   * nothing else, so the value is read with a {@code null} default and answered here instead.
+   */
+  private static String[] splitEdgeSourceEndpoint(final String edgeType, final String endpoint, final String value) {
+    if (value == null)
+      throw new IllegalArgumentException("Edge source '" + edgeType + "' declares no '" + endpoint
+          + "' endpoint: add \"" + endpoint + "\": \"attribute:VertexType\" to it, naming the attribute that holds "
+          + "the key and the vertex type it resolves against");
+
+    final String[] parts = value.split(":");
+    if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty())
+      throw new IllegalArgumentException("Edge source '" + edgeType + "' declares its '" + endpoint
+          + "' endpoint as '" + value + "': the form is \"" + endpoint + "\": \"attribute:VertexType\", naming the "
+          + "attribute that holds the key and the vertex type it resolves against");
+
+    return parts;
   }
 
   private static void parsePropertySpec(final PropertyConfig v, final String propName, final String spec) {

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue7266ImporterConfigValidationTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue7266ImporterConfigValidationTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.integration.importer.graph.GraphImporter;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for finding 1 of issue #7266.
+ * <p>
+ * Commit {@code 2a3cb60ef} taught the programmatic path to say what is wrong when an edge source declares no
+ * endpoint - "Edge source 'X' declares no 'from' endpoint" - but the JSON path never reached it: it split the
+ * {@code "attribute:VertexType"} value on {@code :} and read {@code [1]} unconditionally, so a value that forgot
+ * the {@code :VertexType} half (precisely the mistake the new sentence describes) died on an
+ * {@code ArrayIndexOutOfBoundsException} inside {@code Builder.edgeSource}'s eagerly-run consumer, before
+ * {@code build()} could validate anything.
+ * <p>
+ * Each test therefore asserts two things that are NOT the same claim: that the exception is not the array one, and
+ * that its message names the offending value. A config file is edited by hand, so the message is the whole fix -
+ * an {@code IllegalArgumentException} saying nothing useful would pass a "does not throw AIOOBE" assertion while
+ * leaving the operator exactly where they were.
+ */
+class Issue7266ImporterConfigValidationTest {
+
+  private static final String DB_PATH = "target/databases/issue7266-importer-config-validation";
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    database = new DatabaseFactory(DB_PATH).create();
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Post");
+      database.getSchema().createEdgeType("LinkedTo");
+    });
+  }
+
+  @AfterEach
+  void cleanup() {
+    if (database != null)
+      database.close();
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  @Test
+  void aFromEndpointMissingItsVertexTypeIsReported() {
+    assertThatThrownBy(() -> GraphImporter.fromJSON(database, edgeSourceConfig("PostId", "RelatedId:Post"), baseDir()))
+        .as("the mistake the endpoint validation was written for must not die on an array index first")
+        .isInstanceOf(IllegalArgumentException.class)
+        .isNotInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining("LinkedTo")
+        .hasMessageContaining("from")
+        .hasMessageContaining("PostId");
+  }
+
+  @Test
+  void aToEndpointMissingItsVertexTypeIsReported() {
+    assertThatThrownBy(() -> GraphImporter.fromJSON(database, edgeSourceConfig("PostId:Post", "RelatedId"), baseDir()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .isNotInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining("LinkedTo")
+        .hasMessageContaining("to")
+        .hasMessageContaining("RelatedId");
+  }
+
+  /**
+   * The other two shapes the old code accepted in silence rather than crashing on: a third colon was dropped on the
+   * floor, and an empty half became an empty attribute or vertex type that would match nothing, row after row.
+   */
+  @Test
+  void anEndpointWithTheWrongNumberOfPartsIsReported() {
+    for (final String malformed : new String[] { "PostId:Post:extra", ":Post", "PostId:", "", ":" })
+      assertThatThrownBy(() -> GraphImporter.fromJSON(database, edgeSourceConfig(malformed, "RelatedId:Post"), baseDir()))
+          .as("'%s' is not an 'attribute:VertexType' pair", malformed)
+          .isInstanceOf(IllegalArgumentException.class)
+          .isNotInstanceOf(ArrayIndexOutOfBoundsException.class)
+          .hasMessageContaining("LinkedTo");
+  }
+
+  /**
+   * An absent key is the same mistake one step earlier, and the one the programmatic path's sentence describes
+   * word for word: "declares no 'from' endpoint". {@code JSONObject.getString(key)} threw a {@code JSONException}
+   * naming the key and nothing else, so the reader still had to guess what the key was for.
+   */
+  @Test
+  void anAbsentEndpointKeyIsReportedAsTheMissingEndpointItIs() {
+    final JSONObject edgeSource = new JSONObject()
+        .put("edge", "LinkedTo")
+        .put("file", "issue7266-links.csv")
+        .put("to", "RelatedId:Post");
+
+    final JSONObject config = new JSONObject().put("edgeSources", new JSONArray().put(edgeSource));
+
+    assertThatThrownBy(() -> GraphImporter.fromJSON(database, config, baseDir()))
+        .as("an edge source with no 'from' key at all must read as a configuration mistake, not as a JSON one")
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("LinkedTo")
+        .hasMessageContaining("from")
+        .hasMessageContaining("attribute:VertexType");
+  }
+
+  /**
+   * The public API has two {@code fromJSON} overloads. They funnel through the same parser, and this is the
+   * assertion that says so rather than assuming it.
+   */
+  @Test
+  void theStringOverloadReportsItToo() {
+    final String json = edgeSourceConfig("PostId", "RelatedId:Post").toString();
+
+    assertThatThrownBy(() -> GraphImporter.fromJSON(database, json, baseDir()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .isNotInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining("PostId");
+  }
+
+  /**
+   * The sibling of the same shape, in the same parser: a vertex source's {@code "filter"} is
+   * {@code "attribute=value"} and was split on {@code =} with the same unguarded {@code [1]}.
+   */
+  @Test
+  void aFilterWithoutAnEqualsIsReported() {
+    final JSONObject vertex = new JSONObject()
+        .put("type", "Post")
+        .put("file", "issue7266-posts.csv")
+        .put("id", "Id")
+        .put("filter", "PostTypeId");
+
+    final JSONObject config = new JSONObject().put("vertices", new JSONArray().put(vertex));
+
+    assertThatThrownBy(() -> GraphImporter.fromJSON(database, config, baseDir()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .isNotInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining("Post")
+        .hasMessageContaining("PostTypeId");
+  }
+
+  /**
+   * The guard has to refuse only what is malformed. Without this the four tests above would all pass against a
+   * parser that refused every config it was handed.
+   */
+  @Test
+  void aWellFormedConfigStillParses() {
+    final JSONObject vertex = new JSONObject()
+        .put("type", "Post")
+        .put("file", "issue7266-posts.csv")
+        .put("id", "Id")
+        .put("filter", "PostTypeId=1");
+
+    final JSONObject config = edgeSourceConfig("PostId:Post", "RelatedId:Post")
+        .put("vertices", new JSONArray().put(vertex));
+
+    try (final GraphImporter importer = GraphImporter.fromJSON(database, config, baseDir())) {
+      assertThat(importer).isNotNull();
+    }
+  }
+
+  /** A config with one edge source, whose endpoints are whatever the caller passes. */
+  private static JSONObject edgeSourceConfig(final String from, final String to) {
+    final JSONObject edgeSource = new JSONObject()
+        .put("edge", "LinkedTo")
+        .put("file", "issue7266-links.csv")
+        .put("from", from)
+        .put("to", to);
+
+    return new JSONObject().put("edgeSources", new JSONArray().put(edgeSource));
+  }
+
+  /**
+   * The data files are never opened: {@code CsvRowSource} resolves its path lazily and reads it only from
+   * {@code forEach}, which the config parse never calls. The directory only has to exist for the path join.
+   */
+  private static String baseDir() {
+    return new File("target").getAbsolutePath();
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue7266ImporterConfigValidationTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue7266ImporterConfigValidationTest.java
@@ -164,6 +164,28 @@ class Issue7266ImporterConfigValidationTest {
   }
 
   /**
+   * The asymmetry between the two guards added in the same commit, pinned so it stays deliberate: the edge-endpoint
+   * guard rejects an empty half on either side, the filter guard rejects it on the attribute only. {@code "attr="}
+   * selects the rows whose attribute IS empty, and two of the three record sources can answer that -
+   * {@code XmlRowSource} hands back the raw attribute value and {@code JsonlRowSource} returns {@code ""} for an
+   * explicit empty string, while only {@code CsvRowSource} folds empty to null.
+   */
+  @Test
+  void aFilterWithAnEmptyValueIsAccepted() {
+    final JSONObject vertex = new JSONObject()
+        .put("type", "Post")
+        .put("file", "issue7266-posts.xml")
+        .put("id", "Id")
+        .put("filter", "PostTypeId=");
+
+    final JSONObject config = new JSONObject().put("vertices", new JSONArray().put(vertex));
+
+    try (final GraphImporter importer = GraphImporter.fromJSON(database, config, baseDir())) {
+      assertThat(importer).as("filtering for an empty attribute is meaningful on an XML or JSONL source").isNotNull();
+    }
+  }
+
+  /**
    * The guard has to refuse only what is malformed. Without this the four tests above would all pass against a
    * parser that refused every config it was handed.
    */

--- a/studio/src/main/resources/static/js/studio-server.js
+++ b/studio/src/main/resources/static/js/studio-server.js
@@ -152,7 +152,13 @@ function displayServerSummary() {
   // Disk
   var diskFree = (p.diskFreeSpace && p.diskFreeSpace.space) || 0;
   var diskTotal = (p.diskTotalSpace && p.diskTotalSpace.space) || 1;
-  var diskUsed = diskTotal - diskFree;
+  // #7266: the server reports what is ALLOCATED on the volume, because the card cannot derive it: #7223 made
+  // diskFreeSpace the USABLE space, which excludes the blocks the filesystem reserves for root, while diskTotalSpace
+  // counts them - so "total - free" charged that reservation, 5% of an ext4 by default, to the databases. On a
+  // 100 GB volume holding 1 GB it read as roughly 6 GB used, a constant offset that looks like data to anyone
+  // watching the card for growth. A server older than the field leaves that difference as the only answer available.
+  // Tested for null rather than truthiness so a genuine zero renders as zero (#5636).
+  var diskUsed = (p.diskUsedSpace && p.diskUsedSpace.space != null) ? p.diskUsedSpace.space : (diskTotal - diskFree);
   $("#summDiskUsed").text(globalFormatSpace(diskUsed));
   $("#summDiskTotal").text(globalFormatSpace(diskTotal));
   $("#summDiskBar").css("width", Math.round(diskUsed / diskTotal * 100) + "%");
@@ -270,7 +276,7 @@ function displayMetrics() {
 
   // Profiler details table (remaining metrics without rate tracking)
   var skipProfiler = { cpuLoad: 1, ramHeapUsed: 1, ramHeapMax: 1, ramOsUsed: 1, ramOsTotal: 1,
-    diskFreeSpace: 1, diskTotalSpace: 1, diskDirectory: 1, readCacheUsed: 1, cacheMax: 1, configuration: 1,
+    diskFreeSpace: 1, diskUsedSpace: 1, diskTotalSpace: 1, diskDirectory: 1, readCacheUsed: 1, cacheMax: 1, configuration: 1,
     writeTx: 1, readTx: 1, txRollbacks: 1, queries: 1, concurrentModificationExceptions: 1,
     edgeAppendMerges: 1, txPageSlotMerges: 1, mergesDeclinedByCoverage: 1 };
   var profilerHtml = "";

--- a/studio/test/server-disk-used.test.js
+++ b/studio/test/server-disk-used.test.js
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Issue #7266, finding 2: the "Databases Disk" card derived used as `total - free`, and after #7223 those two
+// readings no longer agree on what the blocks a filesystem reserves for root are - getTotalSpace() counts them in
+// the total, getUsableSpace() (which is what diskFreeSpace became) counts them as neither free nor available. So
+// the reservation, 5% of an ext4 by default, landed in the "used by databases" number: on a mostly-empty volume it
+// is the dominant term, and an operator watching the card for growth reads a constant offset as data. The server
+// now reports the allocated figure itself. Run with:
+//
+//     node --test studio/test/server-disk-used.test.js
+//
+// The numbers here are synthetic on purpose - the arithmetic is the whole defect, and a real filesystem that
+// reserves nothing cannot tell the two formulas apart.
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const SRC_PATH = path.join(__dirname, "..", "src", "main", "resources", "static", "js", "studio-server.js");
+const src = fs.readFileSync(SRC_PATH, "utf8");
+
+// Pulls one top-level `function name(...) {...}` out of the source by counting braces, as the sibling tests do.
+function extractFn(name) {
+  const start = src.indexOf("function " + name + "(");
+  if (start < 0) throw new Error("function not found in studio-server.js: " + name);
+  let i = src.indexOf("{", start);
+  let depth = 1;
+  i++;
+  while (i < src.length && depth > 0) {
+    const c = src[i];
+    if (c === "{") depth++;
+    else if (c === "}") depth--;
+    i++;
+  }
+  if (depth !== 0) throw new Error("unbalanced braces while extracting " + name + ": reached end of file");
+
+  const source = src.substring(start, i);
+  try {
+    new Function("return (" + source + ")");
+  } catch (e) {
+    throw new Error("the extracted source of " + name + " does not parse: " + e.message);
+  }
+  return source;
+}
+
+// What displayServerSummary() hands to each element, keyed by selector.
+const text = {};
+const css = {};
+
+function $(selector) {
+  const node = {
+    text: function (value) {
+      text[selector] = value;
+      return node;
+    },
+    css: function (name, value) {
+      (css[selector] || (css[selector] = {}))[name] = value;
+      return node;
+    },
+  };
+  for (const noop of ["html", "show", "hide", "val", "addClass", "removeClass", "attr", "empty", "append"])
+    node[noop] = function () {
+      return node;
+    };
+  return node;
+}
+
+function globalFormatDouble(v, decimals) {
+  return Number(v).toFixed(decimals);
+}
+
+function globalFormatSpace(v) {
+  return Number(v) + " b";
+}
+
+// The tail of the function builds the ops chart; none of it is what this test is about, so it gets the smallest
+// stubs that let it run to completion.
+const document = { documentElement: {}, querySelector: () => ({}) };
+const getComputedStyle = () => ({ getPropertyValue: () => "" });
+function ApexCharts() {
+  this.render = function () {};
+  this.destroy = function () {};
+}
+
+var opsPerSecHistory = {};
+var serverChartCommands = null;
+var serverData = {};
+
+eval(extractFn("diskDirectoryOf"));
+eval(extractFn("displayServerSummary"));
+
+function render(profiler) {
+  serverData = { metrics: { profiler: profiler, events: {} } };
+  opsPerSecHistory = {};
+  displayServerSummary();
+}
+
+// A 100 GB volume holding 1 GB of databases, with the 5% ext4 reservation: 5 GB is reserved, so usable is 94 GB
+// while 99 GB is genuinely unallocated. `total - usable` answers 6 GB, five sixths of which is the reservation.
+const GB = 1024 * 1024 * 1024;
+const MOSTLY_EMPTY_EXT4 = {
+  diskTotalSpace: { space: 100 * GB },
+  diskFreeSpace: { space: 94 * GB },
+  diskUsedSpace: { space: 1 * GB },
+};
+
+test("the card renders the used figure the server reports, not a difference across two definitions of free", () => {
+  render(MOSTLY_EMPTY_EXT4);
+
+  assert.strictEqual(text["#summDiskUsed"], 1 * GB + " b");
+  assert.strictEqual(text["#summDiskTotal"], 100 * GB + " b");
+  // and not the 6 GB the old arithmetic produced
+  assert.notStrictEqual(text["#summDiskUsed"], 6 * GB + " b");
+});
+
+test("the bar is drawn from the same figure the label shows", () => {
+  render(MOSTLY_EMPTY_EXT4);
+
+  // 1 of 100 GB. The old arithmetic drew 6%, so a bar that looked like real occupancy on an empty volume.
+  assert.strictEqual(css["#summDiskBar"].width, "1%");
+});
+
+test("a used figure of zero renders as zero rather than falling back", () => {
+  // #5636's rule applied here: a value sitting at zero is DATA. A truthiness test would have discarded it and
+  // silently shown the old difference instead, which is the one case where the two disagree most.
+  render({ diskTotalSpace: { space: 100 * GB }, diskFreeSpace: { space: 94 * GB }, diskUsedSpace: { space: 0 } });
+
+  assert.strictEqual(text["#summDiskUsed"], "0 b");
+});
+
+test("a server that does not report the used figure keeps the old difference", () => {
+  // An older build. There is no way to derive the right number from a payload that does not carry it, and the
+  // fallback is what keeps the card rendering at all.
+  render({ diskTotalSpace: { space: 100 * GB }, diskFreeSpace: { space: 94 * GB } });
+
+  assert.strictEqual(text["#summDiskUsed"], 6 * GB + " b");
+});
+
+test("the used figure is not repeated in the profiler details table", () => {
+  // The card already shows it, which is what the skip list is for - every other figure the card renders is in it.
+  const skipList = src.substring(src.indexOf("var skipProfiler = {"), src.indexOf("var profilerHtml"));
+  assert.ok(/\bdiskUsedSpace:\s*1\b/.test(skipList), "diskUsedSpace must be in skipProfiler alongside its siblings");
+});


### PR DESCRIPTION
Closes #7266

Three unrelated defects, filed together, sharing a shape: a guard or a figure added or corrected recently whose new form does not do what its own comment or contract says. Each is fixed at the site that produces it, with a regression test that fails against `main`.

**1. The JSON importer config no longer crashes before its own validation can speak.** `GraphImporter` split an edge source's `"from"` / `"to"` on `:` and read `[1]` unguarded, so a value that forgot the `:VertexType` half - precisely the mistake `checkEdgeSourceEndpoint` was added to describe in a sentence - threw `ArrayIndexOutOfBoundsException` inside the consumer `Builder.edgeSource` runs eagerly, before `build()` reached the validation. An absent key threw a bare `JSONException` naming the key and nothing else. Both now raise an `IllegalArgumentException` naming the edge source, the endpoint and the offending value, and two mis-shapes that used to pass in silence - a third colon dropped on the floor, an empty half matching nothing row after row - are reported too. The `"filter"` parse in the same class carried the identical unguarded `[1]` and gets the same guard.

**2. Studio's "Databases Disk" card stops charging the filesystem's reserved blocks to the databases.** #7223 made the profiler's free reading `getUsableSpace()`, which excludes the blocks a filesystem reserves for root, while the total stayed `getTotalSpace()`, which counts them - so the card's `total - free` charged that reservation, 5% of an ext4 by default, to the databases. On a 100 GB volume holding 1 GB it read as roughly 6 GB used, a constant offset that an operator watching for growth reads as data. The server now reports `diskUsedSpace`, derived from the two readings that count those blocks the same way, and the card renders it, falling back to the old difference against a server that predates the field. `diskFreeSpace` stays usable space on purpose: "how much room is left" is a different question, and the low-space warning and the percentage are the right consumers of it.

**3. The second-pass full-rebuild guard in `LocalSchema.loadIncremental` is reachable.** The loop narrowed on `getMainComponent() instanceof IndexInternal` before consulting `NON_INCREMENTAL_COMPONENT_EXTENSIONS`, and a bloom filter answers *itself* from `getMainComponent()` - so a touched `.bfidx` short-circuited out before the guard, leaving its in-RAM directory describing the file as it was before the entry appended to it. The extension check now runs first.

One correction to the issue's reading, verified by test rather than argued: a touched **compacted index** did already refuse, because `LSMTreeIndexMutable.onAfterLoad` wires `mainIndex` into it and so `getMainComponent()` answers an `IndexInternal`. That was an accident of wiring rather than a rule - a factory-built compacted component starts with that field null - so the fix makes it a rule. The **dictionary** is deliberately left off the new set: `walTouchedFileIds` is every file id the entry's WAL wrote a page into, and every DDL entry that adds a type or property name writes dictionary pages, so refusing on those would send the common case straight back to the O(entries x total files) rebuild #6988 removed. Both sets now say in their own javadoc which pass they govern and why they differ, and `Issue6988IncrementalSchemaApplyIT` is green, which is the run that proves the common DDL path stayed incremental.

## Test plan

- [ ] `mvn -o -pl integration -am test -Dtest=Issue7266ImporterConfigValidationTest` - 7/7. Against `main`, 5 of them fail with `ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1`, one with a `JSONException`, and `aWellFormedConfigStillParses` passes (so the guard refuses only what is malformed).
- [ ] `mvn -o -pl engine -am test -Dtest=Issue7266IncrementalSchemaSecondPassTest` - 3/3. Against `main`, `aTouchedBloomFilterForcesTheFullRebuild` fails with "Expecting value to be false but was true".
- [ ] `mvn -o -pl engine -am test -Dtest=Issue7266ProfilerDiskUsedSpaceTest` - 3 tests. `theReservedBlocksAreNotChargedToTheDatabases` needs a filesystem that actually reserves blocks and `assumeTrue`-skips on APFS/tmpfs rather than passing for the wrong reason; it runs on ext4.
- [ ] `node --test studio/test/server-disk-used.test.js` - 5/5. Reverting the one JS line turns 3 of them red, which is the proof they can fail. The numbers are synthetic on purpose: a filesystem that reserves nothing cannot tell the two formulas apart.
- [ ] Regression: `mvn -o -pl integration -am test -Dtest='GraphImporter*Test,UberTripsImportTest,StackOverflowImporterConfigTest'` (67 run, 0 failures), `mvn -o -pl engine -am test -Dtest='Issue7223*,Issue6988*,ProfilerTest,SchemaTest,LSMTreeIndexTest,Issue5662*,Issue5119*,Issue5120*'` (94 run, 0 failures), `node studio/scripts/run-tests.js` (76/76).
- [ ] The one that matters for finding 3: `mvn -o -pl ha-raft -am test -Dtest='Issue6988*'` - 6/6, including `Issue6988FullRebuildFallbackIT` and `Issue6988IncrementalSchemaApplyIT`.

## Coverage

Entry points the fix covers, one test each, per the tracking doc's completeness table:

| Finding | Entry point | Test |
|---|---|---|
| 1 | `fromJSON(db, JSONObject, dir)` -> `"from"` malformed | `aFromEndpointMissingItsVertexTypeIsReported` |
| 1 | ... `"to"` malformed | `aToEndpointMissingItsVertexTypeIsReported` |
| 1 | ... wrong number of parts / an empty half | `anEndpointWithTheWrongNumberOfPartsIsReported` |
| 1 | ... the key absent entirely | `anAbsentEndpointKeyIsReportedAsTheMissingEndpointItIs` |
| 1 | `fromJSON(db, String, dir)` (the other public overload) | `theStringOverloadReportsItToo` |
| 1 | `parseVertexSource` -> `"filter"` without `=` | `aFilterWithoutAnEqualsIsReported` |
| 2 | `Profiler.toJSON()` -> `diskUsedSpace` | `Issue7266ProfilerDiskUsedSpaceTest` |
| 2 | Studio card, server that reports the field / one that does not | `server-disk-used.test.js` |
| 3 | second pass, touched `.bfidx` | `aTouchedBloomFilterForcesTheFullRebuild` |
| 3 | second pass, touched `.uctidx`/`.nuctidx` | `aTouchedCompactedIndexForcesTheFullRebuild` |
| 3 | second pass, touched `dict` stays incremental | `aTouchedDictionaryStaysIncremental` |

Argued with evidence rather than fixed, each recorded in the tracking doc: `GraphImporter.main()` adds no parsing of its own and reaches both guards through `fromJSON`; `ServerMonitor.checkDiskSpace()` reports available space and its percentage and computes no used figure, so it never carried finding 2; `SparseSegmentComponent` also answers `this` from `getMainComponent()` but its extension was never in the non-incremental set, so it is untouched by finding 3.

**One behavior change beyond the stated bug**, called out because it is not in the issue: the `existsFile()` check in the second pass now runs before the `instanceof` narrowing, so a touched **non-index** component (a bucket, say) whose file the `FileManager` no longer holds sends the caller to the full rebuild where it used to be skipped by `continue`. It is only reachable from an already-inconsistent state, and the full rebuild is the fallback, so it fails to the safer side - a file retired by this entry already makes `loadIncremental` refuse at its first guard, and one retired by an earlier entry leaves neither a component nor a `FileManager` entry, so the loop still continues as before.

**Known gaps:** None. No row of the completeness table was left for a follow-up issue, so none was filed.

Two things this does *not* cover, stated plainly rather than left to be discovered: a Studio talking to a server older than this change keeps the old, overstated figure, because there is no way to derive the right one from a payload that does not carry it; and a touched dictionary stays on the incremental path on purpose, which is today's behaviour and is now argued in both places the contract is written down instead of being implied.

The full analysis, the greps behind every exhaustive claim, the completeness table and the adversarial pass are in `docs/7266-three-small-defects.md` in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuuFV2rsSfiK4yvr6i91uz
