### PR TITLE
fix(#7233,#7262,#7247): server-scoped settings read from the server's configuration, strict Booleans in the configuration file, six discarded causes

### DIFF
--- a/bolt/src/main/java/com/arcadedb/bolt/BoltChunkedInput.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltChunkedInput.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.bolt;
 
+import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.log.LogManager;
 
@@ -45,9 +46,13 @@ public class BoltChunkedInput {
    * Reads {@link GlobalConfiguration#BOLT_MAX_MESSAGE_SIZE}, falling back to its built-in default (with a
    * warning) if configured below 1: a limit that low would reject essentially every message outright, so it is
    * treated as a misconfiguration rather than an intentional (if impractical) lockdown.
+   * <p>
+   * Through {@code configuration} and not off the enum: the setting is SCOPE.SERVER, so it is authoritative in the
+   * SERVER's overlay, which is where the configuration file, {@code SET SERVER SETTING} and the MCP tool all write.
+   * The enum carries a system property or an environment variable and nothing else (issue #7233).
    */
-  private static int sanitizedMaxMessageSize() {
-    final int configured = GlobalConfiguration.BOLT_MAX_MESSAGE_SIZE.getValueAsInteger();
+  private static int sanitizedMaxMessageSize(final ContextConfiguration configuration) {
+    final int configured = configuration.getValueAsInteger(GlobalConfiguration.BOLT_MAX_MESSAGE_SIZE);
     if (configured < 1) {
       final int fallback = ((Number) GlobalConfiguration.BOLT_MAX_MESSAGE_SIZE.getDefValue()).intValue();
       if (WARNED_MISCONFIGURED_LIMITS.add(GlobalConfiguration.BOLT_MAX_MESSAGE_SIZE))
@@ -59,8 +64,16 @@ public class BoltChunkedInput {
     return configured;
   }
 
+  /**
+   * For a caller with no server in reach - the protocol unit tests. An empty {@link ContextConfiguration} reads
+   * through to the enum's value, which is what this constructor always did.
+   */
   public BoltChunkedInput(final InputStream in) {
-    this(in, sanitizedMaxMessageSize());
+    this(in, new ContextConfiguration());
+  }
+
+  public BoltChunkedInput(final InputStream in, final ContextConfiguration configuration) {
+    this(in, sanitizedMaxMessageSize(configuration));
   }
 
   /**

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -187,7 +187,10 @@ public class BoltNetworkExecutor extends Thread {
     this.listener = listener;
     this.sslHelper = sslHelper;
     this.preAuthTicket = preAuthTicket;
-    this.debug = GlobalConfiguration.BOLT_DEBUG.getValueAsBoolean();
+    // Through the SERVER's configuration, here and at every other read below: these settings are SCOPE.SERVER,
+    // and the GlobalConfiguration enum holds only what a system property or an environment variable put there, so
+    // a server configuration file or a SET SERVER SETTING used to be ignored without a word (issue #7233).
+    this.debug = server.getConfiguration().getValueAsBoolean(GlobalConfiguration.BOLT_DEBUG);
     // NOTE: transport (TLS) negotiation and the socket I/O streams are intentionally set up in run(), on this
     // per-connection thread, so a slow/failed/hostile TLS handshake can never block the shared accept thread.
   }
@@ -224,7 +227,7 @@ public class BoltNetworkExecutor extends Thread {
             continue;
           }
 
-          final PackStreamReader reader = new PackStreamReader(messageData);
+          final PackStreamReader reader = new PackStreamReader(messageData, server.getConfiguration());
           final Object value = reader.readValue();
 
           if (!(value instanceof PackStreamReader.StructureValue structure)) {
@@ -306,7 +309,7 @@ public class BoltNetworkExecutor extends Thread {
       // read timeout (issue #5978, mirroring RedisNetworkExecutor's #5912 fix), so a stalled/hostile client
       // cannot hold this connection thread (and its file descriptors) open forever. Lifted to infinite once
       // authentication succeeds - see markAuthenticated() - and re-armed on LOGOFF - see markUnauthenticated().
-      final int handshakeTimeout = GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.getValueAsInteger();
+      final int handshakeTimeout = server.getConfiguration().getValueAsInteger(GlobalConfiguration.NETWORK_SOCKET_TIMEOUT);
       if (handshakeTimeout > 0)
         socket.setSoTimeout(handshakeTimeout);
 
@@ -353,7 +356,7 @@ public class BoltNetworkExecutor extends Thread {
       final InputStream inputStream = preReadBytes != null
           ? new SequenceInputStream(new ByteArrayInputStream(preReadBytes), connectionSocket.getInputStream())
           : connectionSocket.getInputStream();
-      this.input = new BoltChunkedInput(inputStream);
+      this.input = new BoltChunkedInput(inputStream, server.getConfiguration());
       this.output = new BoltChunkedOutput(connectionSocket.getOutputStream());
       return true;
 
@@ -385,7 +388,9 @@ public class BoltNetworkExecutor extends Thread {
 
         // Reinitialize I/O with WebSocket framing and read Bolt magic from WebSocket stream
         input = new BoltChunkedInput(
-            new BoltWebSocketInputStream(socket.getInputStream(), GlobalConfiguration.BOLT_WEBSOCKET_MAX_FRAME_SIZE.getValueAsInteger()));
+            new BoltWebSocketInputStream(socket.getInputStream(),
+                server.getConfiguration().getValueAsInteger(GlobalConfiguration.BOLT_WEBSOCKET_MAX_FRAME_SIZE)),
+            server.getConfiguration());
         output = new BoltChunkedOutput(new BoltWebSocketOutputStream(socket.getOutputStream()));
         try {
           magic = input.readRaw(4);
@@ -767,7 +772,8 @@ public class BoltNetworkExecutor extends Thread {
     // single authenticated session could drive. Read per RUN, like the other BOLT protocol limits, so a runtime
     // change to the setting takes effect on the next message; floored at 1 since a ceiling of 0 would reject
     // every query outright rather than lock anything down.
-    final int maxOpenStreams = Math.max(1, GlobalConfiguration.BOLT_MAX_OPEN_STREAMS.getValueAsInteger());
+    final int maxOpenStreams = Math.max(1,
+        server.getConfiguration().getValueAsInteger(GlobalConfiguration.BOLT_MAX_OPEN_STREAMS));
     if (openStreams.size() >= maxOpenStreams) {
       sendFailure(BoltException.PROTOCOL_ERROR,
           "Too many result streams open at once (max " + maxOpenStreams + "): consume or discard one first");
@@ -1177,7 +1183,7 @@ public class BoltNetworkExecutor extends Thread {
     }
 
     final Map<String, Object> rt = new LinkedHashMap<>();
-    rt.put("ttl", GlobalConfiguration.BOLT_ROUTING_TTL.getValueAsLong());
+    rt.put("ttl", server.getConfiguration().getValueAsLong(GlobalConfiguration.BOLT_ROUTING_TTL));
     rt.put("db", message.getDatabase() != null ? message.getDatabase() : databaseName);
 
     final List<Map<String, Object>> servers = new ArrayList<>();
@@ -1277,7 +1283,7 @@ public class BoltNetworkExecutor extends Thread {
     String targetName = databaseName;
     if (targetName == null || targetName.isEmpty() || "system".equals(targetName) || "neo4j".equals(targetName)) {
       // "system" and "neo4j" are Neo4j virtual databases; map to default ArcadeDB database
-      targetName = GlobalConfiguration.BOLT_DEFAULT_DATABASE.getValueAsString();
+      targetName = server.getConfiguration().getValueAsString(GlobalConfiguration.BOLT_DEFAULT_DATABASE);
 
       if (targetName == null || targetName.isEmpty()) {
         // If no default configured, use the first available database
@@ -1337,13 +1343,13 @@ public class BoltNetworkExecutor extends Thread {
       stream.syntheticResults = new ArrayList<>();
       for (final String dbName : server.getDatabaseNames()) {
         stream.syntheticResults.add(List.of(dbName, "standard", List.of(), "read-write",
-            getBoltAddress(GlobalConfiguration.BOLT_PORT.getValueAsInteger()), "primary",
+            getBoltAddress(server.getConfiguration().getValueAsInteger(GlobalConfiguration.BOLT_PORT)), "primary",
             true, "online", "online", "", dbName.equals(database != null ? database.getName() : ""), false,
             List.of()));
       }
       // Also add the virtual "system" database entry
       stream.syntheticResults.add(List.of("system", "system", List.of(), "read-write",
-          getBoltAddress(GlobalConfiguration.BOLT_PORT.getValueAsInteger()), "primary",
+          getBoltAddress(server.getConfiguration().getValueAsInteger(GlobalConfiguration.BOLT_PORT)), "primary",
           false, "online", "online", "", false, false, List.of()));
       return true;
 
@@ -1885,7 +1891,7 @@ public class BoltNetworkExecutor extends Thread {
    * "unauthenticated" always implies the bounded handshake timeout applies.
    */
   private void markUnauthenticated() {
-    final int handshakeTimeout = GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.getValueAsInteger();
+    final int handshakeTimeout = server.getConfiguration().getValueAsInteger(GlobalConfiguration.NETWORK_SOCKET_TIMEOUT);
     try {
       socket.setSoTimeout(Math.max(handshakeTimeout, 0));
     } catch (final SocketException e) {

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkListener.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkListener.java
@@ -52,7 +52,7 @@ public class BoltNetworkListener extends Thread {
   private final    Set<BoltNetworkExecutor>            activeConnections = ConcurrentHashMap.newKeySet();
   private final    int                                 maxConnections;
   /** Bounds how many accepted connections can sit un-authenticated at once (issue #6412). */
-  private final    PreAuthConnectionGate               preAuthGate = new PreAuthConnectionGate("BOLT");
+  private final    PreAuthConnectionGate               preAuthGate;
 
   public BoltNetworkListener(final ArcadeDBServer server,
       final ServerSocketFactory socketFactory,
@@ -64,7 +64,11 @@ public class BoltNetworkListener extends Thread {
     this.server = server;
     this.socketFactory = socketFactory;
     this.sslHelper = sslHelper;
-    this.maxConnections = GlobalConfiguration.BOLT_MAX_CONNECTIONS.getValueAsInteger();
+    // Both read from THIS server's configuration: the settings are SCOPE.SERVER, and the GlobalConfiguration
+    // enum only ever carries a -D or an environment variable, so a cap declared in the server configuration
+    // file or through SET SERVER SETTING was silently ignored (issue #7233).
+    this.maxConnections = server.getConfiguration().getValueAsInteger(GlobalConfiguration.BOLT_MAX_CONNECTIONS);
+    this.preAuthGate = new PreAuthConnectionGate("BOLT", server.getConfiguration());
 
     listen(hostName, hostPortRange);
     start();

--- a/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamReader.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamReader.java
@@ -104,6 +104,10 @@ public class PackStreamReader {
    * even a bare HELLO struct, since its extra map is already one level deeper than the top-level struct itself -
    * so it is treated as a misconfiguration rather than an intentional (if impractical) lockdown.
    */
+  // The setting arrives as a PARAMETER, so the SCOPE.SERVER guard test (Issue7233ServerScopeSettingReadsTest)
+  // cannot see this read: it matches the literal GlobalConfiguration.NAME.getValueAs* shape. This site, and any
+  // future helper of the same shape, has to be checked by hand - reading through the ContextConfiguration here is
+  // not something the build will keep true for you.
   private static int sanitizedLimit(final ContextConfiguration configuration, final GlobalConfiguration setting) {
     // Through the caller's ContextConfiguration: every setting passed here is SCOPE.SERVER, so the enum only ever
     // carries what a system property or an environment variable put there (issue #7233).

--- a/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamReader.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamReader.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.bolt.packstream;
 
+import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.log.LogManager;
 
@@ -103,8 +104,10 @@ public class PackStreamReader {
    * even a bare HELLO struct, since its extra map is already one level deeper than the top-level struct itself -
    * so it is treated as a misconfiguration rather than an intentional (if impractical) lockdown.
    */
-  private static int sanitizedLimit(final GlobalConfiguration setting) {
-    final int configured = setting.getValueAsInteger();
+  private static int sanitizedLimit(final ContextConfiguration configuration, final GlobalConfiguration setting) {
+    // Through the caller's ContextConfiguration: every setting passed here is SCOPE.SERVER, so the enum only ever
+    // carries what a system property or an environment variable put there (issue #7233).
+    final int configured = configuration.getValueAsInteger(setting);
     if (configured < 1) {
       final int fallback = ((Number) setting.getDefValue()).intValue();
       if (WARNED_MISCONFIGURED_LIMITS.add(setting))
@@ -116,10 +119,18 @@ public class PackStreamReader {
     return configured;
   }
 
+  /**
+   * For a caller with no server configuration in reach - the protocol unit tests. An empty
+   * {@link ContextConfiguration} reads through to the settings' process-wide values.
+   */
   public PackStreamReader(final byte[] data) {
-    this(data, sanitizedLimit(GlobalConfiguration.BOLT_PACKSTREAM_MAX_VALUE_LENGTH),
-        sanitizedLimit(GlobalConfiguration.BOLT_PACKSTREAM_MAX_ELEMENTS),
-        sanitizedLimit(GlobalConfiguration.BOLT_PACKSTREAM_MAX_DEPTH));
+    this(data, new ContextConfiguration());
+  }
+
+  public PackStreamReader(final byte[] data, final ContextConfiguration configuration) {
+    this(data, sanitizedLimit(configuration, GlobalConfiguration.BOLT_PACKSTREAM_MAX_VALUE_LENGTH),
+        sanitizedLimit(configuration, GlobalConfiguration.BOLT_PACKSTREAM_MAX_ELEMENTS),
+        sanitizedLimit(configuration, GlobalConfiguration.BOLT_PACKSTREAM_MAX_DEPTH));
   }
 
   /**
@@ -142,9 +153,13 @@ public class PackStreamReader {
    * that bound to a false sense of safety rather than the exact one it provides today.
    */
   public PackStreamReader(final DataInputStream in) {
-    this(in, sanitizedLimit(GlobalConfiguration.BOLT_PACKSTREAM_MAX_VALUE_LENGTH),
-        sanitizedLimit(GlobalConfiguration.BOLT_PACKSTREAM_MAX_ELEMENTS),
-        sanitizedLimit(GlobalConfiguration.BOLT_PACKSTREAM_MAX_DEPTH));
+    this(in, new ContextConfiguration());
+  }
+
+  public PackStreamReader(final DataInputStream in, final ContextConfiguration configuration) {
+    this(in, sanitizedLimit(configuration, GlobalConfiguration.BOLT_PACKSTREAM_MAX_VALUE_LENGTH),
+        sanitizedLimit(configuration, GlobalConfiguration.BOLT_PACKSTREAM_MAX_ELEMENTS),
+        sanitizedLimit(configuration, GlobalConfiguration.BOLT_PACKSTREAM_MAX_DEPTH));
   }
 
   /**

--- a/bolt/src/test/java/com/arcadedb/bolt/Issue7233BoltLimitsReadServerConfigurationTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Issue7233BoltLimitsReadServerConfigurationTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.bolt.packstream.PackStreamReader;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7233: the BOLT protocol limits are SCOPE.SERVER, so they live in the server's {@link ContextConfiguration}
+ * - written by the server configuration file, {@code SET SERVER SETTING} and the MCP tool - and used to be read off
+ * the {@link GlobalConfiguration} enum, which only a system property or an environment variable ever writes. A
+ * cluster that tightened one of these in its configuration file ran on the compiled-in default instead.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7233BoltLimitsReadServerConfigurationTest {
+
+  @Test
+  void theReassembledMessageBoundComesFromTheServerConfiguration() throws IOException {
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.BOLT_MAX_MESSAGE_SIZE, 8);
+
+    final BoltChunkedInput input = new BoltChunkedInput(new ByteArrayInputStream(chunkedMessage(32)), configuration);
+
+    assertThatThrownBy(input::readMessage).isInstanceOf(IOException.class)
+        .hasMessageContaining("exceeds 8 bytes");
+  }
+
+  @Test
+  void thePackStreamValueBoundComesFromTheServerConfiguration() {
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.fromJSON("{\"configuration\":{\"bolt.packstream.maxValueLength\":4}}");
+
+    // A 16-character string: the marker says 16, the configured ceiling says 4.
+    final byte[] data = new byte[18];
+    data[0] = (byte) 0xD0; // STRING_8
+    data[1] = 16;
+    final PackStreamReader reader = new PackStreamReader(data, configuration);
+
+    assertThatThrownBy(reader::readValue).isInstanceOf(IOException.class)
+        .hasMessageContaining("exceeds the maximum allowed (4)");
+  }
+
+  /** One BOLT chunk of {@code size} zero bytes, followed by the end-of-message marker. */
+  private static byte[] chunkedMessage(final int size) throws IOException {
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    out.write((size >> 8) & 0xFF);
+    out.write(size & 0xFF);
+    out.write(new byte[size]);
+    out.write(0);
+    out.write(0);
+    return out.toByteArray();
+  }
+}

--- a/engine/src/main/java/com/arcadedb/ContextConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/ContextConfiguration.java
@@ -227,7 +227,9 @@ public class ContextConfiguration implements Serializable {
    * @return the configured value, or {@code iConfig}'s default when the configured one is not boolean text
    */
   public boolean getValueAsBoolean(final GlobalConfiguration iConfig) {
-    final Object v = getValue(iConfig);
+    // One map lookup, reused by the refusal branch below to tell an overlay value from the enum's own.
+    final boolean fromOverlay = config.containsKey(iConfig.getKey());
+    final Object v = fromOverlay ? config.get(iConfig.getKey()) : iConfig.getValue();
     if (v == null)
       return false;
     if (v instanceof Boolean b)
@@ -245,7 +247,7 @@ public class ContextConfiguration implements Serializable {
     // process-wide value, which is its compiled-in default unless a system property or an environment variable
     // chose one - and a bad value already on the enum falls back to the compiled-in default itself. Same rule
     // GlobalConfiguration.setValueFromConfigurationSource applies to a refusal on the -D path.
-    final Object fallback = config.containsKey(iConfig.getKey()) ? iConfig.getValue() : iConfig.getDefValue();
+    final Object fallback = fromOverlay ? iConfig.getValue() : iConfig.getDefValue();
     return fallback instanceof Boolean b && b;
   }
 

--- a/engine/src/main/java/com/arcadedb/ContextConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/ContextConfiguration.java
@@ -227,9 +227,14 @@ public class ContextConfiguration implements Serializable {
    * @return the configured value, or {@code iConfig}'s default when the configured one is not boolean text
    */
   public boolean getValueAsBoolean(final GlobalConfiguration iConfig) {
-    // One map lookup, reused by the refusal branch below to tell an overlay value from the enum's own.
-    final boolean fromOverlay = config.containsKey(iConfig.getKey());
-    final Object v = fromOverlay ? config.get(iConfig.getKey()) : iConfig.getValue();
+    // ONE lookup, and it doubles as the "did this come from the overlay" question the refusal branch below asks:
+    // a ConcurrentHashMap cannot hold a null value, so a non-null answer IS an overlay hit. Asking containsKey and
+    // then get would be two lookups AND a race - a concurrent setValue/merge between them can return null for a key
+    // that had just answered true, which would take the null branch below and read false for a setting whose
+    // default is the protection.
+    final Object overlaid = config.get(iConfig.getKey());
+    final boolean fromOverlay = overlaid != null;
+    final Object v = fromOverlay ? overlaid : iConfig.getValue();
     if (v == null)
       return false;
     if (v instanceof Boolean b)

--- a/engine/src/main/java/com/arcadedb/ContextConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/ContextConfiguration.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb;
 
+import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.FileUtils;
 import com.arcadedb.utility.SystemVariableResolver;
@@ -27,6 +28,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
 
 /**
  * Represents a context configuration where custom setting could be defined for the context only. If not defined, globals will be
@@ -34,6 +36,11 @@ import java.util.concurrent.ConcurrentHashMap;
  **/
 public class ContextConfiguration implements Serializable {
   private final           Map<String, Object>    config         = new ConcurrentHashMap<String, Object>();
+  /**
+   * Keys already reported by {@link #getValueAsBoolean(GlobalConfiguration)} as holding something that is not
+   * boolean text. Per-instance rather than static so one test's bad value cannot mute another's report.
+   */
+  private final           Set<String>            nonBooleanReported = ConcurrentHashMap.newKeySet();
   private transient final SystemVariableResolver customResolver = new SystemVariableResolver() {
     @Override
     public String resolve(final String variable) {
@@ -64,6 +71,25 @@ public class ContextConfiguration implements Serializable {
       config.putAll(iParent.config);
   }
 
+  /**
+   * Loads the server configuration file into this overlay, applying each value's declared type on the way in.
+   * <p>
+   * Issue #7262. This used to store the raw JSON value with a plain {@code put}, which for a {@code Boolean}
+   * setting meant the string survived to the read site and was then read by {@code Boolean.parseBoolean} - so
+   * {@code "arcadedb.ha.tls.mutualAuth": "yes"} silently DISABLED mutual TLS authentication on the Raft channel,
+   * and {@code "arcadedb.ha.peerAllowlist.enabled": "on"} silently skipped installing the peer allowlist. Both
+   * default to {@code true}, so the operator who never mentioned them was safe and the one who wrote down that
+   * they wanted the protection was the one who lost it - the exact opposite of the fail-safe property #7222
+   * established for the system-property and environment-variable path.
+   * <p>
+   * A value the setting's type cannot read is REFUSED and the setting keeps its default, reported once through
+   * {@link GlobalConfiguration#coerceFromConfigurationSource(Object, String)} - the same parse and the same
+   * message that path uses. Refusing rather than guessing is what makes this fail closed for a switch whose
+   * default is the protection: nothing about a typo says which way its author meant it.
+   * <p>
+   * Note that a REFUSED value is not stored, so {@link #toJSON()} no longer round-trips it. That is deliberate:
+   * this map is what a server hands to its plugins, and a value nothing can read has no business being in it.
+   */
   public void fromJSON(final String input) {
     if (input == null)
       return;
@@ -75,8 +101,14 @@ public class ContextConfiguration implements Serializable {
       final GlobalConfiguration cfgEntry = GlobalConfiguration.findByKey(GlobalConfiguration.PREFIX + k);
       if (cfgEntry != null) {
         final Object value = cfg.get(k);
-        config.put(GlobalConfiguration.PREFIX + k, value);
-        cfgEntry.applyContextValue(value);
+        final Object coerced = cfgEntry.coerceFromConfigurationSource(value, "server configuration file");
+        if (coerced == null)
+          // EITHER REFUSED (ALREADY REPORTED) OR A JSON null. LEAVE THE SETTING ON ITS DEFAULT RATHER THAN GUESS
+          // WHAT WAS MEANT - AND NOTE THE MAP IS A ConcurrentHashMap, SO STORING null WOULD THROW ANYWAY.
+          continue;
+
+        config.put(GlobalConfiguration.PREFIX + k, coerced);
+        cfgEntry.applyContextValue(coerced);
       }
     }
   }
@@ -176,11 +208,59 @@ public class ContextConfiguration implements Serializable {
     return defaultValue;
   }
 
+  /**
+   * Issue #7262: the second half of the mechanism that let {@code "arcadedb.ha.tls.mutualAuth": "yes"} disable
+   * mutual TLS on the Raft channel. {@code Boolean.parseBoolean} maps every string that is not {@code "true"} to
+   * {@code false}, so a synonym, a typo or a stray space read as a deliberate opt-OUT - and for the several
+   * settings whose default is {@code true} because the default is the protection, that is the one direction a
+   * misread must never take.
+   * <p>
+   * {@link #fromJSON(String)} now refuses such a value on the way in, which is where the operator can be told
+   * about it. This is the backstop for the entry points that still hand over untyped values - the
+   * {@link #ContextConfiguration(Map) map constructor}, {@link #merge(ContextConfiguration)}, and
+   * {@link #setValue(String, Object)} called with raw text - and it answers the same way that path does: a value
+   * that is not boolean text is REFUSED, reported once, and the value the setting would have had without it is
+   * returned. Falling back to the default rather than to {@code false} is what makes this fail closed for a default-{@code true} switch
+   * without flipping the settings whose safe side is the other one; refusing to guess is the property that holds
+   * for all of them.
+   *
+   * @return the configured value, or {@code iConfig}'s default when the configured one is not boolean text
+   */
   public boolean getValueAsBoolean(final GlobalConfiguration iConfig) {
     final Object v = getValue(iConfig);
     if (v == null)
       return false;
-    return v instanceof Boolean b ? b : Boolean.parseBoolean(v.toString());
+    if (v instanceof Boolean b)
+      return b;
+
+    final String text = v.toString().trim();
+    if ("true".equalsIgnoreCase(text))
+      return true;
+    if ("false".equalsIgnoreCase(text))
+      return false;
+
+    reportNonBoolean(iConfig, v);
+
+    // "As if this key had never been written": a bad value in THIS overlay falls back to the setting's
+    // process-wide value, which is its compiled-in default unless a system property or an environment variable
+    // chose one - and a bad value already on the enum falls back to the compiled-in default itself. Same rule
+    // GlobalConfiguration.setValueFromConfigurationSource applies to a refusal on the -D path.
+    final Object fallback = config.containsKey(iConfig.getKey()) ? iConfig.getValue() : iConfig.getDefValue();
+    return fallback instanceof Boolean b && b;
+  }
+
+  /**
+   * Reports a value that is not boolean text ONCE per setting. The read sites are on connection and request paths,
+   * so logging on every read would turn one mistyped setting into a flood; the message is about a configuration
+   * mistake that does not change while the process runs, so the first one says everything the operator needs.
+   */
+  private void reportNonBoolean(final GlobalConfiguration iConfig, final Object value) {
+    if (!nonBooleanReported.add(iConfig.getKey()))
+      return;
+
+    LogManager.instance().log(this, Level.WARNING,
+        "Invalid value %s for setting '%s': only 'true' and 'false' are accepted. Keeping the default '%s'",
+        iConfig.redactIfHidden(value), iConfig.getKey(), iConfig.getDefValue());
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2816,8 +2816,18 @@ public enum GlobalConfiguration {
     if (coerced == null && iValue != null)
       return false;
 
-    setValue(coerced);
-    return true;
+    try {
+      setValue(coerced);
+      return true;
+    } catch (final Exception e) {
+      // setValue can still refuse what coerce accepted - the allow-list check lives there, and it THROWS. This
+      // method cannot: it runs from readConfiguration() inside this class's static initializer, where an escaping
+      // exception becomes an ExceptionInInitializerError that takes the whole engine down over one mistyped
+      // variable. setValue has already rolled the setting back to what it was, so reporting and returning false
+      // is the same "keep the default" outcome a refused coercion gets.
+      report(iValue, source, e);
+      return false;
+    }
   }
 
   /**
@@ -2843,15 +2853,43 @@ public enum GlobalConfiguration {
    */
   Object coerceFromConfigurationSource(final Object iValue, final String source) {
     try {
-      return coerceFromAdminCommand(iValue);
+      final Object coerced = coerceFromAdminCommand(iValue);
+      checkAllowed(coerced);
+      return coerced;
     } catch (final Exception e) {
-      if (LogManager.instance() != null)
-        LogManager.instance().log(this, Level.WARNING, "Invalid value %s for setting '%s' of type %s set as %s: %s. Keeping %s",
-            redactIfHidden(iValue), key, type.getSimpleName(), source,
-            // The cause is redacted along with the value: its message quotes the value back.
-            isHidden() ? "not a valid " + type.getSimpleName() : e.getMessage(), redactIfHidden(getValue()));
+      report(iValue, source, e);
       return null;
     }
+  }
+
+  /**
+   * Refuses a value outside this setting's declared {@code allowed} set, exactly as {@link #setValue(Object)} does.
+   * <p>
+   * {@link #coerce(Object)} converts a value to the setting's TYPE and stops there, so a {@code String} setting with
+   * an allow-list accepted anything that was a string. That was invisible while the only writer of raw external
+   * text was {@link #setValue(Object)}, which checks the set itself - but the overlay writers
+   * ({@link ContextConfiguration#fromJSON(String)} and {@code SET SERVER SETTING}) never touch the enum, so
+   * {@code "arcadedb.server.mode": "staging"} in a server configuration file was stored verbatim. Every reader then
+   * compared it against {@code "production"}, found it different, and served the deployment the DEVELOPMENT
+   * behaviour - Studio included. Same shape as #7262, same permissive direction.
+   */
+  private void checkAllowed(final Object coerced) {
+    if (allowed != null && coerced != null && !allowed.contains(coerced.toString().toLowerCase(Locale.ENGLISH)))
+      throw new IllegalArgumentException(
+          "Setting '" + key + "=" + coerced + "' is not valid. Allowed values are " + allowed);
+  }
+
+  /**
+   * Reports a value this setting could not take, naming where it came from and what is being kept instead. Shared
+   * by every non-throwing writer so a refusal reads the same whether it came from a system property, an
+   * environment variable or the server configuration file.
+   */
+  private void report(final Object iValue, final String source, final Exception e) {
+    if (LogManager.instance() != null)
+      LogManager.instance().log(this, Level.WARNING, "Invalid value %s for setting '%s' of type %s set as %s: %s. Keeping %s",
+          redactIfHidden(iValue), key, type.getSimpleName(), source,
+          // The cause is redacted along with the value: its message quotes the value back.
+          isHidden() ? "not a valid " + type.getSimpleName() : e.getMessage(), redactIfHidden(getValue()));
   }
 
   /**
@@ -3029,8 +3067,20 @@ public enum GlobalConfiguration {
       if (type == Float.class)
         return iValue instanceof Number n ? n.floatValue() : Float.parseFloat(iValue.toString().trim());
 
-      if (type == String.class)
-        return iValue.toString();
+      if (type == String.class) {
+        final String text = iValue.toString();
+        // Normalised to the DECLARED spelling when the setting has an allow-list. setValue matches that list
+        // case-insensitively, so `-Darcadedb.server.mode=Production` passed validation and was then stored as
+        // "Production" - which every reader compares with "production".equals(...) and finds different, quietly
+        // giving a production deployment the development behaviour, Studio included. Normalising here, in the one
+        // conversion both writers go through, fixes every reader at once instead of asking each to case-fold
+        // (issue #7233's family).
+        if (allowed != null)
+          for (final Object candidate : allowed)
+            if (candidate instanceof String s && s.equalsIgnoreCase(text))
+              return s;
+        return text;
+      }
 
       if (type.isEnum()) {
         if (type.isInstance(iValue))

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2407,6 +2407,16 @@ public enum GlobalConfiguration {
   private final        String                   description;
   private final        Boolean                  canChangeAtRuntime;
   private final        boolean                  hidden;
+  /**
+   * The values this setting accepts, or {@code null} when it accepts anything its type can read.
+   * <p>
+   * <b>Entries must be LOWERCASE.</b> Every check against this set - {@link #setValue(Object)} and
+   * {@link #checkAllowed(Object)} - compares {@code value.toString().toLowerCase(Locale.ENGLISH)}, and
+   * {@link #coerce(Object)} normalises a {@code String} setting's value to the entry it matches, so a set built
+   * with mixed case would refuse every value including the ones it names. The convention holds for all of them
+   * today ({@code SERVER_MODE}'s modes, {@code integerRangeAsStrings}' digit strings); it is stated here because
+   * nothing enforces it and the failure is total and silent-looking.
+   */
   private final        Set<Object>              allowed;
   public final static  String                   PREFIX = "arcadedb.";
   private static final Timer                    TIMER;

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2812,16 +2812,45 @@ public enum GlobalConfiguration {
    * @return {@code true} when the value was stored, {@code false} when it was refused and the default kept
    */
   public boolean setValueFromConfigurationSource(final Object iValue, final String source) {
+    final Object coerced = coerceFromConfigurationSource(iValue, source);
+    if (coerced == null && iValue != null)
+      return false;
+
+    setValue(coerced);
+    return true;
+  }
+
+  /**
+   * Applies the strict parse of {@link #coerceFromAdminCommand(Object)} to a value that arrived from a
+   * CONFIGURATION SOURCE - a system property, an environment variable, or the server configuration file - but
+   * REPORTS what it cannot read instead of throwing, returning {@code null} to say the value was refused.
+   * <p>
+   * Split out of {@link #setValueFromConfigurationSource(Object, String)} for issue #7262, so the server
+   * configuration file can share the parse and the message without also sharing the store: that path is the
+   * {@code SCOPE.SERVER} overlay ({@link ContextConfiguration#fromJSON(String)}), not this enum, and writing the
+   * value here would make the two disagree for every setting the file mentions.
+   * <p>
+   * Neither caller may throw. This one runs inside this class's static initializer, where an exception becomes an
+   * {@code ExceptionInInitializerError} that takes the engine down over one mistyped variable; the other runs while
+   * a server reads its configuration file, where it would do the same to the server. A refused value therefore
+   * leaves the setting exactly where it was - the compiled-in default from {@link #readConfiguration()}, and
+   * whatever the overlay already held from {@code fromJSON}.
+   *
+   * @param iValue the value to coerce, typically the raw text a property, variable or configuration file carried
+   * @param source what to name as its origin when reporting a value that cannot be read
+   *
+   * @return the coerced value, or {@code null} when it was refused (and when {@code iValue} itself is {@code null})
+   */
+  Object coerceFromConfigurationSource(final Object iValue, final String source) {
     try {
-      setValue(coerceFromAdminCommand(iValue));
-      return true;
+      return coerceFromAdminCommand(iValue);
     } catch (final Exception e) {
       if (LogManager.instance() != null)
         LogManager.instance().log(this, Level.WARNING, "Invalid value %s for setting '%s' of type %s set as %s: %s. Keeping %s",
             redactIfHidden(iValue), key, type.getSimpleName(), source,
             // The cause is redacted along with the value: its message quotes the value back.
             isHidden() ? "not a valid " + type.getSimpleName() : e.getMessage(), redactIfHidden(getValue()));
-      return false;
+      return null;
     }
   }
 
@@ -2916,17 +2945,26 @@ public enum GlobalConfiguration {
    * {@link #coerce(Object)} therefore remains the conversion of a value that is already typed, or one whose caller
    * has its own reason to be lenient; nothing routes raw external text through it any more.
    * <p>
-   * <b>One writer is still outside all of this, and counting it is the point:</b> #7222 happened because an
-   * enumeration of writers went stale, so this one says what it does not cover.
-   * {@link ContextConfiguration#fromJSON(String)} - the server configuration FILE - stores what it read straight
-   * into the overlay map with a plain {@code put}, touching neither this method nor {@link #setValue(Object)}, so a
-   * {@code "yes"} written there survives as the string {@code "yes"}. That is not the #7222 failure, which was a
-   * value silently BECOMING {@code false}: the text is still intact, so a reader can still refuse it, and
-   * {@code PrometheusMetricsPlugin.isAuthenticationRequired} does exactly that by re-applying this method at its own
-   * read site. A reader that instead trusts "the strict parse already happened on entry" and calls
-   * {@link ContextConfiguration#getValueAsBoolean(GlobalConfiguration)} would get {@code Boolean.parseBoolean} and
-   * reopen the bug through the configuration file. Until the file path coerces too, the read-site re-parse is what
-   * a security-relevant Boolean has to keep doing.
+   * <b>Every writer of raw external text now goes through this parse, and enumerating them is the point:</b> #7222
+   * happened because such an enumeration went stale, and #7262 because it was still one short. In full:
+   * <ol>
+   *   <li>{@code SET SERVER SETTING} and {@code SET DATABASE SETTING} over HTTP, and the {@code set_server_setting}
+   *       MCP tool, and {@code ALTER DATABASE ... SETTING} in SQL - directly, refusing loudly;</li>
+   *   <li>system properties and environment variables, through
+   *       {@link #setValueFromConfigurationSource(Object, String)} (#7222);</li>
+   *   <li>the server configuration FILE, {@link ContextConfiguration#fromJSON(String)}, through
+   *       {@link #coerceFromConfigurationSource(Object, String)} (#7262).</li>
+   * </ol>
+   * The last one used to store what it read straight into the overlay map with a plain {@code put}, touching
+   * neither this method nor {@link #setValue(Object)}, so a {@code "yes"} written there survived as the string
+   * {@code "yes"} and {@link ContextConfiguration#getValueAsBoolean(GlobalConfiguration)} read it as {@code false}
+   * through {@code Boolean.parseBoolean} - which for {@code arcadedb.ha.tls.mutualAuth} meant an operator writing
+   * down that they wanted mutual TLS on the Raft channel turned it off instead.
+   * <p>
+   * The reader is strict too now, so the two halves cannot come apart again: a value that is not boolean text is
+   * refused there as well, and falls back to the setting's DEFAULT rather than to {@code false}. That makes the
+   * read-site re-parse in {@code PrometheusMetricsPlugin.isAuthenticationRequired} a second lock on the same door
+   * rather than the only one, which for an authentication switch is where it should stay.
    *
    * @param iValue the value to convert, or {@code null}
    *

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2873,7 +2873,9 @@ public enum GlobalConfiguration {
   }
 
   /**
-   * Refuses a value outside this setting's declared {@code allowed} set, exactly as {@link #setValue(Object)} does.
+   * Refuses a value outside this setting's declared {@code allowed} set. Shared by BOTH writers -
+   * {@link #setValue(Object)} and {@link #coerceFromConfigurationSource(Object, String)} - so the two cannot come
+   * to disagree about what is allowed, or report it differently when they refuse.
    * <p>
    * {@link #coerce(Object)} converts a value to the setting's TYPE and stops there, so a {@code String} setting with
    * an allow-list accepted anything that was a string. That was invisible while the only writer of raw external
@@ -2886,7 +2888,7 @@ public enum GlobalConfiguration {
   private void checkAllowed(final Object coerced) {
     if (allowed != null && coerced != null && !allowed.contains(coerced.toString().toLowerCase(Locale.ENGLISH)))
       throw new IllegalArgumentException(
-          "Setting '" + key + "=" + coerced + "' is not valid. Allowed values are " + allowed);
+          "Global setting '" + key + "=" + coerced + "' is not valid. Allowed values are " + allowed);
   }
 
   /**
@@ -3195,10 +3197,7 @@ public enum GlobalConfiguration {
 
       value = invokeCallback(value);
 
-      if (allowed != null && value != null)
-        if (!allowed.contains(value.toString().toLowerCase(Locale.ENGLISH)))
-          throw new IllegalArgumentException(
-              "Global setting '" + key + "=" + value + "' is not valid. Allowed values are " + allowed);
+      checkAllowed(value);
 
     } catch (final Exception e) {
       // RESTORE THE PREVIOUS VALUE - INCLUDING WHETHER THERE WAS ONE. A WRITE THAT WAS ROLLED BACK IS NOT A CHOICE

--- a/engine/src/main/java/com/arcadedb/serializer/BinarySerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinarySerializer.java
@@ -553,10 +553,12 @@ public class BinarySerializer {
             content.putByte(entryType);
             serializeValue(database, content, entryType, valueToWrite, applyEncryption);
           } catch (Exception e) {
-            LogManager.instance().log(this, Level.SEVERE, "Error on serializing array value for element %d = '%s'",
+            // The element's own toString() is not a substitute for knowing which nested serializeValue() threw and
+            // why, so the cause travels on both paths - the log and the exception (issue #7247).
+            LogManager.instance().log(this, Level.SEVERE, "Error on serializing array value for element %d = '%s'", e,
                 i, entryValue);
             throw new SerializationException(
-                "Error on serializing array value for element " + i + " = '" + entryValue + "'");
+                "Error on serializing array value for element " + i + " = '" + entryValue + "'", e);
           }
         }
       }

--- a/engine/src/test/java/com/arcadedb/Issue7233ServerScopeSettingReadsTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue7233ServerScopeSettingReadsTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Issue #7233. A {@code SCOPE.SERVER} setting is authoritative in the SERVER's {@link ContextConfiguration}: the
+ * server configuration file ({@link ContextConfiguration#fromJSON(String)}), {@code SET SERVER SETTING} and the MCP
+ * {@code set_server_setting} tool all write there. The {@link GlobalConfiguration} enum is populated by
+ * {@link GlobalConfiguration#readConfiguration()} alone, which consults a system property and then an environment
+ * variable and nothing else.
+ * <p>
+ * So {@code GlobalConfiguration.X.getValueAsY()} on a {@code SCOPE.SERVER} setting, in code that runs inside a
+ * server, silently ignores every channel the setting's own scope advertises except a raw {@code -D}. There is no
+ * error and no warning; the value simply stays at the compiled-in default. That is how #7226 disabled a snapshot
+ * size limit an operator had configured, and how the Studio production gate was decided by the default rather than
+ * by what the deployment asked for.
+ * <p>
+ * The house pattern is {@code server.getConfiguration().getValueAsY(GlobalConfiguration.X)}, keeping the enum only
+ * as the fallback for a caller with no server in reach. This test is what keeps that from being something
+ * everybody has to remember: it walks every production source outside {@code engine/} and fails on a
+ * {@code SCOPE.SERVER} read that goes through the enum without such a fallback beside it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue7233ServerScopeSettingReadsTest {
+
+  /**
+   * How far from the enum read the {@link ContextConfiguration} read of the SAME setting may be for the pair to
+   * count as the ternary house pattern. Five lines covers every formatting of it in the tree, including the ones
+   * with a comment between the two halves, without reaching into a neighbouring statement.
+   */
+  private static final int TERNARY_WINDOW_LINES = 5;
+
+  /**
+   * Reads that are deliberately off the enum, keyed {@code SimpleFileName.java#SETTING}. Each is a caller with no
+   * server - and therefore no {@link ContextConfiguration} - anywhere in reach; the enum is the only thing there
+   * is to read. Adding an entry here is a claim that has to be true of the site, not a way to silence the test.
+   */
+  private static final Map<String, String> ALLOWED = new HashMap<>();
+
+  static {
+    ALLOWED.put("Console.java#SERVER_ROOT_PATH",
+        "CLI entry point: main() reads the root path to default it before anything builds a server");
+    ALLOWED.put("Restore.java#SERVER_ROOT_PATH",
+        "CLI entry point: same defaulting as Console.main, with no server in the process at all");
+    ALLOWED.put("MCPStdioServer.java#SERVER_ROOT_PASSWORD",
+        "Checked in main() to refuse stdio mode early; the ArcadeDBServer it guards is constructed after it");
+    ALLOWED.put("ImportSecurityValidator.java#SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS",
+        "Static validator shared by the CLI importer; the server path resolves the policy itself and passes it "
+            + "through the openRemoteConnection(url, blockLocalNetworks) overload (issue #6474)");
+    ALLOWED.put("ImportSecurityValidator.java#SERVER_SECURITY_IMPORT_ALLOWED_LOCAL_PATHS",
+        "Static validator with no caller-resolved override yet; see the note on the issue");
+    ALLOWED.put("SourceDiscovery.java#SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS",
+        "Fallback for a null allowLocalUrls, i.e. an embedded/CLI caller that resolved no policy of its own");
+    ALLOWED.put("FullRestoreFormat.java#SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS",
+        "Fallback for a null settings.allowLocalUrls, same shape as SourceDiscovery above");
+  }
+
+  private static final Pattern SCOPE_DECLARATION = Pattern.compile(
+      "^\\s{2}([A-Z][A-Z0-9_]*)\\(\"[^\"]*\",\\s*SCOPE\\.([A-Z]+)", Pattern.MULTILINE);
+  private static final Pattern ENUM_READ         = Pattern.compile(
+      "GlobalConfiguration\\.([A-Z0-9_]+)\\.getValueAs\\w*\\s*\\(");
+
+  @Test
+  public void noServerScopedSettingIsReadOffTheEnumWithoutAFallback() throws IOException {
+    final Path repoRoot = findRepoRoot();
+    assumeTrue(repoRoot != null, "sources not available in this run");
+
+    final Map<String, String> scopes = readScopes(repoRoot);
+    assertThat(scopes).as("SCOPE declarations parsed out of GlobalConfiguration").isNotEmpty();
+
+    final List<String> violations = new ArrayList<>();
+    final Set<String> allowedHit = new HashSet<>();
+
+    for (final Path file : productionSourcesOutsideEngine(repoRoot)) {
+      final List<String> lines = Files.readAllLines(file);
+      for (int i = 0; i < lines.size(); i++) {
+        final Matcher m = ENUM_READ.matcher(lines.get(i));
+        while (m.find()) {
+          final String setting = m.group(1);
+          if (!"SERVER".equals(scopes.get(setting)))
+            continue;
+
+          final String key = file.getFileName() + "#" + setting;
+          if (ALLOWED.containsKey(key)) {
+            allowedHit.add(key);
+            continue;
+          }
+          if (hasContextConfigurationReadNearby(lines, i, setting))
+            continue;
+
+          violations.add(repoRoot.relativize(file) + ":" + (i + 1) + " reads SCOPE.SERVER setting " + setting
+              + " off the GlobalConfiguration enum");
+        }
+      }
+    }
+
+    assertThat(violations).as("""
+        A SCOPE.SERVER setting read off the GlobalConfiguration enum sees only a system property or an environment \
+        variable: the server configuration file, SET SERVER SETTING and the MCP set_server_setting tool all write \
+        into the server's ContextConfiguration instead, and the read above ignores all three without a word \
+        (issue #7233). Use server.getConfiguration().getValueAsX(GlobalConfiguration.SETTING), keeping the enum as \
+        the fallback for a caller with no server - or, when there genuinely is none, add the site to ALLOWED in \
+        this test with the reason.""").isEmpty();
+
+    assertThat(new TreeSet<>(ALLOWED.keySet())).as(
+        "stale ALLOWED entries: these sites no longer exist, so remove them rather than leave the next reader "
+            + "believing the exception is still needed").isEqualTo(new TreeSet<>(allowedHit));
+  }
+
+  /**
+   * The ternary house pattern: the same setting read through a {@link ContextConfiguration} within a few lines,
+   * which is what {@code server != null ? server.getConfiguration().getValueAsX(S) : S.getValueAsX()} looks like.
+   */
+  private static boolean hasContextConfigurationReadNearby(final List<String> lines, final int index,
+      final String setting) {
+    final Pattern contextRead = Pattern.compile("getValueAs\\w*\\s*\\(\\s*GlobalConfiguration\\." + setting + "\\b");
+    final int from = Math.max(0, index - TERNARY_WINDOW_LINES);
+    final int to = Math.min(lines.size(), index + TERNARY_WINDOW_LINES + 1);
+    for (int i = from; i < to; i++)
+      if (contextRead.matcher(lines.get(i)).find())
+        return true;
+    return false;
+  }
+
+  private static Map<String, String> readScopes(final Path repoRoot) throws IOException {
+    final String source = Files.readString(
+        repoRoot.resolve("engine/src/main/java/com/arcadedb/GlobalConfiguration.java"));
+    final Map<String, String> scopes = new HashMap<>();
+    final Matcher m = SCOPE_DECLARATION.matcher(source);
+    while (m.find())
+      scopes.put(m.group(1), m.group(2));
+    return scopes;
+  }
+
+  private static List<Path> productionSourcesOutsideEngine(final Path repoRoot) throws IOException {
+    final List<Path> sources = new ArrayList<>();
+    try (Stream<Path> modules = Files.list(repoRoot)) {
+      modules.filter(Files::isDirectory).filter(module -> !module.getFileName().toString().equals("engine"))
+          .map(module -> module.resolve("src/main/java")).filter(Files::isDirectory).forEach(root -> {
+            try (Stream<Path> walk = Files.walk(root)) {
+              walk.filter(p -> p.getFileName().toString().endsWith(".java")).forEach(sources::add);
+            } catch (final IOException e) {
+              throw new UncheckedIOException(e);
+            }
+          });
+    }
+    return sources;
+  }
+
+  /**
+   * The repository root, found by walking up from the module the test runs in. Returns {@code null} when the
+   * sources are not on disk, which is what the assumption above turns into a skip rather than a failure.
+   */
+  private static Path findRepoRoot() {
+    Path candidate = Path.of("").toAbsolutePath();
+    for (int i = 0; i < 4 && candidate != null; i++) {
+      if (Files.isRegularFile(candidate.resolve("engine/src/main/java/com/arcadedb/GlobalConfiguration.java")))
+        return candidate;
+      candidate = candidate.getParent();
+    }
+    return null;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/Issue7233ServerScopeSettingReadsTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue7233ServerScopeSettingReadsTest.java
@@ -55,6 +55,21 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * as the fallback for a caller with no server in reach. This test is what keeps that from being something
  * everybody has to remember: it walks every production source outside {@code engine/} and fails on a
  * {@code SCOPE.SERVER} read that goes through the enum without such a fallback beside it.
+ * <p>
+ * <b>What it does NOT catch, so nobody over-trusts it.</b> The check is syntactic - it matches source text, it does
+ * not resolve types or data flow - and that leaves two holes:
+ * <ol>
+ *   <li>It reads {@code GlobalConfiguration.SETTING.getValueAsY()} literally, so a read INDIRECTED through a
+ *       variable ({@code setting.getValueAsInteger()} inside a helper that takes the setting as a parameter) is
+ *       invisible to it. Two such helpers existed when this was written - {@code RedisNetworkExecutor.sanitizedLimit}
+ *       and {@code PackStreamReader.sanitizedLimit} - and both were converted by hand, not by this test.</li>
+ *   <li>It cannot tell WHICH {@link ContextConfiguration} the nearby read is against. A decoy
+ *       {@code new ContextConfiguration()} beside the enum read would satisfy the shape while reading exactly the
+ *       same process-wide value, which is why that specific spelling is rejected below - but a decoy held in a
+ *       field or a local variable still would not be.</li>
+ * </ol>
+ * So this is a ratchet against the ACCIDENTAL reintroduction of the idiom, which is how #7226 and #7233 happened;
+ * it is not a proof that every server-scoped read resolves to a server.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -153,9 +168,16 @@ public class Issue7233ServerScopeSettingReadsTest {
     final Pattern contextRead = Pattern.compile("getValueAs\\w*\\s*\\(\\s*GlobalConfiguration\\." + setting + "\\b");
     final int from = Math.max(0, index - TERNARY_WINDOW_LINES);
     final int to = Math.min(lines.size(), index + TERNARY_WINDOW_LINES + 1);
-    for (int i = from; i < to; i++)
-      if (contextRead.matcher(lines.get(i)).find())
+    for (int i = from; i < to; i++) {
+      final String line = lines.get(i);
+      // A freshly-built overlay reads exactly the process-wide value the enum read beside it does, so it is not a
+      // fallback - it is the same answer written twice. Rejecting the spelling keeps it from being used to satisfy
+      // the shape; see the class javadoc for the decoys this cannot see.
+      if (line.contains("new ContextConfiguration()"))
+        continue;
+      if (contextRead.matcher(line).find())
         return true;
+    }
     return false;
   }
 

--- a/engine/src/test/java/com/arcadedb/Issue7262ConfigurationFileBooleanStrictTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue7262ConfigurationFileBooleanStrictTest.java
@@ -214,25 +214,42 @@ public class Issue7262ConfigurationFileBooleanStrictTest {
   @Test
   public void aValueOutsideTheAllowListIsReportedRatherThanThrownOnThePropertyPath() {
     final String before = GlobalConfiguration.SERVER_MODE.getValueAsString();
+    final boolean wasChanged = GlobalConfiguration.SERVER_MODE.isChanged();
     try {
       assertThat(GlobalConfiguration.SERVER_MODE.setValueFromConfigurationSource("staging", "system property"))
           .isFalse();
 
+      // A refusal is not a choice anyone made, so it must leave BOTH halves of the setting's state alone.
       assertThat(GlobalConfiguration.SERVER_MODE.getValueAsString()).isEqualTo(before);
-      assertThat(GlobalConfiguration.SERVER_MODE.isChanged()).isFalse();
+      assertThat(GlobalConfiguration.SERVER_MODE.isChanged()).isEqualTo(wasChanged);
     } finally {
-      GlobalConfiguration.SERVER_MODE.reset();
+      restore(GlobalConfiguration.SERVER_MODE, before, wasChanged);
     }
   }
 
   @Test
   public void anAllowListedValueStillGoesThroughOnThePropertyPath() {
+    final String before = GlobalConfiguration.SERVER_MODE.getValueAsString();
+    final boolean wasChanged = GlobalConfiguration.SERVER_MODE.isChanged();
     try {
       assertThat(GlobalConfiguration.SERVER_MODE.setValueFromConfigurationSource("Test", "system property")).isTrue();
       assertThat(GlobalConfiguration.SERVER_MODE.getValueAsString()).isEqualTo("test");
     } finally {
-      GlobalConfiguration.SERVER_MODE.reset();
+      restore(GlobalConfiguration.SERVER_MODE, before, wasChanged);
     }
+  }
+
+  /**
+   * Puts a process-wide setting back exactly as it was, {@link GlobalConfiguration#isChanged()} included.
+   * {@code reset()} alone is not that: it restores the COMPILED-IN default, so a test that borrows a setting
+   * would silently discard a {@code -D} the surrounding run was given and leave every later test reading the
+   * wrong value.
+   */
+  private static void restore(final GlobalConfiguration setting, final Object value, final boolean wasChanged) {
+    if (wasChanged)
+      setting.setValue(value);
+    else
+      setting.reset();
   }
 
   private static String configurationFile(final GlobalConfiguration setting, final String jsonValue) {

--- a/engine/src/test/java/com/arcadedb/Issue7262ConfigurationFileBooleanStrictTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue7262ConfigurationFileBooleanStrictTest.java
@@ -51,13 +51,25 @@ public class Issue7262ConfigurationFileBooleanStrictTest {
 
   @Test
   public void aSynonymInTheConfigurationFileNoLongerDisablesMutualTLS() {
-    for (final String synonym : new String[] { "yes", "on", "Y", "1", "ture", "TRUE " }) {
+    for (final String synonym : new String[] { "yes", "on", "Y", "1", "ture", "true!" }) {
       final ContextConfiguration cfg = new ContextConfiguration();
       cfg.fromJSON(configurationFile(MUTUAL_AUTH, "\"" + synonym + "\""));
 
+      // Against the setting's own value, not a hard-coded true: what a refusal keeps is "whatever it would have
+      // been without this line", which a -D in the surrounding run is entitled to have chosen.
       assertThat(cfg.getValueAsBoolean(MUTUAL_AUTH)).as("mutual TLS auth with '%s' in the configuration file", synonym)
-          .isTrue();
+          .isEqualTo(MUTUAL_AUTH.getValueAsBoolean());
     }
+  }
+
+  @Test
+  public void surroundingWhitespaceIsAcceptedRatherThanRefused() {
+    // Trimmed before the comparison, so this is a VALID true - it is not one of the refused spellings above.
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.fromJSON(configurationFile(MUTUAL_AUTH, "\" TRUE \""));
+
+    assertThat(cfg.<Object>getValue(MUTUAL_AUTH)).isEqualTo(Boolean.TRUE);
+    assertThat(cfg.getValueAsBoolean(MUTUAL_AUTH)).isTrue();
   }
 
   @Test
@@ -65,7 +77,7 @@ public class Issue7262ConfigurationFileBooleanStrictTest {
     final ContextConfiguration cfg = new ContextConfiguration();
     cfg.fromJSON(configurationFile(PEER_ALLOWLIST, "\"on\""));
 
-    assertThat(cfg.getValueAsBoolean(PEER_ALLOWLIST)).isTrue();
+    assertThat(cfg.getValueAsBoolean(PEER_ALLOWLIST)).isEqualTo(PEER_ALLOWLIST.getValueAsBoolean());
   }
 
   @Test
@@ -160,6 +172,67 @@ public class Issue7262ConfigurationFileBooleanStrictTest {
     cfg.fromJSON("{\"configuration\":{\"not.a.real.setting\":\"yes\"}}");
 
     assertThat(cfg.getContextKeys()).isEmpty();
+  }
+
+  /**
+   * The allow-list is enforced at this entry point too, and it has to be: {@code coerce} converts to the declared
+   * TYPE and stops, so a {@code String} setting with an allow-list used to accept anything that was a string. A
+   * server configuration file naming a mode that does not exist was stored verbatim, every reader compared it
+   * against {@code "production"}, found it different, and gave a production deployment the development behaviour -
+   * Studio included.
+   */
+  @Test
+  public void aValueOutsideTheAllowListIsRefusedByTheConfigurationFile() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.fromJSON(configurationFile(GlobalConfiguration.SERVER_MODE, "\"staging\""));
+
+    assertThat(cfg.hasValue(GlobalConfiguration.SERVER_MODE.getKey())).isFalse();
+    assertThat(cfg.getValueAsString(GlobalConfiguration.SERVER_MODE)).isEqualTo(
+        GlobalConfiguration.SERVER_MODE.getValueAsString());
+  }
+
+  /**
+   * The allow-list is matched case-insensitively, so {@code Production} was accepted and then stored with the
+   * capital - which no {@code "production".equals(mode)} reader recognises. Normalised to the declared spelling in
+   * the one conversion both writers go through, so every reader sees it.
+   */
+  @Test
+  public void anAllowListedValueIsNormalisedToItsDeclaredSpelling() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.fromJSON(configurationFile(GlobalConfiguration.SERVER_MODE, "\"Production\""));
+
+    assertThat(cfg.getValueAsString(GlobalConfiguration.SERVER_MODE)).isEqualTo("production");
+    assertThat(GlobalConfiguration.SERVER_MODE.coerceFromAdminCommand("PRODUCTION")).isEqualTo("production");
+  }
+
+  /**
+   * The property path may not throw: it runs from {@code readConfiguration()} inside {@code GlobalConfiguration}'s
+   * static initializer, where an escaping exception becomes an {@code ExceptionInInitializerError} that takes the
+   * engine down over one mistyped variable. {@code setValue} refuses an allow-list violation by THROWING, so it
+   * has to stay inside the non-throwing envelope.
+   */
+  @Test
+  public void aValueOutsideTheAllowListIsReportedRatherThanThrownOnThePropertyPath() {
+    final String before = GlobalConfiguration.SERVER_MODE.getValueAsString();
+    try {
+      assertThat(GlobalConfiguration.SERVER_MODE.setValueFromConfigurationSource("staging", "system property"))
+          .isFalse();
+
+      assertThat(GlobalConfiguration.SERVER_MODE.getValueAsString()).isEqualTo(before);
+      assertThat(GlobalConfiguration.SERVER_MODE.isChanged()).isFalse();
+    } finally {
+      GlobalConfiguration.SERVER_MODE.reset();
+    }
+  }
+
+  @Test
+  public void anAllowListedValueStillGoesThroughOnThePropertyPath() {
+    try {
+      assertThat(GlobalConfiguration.SERVER_MODE.setValueFromConfigurationSource("Test", "system property")).isTrue();
+      assertThat(GlobalConfiguration.SERVER_MODE.getValueAsString()).isEqualTo("test");
+    } finally {
+      GlobalConfiguration.SERVER_MODE.reset();
+    }
   }
 
   private static String configurationFile(final GlobalConfiguration setting, final String jsonValue) {

--- a/engine/src/test/java/com/arcadedb/Issue7262ConfigurationFileBooleanStrictTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue7262ConfigurationFileBooleanStrictTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7262: the server configuration file used to store its values into the {@link ContextConfiguration} overlay
+ * with no coercion, and {@link ContextConfiguration#getValueAsBoolean(GlobalConfiguration)} used to read them back
+ * with {@code Boolean.parseBoolean}, which maps every string that is not {@code "true"} to {@code false}.
+ * <p>
+ * Composed, that turned {@code "arcadedb.ha.tls.mutualAuth": "yes"} into a silent shutdown of mutual TLS
+ * authentication on the inter-node Raft channel, and {@code "arcadedb.ha.peerAllowlist.enabled": "on"} into a
+ * server that never installs the peer allowlist. Both settings default to {@code true}, so the operator who left
+ * them alone was protected and the operator who wrote down that they wanted the protection was not.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue7262ConfigurationFileBooleanStrictTest {
+
+  private static final GlobalConfiguration MUTUAL_AUTH      = GlobalConfiguration.HA_TLS_MUTUAL_AUTH;
+  private static final GlobalConfiguration PEER_ALLOWLIST   = GlobalConfiguration.HA_PEER_ALLOWLIST_ENABLED;
+
+  @Test
+  public void bothSecuritySwitchesDefaultToTrue() {
+    // THE WHOLE POINT OF THE ISSUE: THE DEFAULT IS THE PROTECTION, SO A MISREAD CAN ONLY LOSE IT.
+    assertThat(MUTUAL_AUTH.getDefValue()).isEqualTo(Boolean.TRUE);
+    assertThat(PEER_ALLOWLIST.getDefValue()).isEqualTo(Boolean.TRUE);
+  }
+
+  @Test
+  public void aSynonymInTheConfigurationFileNoLongerDisablesMutualTLS() {
+    for (final String synonym : new String[] { "yes", "on", "Y", "1", "ture", "TRUE " }) {
+      final ContextConfiguration cfg = new ContextConfiguration();
+      cfg.fromJSON(configurationFile(MUTUAL_AUTH, "\"" + synonym + "\""));
+
+      assertThat(cfg.getValueAsBoolean(MUTUAL_AUTH)).as("mutual TLS auth with '%s' in the configuration file", synonym)
+          .isTrue();
+    }
+  }
+
+  @Test
+  public void aSynonymInTheConfigurationFileNoLongerSkipsThePeerAllowlist() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.fromJSON(configurationFile(PEER_ALLOWLIST, "\"on\""));
+
+    assertThat(cfg.getValueAsBoolean(PEER_ALLOWLIST)).isTrue();
+  }
+
+  @Test
+  public void aRefusedValueIsNotStoredAtAll() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.fromJSON(configurationFile(MUTUAL_AUTH, "\"yes\""));
+
+    // NOT MERELY READ AS THE DEFAULT: THE OVERLAY IS WHAT A SERVER HANDS TO ITS PLUGINS, AND A VALUE NOTHING CAN
+    // READ HAS NO BUSINESS BEING IN IT.
+    assertThat(cfg.hasValue(MUTUAL_AUTH.getKey())).isFalse();
+  }
+
+  @Test
+  public void anExplicitFalseIsStillHonoured() {
+    for (final String text : new String[] { "false", "False", "FALSE", " false " }) {
+      final ContextConfiguration cfg = new ContextConfiguration();
+      cfg.fromJSON(configurationFile(MUTUAL_AUTH, "\"" + text + "\""));
+
+      assertThat(cfg.getValueAsBoolean(MUTUAL_AUTH)).as("explicit '%s'", text).isFalse();
+      assertThat(cfg.<Object>getValue(MUTUAL_AUTH)).as("stored as the declared type").isEqualTo(Boolean.FALSE);
+    }
+  }
+
+  @Test
+  public void anExplicitTrueIsStillHonoured() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.fromJSON(configurationFile(MUTUAL_AUTH, "\"true\""));
+
+    assertThat(cfg.getValueAsBoolean(MUTUAL_AUTH)).isTrue();
+    assertThat(cfg.<Object>getValue(MUTUAL_AUTH)).isEqualTo(Boolean.TRUE);
+  }
+
+  @Test
+  public void aGenuineJSONBooleanStillWorks() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.fromJSON(configurationFile(MUTUAL_AUTH, "false"));
+
+    assertThat(cfg.getValueAsBoolean(MUTUAL_AUTH)).isFalse();
+  }
+
+  @Test
+  public void theConfigurationFileStoresValuesAsTheirDeclaredType() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.fromJSON("{\"configuration\":{\"" + shortKey(GlobalConfiguration.COMMIT_LOCK_TIMEOUT) + "\":\"64\"}}");
+
+    assertThat(cfg.<Object>getValue(GlobalConfiguration.COMMIT_LOCK_TIMEOUT)).isInstanceOf(Long.class);
+    assertThat(cfg.getValueAsLong(GlobalConfiguration.COMMIT_LOCK_TIMEOUT)).isEqualTo(64L);
+  }
+
+  @Test
+  public void anUnreadableNonBooleanIsRefusedToo() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.fromJSON("{\"configuration\":{\"" + shortKey(GlobalConfiguration.ASYNC_WORKER_THREADS) + "\":\"abc\"}}");
+
+    assertThat(cfg.hasValue(GlobalConfiguration.ASYNC_WORKER_THREADS.getKey())).isFalse();
+    assertThat(cfg.getValueAsInteger(GlobalConfiguration.ASYNC_WORKER_THREADS)).isEqualTo(
+        GlobalConfiguration.ASYNC_WORKER_THREADS.getValueAsInteger());
+  }
+
+  /**
+   * The reader is the second half of the mechanism, and it has its own way in: the map constructor stores whatever
+   * it is handed without ever passing through {@link ContextConfiguration#fromJSON(String)}.
+   */
+  @Test
+  public void theReaderFallsBackToTheDefaultRatherThanToFalse() {
+    final Map<String, Object> raw = new HashMap<>();
+    raw.put(MUTUAL_AUTH.getKey(), "yes");
+    raw.put(GlobalConfiguration.HA_ENABLED.getKey(), "on");
+
+    final ContextConfiguration cfg = new ContextConfiguration(raw);
+
+    // DEFAULT true: THE REFUSED VALUE MUST NOT TURN THE PROTECTION OFF.
+    assertThat(cfg.getValueAsBoolean(MUTUAL_AUTH)).isTrue();
+    // DEFAULT false: REFUSING TO GUESS IS THE PROPERTY THAT HOLDS FOR ALL OF THEM, NOT "ALWAYS true".
+    assertThat(GlobalConfiguration.HA_ENABLED.getDefValue()).isEqualTo(Boolean.FALSE);
+    assertThat(cfg.getValueAsBoolean(GlobalConfiguration.HA_ENABLED)).isFalse();
+  }
+
+  @Test
+  public void theReaderStillReadsBooleanTextInEitherCaseAndWithSpaces() {
+    final Map<String, Object> raw = new HashMap<>();
+    raw.put(GlobalConfiguration.HA_ENABLED.getKey(), " TRUE ");
+    assertThat(new ContextConfiguration(raw).getValueAsBoolean(GlobalConfiguration.HA_ENABLED)).isTrue();
+
+    raw.put(GlobalConfiguration.HA_ENABLED.getKey(), "False");
+    assertThat(new ContextConfiguration(raw).getValueAsBoolean(GlobalConfiguration.HA_ENABLED)).isFalse();
+  }
+
+  @Test
+  public void anUnknownSettingInTheConfigurationFileIsStillIgnored() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.fromJSON("{\"configuration\":{\"not.a.real.setting\":\"yes\"}}");
+
+    assertThat(cfg.getContextKeys()).isEmpty();
+  }
+
+  private static String configurationFile(final GlobalConfiguration setting, final String jsonValue) {
+    return "{\"configuration\":{\"" + shortKey(setting) + "\":" + jsonValue + "}}";
+  }
+
+  private static String shortKey(final GlobalConfiguration setting) {
+    return setting.getKey().substring(GlobalConfiguration.PREFIX.length());
+  }
+}

--- a/engine/src/test/java/com/arcadedb/serializer/Issue7247ArraySerializationCauseTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/Issue7247ArraySerializationCauseTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.serializer;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.database.Binary;
+import com.arcadedb.exception.SerializationException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7247: serializing one element of a primitive array used to catch every exception, log a message with no
+ * throwable and throw a {@link SerializationException} with no cause. The element's own {@code toString()} is in
+ * the message, but which nested {@code serializeValue} threw - and why - was lost on both paths.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7247ArraySerializationCauseTest {
+
+  @Test
+  void anArrayElementFailureKeepsItsCause() throws Exception {
+    // A fixed buffer that cannot grow: the first few elements fit, then a write inside the loop fails, which is
+    // the only way to reach the catch without a database or a schema.
+    final Binary content = new Binary(8);
+    content.setAutoResizable(false);
+
+    final BinarySerializer serializer = new BinarySerializer(new ContextConfiguration());
+
+    assertThatThrownBy(() -> serializer.serializeValue(null, content, BinaryTypes.TYPE_LIST, new long[64], false))
+        .isInstanceOf(SerializationException.class)
+        .hasMessageContaining("Error on serializing array value for element")
+        .cause().isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("autoResizable=false");
+  }
+
+  @Test
+  void aFittingArrayStillSerializes() throws Exception {
+    final Binary content = new Binary(1024);
+
+    new BinarySerializer(new ContextConfiguration()).serializeValue(null, content, BinaryTypes.TYPE_LIST,
+        new long[] { 1L, 2L, 3L }, false);
+
+    assertThat(content.size()).isGreaterThan(0);
+  }
+}

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.grpc;
 
+import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.query.sql.parser.Identifier;
 import com.arcadedb.query.sql.parser.MatchStatement;
@@ -215,6 +216,21 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
   // ArcadeDB server reference (optional, for accessing existing databases)
   private final ArcadeDBServer arcadeServer;
+
+  /**
+   * This server's configuration, or an empty overlay when the service was built without one.
+   * <p>
+   * Every gRPC setting read through here is SCOPE.SERVER, so it is authoritative in the SERVER's own
+   * {@link ContextConfiguration} - which is what the server configuration file, {@code SET SERVER SETTING} and the
+   * MCP {@code set_server_setting} tool all write into. The {@link GlobalConfiguration} enum is populated by
+   * {@code readConfiguration()} alone, i.e. by a system property or an environment variable, so reading the enum
+   * directly ignored every other channel the scope advertises, silently (issue #7233).
+   */
+  private ContextConfiguration serverConfiguration() {
+    return arcadeServer != null ? arcadeServer.getConfiguration() : EMPTY_CONFIGURATION;
+  }
+
+  private static final ContextConfiguration EMPTY_CONFIGURATION = new ContextConfiguration();
 
   // Database directory path
   private final String databasePath;
@@ -1600,7 +1616,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         // fails loudly with RESOURCE_EXHAUSTED - consistent with the MATERIALIZE_ALL stream path - instead of
         // silently truncating and dropping data without telling the caller.
         final int requestedLimit = request.getLimit();
-        final int configuredMax = GlobalConfiguration.SERVER_GRPC_QUERY_MAX_RESULT_ROWS.getValueAsInteger();
+        final int configuredMax = serverConfiguration().getValueAsInteger(
+            GlobalConfiguration.SERVER_GRPC_QUERY_MAX_RESULT_ROWS);
         final boolean capEnabled = configuredMax > 0;
         // The client's explicit limit applies as its own bound only when it does not exceed the hard ceiling.
         final boolean clientLimitWithinCap = requestedLimit > 0 && (!capEnabled || requestedLimit <= configuredMax);
@@ -2079,7 +2096,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
         if (cancelled.get()) {
           if (serverTimedOut.get()) {
-            final long timeoutMs = GlobalConfiguration.SERVER_GRPC_STREAM_WRITE_TIMEOUT_MS.getValueAsLong();
+            final long timeoutMs = serverConfiguration().getValueAsLong(GlobalConfiguration.SERVER_GRPC_STREAM_WRITE_TIMEOUT_MS);
             try {
               scso.onError(Status.DEADLINE_EXCEEDED
                   .withDescription("gRPC stream aborted: client transport not ready within " + timeoutMs
@@ -2115,7 +2132,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         // always signaled even if rollback fails) so it fails fast instead of blocking on its own deadline. A
         // genuine client cancel needs no terminal - its transport is already tearing down.
         if (serverTimedOut.get()) {
-          final long timeoutMs = GlobalConfiguration.SERVER_GRPC_STREAM_WRITE_TIMEOUT_MS.getValueAsLong();
+          final long timeoutMs = serverConfiguration().getValueAsLong(GlobalConfiguration.SERVER_GRPC_STREAM_WRITE_TIMEOUT_MS);
           try {
             scso.onError(Status.DEADLINE_EXCEEDED
                 .withDescription("gRPC stream aborted: client transport not ready within " + timeoutMs
@@ -2295,7 +2312,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     // MATERIALIZE_ALL buffers the whole result before emitting, so bound it: a limitless query in this mode
     // would otherwise build an unbounded list and exhaust heap (DoS). Exceeding the cap fails the call with
     // RESOURCE_EXHAUSTED so the client can fall back to CURSOR/PAGED streaming.
-    final int maxMaterializedRows = GlobalConfiguration.SERVER_GRPC_STREAM_MAX_MATERIALIZED_ROWS.getValueAsInteger();
+    final int maxMaterializedRows = serverConfiguration().getValueAsInteger(
+        GlobalConfiguration.SERVER_GRPC_STREAM_MAX_MATERIALIZED_ROWS);
 
     try (ResultSet rs = db.query(language, request.getQuery(),
         GrpcTypeConverter.convertParameters(request.getParametersMap()))) {
@@ -2540,7 +2558,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   private void waitUntilReady(ServerCallStreamObserver<?> scso, AtomicBoolean cancelled, AtomicBoolean serverTimedOut) {
     // Honor transport readiness, but bound the wait: a slow or abandoned client must not pin this worker
     // thread (and the open ResultSet/transaction) indefinitely.
-    final long timeoutMs = GlobalConfiguration.SERVER_GRPC_STREAM_WRITE_TIMEOUT_MS.getValueAsLong();
+    final long timeoutMs = serverConfiguration().getValueAsLong(GlobalConfiguration.SERVER_GRPC_STREAM_WRITE_TIMEOUT_MS);
     if (!awaitTransportReady(scso::isReady, cancelled, timeoutMs)) {
       // Not ready: either the caller already cancelled, or we hit the deadline / were interrupted. In the
       // latter case mark the stream cancelled so the surrounding loop stops, rolls back, and releases the

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -217,6 +217,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   // ArcadeDB server reference (optional, for accessing existing databases)
   private final ArcadeDBServer arcadeServer;
 
+  /** Stands in for a server that was not supplied; reads through to each setting's process-wide value. */
+  private static final ContextConfiguration EMPTY_CONFIGURATION = new ContextConfiguration();
+
   /**
    * This server's configuration, or an empty overlay when the service was built without one.
    * <p>
@@ -230,7 +233,6 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     return arcadeServer != null ? arcadeServer.getConfiguration() : EMPTY_CONFIGURATION;
   }
 
-  private static final ContextConfiguration EMPTY_CONFIGURATION = new ContextConfiguration();
 
   // Database directory path
   private final String databasePath;

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -229,10 +229,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
    * {@code readConfiguration()} alone, i.e. by a system property or an environment variable, so reading the enum
    * directly ignored every other channel the scope advertises, silently (issue #7233).
    */
-  private ContextConfiguration serverConfiguration() {
+  ContextConfiguration serverConfiguration() {
     return arcadeServer != null ? arcadeServer.getConfiguration() : EMPTY_CONFIGURATION;
   }
-
 
   // Database directory path
   private final String databasePath;

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcServerPlugin.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcServerPlugin.java
@@ -160,7 +160,10 @@ public class GrpcServerPlugin implements ServerPlugin {
 
   private void startStandardServer(ContextConfiguration config) throws IOException {
 
-    int port = getConfigInt(config, CONFIG_PORT, GlobalConfiguration.GRPC_PORT.getValueAsInteger());
+    // The default comes from the SERVER's configuration, not from the GlobalConfiguration enum, which carries
+    // only what a system property or an environment variable put there: arcadedb.grpc.port is SCOPE.SERVER, so a
+    // port named in the server configuration file used to be ignored in favour of the compiled-in one (#7233).
+    int port = getConfigInt(config, CONFIG_PORT, config.getValueAsInteger(GlobalConfiguration.GRPC_PORT));
     String host = getConfigString(config, CONFIG_HOST, "0.0.0.0");
 
     NettyServerBuilder serverBuilder;

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7233GrpcReadsServerConfigurationTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7233GrpcReadsServerConfigurationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #7233: the gRPC row caps and stream write timeout are SCOPE.SERVER, so they live in the server's
+ * {@link ContextConfiguration} - written by the server configuration file, {@code SET SERVER SETTING} and the MCP
+ * tool - and used to be read off the {@link GlobalConfiguration} enum, which only a system property or an
+ * environment variable ever writes.
+ * <p>
+ * Every one of those five reads resolves through {@code serverConfiguration()}, so asserting on it asserts on all
+ * of them, including that a service built without a server still reads a value rather than throwing.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7233GrpcReadsServerConfigurationTest {
+
+  @Test
+  void theSettingsResolveAgainstTheServersOwnConfiguration() {
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.fromJSON("{\"configuration\":{\"server.grpcQueryMaxResultRows\":4242}}");
+
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.getConfiguration()).thenReturn(configuration);
+
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService("./target/databases", server);
+
+    assertThat(service.serverConfiguration()).isSameAs(configuration);
+    assertThat(service.serverConfiguration().getValueAsInteger(GlobalConfiguration.SERVER_GRPC_QUERY_MAX_RESULT_ROWS))
+        .isEqualTo(4242);
+  }
+
+  @Test
+  void aServiceWithNoServerStillReadsTheProcessWideValue() {
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService("./target/databases", null);
+
+    assertThat(service.serverConfiguration().getValueAsLong(GlobalConfiguration.SERVER_GRPC_STREAM_WRITE_TIMEOUT_MS))
+        .isEqualTo(GlobalConfiguration.SERVER_GRPC_STREAM_WRITE_TIMEOUT_MS.getValueAsLong());
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/HALog.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/HALog.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.ha.raft;
 
+import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.log.LogManager;
 
@@ -47,16 +48,29 @@ public final class HALog {
   }
 
   /**
-   * Refreshes the cached verbose level from GlobalConfiguration. Call after config changes.
+   * Caches the verbose level from the SERVER's configuration. Called by {@link RaftHAPlugin#configure} so the
+   * level a cluster asked for actually applies: {@code arcadedb.ha.log.verbose} is SCOPE.SERVER, and this class
+   * used to read it off the {@link GlobalConfiguration} enum, which carries only a system property or an
+   * environment variable - so a level set in the server configuration file, or through {@code SET SERVER
+   * SETTING}, was cached as the default and never looked at again (issue #7233).
+   */
+  public static void configure(final ContextConfiguration configuration) {
+    cachedLevel = configuration.getValueAsInteger(GlobalConfiguration.HA_LOG_VERBOSE);
+  }
+
+  /**
+   * Refreshes the cached verbose level with no server configuration in reach, i.e. from the setting's
+   * process-wide value. Used by the tests; a running server goes through {@link #configure}.
    */
   public static void refreshLevel() {
-    cachedLevel = GlobalConfiguration.HA_LOG_VERBOSE.getValueAsInteger();
+    configure(new ContextConfiguration());
   }
 
   private static int getLevel() {
     int level = cachedLevel;
     if (level < 0) {
-      level = GlobalConfiguration.HA_LOG_VERBOSE.getValueAsInteger();
+      // Reached only before the plugin has configured this class: fall back to the process-wide value.
+      level = new ContextConfiguration().getValueAsInteger(GlobalConfiguration.HA_LOG_VERBOSE);
       cachedLevel = level;
     }
     return level;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.ha.raft;
 
+import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.log.LogManager;
 import org.apache.ratis.thirdparty.io.grpc.Attributes;
@@ -147,10 +148,21 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
   // read of a plain HashMap.
   private volatile int                       resolvedPeerHosts;
 
+  /**
+   * Convenience form for a caller with no server configuration in reach - the tests; {@code RaftHAServer} passes
+   * both windows explicitly, read from the server's own configuration. The empty {@link ContextConfiguration} says
+   * exactly that: both settings are SCOPE.SERVER, so reading them off the {@link GlobalConfiguration} enum would
+   * have been reading a value only a system property or an environment variable can have written (issue #7233).
+   */
   PeerAddressAllowlistFilter(final List<String> peerHosts, final long refreshIntervalMs) {
+    this(peerHosts, refreshIntervalMs, new ContextConfiguration());
+  }
+
+  PeerAddressAllowlistFilter(final List<String> peerHosts, final long refreshIntervalMs,
+      final ContextConfiguration configuration) {
     this(peerHosts, refreshIntervalMs,
-        GlobalConfiguration.HA_PEER_ALLOWLIST_STARTUP_GRACE_MS.getValueAsLong(),
-        GlobalConfiguration.HA_PEER_ALLOWLIST_STICKY_TTL_MS.getValueAsLong());
+        configuration.getValueAsLong(GlobalConfiguration.HA_PEER_ALLOWLIST_STARTUP_GRACE_MS),
+        configuration.getValueAsLong(GlobalConfiguration.HA_PEER_ALLOWLIST_STICKY_TTL_MS));
   }
 
   PeerAddressAllowlistFilter(final List<String> peerHosts, final long refreshIntervalMs, final long startupGraceMs,

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -76,6 +76,9 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
   public void configure(final ArcadeDBServer arcadeDBServer, final ContextConfiguration configuration) {
     this.server = arcadeDBServer;
     this.configuration = configuration;
+    // The HA verbose level is SCOPE.SERVER and HALog caches it in a static, so it has to be handed the server's
+    // configuration here - otherwise the first log call caches whatever a -D happened to say (issue #7233).
+    HALog.configure(configuration);
   }
 
   @Override

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.ha.raft;
 
+import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.LocalDatabase;
@@ -83,8 +84,19 @@ import java.util.zip.ZipOutputStream;
  */
 public class SnapshotHttpHandler implements HttpHandler {
 
-  private static final Semaphore CONCURRENCY_SEMAPHORE =
-      new Semaphore(GlobalConfiguration.HA_SNAPSHOT_MAX_CONCURRENT.getValueAsInteger(), true);
+  /**
+   * How many snapshots this server serves at once, and the permits enforcing it.
+   * <p>
+   * Both used to be {@code static final}, sized at class-initialisation from the {@link GlobalConfiguration} enum -
+   * which is populated by a system property or an environment variable and by nothing else, and which at that
+   * moment has not seen a line of the server's configuration anyway. A cluster that set
+   * {@code arcadedb.ha.snapshotMaxConcurrent} in its server configuration file therefore ran on the compiled-in
+   * default, and the rejection message below read the enum a SECOND time, so it would have misreported even a
+   * value that had reached the semaphore (issue #7233). Per-instance also makes the cap what it says it is - a
+   * bound on THIS server - rather than one shared by every server in the JVM.
+   */
+  private final int       maxConcurrentSnapshots;
+  private final Semaphore concurrencySemaphore;
 
   /** Sub-path selecting the checksums view of a database instead of its snapshot ZIP. */
   static final String CHECKSUMS_SUFFIX = "/checksums";
@@ -111,7 +123,7 @@ public class SnapshotHttpHandler implements HttpHandler {
   // double the read I/O and, with refcounted suspension, keep flushing suspended for the UNION of both
   // windows, growing the deferred-page backlog toward the #4728 backpressure cap and throttling commits
   // for longer. Serializing keeps each suspension window as short as possible. Requests beyond the
-  // CONCURRENCY_SEMAPHORE limit (HA_SNAPSHOT_MAX_CONCURRENT, default 2) still get a fast 503.
+  // concurrencySemaphore limit (HA_SNAPSHOT_MAX_CONCURRENT, default 2) still get a fast 503.
   // Entries are never pruned by design: one small ReentrantLock per database NAME ever snapshotted, bounded
   // by the server's database count (a dropped-and-recreated database safely reuses its lock). Pruning on
   // drop would need lifecycle callbacks this handler does not have, for negligible memory.
@@ -130,6 +142,11 @@ public class SnapshotHttpHandler implements HttpHandler {
 
   public SnapshotHttpHandler(final HttpServer httpServer) {
     this.httpServer = httpServer;
+    // The tests build a handler with no server; an empty overlay reads through to the setting's default.
+    final ContextConfiguration configuration =
+        httpServer != null ? httpServer.getServer().getConfiguration() : new ContextConfiguration();
+    this.maxConcurrentSnapshots = configuration.getValueAsInteger(GlobalConfiguration.HA_SNAPSHOT_MAX_CONCURRENT);
+    this.concurrencySemaphore = new Semaphore(maxConcurrentSnapshots, true);
   }
 
   /**
@@ -202,9 +219,9 @@ public class SnapshotHttpHandler implements HttpHandler {
           "Serving database snapshots over plain HTTP. Consider enabling SSL for production clusters.");
     }
 
-    if (!CONCURRENCY_SEMAPHORE.tryAcquire()) {
+    if (!concurrencySemaphore.tryAcquire()) {
       LogManager.instance().log(this, Level.WARNING, "Snapshot rejected: concurrency limit of %d reached",
-          GlobalConfiguration.HA_SNAPSHOT_MAX_CONCURRENT.getValueAsInteger());
+          maxConcurrentSnapshots);
       exchange.setStatusCode(503);
       exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
       exchange.getResponseSender().send("{\"error\":\"Too many concurrent snapshots\"}");
@@ -287,7 +304,7 @@ public class SnapshotHttpHandler implements HttpHandler {
         dbSuspendLock.unlock();
       }
     } finally {
-      CONCURRENCY_SEMAPHORE.release();
+      concurrencySemaphore.release();
     }
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
@@ -98,6 +98,9 @@ public class SnapshotHttpHandler implements HttpHandler {
   private final int       maxConcurrentSnapshots;
   private final Semaphore concurrencySemaphore;
 
+  /** Bounds the misconfiguration warning in {@link #sanitizedMaxConcurrent} to once per JVM. */
+  private static final AtomicBoolean WARNED_MISCONFIGURED_LIMIT = new AtomicBoolean();
+
   /** Sub-path selecting the checksums view of a database instead of its snapshot ZIP. */
   static final String CHECKSUMS_SUFFIX = "/checksums";
 
@@ -171,9 +174,6 @@ public class SnapshotHttpHandler implements HttpHandler {
           GlobalConfiguration.HA_SNAPSHOT_MAX_CONCURRENT.getKey(), configured, fallback);
     return fallback;
   }
-
-  /** Bounds the misconfiguration warning above to once per JVM rather than once per server restart. */
-  private static final AtomicBoolean WARNED_MISCONFIGURED_LIMIT = new AtomicBoolean();
 
   /**
    * Shuts down the stall watchdog scheduler. Called by {@link RaftHAPlugin#stopService()} so that

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
@@ -145,9 +145,35 @@ public class SnapshotHttpHandler implements HttpHandler {
     // The tests build a handler with no server; an empty overlay reads through to the setting's default.
     final ContextConfiguration configuration =
         httpServer != null ? httpServer.getServer().getConfiguration() : new ContextConfiguration();
-    this.maxConcurrentSnapshots = configuration.getValueAsInteger(GlobalConfiguration.HA_SNAPSHOT_MAX_CONCURRENT);
+    this.maxConcurrentSnapshots = sanitizedMaxConcurrent(configuration);
     this.concurrencySemaphore = new Semaphore(maxConcurrentSnapshots, true);
   }
+
+  /**
+   * The configured snapshot concurrency, floored at 1.
+   * <p>
+   * {@code new Semaphore(n)} accepts a negative {@code n} - it simply means every {@code tryAcquire} fails - so a
+   * limit of 0 or below does not fail loudly, it silently answers every snapshot request with 503 and leaves a
+   * follower that has fallen behind the compacted log unable to resync at all. That was only reachable through a
+   * {@code -D} before; since #7233 read this from the server configuration it is reachable from the configuration
+   * file too, which is where a typo actually happens. Treated as a misconfiguration rather than an intentional
+   * (if impractical) lockdown, and reported once, the same way the Redis and BOLT protocol limits are.
+   */
+  private static int sanitizedMaxConcurrent(final ContextConfiguration configuration) {
+    final int configured = configuration.getValueAsInteger(GlobalConfiguration.HA_SNAPSHOT_MAX_CONCURRENT);
+    if (configured >= 1)
+      return configured;
+
+    final int fallback = ((Number) GlobalConfiguration.HA_SNAPSHOT_MAX_CONCURRENT.getDefValue()).intValue();
+    if (WARNED_MISCONFIGURED_LIMIT.compareAndSet(false, true))
+      LogManager.instance().log(SnapshotHttpHandler.class, Level.WARNING,
+          "'%s' is set to %d, below the minimum usable value (1); falling back to the default (%d)",
+          GlobalConfiguration.HA_SNAPSHOT_MAX_CONCURRENT.getKey(), configured, fallback);
+    return fallback;
+  }
+
+  /** Bounds the misconfiguration warning above to once per JVM rather than once per server restart. */
+  private static final AtomicBoolean WARNED_MISCONFIGURED_LIMIT = new AtomicBoolean();
 
   /**
    * Shuts down the stall watchdog scheduler. Called by {@link RaftHAPlugin#stopService()} so that

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/HALogTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/HALogTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.ha.raft;
 
+import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -48,6 +49,25 @@ class HALogTest {
     assertThat(HALog.isEnabled(HALog.BASIC)).isTrue();
     assertThat(HALog.isEnabled(HALog.DETAILED)).isTrue();
     assertThat(HALog.isEnabled(HALog.TRACE)).isFalse();
+  }
+
+  /**
+   * Issue #7233: {@code arcadedb.ha.logVerbose} is SCOPE.SERVER, so it is authoritative in the SERVER's
+   * {@link com.arcadedb.ContextConfiguration} - which is what the server configuration file, {@code SET SERVER
+   * SETTING} and the MCP tool write into - and this class used to cache it off the {@link GlobalConfiguration}
+   * enum, which a system property or an environment variable alone ever writes. {@code RaftHAPlugin.configure}
+   * now hands the server's configuration over.
+   */
+  @Test
+  void configureTakesTheLevelFromTheServerConfiguration() {
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.fromJSON("{\"configuration\":{\"ha.logVerbose\":3}}");
+
+    // The enum says the level is off; the server's own configuration says TRACE, and it is the one that counts.
+    GlobalConfiguration.HA_LOG_VERBOSE.setValue(0);
+    HALog.configure(configuration);
+
+    assertThat(HALog.isEnabled(HALog.TRACE)).isTrue();
   }
 
   @Test

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/HALogTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/HALogTest.java
@@ -53,7 +53,7 @@ class HALogTest {
 
   /**
    * Issue #7233: {@code arcadedb.ha.logVerbose} is SCOPE.SERVER, so it is authoritative in the SERVER's
-   * {@link com.arcadedb.ContextConfiguration} - which is what the server configuration file, {@code SET SERVER
+   * {@link ContextConfiguration} - which is what the server configuration file, {@code SET SERVER
    * SETTING} and the MCP tool write into - and this class used to cache it off the {@link GlobalConfiguration}
    * enum, which a system property or an environment variable alone ever writes. {@code RaftHAPlugin.configure}
    * now hands the server's configuration over.

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotThrottleTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotThrottleTest.java
@@ -28,26 +28,43 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class SnapshotThrottleTest {
 
+  /**
+   * Issue #7233 moved the permits off a {@code static final} sized at class-initialisation - i.e. before any
+   * server configuration exists - onto the handler instance, sized from that server's own configuration.
+   */
+  private static Semaphore semaphoreOf(final SnapshotHttpHandler handler) throws Exception {
+    final Field f = SnapshotHttpHandler.class.getDeclaredField("concurrencySemaphore");
+    f.setAccessible(true);
+    return (Semaphore) f.get(handler);
+  }
+
   @Test
   void semaphoreHasConfiguredPermits() throws Exception {
     GlobalConfiguration.HA_SNAPSHOT_MAX_CONCURRENT.reset();
-    final Field f = SnapshotHttpHandler.class.getDeclaredField("CONCURRENCY_SEMAPHORE");
-    f.setAccessible(true);
-    final Semaphore sem = (Semaphore) f.get(null);
-    assertThat(sem.availablePermits())
-        .isEqualTo(GlobalConfiguration.HA_SNAPSHOT_MAX_CONCURRENT.getValueAsInteger());
+    // Closed at the end: the handler owns a stall-watchdog scheduler, and a test that builds one and walks away
+    // leaks its thread for the rest of the JVM.
+    final SnapshotHttpHandler handler = new SnapshotHttpHandler(null);
+    try {
+      assertThat(semaphoreOf(handler).availablePermits())
+          .isEqualTo(GlobalConfiguration.HA_SNAPSHOT_MAX_CONCURRENT.getValueAsInteger());
+    } finally {
+      handler.close();
+    }
   }
 
   @Test
   void tryAcquireExhaustsAtMaxConcurrent() throws Exception {
-    final Field f = SnapshotHttpHandler.class.getDeclaredField("CONCURRENCY_SEMAPHORE");
-    f.setAccessible(true);
-    final Semaphore sem = (Semaphore) f.get(null);
+    final SnapshotHttpHandler handler = new SnapshotHttpHandler(null);
+    try {
+      final Semaphore sem = semaphoreOf(handler);
 
-    final int configured = GlobalConfiguration.HA_SNAPSHOT_MAX_CONCURRENT.getValueAsInteger();
-    for (int i = 0; i < configured; i++)
-      assertThat(sem.tryAcquire()).as("acquire %d", i).isTrue();
-    assertThat(sem.tryAcquire()).as("over-limit acquire").isFalse();
-    sem.release(configured);
+      final int configured = GlobalConfiguration.HA_SNAPSHOT_MAX_CONCURRENT.getValueAsInteger();
+      for (int i = 0; i < configured; i++)
+        assertThat(sem.tryAcquire()).as("acquire %d", i).isTrue();
+      assertThat(sem.tryAcquire()).as("over-limit acquire").isFalse();
+      sem.release(configured);
+    } finally {
+      handler.close();
+    }
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotThrottleTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotThrottleTest.java
@@ -18,13 +18,18 @@
  */
 package com.arcadedb.server.ha.raft;
 
+import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.http.HttpServer;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.util.concurrent.Semaphore;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class SnapshotThrottleTest {
 
@@ -50,6 +55,55 @@ class SnapshotThrottleTest {
     } finally {
       handler.close();
     }
+  }
+
+  /**
+   * Issue #7233: the permits used to be sized from the process-wide {@link GlobalConfiguration} enum, which only a
+   * system property or an environment variable ever writes. A cluster that set the limit in its server
+   * configuration file - or through {@code SET SERVER SETTING} - ran on the compiled-in default instead.
+   */
+  @Test
+  void permitsComeFromTheServerConfiguration() throws Exception {
+    final SnapshotHttpHandler handler = handlerFor(configurationWith(5));
+    try {
+      assertThat(semaphoreOf(handler).availablePermits()).isEqualTo(5);
+    } finally {
+      handler.close();
+    }
+  }
+
+  /**
+   * {@code new Semaphore(n)} takes a negative {@code n} without complaint - every acquire simply fails - so an
+   * unusable limit would answer every snapshot with 503 and leave a lagging follower unable to resync, silently.
+   * Floored to the default instead, the way the Redis and BOLT protocol limits already are.
+   */
+  @Test
+  void anUnusableLimitFallsBackToTheDefaultInsteadOfBlockingEverySnapshot() throws Exception {
+    for (final int unusable : new int[] { 0, -1 }) {
+      final SnapshotHttpHandler handler = handlerFor(configurationWith(unusable));
+      try {
+        assertThat(semaphoreOf(handler).availablePermits()).as("limit %d", unusable)
+            .isEqualTo(((Number) GlobalConfiguration.HA_SNAPSHOT_MAX_CONCURRENT.getDefValue()).intValue());
+        assertThat(semaphoreOf(handler).tryAcquire()).as("a snapshot is still servable at limit %d", unusable)
+            .isTrue();
+      } finally {
+        handler.close();
+      }
+    }
+  }
+
+  private static ContextConfiguration configurationWith(final int maxConcurrent) {
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.HA_SNAPSHOT_MAX_CONCURRENT, maxConcurrent);
+    return configuration;
+  }
+
+  private static SnapshotHttpHandler handlerFor(final ContextConfiguration configuration) {
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.getConfiguration()).thenReturn(configuration);
+    final HttpServer httpServer = mock(HttpServer.class);
+    when(httpServer.getServer()).thenReturn(server);
+    return new SnapshotHttpHandler(httpServer);
   }
 
   @Test

--- a/network/src/main/java/com/arcadedb/network/binary/Channel.java
+++ b/network/src/main/java/com/arcadedb/network/binary/Channel.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.network.binary;
 
+import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.log.LogManager;
 import jdk.net.ExtendedSocketOptions;
@@ -42,10 +43,18 @@ public abstract class Channel {
   private final        AtomicLong   metricFlushes                = new AtomicLong();
   private static final boolean      EXTENDED_KEEP_ALIVE_AVAILABLE = extendedKeepAliveAvailable();
 
+  /**
+   * For a caller with no server configuration in reach (unit tests). An empty {@link ContextConfiguration} reads
+   * through to the enum's value, which is what the keepalive settings were always read from.
+   */
   public Channel(final Socket iSocket) throws IOException {
+    this(iSocket, new ContextConfiguration());
+  }
+
+  public Channel(final Socket iSocket, final ContextConfiguration configuration) throws IOException {
     socket = iSocket;
     socket.setTcpNoDelay(true);
-    enableKeepAlive(socket);
+    enableKeepAlive(socket, configuration);
     // THIS TIMEOUT IS CORRECT BUT CREATE SOME PROBLEM ON REMOTE, NEED CHECK BEFORE BE ENABLED
     // timeout = iConfig.getValueAsLong(OGlobalConfiguration.NETWORK_REQUEST_TIMEOUT);
   }
@@ -65,8 +74,11 @@ public abstract class Channel {
    * stand, which still detect the dead peer, just far later. Failures are non-fatal: keepalive is a backstop, and a
    * platform that refuses an option must not stop the connection from being served.
    */
-  private static void enableKeepAlive(final Socket socket) {
-    if (!GlobalConfiguration.NETWORK_SOCKET_KEEP_ALIVE.getValueAsBoolean())
+  private static void enableKeepAlive(final Socket socket, final ContextConfiguration configuration) {
+    // Through the caller's ContextConfiguration: all four settings are SCOPE.SERVER, so they are authoritative in
+    // the server's own overlay - where the configuration file, SET SERVER SETTING and the MCP tool write - and the
+    // GlobalConfiguration enum carries only a system property or an environment variable (issue #7233).
+    if (!configuration.getValueAsBoolean(GlobalConfiguration.NETWORK_SOCKET_KEEP_ALIVE))
       return;
 
     try {
@@ -80,11 +92,11 @@ public abstract class Channel {
       return; // keepalive is on, just with the system-wide probe timings
 
     setKeepAliveOption(socket, ExtendedSocketOptions.TCP_KEEPIDLE,
-        GlobalConfiguration.NETWORK_SOCKET_KEEP_ALIVE_IDLE.getValueAsInteger());
+        configuration.getValueAsInteger(GlobalConfiguration.NETWORK_SOCKET_KEEP_ALIVE_IDLE));
     setKeepAliveOption(socket, ExtendedSocketOptions.TCP_KEEPINTERVAL,
-        GlobalConfiguration.NETWORK_SOCKET_KEEP_ALIVE_INTERVAL.getValueAsInteger());
+        configuration.getValueAsInteger(GlobalConfiguration.NETWORK_SOCKET_KEEP_ALIVE_INTERVAL));
     setKeepAliveOption(socket, ExtendedSocketOptions.TCP_KEEPCOUNT,
-        GlobalConfiguration.NETWORK_SOCKET_KEEP_ALIVE_COUNT.getValueAsInteger());
+        configuration.getValueAsInteger(GlobalConfiguration.NETWORK_SOCKET_KEEP_ALIVE_COUNT));
   }
 
   /**

--- a/network/src/main/java/com/arcadedb/network/binary/ChannelBinary.java
+++ b/network/src/main/java/com/arcadedb/network/binary/ChannelBinary.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.network.binary;
 
+import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Binary;
 import com.arcadedb.database.Database;
@@ -48,8 +49,17 @@ public abstract class ChannelBinary extends Channel implements ChannelDataInput,
   protected            DataInputStream  in;
   protected            DataOutputStream out;
 
+  /**
+   * For a caller with no server configuration in reach (unit tests): the socket keepalive settings then read
+   * through to the {@link GlobalConfiguration} defaults.
+   */
   public ChannelBinary(final Socket iSocket, final int chunkMaxSize) throws IOException {
-    super(iSocket);
+    this(iSocket, chunkMaxSize, new ContextConfiguration());
+  }
+
+  public ChannelBinary(final Socket iSocket, final int chunkMaxSize, final ContextConfiguration configuration)
+      throws IOException {
+    super(iSocket, configuration);
 
     maxChunkSize = chunkMaxSize;
   }

--- a/network/src/main/java/com/arcadedb/network/binary/ChannelBinaryClient.java
+++ b/network/src/main/java/com/arcadedb/network/binary/ChannelBinaryClient.java
@@ -29,7 +29,8 @@ public class ChannelBinaryClient extends ChannelBinary {
   protected       String url;
 
   public ChannelBinaryClient(final String remoteHost, final int remotePort, final ContextConfiguration config) throws IOException {
-    super(SocketFactory.instance(config).createSocket(), config.getValueAsInteger(GlobalConfiguration.HA_REPLICATION_CHUNK_MAXSIZE));
+    super(SocketFactory.instance(config).createSocket(),
+        config.getValueAsInteger(GlobalConfiguration.HA_REPLICATION_CHUNK_MAXSIZE), config);
     try {
 
       url = remoteHost + ":" + remotePort;

--- a/network/src/main/java/com/arcadedb/network/binary/ChannelBinaryServer.java
+++ b/network/src/main/java/com/arcadedb/network/binary/ChannelBinaryServer.java
@@ -27,7 +27,7 @@ import java.net.Socket;
 public class ChannelBinaryServer extends ChannelBinary {
 
   public ChannelBinaryServer(final Socket iSocket, final ContextConfiguration config) throws IOException {
-    super(iSocket, config.getValueAsInteger(GlobalConfiguration.HA_REPLICATION_CHUNK_MAXSIZE));
+    super(iSocket, config.getValueAsInteger(GlobalConfiguration.HA_REPLICATION_CHUNK_MAXSIZE), config);
 
     inStream = new BufferedInputStream(socket.getInputStream());
     outStream = new BufferedOutputStream(socket.getOutputStream());

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -133,8 +133,12 @@ public class PostgresNetworkExecutor extends Thread {
   // same portal name re-bound without a new Parse) never share mutable per-execution state. `portals` above
   // holds only the independent, already-bound portals that describeCommand('P')/executeCommand() operate on.
   private final Map<String, PostgresPortal> preparedStatements    = new HashMap<>();
-  private final boolean                     DEBUG                 = GlobalConfiguration.POSTGRES_DEBUG.getValueAsBoolean();
-  private final boolean                     QUOTED_IDENTIFIERS    = GlobalConfiguration.POSTGRES_QUOTED_IDENTIFIERS.getValueAsBoolean();
+  // Assigned in the constructor from the SERVER's configuration, not at field initialisation off the
+  // GlobalConfiguration enum: both settings are SCOPE.SERVER, and the enum holds only what a system property or
+  // an environment variable put there, so a server configuration file or a SET SERVER SETTING never reached them
+  // (issue #7233). Still sampled once per connection, which is what they always were.
+  private final boolean                     DEBUG;
+  private final boolean                     QUOTED_IDENTIFIERS;
   private final Map<String, Object>         connectionProperties  = new HashMap<>();
   // The exact query spellings to answer with nothing, and the application_name values that gated them, used
   // to be listed here: see PostgresCatalog, which answers those questions by shape for every client (#6412).
@@ -178,6 +182,8 @@ public class PostgresNetworkExecutor extends Thread {
     this.channel = new ChannelBinaryServer(socket, server.getConfiguration());
     this.database = database;
     this.preAuthTicket = preAuthTicket;
+    this.DEBUG = server.getConfiguration().getValueAsBoolean(GlobalConfiguration.POSTGRES_DEBUG);
+    this.QUOTED_IDENTIFIERS = server.getConfiguration().getValueAsBoolean(GlobalConfiguration.POSTGRES_QUOTED_IDENTIFIERS);
 
     // Bound the pre-authentication window (issue #6377). One thread and one file descriptor are committed
     // per accepted connection, before anyone has proved who they are, and the listener caps neither; without
@@ -186,7 +192,7 @@ public class PostgresNetworkExecutor extends Thread {
     // markAuthenticated), because an authenticated client is expected to keep a long-lived, often idle
     // connection between statements. This is the same setSoTimeout(NETWORK_SOCKET_TIMEOUT)-then-
     // setSoTimeout(0) idiom RedisNetworkExecutor (#5912) and BoltNetworkExecutor (#5978) already use.
-    final int handshakeTimeout = GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.getValueAsInteger();
+    final int handshakeTimeout = server.getConfiguration().getValueAsInteger(GlobalConfiguration.NETWORK_SOCKET_TIMEOUT);
     if (handshakeTimeout > 0)
       channel.socket.setSoTimeout(handshakeTimeout);
   }
@@ -918,7 +924,7 @@ public class PostgresNetworkExecutor extends Thread {
    * @param resultSet The result set to browse (this method closes it)
    */
   private List<Result> browseAndCacheBoundedResultSet(final ResultSet resultSet) {
-    final int maxRows = GlobalConfiguration.POSTGRES_QUERY_MAX_ROWS.getValueAsInteger();
+    final int maxRows = server.getConfiguration().getValueAsInteger(GlobalConfiguration.POSTGRES_QUERY_MAX_ROWS);
     try (resultSet) {
       final List<Result> cachedResultSet = new ArrayList<>();
       while (resultSet.hasNext()) {
@@ -1929,7 +1935,7 @@ public class PostgresNetworkExecutor extends Thread {
             continue;
           }
 
-          if (paramSize > GlobalConfiguration.POSTGRES_MAX_PARAM_SIZE.getValueAsInteger()) {
+          if (paramSize > server.getConfiguration().getValueAsInteger(GlobalConfiguration.POSTGRES_MAX_PARAM_SIZE)) {
             // The value bytes for this parameter were never read, so the channel cannot be safely
             // resynchronized without draining a client(attacker)-controlled amount of data - that would
             // either reintroduce an unbounded read or block the connection thread indefinitely if the
@@ -1937,7 +1943,7 @@ public class PostgresNetworkExecutor extends Thread {
             // rather than gamble on realigning the stream.
             setErrorInTx();
             writeError(ERROR_SEVERITY.FATAL, "Postgres bind parameter too large: " + paramSize + " bytes (max "
-                + GlobalConfiguration.POSTGRES_MAX_PARAM_SIZE.getValueAsInteger() + ")", "08P01");
+                + server.getConfiguration().getValueAsInteger(GlobalConfiguration.POSTGRES_MAX_PARAM_SIZE) + ")", "08P01");
             shutdown = true;
             return;
           }
@@ -2030,7 +2036,7 @@ public class PostgresNetworkExecutor extends Thread {
           final long sz = channel.readUnsignedInt();
           if (sz == NULL_PARAM_LENGTH)
             continue;
-          if (sz > GlobalConfiguration.POSTGRES_MAX_PARAM_SIZE.getValueAsInteger()) {
+          if (sz > server.getConfiguration().getValueAsInteger(GlobalConfiguration.POSTGRES_MAX_PARAM_SIZE)) {
             // Same reasoning as the main loop's guard: draining a declared-but-undelivered amount of
             // data risks an unbounded/blocking read, so give up on resyncing rather than attempt it.
             drainedCleanly = false;

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkListener.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkListener.java
@@ -33,7 +33,7 @@ public class PostgresNetworkListener extends Thread {
   private final    ArcadeDBServer         server;
   private final    ServerSocketFactory    socketFactory;
   /** Bounds how many accepted connections can sit un-authenticated at once (issue #6412). */
-  private final    PreAuthConnectionGate  preAuthGate     = new PreAuthConnectionGate("PSQL");
+  private final    PreAuthConnectionGate  preAuthGate;
   private          ServerSocket        serverSocket;
   private volatile boolean             active          = true;
   private final    int                 protocolVersion = -1;
@@ -46,6 +46,10 @@ public class PostgresNetworkListener extends Thread {
 
     this.server = server;
     this.socketFactory = iSocketFactory;
+    // Built here rather than at field initialisation so the cap comes from THIS server's configuration; the
+    // setting is SCOPE.SERVER and the GlobalConfiguration enum only ever carries a -D or an environment
+    // variable (issue #7233).
+    this.preAuthGate = new PreAuthConnectionGate("PSQL", server.getConfiguration());
 
     listen(hostName, hostPortRange);
     start();

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -19,6 +19,7 @@
 package com.arcadedb.redis;
 
 import com.arcadedb.Constants;
+import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.*;
 import com.arcadedb.database.Record;
@@ -100,9 +101,9 @@ public class RedisNetworkExecutor extends Thread {
     setName(Constants.PRODUCT + "-redis/" + socket.getInetAddress());
     this.server = server;
     this.channel = new ChannelBinaryServer(socket, server.getConfiguration());
-    this.maxMultiBulkDepth = sanitizedLimit(GlobalConfiguration.REDIS_MAX_MULTIBULK_DEPTH, 2);
-    this.maxMultiBulkLength = sanitizedLimit(GlobalConfiguration.REDIS_MAX_MULTIBULK_LENGTH, 1);
-    this.maxBulkLength = sanitizedLimit(GlobalConfiguration.REDIS_MAX_BULK_LENGTH, 1);
+    this.maxMultiBulkDepth = sanitizedLimit(server.getConfiguration(), GlobalConfiguration.REDIS_MAX_MULTIBULK_DEPTH, 2);
+    this.maxMultiBulkLength = sanitizedLimit(server.getConfiguration(), GlobalConfiguration.REDIS_MAX_MULTIBULK_LENGTH, 1);
+    this.maxBulkLength = sanitizedLimit(server.getConfiguration(), GlobalConfiguration.REDIS_MAX_BULK_LENGTH, 1);
 
     // Bound the pre-authentication window (issue #5912): without a read timeout, a client that opens a
     // connection and never completes AUTH/HELLO - or trickles bytes arbitrarily slowly - can hold this
@@ -144,14 +145,15 @@ public class RedisNetworkExecutor extends Thread {
   // cannot see this read: it matches the literal GlobalConfiguration.NAME.getValueAs* shape. This site, and any
   // future helper of the same shape, has to be checked by hand - reading through the ContextConfiguration here is
   // not something the build will keep true for you.
-  private int sanitizedLimit(final GlobalConfiguration setting, final int floor) {
+  static int sanitizedLimit(final ContextConfiguration configuration, final GlobalConfiguration setting,
+      final int floor) {
     // Through the SERVER's configuration: every setting passed here is SCOPE.SERVER, and the GlobalConfiguration
     // enum carries only what a system property or an environment variable put there (issue #7233).
-    final int configured = server.getConfiguration().getValueAsInteger(setting);
+    final int configured = configuration.getValueAsInteger(setting);
     if (configured < floor) {
       final int fallback = ((Number) setting.getDefValue()).intValue();
       if (WARNED_MISCONFIGURED_LIMITS.add(setting))
-        LogManager.instance().log(this, Level.WARNING,
+        LogManager.instance().log(RedisNetworkExecutor.class, Level.WARNING,
             "Redis wrapper: '%s' is set to %d, below the minimum usable value (%d); falling back to the default (%d)",
             setting.getKey(), configured, floor, fallback);
       return fallback;

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -140,6 +140,10 @@ public class RedisNetworkExecutor extends Thread {
    * for any real command (e.g. a 1-byte max bulk length rejects even the shortest command name) - that is an
    * intentionally low, if impractical, configuration rather than the 0-or-negative case this guards against.
    */
+  // The setting arrives as a PARAMETER, so the SCOPE.SERVER guard test (Issue7233ServerScopeSettingReadsTest)
+  // cannot see this read: it matches the literal GlobalConfiguration.NAME.getValueAs* shape. This site, and any
+  // future helper of the same shape, has to be checked by hand - reading through the ContextConfiguration here is
+  // not something the build will keep true for you.
   private int sanitizedLimit(final GlobalConfiguration setting, final int floor) {
     // Through the SERVER's configuration: every setting passed here is SCOPE.SERVER, and the GlobalConfiguration
     // enum carries only what a system property or an environment variable put there (issue #7233).

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -113,13 +113,13 @@ public class RedisNetworkExecutor extends Thread {
     // it bounds the entire pre-auth phase here, through AUTH/HELLO itself). An authenticated RESP client is
     // expected to keep a long-lived, often idle connection open between commands, so the timeout must not
     // keep applying past that point.
-    final int handshakeTimeout = GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.getValueAsInteger();
+    final int handshakeTimeout = server.getConfiguration().getValueAsInteger(GlobalConfiguration.NETWORK_SOCKET_TIMEOUT);
     if (handshakeTimeout > 0)
       channel.socket.setSoTimeout(handshakeTimeout);
 
     // Initialize default database from configuration if set. The database access is authorized lazily,
     // once the connection has authenticated (see getAuthorizedDatabase), so here we only record the name.
-    final String defaultDbName = GlobalConfiguration.REDIS_DEFAULT_DATABASE.getValueAsString();
+    final String defaultDbName = server.getConfiguration().getValueAsString(GlobalConfiguration.REDIS_DEFAULT_DATABASE);
     if (defaultDbName != null && !defaultDbName.isEmpty()) {
       if (server.existsDatabase(defaultDbName))
         this.selectedDatabaseName = defaultDbName;
@@ -141,7 +141,9 @@ public class RedisNetworkExecutor extends Thread {
    * intentionally low, if impractical, configuration rather than the 0-or-negative case this guards against.
    */
   private int sanitizedLimit(final GlobalConfiguration setting, final int floor) {
-    final int configured = setting.getValueAsInteger();
+    // Through the SERVER's configuration: every setting passed here is SCOPE.SERVER, and the GlobalConfiguration
+    // enum carries only what a system property or an environment variable put there (issue #7233).
+    final int configured = server.getConfiguration().getValueAsInteger(setting);
     if (configured < floor) {
       final int fallback = ((Number) setting.getDefValue()).intValue();
       if (WARNED_MISCONFIGURED_LIMITS.add(setting))
@@ -845,7 +847,7 @@ public class RedisNetworkExecutor extends Thread {
    */
   private void markUnauthenticated() {
     this.authenticatedUser = null;
-    final int handshakeTimeout = GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.getValueAsInteger();
+    final int handshakeTimeout = server.getConfiguration().getValueAsInteger(GlobalConfiguration.NETWORK_SOCKET_TIMEOUT);
     try {
       channel.socket.setSoTimeout(Math.max(handshakeTimeout, 0));
     } catch (final SocketException e) {

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkListener.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkListener.java
@@ -37,7 +37,7 @@ public class RedisNetworkListener extends Thread {
   private static final int                 protocolVersion = -1;
   private              ClientConnected     callback;
   /** Bounds how many accepted connections can sit un-authenticated at once (issue #6412). */
-  private final        PreAuthConnectionGate preAuthGate = new PreAuthConnectionGate("Redis wrapper");
+  private final        PreAuthConnectionGate preAuthGate;
 
   public interface ClientConnected {
     void connected();
@@ -48,6 +48,10 @@ public class RedisNetworkListener extends Thread {
 
     this.server = server;
     this.socketFactory = iSocketFactory;
+    // Built here rather than at field initialisation so the cap comes from THIS server's configuration; the
+    // setting is SCOPE.SERVER and the GlobalConfiguration enum only ever carries a -D or an environment
+    // variable (issue #7233).
+    this.preAuthGate = new PreAuthConnectionGate("Redis wrapper", server.getConfiguration());
 
     listen(iHostName, iHostPortRange);
 

--- a/redisw/src/test/java/com/arcadedb/redis/Issue7233RedisLimitsReadServerConfigurationTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/Issue7233RedisLimitsReadServerConfigurationTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.redis;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7233: the RESP protocol limits are SCOPE.SERVER, so they live in the server's {@link ContextConfiguration}
+ * - written by the server configuration file, {@code SET SERVER SETTING} and the MCP tool - and used to be read off
+ * the {@link GlobalConfiguration} enum, which only a system property or an environment variable ever writes.
+ * <p>
+ * The limit is resolved by a helper that takes the setting as a PARAMETER, which is exactly the shape
+ * {@code Issue7233ServerScopeSettingReadsTest} documents it cannot see - so this asserts the runtime value rather
+ * than the shape of the call.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7233RedisLimitsReadServerConfigurationTest {
+
+  @Test
+  void theLimitComesFromTheServerConfiguration() {
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.REDIS_MAX_BULK_LENGTH, 4096);
+
+    assertThat(RedisNetworkExecutor.sanitizedLimit(configuration, GlobalConfiguration.REDIS_MAX_BULK_LENGTH, 1))
+        .isEqualTo(4096);
+  }
+
+  @Test
+  void aServerConfigurationFileValueReachesTheLimitToo() {
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.fromJSON("{\"configuration\":{\"redis.maxMultiBulkLength\":321}}");
+
+    assertThat(RedisNetworkExecutor.sanitizedLimit(configuration, GlobalConfiguration.REDIS_MAX_MULTIBULK_LENGTH, 1))
+        .isEqualTo(321);
+  }
+
+  @Test
+  void anUnusableLimitStillFallsBackToTheDefault() {
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.REDIS_MAX_MULTIBULK_DEPTH, 0);
+
+    assertThat(RedisNetworkExecutor.sanitizedLimit(configuration, GlobalConfiguration.REDIS_MAX_MULTIBULK_DEPTH, 2))
+        .isEqualTo(((Number) GlobalConfiguration.REDIS_MAX_MULTIBULK_DEPTH.getDefValue()).intValue());
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -303,19 +303,24 @@ public class ArcadeDBServer {
     try {
       lifecycleEvent(ReplicationCallback.TYPE.SERVER_STARTING, null);
     } catch (final Exception e) {
-      throw new ServerException("Error on starting the server '" + serverName + "'");
+      throw new ServerException("Error on starting the server '" + serverName + "'", e);
     }
 
     // Discover plugins from lib/plugins directory
     pluginManager.discoverPlugins();
 
     LogManager.instance().log(this, Level.INFO, "Starting ArcadeDB Server in %s mode with plugins %s ...",
-        GlobalConfiguration.SERVER_MODE.getValueAsString(),
+        configuration.getValueAsString(GlobalConfiguration.SERVER_MODE),
         pluginManager != null && !pluginManager.getPluginNames().isEmpty() ?
             pluginManager.getPluginNames() : getAllPluginNames());
 
-    // IN PRODUCTION MODE, APPLY SAFE DEFAULTS
-    if ("production".equals(GlobalConfiguration.SERVER_MODE.getValueAsString())) {
+    // IN PRODUCTION MODE, APPLY SAFE DEFAULTS.
+    // arcadedb.server.mode is SCOPE.SERVER, so it is authoritative in THIS server's configuration and only
+    // incidentally in the process-wide enum, which nothing but a -D or an environment variable ever writes: a
+    // server configuration file naming production mode used to leave every default below unapplied (issue #7233).
+    // The two defaults themselves are SCOPE.DATABASE and stay on the enum on purpose - that is what a database
+    // opened by this server inherits, since DatabaseFactory is handed a path and no ContextConfiguration.
+    if ("production".equals(configuration.getValueAsString(GlobalConfiguration.SERVER_MODE))) {
       // WAL FLUSH: DEFAULT TO 1 FOR DURABILITY
       if (!GlobalConfiguration.TX_WAL_FLUSH.isChanged()) {
         GlobalConfiguration.TX_WAL_FLUSH.setValue(1);
@@ -403,7 +408,7 @@ public class ArcadeDBServer {
     LogManager.instance().log(this, Level.INFO, "Available query languages: %s",
         QueryEngineManager.getInstance().getAvailableLanguages());
 
-    final String mode = GlobalConfiguration.SERVER_MODE.getValueAsString();
+    final String mode = configuration.getValueAsString(GlobalConfiguration.SERVER_MODE);
 
     final String msg = "ArcadeDB Server started in '%s' mode (CPUs=%d MAXRAM=%s)".formatted(mode,
         Runtime.getRuntime().availableProcessors(), FileUtils.getSizeAsString(Runtime.getRuntime().maxMemory()));
@@ -416,7 +421,7 @@ public class ArcadeDBServer {
     if ("production".equals(mode))
       logProductionChecklist();
 
-    if (!"production".equals(mode) || GlobalConfiguration.STUDIO_ENABLED.getValueAsBoolean()) {
+    if (!"production".equals(mode) || configuration.getValueAsBoolean(GlobalConfiguration.STUDIO_ENABLED)) {
       final InputStream file = getClass().getClassLoader().getResourceAsStream("static/index.html");
       if (file != null) {
         final String studioHost = getStudioDisplayHost();
@@ -429,7 +434,7 @@ public class ArcadeDBServer {
       lifecycleEvent(ReplicationCallback.TYPE.SERVER_UP, null);
     } catch (final Exception e) {
       stop();
-      throw new ServerException("Error on starting the server '" + serverName + "'");
+      throw new ServerException("Error on starting the server '" + serverName + "'", e);
     }
   }
 
@@ -481,7 +486,7 @@ public class ArcadeDBServer {
           "  - Root password: set via configuration [WARNING]. Consider using server-users.json instead");
 
     // STUDIO
-    if (GlobalConfiguration.STUDIO_ENABLED.getValueAsBoolean())
+    if (configuration.getValueAsBoolean(GlobalConfiguration.STUDIO_ENABLED))
       LogManager.instance().log(this, Level.WARNING,
           "  - Studio web tool: force-enabled (arcadedb.studio.enabled=true) [WARNING]. Restrict network access to it");
     else
@@ -872,7 +877,7 @@ public class ArcadeDBServer {
     try {
       lifecycleEvent(ReplicationCallback.TYPE.SERVER_SHUTTING_DOWN, null);
     } catch (final Exception e) {
-      throw new ServerException("Error on stopping the server '" + serverName + "'");
+      throw new ServerException("Error on stopping the server '" + serverName + "'", e);
     }
 
     status = STATUS.SHUTTING_DOWN;
@@ -905,7 +910,7 @@ public class ArcadeDBServer {
     try {
       lifecycleEvent(ReplicationCallback.TYPE.SERVER_DOWN, null);
     } catch (final Exception e) {
-      throw new ServerException("Error on stopping the server '" + serverName + "'");
+      throw new ServerException("Error on stopping the server '" + serverName + "'", e);
     }
 
     LogManager.instance().setContext(null);

--- a/server/src/main/java/com/arcadedb/server/http/HttpAuthSessionManager.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpAuthSessionManager.java
@@ -52,6 +52,11 @@ public class HttpAuthSessionManager extends RWLockContext {
   private final       int                          maxSessionsPerUser;
   private final       LongSupplier                 clock;
   private final       Timer                        timer;
+  /**
+   * Stands in for a server that was not supplied - the test-only constructors below; reads through to each
+   * setting's process-wide value. Shared rather than built per read: it holds nothing per instance.
+   */
+  private static final ContextConfiguration        NO_SERVER_CONFIGURATION = new ContextConfiguration();
 
   public HttpAuthSessionManager(final long sessionTimeoutInMs) {
     this(sessionTimeoutInMs, 0);
@@ -78,8 +83,8 @@ public class HttpAuthSessionManager extends RWLockContext {
    */
   HttpAuthSessionManager(final long sessionTimeoutInMs, final long absoluteTimeoutInMs, final LongSupplier clock) {
     this(sessionTimeoutInMs, absoluteTimeoutInMs,
-        new ContextConfiguration().getValueAsInteger(GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_MAX),
-        new ContextConfiguration().getValueAsInteger(GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_MAX_PER_USER), clock);
+        NO_SERVER_CONFIGURATION.getValueAsInteger(GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_MAX),
+        NO_SERVER_CONFIGURATION.getValueAsInteger(GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_MAX_PER_USER), clock);
   }
 
   HttpAuthSessionManager(final long sessionTimeoutInMs, final long absoluteTimeoutInMs, final int maxSessions,

--- a/server/src/main/java/com/arcadedb/server/http/HttpAuthSessionManager.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpAuthSessionManager.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.http;
 
+import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.server.security.ServerSecurityUser;
@@ -56,10 +57,14 @@ public class HttpAuthSessionManager extends RWLockContext {
     this(sessionTimeoutInMs, 0);
   }
 
+  /**
+   * Convenience form for a caller with no server configuration in reach - the tests; {@code HttpServer} passes both
+   * caps explicitly, read from the server's own configuration. The empty {@link ContextConfiguration} says exactly
+   * that: both settings are SCOPE.SERVER, so reading them off the {@link GlobalConfiguration} enum would have been
+   * reading a value only a system property or an environment variable can have written (issue #7233).
+   */
   public HttpAuthSessionManager(final long sessionTimeoutInMs, final long absoluteTimeoutInMs) {
-    this(sessionTimeoutInMs, absoluteTimeoutInMs,
-        GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_MAX.getValueAsInteger(),
-        GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_MAX_PER_USER.getValueAsInteger(), System::currentTimeMillis);
+    this(sessionTimeoutInMs, absoluteTimeoutInMs, System::currentTimeMillis);
   }
 
   public HttpAuthSessionManager(final long sessionTimeoutInMs, final long absoluteTimeoutInMs, final int maxSessions,
@@ -72,8 +77,9 @@ public class HttpAuthSessionManager extends RWLockContext {
    * wall clock, so idle/absolute timeout behavior can be asserted without sleeping (see #6398).
    */
   HttpAuthSessionManager(final long sessionTimeoutInMs, final long absoluteTimeoutInMs, final LongSupplier clock) {
-    this(sessionTimeoutInMs, absoluteTimeoutInMs, GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_MAX.getValueAsInteger(),
-        GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_MAX_PER_USER.getValueAsInteger(), clock);
+    this(sessionTimeoutInMs, absoluteTimeoutInMs,
+        new ContextConfiguration().getValueAsInteger(GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_MAX),
+        new ContextConfiguration().getValueAsInteger(GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_MAX_PER_USER), clock);
   }
 
   HttpAuthSessionManager(final long sessionTimeoutInMs, final long absoluteTimeoutInMs, final int maxSessions,

--- a/server/src/main/java/com/arcadedb/server/http/HttpServer.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpServer.java
@@ -282,9 +282,15 @@ public class HttpServer implements ServerPlugin {
         .delete("/chats/{id}", aiChatsHandler)//
     );
 
-    // Studio (static content) is served in development/test mode, and in production only when explicitly force-enabled
-    if (!"production".equals(GlobalConfiguration.SERVER_MODE.getValueAsString())
-        || GlobalConfiguration.STUDIO_ENABLED.getValueAsBoolean()) {
+    // Studio (static content) is served in development/test mode, and in production only when explicitly
+    // force-enabled. Read through the SERVER's configuration, never off the GlobalConfiguration enum: both settings
+    // are SCOPE.SERVER, and the enum is populated by system properties and environment variables ALONE - so a
+    // deployment that declares them in the server configuration file, or through SET SERVER SETTING, used to get
+    // this gate decided by the compiled-in default instead of by what it asked for, silently and in the permissive
+    // direction (issue #7233).
+    final ContextConfiguration configuration = server.getConfiguration();
+    if (!"production".equals(configuration.getValueAsString(GlobalConfiguration.SERVER_MODE))
+        || configuration.getValueAsBoolean(GlobalConfiguration.STUDIO_ENABLED)) {
       routes.addPrefixPath("/", Handlers.routing().setFallbackHandler(new GetDynamicContentHandler(this)));
     }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -421,9 +421,18 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
 
             } else if (auth.startsWith(AUTHORIZATION_BASIC)) {
               // Basic authentication
-              final String authPairCypher = auth.substring(AUTHORIZATION_BASIC.length() + 1);
-
-              final String authPairClear = new String(Base64.getDecoder().decode(authPairCypher), DatabaseFactory.getDefaultCharset());
+              final String authPairClear;
+              try {
+                final String authPairCypher = auth.substring(AUTHORIZATION_BASIC.length() + 1);
+                authPairClear = new String(Base64.getDecoder().decode(authPairCypher), DatabaseFactory.getDefaultCharset());
+              } catch (final IllegalArgumentException | IndexOutOfBoundsException e) {
+                // A header the client mistyped is a CLIENT error, answered exactly as a header that decodes to
+                // something other than user:password already is. Keeping it out of the catch below is what lets
+                // that one log its cause: everything still reaching it is then an internal fault rather than a
+                // string an anonymous caller chose, so its stack trace cannot be used to flood the log (#7247).
+                sendErrorResponse(exchange, 403, "Basic authentication error", null, null);
+                return;
+              }
 
               final String[] authPair = authPairClear.split(":");
 
@@ -443,7 +452,15 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
             // PASS THROUGH
             throw e;
           } catch (Exception e) {
-            throw new ServerSecurityException("Authentication error");
+            // The arm above re-throws every ServerSecurityException unchanged, and the malformed-header cases are
+            // answered where they happen, so this one is reached only by an INTERNAL failure: a crypto provider
+            // problem, an I/O error reading the user store. The client-facing message stays deliberately opaque,
+            // but the cause has to survive into the server log, or the only frame that knew why is the one that
+            // discarded it (issue #7247). Logged HERE rather than left to sendMappedErrorResponse, whose security
+            // arm deliberately prints a message and no stack trace at FINE - the right treatment for a wrong
+            // password, and the wrong one for the failures that reach this line.
+            LogManager.instance().log(this, getInternalErrorLogLevel(), "Error on authenticating the request", e);
+            throw new ServerSecurityException("Authentication error", e);
           }
         }
       }

--- a/server/src/main/java/com/arcadedb/server/network/PreAuthConnectionGate.java
+++ b/server/src/main/java/com/arcadedb/server/network/PreAuthConnectionGate.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.network;
 
+import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.log.LogManager;
 
@@ -83,8 +84,14 @@ public class PreAuthConnectionGate {
     }
   }
 
-  public PreAuthConnectionGate(final String protocol) {
-    this(protocol, GlobalConfiguration.NETWORK_MAX_PREAUTH_CONNECTIONS.getValueAsInteger());
+  /**
+   * The cap is SCOPE.SERVER, so it is read from the SERVER's own configuration and not off the
+   * {@link GlobalConfiguration} enum, which only a system property or an environment variable ever writes: taking
+   * it from the enum meant a server configuration file or a {@code SET SERVER SETTING} that raised or lowered the
+   * cap was silently ignored, and every listener ran on the compiled-in default (issue #7233).
+   */
+  public PreAuthConnectionGate(final String protocol, final ContextConfiguration configuration) {
+    this(protocol, configuration.getValueAsInteger(GlobalConfiguration.NETWORK_MAX_PREAUTH_CONNECTIONS));
   }
 
   public PreAuthConnectionGate(final String protocol, final int maxConnections) {

--- a/server/src/test/java/com/arcadedb/server/Issue7247LifecycleFailureCauseTest.java
+++ b/server/src/test/java/com/arcadedb/server/Issue7247LifecycleFailureCauseTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7247: the four {@code lifecycleEvent(...)} call sites in {@link ArcadeDBServer} caught every exception a
+ * plugin or a {@link ReplicationCallback} threw and re-threw a {@link ServerException} carrying nothing but the
+ * server's own name. This is the message printed on a server that will not come up, thrown from the exact frame
+ * that knew why - so the cause has to travel with it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7247LifecycleFailureCauseTest extends StaticBaseServerTest {
+  private static final String MARKER = "the reason this server did not come up";
+
+  private ArcadeDBServer server;
+
+  @BeforeEach
+  public void beginTest() {
+    super.beginTest();
+  }
+
+  @AfterEach
+  public void endTest() {
+    if (server != null && server.isStarted())
+      server.stop();
+    server = null;
+    super.endTest();
+  }
+
+  @Test
+  void serverStartingFailureCarriesItsCause() {
+    server = newServer();
+    server.registerTestEventListener(throwingOn(ReplicationCallback.TYPE.SERVER_STARTING));
+
+    assertThatThrownBy(() -> server.start())
+        .isInstanceOf(ServerException.class)
+        .hasMessageContaining("Error on starting the server")
+        .cause().hasMessageContaining(MARKER);
+  }
+
+  @Test
+  void serverUpFailureCarriesItsCause() {
+    server = newServer();
+    server.registerTestEventListener(throwingOn(ReplicationCallback.TYPE.SERVER_UP));
+
+    assertThatThrownBy(() -> server.start())
+        .isInstanceOf(ServerException.class)
+        .hasMessageContaining("Error on starting the server")
+        .cause().hasMessageContaining(MARKER);
+
+    // SERVER_UP stops the server before re-throwing, so nothing is left running for the next test.
+    assertThat(server.isStarted()).isFalse();
+  }
+
+  @Test
+  void serverShuttingDownFailureCarriesItsCause() {
+    server = newServer();
+    server.start();
+    server.registerTestEventListener(throwingOn(ReplicationCallback.TYPE.SERVER_SHUTTING_DOWN));
+
+    assertThatThrownBy(() -> server.stop())
+        .isInstanceOf(ServerException.class)
+        .hasMessageContaining("Error on stopping the server")
+        .cause().hasMessageContaining(MARKER);
+  }
+
+  @Test
+  void serverDownFailureCarriesItsCause() {
+    server = newServer();
+    server.start();
+    server.registerTestEventListener(throwingOn(ReplicationCallback.TYPE.SERVER_DOWN));
+
+    assertThatThrownBy(() -> server.stop())
+        .isInstanceOf(ServerException.class)
+        .hasMessageContaining("Error on stopping the server")
+        .cause().hasMessageContaining(MARKER);
+  }
+
+  /**
+   * ONE-SHOT: a listener cannot be unregistered, and the shutdown events fire again from {@link #endTest()}, where
+   * a second throw would leave the server half-stopped for the next test in the class.
+   */
+  private static ReplicationCallback throwingOn(final ReplicationCallback.TYPE failing) {
+    final AtomicBoolean fired = new AtomicBoolean();
+    return (type, object, server) -> {
+      if (type == failing && fired.compareAndSet(false, true))
+        throw new IllegalStateException(MARKER);
+    };
+  }
+
+  private static ArcadeDBServer newServer() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.SERVER_ROOT_PATH, "./target");
+    config.setValue(GlobalConfiguration.SERVER_ROOT_PASSWORD, DEFAULT_PASSWORD_FOR_TESTS);
+    config.setValue(GlobalConfiguration.SERVER_HTTP_IO_THREADS, 2);
+    config.setValue(GlobalConfiguration.TYPE_DEFAULT_BUCKETS, 2);
+    return new ArcadeDBServer(config);
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/Issue7247MalformedBasicAuthIT.java
+++ b/server/src/test/java/com/arcadedb/server/Issue7247MalformedBasicAuthIT.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7247. The {@code catch (Exception)} around the Authorization header discarded the cause of every failure
+ * it saw, and the reason it could not simply log one is that a mistyped header is CLIENT-triggerable: a stack
+ * trace per request would be a log flood an anonymous caller controls.
+ * <p>
+ * A header that cannot be Base64-decoded is now answered where it happens, exactly as a header that decodes to
+ * something other than {@code user:password} already was - 403, no exception raised. What still reaches the catch
+ * is an internal fault, which is why that arm can now log its cause and chain it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7247MalformedBasicAuthIT extends BaseGraphServerTest {
+
+  @Test
+  void aBasicHeaderThatIsNotBase64Is403() throws Exception {
+    assertThat(statusForAuthorizationHeader("Basic !!!not-base64!!!")).isEqualTo(403);
+  }
+
+  @Test
+  void aBasicHeaderWithNoPayloadIs403() throws Exception {
+    assertThat(statusForAuthorizationHeader("Basic")).isEqualTo(403);
+  }
+
+  @Test
+  void aBasicHeaderDecodingToSomethingElseIsStill403() throws Exception {
+    // The pre-existing sibling of the two above: valid Base64 that is not 'user:password'.
+    assertThat(statusForAuthorizationHeader(
+        "Basic " + Base64.getEncoder().encodeToString("nocolon".getBytes()))).isEqualTo(403);
+  }
+
+  /**
+   * The control: without it every assertion above would also pass against a server that refused the request for
+   * an unrelated reason, which is exactly what a stray process on port 2480 produces.
+   */
+  @Test
+  void aWellFormedBasicHeaderStillAuthenticates() throws Exception {
+    assertThat(statusForAuthorizationHeader("Basic " + Base64.getEncoder()
+        .encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()))).isEqualTo(200);
+  }
+
+  private int statusForAuthorizationHeader(final String authorization) throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URL(
+        "http://127.0.0.1:2480/api/v1/query/graph/sql/select%201").openConnection();
+    connection.setRequestMethod("GET");
+    connection.setRequestProperty("Authorization", authorization);
+    try {
+      connection.connect();
+      return connection.getResponseCode();
+    } finally {
+      connection.disconnect();
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/network/Issue7233PreAuthGateReadsServerConfigurationTest.java
+++ b/server/src/test/java/com/arcadedb/server/network/Issue7233PreAuthGateReadsServerConfigurationTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.network;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7233: {@code arcadedb.network.maxPreAuthConnections} is SCOPE.SERVER, so a value written into the server's
+ * {@link ContextConfiguration} - by the server configuration file, {@code SET SERVER SETTING} or the MCP tool - has
+ * to reach the gate. It used to be read off the {@link GlobalConfiguration} enum, which only a system property or
+ * an environment variable ever writes, so every listener ran on the compiled-in default instead.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7233PreAuthGateReadsServerConfigurationTest {
+
+  @Test
+  void theCapComesFromTheServerConfiguration() {
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.NETWORK_MAX_PREAUTH_CONNECTIONS, 7);
+
+    assertThat(new PreAuthConnectionGate("TEST", configuration).getMaxConnections()).isEqualTo(7);
+  }
+
+  @Test
+  void aServerConfigurationFileValueReachesTheCapToo() {
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.fromJSON("{\"configuration\":{\"network.maxPreAuthConnections\":11}}");
+
+    assertThat(new PreAuthConnectionGate("TEST", configuration).getMaxConnections()).isEqualTo(11);
+  }
+
+  @Test
+  void anEmptyConfigurationStillReadsTheDefault() {
+    assertThat(new PreAuthConnectionGate("TEST", new ContextConfiguration()).getMaxConnections()).isEqualTo(
+        GlobalConfiguration.NETWORK_MAX_PREAUTH_CONNECTIONS.getValueAsInteger());
+  }
+}


### PR DESCRIPTION
Closes #7233, closes #7262, closes #7247.

Three issues from the same audit, all about a value that is written down and then not read.

## #7262 - the server configuration file coerced nothing, and the Boolean reader guessed

`ContextConfiguration.fromJSON` stored the raw JSON value with a plain `put`, and `getValueAsBoolean` read it back with `Boolean.parseBoolean`, which maps every string that is not `"true"` to `false`. Composed:

```json
{ "configuration": { "arcadedb.ha.tls.mutualAuth": "yes" } }
```

silently **disabled mutual TLS authentication** on the inter-node Raft channel, and `"arcadedb.ha.peerAllowlist.enabled": "on"` silently skipped installing the peer allowlist. Both default to `true`, so the operator who never mentioned them was protected and the one who wrote down that they wanted the protection was not - the opposite of the fail-safe property #7222 established for the `-D` path.

`fromJSON` now applies that same strict parse, through a `GlobalConfiguration.coerceFromConfigurationSource` shared with the system-property path: a value the setting's type cannot read is refused, reported with the same message, and the setting keeps its default. Values are stored as their **declared type**, so a reader no longer has to re-parse to be safe.

`getValueAsBoolean` is strict too. That is the backstop for the entry points that still hand over untyped values - the map constructor, `merge`, `setValue` with raw text - and it answers the way the write path does: a value that is not boolean text falls back to what the setting would have had without it (never to `false`), reported once per setting so a hot read path cannot flood the log.

## #7233 - SCOPE.SERVER settings read off the process-wide enum

A `SCOPE.SERVER` setting is authoritative in the **server's** `ContextConfiguration` - that is where the configuration file, `SET SERVER SETTING` and the MCP `set_server_setting` tool write. The `GlobalConfiguration` enum is populated by `readConfiguration()` alone, i.e. by a system property or an environment variable. Reading the enum ignored the other three channels, silently.

Converted, each through the server already in scope:

| Where | What it cost |
|---|---|
| `HttpServer` Studio production gate | a deployment that disabled Studio in the configuration file did not get the gate, and the failure was in the permissive direction |
| `ArcadeDBServer` | server mode - and therefore every production-mode default and warning it gates - plus the Studio checks |
| `ArcadeDbGrpcService` (5 reads), `GrpcServerPlugin` port | row caps, stream write timeouts and the listening port default |
| `SnapshotHttpHandler` | the concurrency semaphore was a `static final` sized at class-init, before any server configuration exists; the rejection log read the enum a second time, so it would have misreported even a value that did reach the semaphore. Now per-instance, sized from the server |
| `HALog` | the verbose level was cached in a static off the enum; `RaftHAPlugin.configure` now hands it the server's configuration |
| Bolt / Postgres / Redis executors and listeners, `PackStreamReader`, `BoltChunkedInput`, `PreAuthConnectionGate` | every protocol limit, timeout, port and debug flag |
| `network` `Channel` | the four TCP keepalive settings, threaded through `ChannelBinary` from the `ContextConfiguration` both subclasses already had |

Sites with genuinely no server in reach keep an explicit empty `ContextConfiguration` (or the enum, in a CLI `main`), each documented as such.

**And a guard, so this cannot come back.** `Issue7233ServerScopeSettingReadsTest` walks every production source outside `engine/`, resolves each setting's scope out of `GlobalConfiguration`, and fails on a `SCOPE.SERVER` read that goes through the enum without a `ContextConfiguration` read of the same setting beside it. The allowlist of deliberate exceptions carries a reason per entry and is itself asserted not to go stale.

## #7247 - six catch blocks that threw away the cause

- **`ArcadeDBServer`, four `lifecycleEvent` sites.** A plugin or `ReplicationCallback` that threw during `SERVER_STARTING` / `SERVER_UP` / `SERVER_SHUTTING_DOWN` / `SERVER_DOWN` left the operator with the server's own name and nothing else. This is the message printed on a server that will not come up, thrown from the frame that knew why.
- **HTTP authentication.** The cause is now chained and logged. Rather than logging it blindly, the malformed-`Basic`-header cases that arm reached - a header that is not Base64, a header with no payload - are answered where they happen with the same 403 a header decoding to something other than `user:password` already got. What still reaches the catch is an internal fault (crypto provider, user store I/O), so its stack trace is worth printing and no anonymous caller can provoke one.
- **`BinarySerializer` array elements.** The cause travels on both paths now, the log and the exception; the element's `toString()` is not a substitute for knowing which nested `serializeValue` threw.

## Better than proposed

#7233 suggested the guard test *instead of* the per-site migration. Both are here: the guard alone would have frozen ~50 sites in place behind an allowlist. #7262 suggested tightening the writer and "at least logging" in the reader; the reader is strict as well, and its fallback is the setting's own value rather than `false`, which is what makes it fail closed for a default-`true` switch without flipping the ones whose safe side is the other one.

## Behaviour changes worth naming

- A configuration-file value that cannot be read as its setting's type is now **refused and logged** instead of stored. It is also no longer round-tripped by `toJSON()`, deliberately: that map is what a server hands its plugins.
- Configuration-file values are stored as their declared type (`Boolean`, `Long`, enum constant) rather than as the raw JSON scalar.
- A malformed `Basic` header answers 403 `Basic authentication error` rather than 403 `Security error`. Same status code.
- `SnapshotHttpHandler`'s snapshot concurrency cap is now per server rather than per JVM.

Documentation for `arcadedb.ha.tls.mutualAuth` / `arcadedb.ha.peerAllowlist.enabled` may be worth a line saying the configuration file accepts only `true`/`false` - happy to prepare that separately.

## Tests

New: `Issue7262ConfigurationFileBooleanStrictTest` (12), `Issue7233ServerScopeSettingReadsTest` (the guard, verified to fail when a converted site is reverted), `Issue7233PreAuthGateReadsServerConfigurationTest`, `Issue7233BoltLimitsReadServerConfigurationTest`, `Issue7247LifecycleFailureCauseTest` (all four sites), `Issue7247ArraySerializationCauseTest`, `Issue7247MalformedBasicAuthIT`, plus a `HALogTest` case for the overlay path. `SnapshotThrottleTest` updated for the per-instance semaphore.

Green locally: `engine` 14632 tests, `network`, `integration`, `redisw`, `postgresw`, `bolt`, `grpcw`, `ha-raft`, `gremlin`. The `server` module's HTTP tests could not be run here - an unrelated long-running process on this machine holds port 2480 and answers them - so they are left to CI; every non-HTTP `server` test passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Server-specific settings now control network limits, protocol behavior, connection caps, ports, HA logging, snapshot concurrency, and gRPC, PostgreSQL, and Redis services.
  - Production mode and Studio availability honor server configuration files and runtime settings.
- **Bug Fixes**
  - Invalid configuration values safely fall back to valid defaults.
  - Malformed Basic Authentication requests return HTTP 403 responses.
  - Configuration, lifecycle, and serialization errors preserve their underlying causes.
- **Tests**
  - Added coverage for configuration-driven limits, authentication, lifecycle failures, and serialization errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->