### PR TITLE
fix(#7268): a split-edge delimiter containing the source's own field separator is refused before any row is read

### DIFF
--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/CsvRowSource.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/CsvRowSource.java
@@ -58,6 +58,11 @@ public class CsvRowSource implements GraphImporter.RecordSource {
   }
 
   @Override
+  public Character fieldSeparator() {
+    return delimiter;
+  }
+
+  @Override
   public void forEach(final GraphImporter.RecordVisitor visitor) throws Exception {
     try (final BufferedReader br = new BufferedReader(
         new InputStreamReader(new FileInputStream(filePath), StandardCharsets.UTF_8), 1 << 16)) {

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -759,6 +759,18 @@ public class GraphImporter implements AutoCloseable {
    */
   public interface RecordSource {
     void forEach(RecordVisitor visitor) throws Exception;
+
+    /**
+     * The single character this source splits a row into fields on, or {@code null} when the format
+     * has none - JSONL and XML values are already distinct, with nothing cutting a row apart on a
+     * delimiter character. Used only so {@code validateEdgeTargets()} can refuse a split-edge
+     * delimiter that contains it (issue #7268): without this, a delimiter such as {@code ", "} over
+     * a comma-delimited CSV is cut into columns before the split-edge walker ever runs, and the
+     * operator sees only an unresolved-edge count pointing at the data files.
+     */
+    default Character fieldSeparator() {
+      return null;
+    }
   }
 
   @FunctionalInterface
@@ -946,6 +958,23 @@ public class GraphImporter implements AutoCloseable {
               + vsd.typeName + "' for attribute '" + ed.fkAttribute + "' declares "
               + (ed.delimiter == null ? "no delimiter" : "an empty delimiter")
               + ": give it the text that separates the field's values, such as \"|\" or \", \"");
+
+        // A delimited source (CsvRowSource) cuts a row into fields on its own field separator before
+        // any GraphImporter code sees it. A split delimiter that contains that character is therefore
+        // cut apart the same way checkNotSplit() diagnoses for an array-valued property: only the
+        // fragment up to the separator survives, and the rest is gone before the split-edge walker
+        // ever runs. Sources with no field-separator concept (XML, JSONL) answer null and are exempt
+        // (issue #7268)
+        if (ed.isSplit) {
+          final Character separator = vsd.source.fieldSeparator();
+          if (separator != null && ed.delimiter.indexOf(separator) >= 0)
+            throw new IllegalArgumentException("Split edge '" + ed.edgeType + "' declared on vertex source '"
+                + vsd.typeName + "' for attribute '" + ed.fkAttribute + "' uses delimiter \"" + ed.delimiter
+                + "\", which contains the source's own field separator '" + separator
+                + "': the source already cut the field into columns using that character, so the split-edge "
+                + "walker never sees the values it is supposed to split. Use a delimiter the field separator "
+                + "does not contain, such as ';'");
+        }
 
         final boolean resolvesByName = ed.byName || ed.isSplit;
         if (!(resolvesByName ? typesWithNameId : typesWithId).contains(ed.targetType))

--- a/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterSplitDelimiterTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterSplitDelimiterTest.java
@@ -24,6 +24,7 @@ import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.integration.importer.graph.CsvRowSource;
 import com.arcadedb.integration.importer.graph.GraphImporter;
+import com.arcadedb.integration.importer.graph.JsonlRowSource;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.utility.FileUtils;
 
@@ -382,6 +383,124 @@ class GraphImporterSplitDelimiterTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("csv-delim.csv")
         .hasMessageContaining("single character");
+  }
+
+  /**
+   * The reporter's exact scenario (issue #7268): a comma-delimited CSV with a split delimiter that
+   * contains the comma. {@link CsvRowSource} cuts the row into fields on the comma before the split
+   * walker ever runs, so the collision is refused before any file is opened - the same register as
+   * {@code checkNotSplit()}'s diagnosis of the identical mechanism on array-valued properties.
+   */
+  @Test
+  void aSplitDelimiterContainingTheSourcesFieldSeparatorIsRejected() throws Exception {
+    final String topics = write("collide-topics.csv",
+        "Code",
+        "scifi",
+        "drama",
+        "horror");
+    final String posts = write("collide-posts.csv",
+        "Id,Tags",
+        "1,scifi, drama, horror");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Topic");
+      database.getSchema().createVertexType("Post");
+      database.getSchema().createEdgeType("Tagged");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Topic", new CsvRowSource(topics), v -> {
+          v.idByName("Code");
+          v.property("code", "Code");
+        })
+        .vertex("Post", new CsvRowSource(posts), v -> {
+          v.id("Id");
+          v.splitEdge("Tags", "Tagged", "Topic", ", ");
+        })
+        .build()) {
+      assertThatThrownBy(importer::run)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Tagged")
+          .hasMessageContaining("Tags")
+          .hasMessageContaining(", ")
+          .hasMessageContaining(",");
+
+      assertThat(importer.getVertexCount()).isZero();
+    }
+  }
+
+  /**
+   * The same validation through the JSON configuration, which is where a hand-picked split delimiter
+   * that happens to collide with the source's default comma is most likely to come from.
+   */
+  @Test
+  void jsonConfigRejectsASplitDelimiterCollidingWithTheSourcesFieldSeparator() throws Exception {
+    write("json-collide-topics.csv",
+        "Code",
+        "scifi",
+        "drama");
+    write("json-collide-posts.csv",
+        "Id,Tags",
+        "1,scifi, drama");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Topic");
+      database.getSchema().createVertexType("Post");
+      database.getSchema().createEdgeType("Tagged");
+    });
+
+    final String config = """
+        {
+          "vertices": [
+            { "type": "Topic", "file": "json-collide-topics.csv", "nameId": "Code" },
+            { "type": "Post", "file": "json-collide-posts.csv", "id": "Id",
+              "edges": [ { "attribute": "Tags", "edge": "Tagged", "target": "Topic", "split": ", " } ] }
+          ]
+        }
+        """;
+
+    try (final GraphImporter importer = GraphImporter.fromJSON(database, config, dataDir.getAbsolutePath())) {
+      assertThatThrownBy(importer::run)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Tagged")
+          .hasMessageContaining(", ");
+    }
+  }
+
+  /**
+   * A source with no field-separator concept - JSONL fields are already distinct JSON values, nothing
+   * cuts a row apart on a delimiter character - must never be flagged for a "collision" that cannot
+   * happen. {@link JsonlRowSource#fieldSeparator()} answers the {@link GraphImporter.RecordSource}
+   * default of {@code null}, and {@code validateEdgeTargets()} must treat that as "nothing to check"
+   * rather than as a source whose separator happens to be absent.
+   */
+  @Test
+  void aSplitEdgeOverANonDelimitedSourceIsNeverFlaggedAsAFieldSeparatorCollision() throws Exception {
+    final String topics = write("jsonl-topics.jsonl",
+        "{\"Code\": \"scifi\"}",
+        "{\"Code\": \"drama\"}",
+        "{\"Code\": \"horror\"}");
+    final String posts = write("jsonl-posts.jsonl",
+        "{\"Id\": 1, \"Tags\": \"scifi, drama, horror\"}");
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Topic");
+      database.getSchema().createVertexType("Post");
+      database.getSchema().createEdgeType("Tagged");
+    });
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Topic", new JsonlRowSource(topics), v -> v.idByName("Code"))
+        .vertex("Post", new JsonlRowSource(posts), v -> {
+          v.id("Id");
+          v.splitEdge("Tags", "Tagged", "Topic", ", ");
+        })
+        .build()) {
+      importer.run();
+
+      assertThat(importer.getEdgeCount()).isEqualTo(3);
+      assertThat(importer.getUnresolvedEdgeCount()).isZero();
+    }
   }
 
   private String write(final String fileName, final String... lines) throws Exception {

--- a/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterSplitDelimiterTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/GraphImporterSplitDelimiterTest.java
@@ -423,7 +423,9 @@ class GraphImporterSplitDelimiterTest {
           .hasMessageContaining("Tagged")
           .hasMessageContaining("Tags")
           .hasMessageContaining(", ")
-          .hasMessageContaining(",");
+          // the separator in its quoted form: a bare "," is already inside the ", " asserted above,
+          // so it would hold whatever the message said about the separator - including nothing
+          .hasMessageContaining("','");
 
       assertThat(importer.getVertexCount()).isZero();
     }


### PR DESCRIPTION
Closes #7268

## Summary

A delimited source cuts a row into fields on its own field separator before any `GraphImporter` code sees it, so a split-edge delimiter that *contains* that character is cut apart the same way. Over a comma-delimited CSV, splitting `"scifi, drama, horror"` on `", "` leaves the walker only `"scifi"` - the other two values are gone before `collectEdge()` runs, and the operator is told those edges "named an identity no vertex carries", which points at the data files for what is really a delimiter problem.

`RecordReader.checkNotSplit()` already diagnoses this exact mechanism for an array-valued property. The split-edge equivalent could not be written, because `validateEdgeTargets()` had no way to ask a source what its field separator is: `RecordSource` declared only `forEach()`, and `CsvRowSource.delimiter` is `private final char` with no accessor.

`RecordSource` gains one non-breaking `default Character fieldSeparator()` answering `null` for a format that has none. `CsvRowSource` overrides it; `XmlRowSource` and `JsonlRowSource` take the default, because nothing cuts their rows apart on a delimiter character and no collision is possible there. `validateEdgeTargets()` then refuses the collision in the same block that already refuses a null or empty delimiter (#7263 / #7270), before a file is opened, with a message in `checkNotSplit()`'s register.

**Refuse rather than warn** - matching the sibling null/empty check three lines above it and `checkNotSplit()`'s precedent for the identical mechanism. An import already emits WARNING lines, and one more would go unread until the unresolved-edge count is investigated, which is the exact failure mode this fixes.

## Test plan

- [x] `mvn -o -pl integration -am install -DskipTests` - exit 0.
- [x] `mvn -o -pl integration test -Dtest=GraphImporterSplitDelimiterTest` - **11/11 green** (8 pre-existing from #7270 + 3 added here).
- [x] `mvn -o -pl integration test -Dtest=GraphImporterIdTypesTest,StackOverflowImporterApiTest` - **27 run, 0 failures, 3 skipped**. The 3 skips are pre-existing `StackOverflowImporterApiTest` skips (they need a data dump the tree does not carry), unrelated to this change.
- [x] `mvn -o -pl integration test -DexcludedGroups=benchmark,vector,slow` - **263 run, 0 failures, 0 errors, 9 skipped**, the whole module.

The regression evidence that ordinary usage is untouched: `GraphImporterIdTypesTest`'s 24 cases use a default `,` CSV source with a `"|"` split delimiter, and pass **unchanged** - `"|"` does not contain `','`, so the new check does not fire. `GraphImporterSplitDelimiterTest`'s pre-existing cases deliberately use `;`-delimited sources with a `", "` split (its own comment says so), and are likewise unaffected.

## Coverage

Every entry point that can produce a split edge, each with a test driving it through *that* path:

| Entry point | Covered | Test |
|---|---|---|
| Fluent `splitEdge(…, delim)` colliding with the CSV source's field separator | yes | `aSplitDelimiterContainingTheSourcesFieldSeparatorIsRejected` |
| JSON `"split": delim` on a CSV source, same collision | yes | `jsonConfigRejectsASplitDelimiterCollidingWithTheSourcesFieldSeparator` |
| A source with no field separator (JSONL/XML) declaring a delimiter that would collide with a comma | yes - proves the check does **not** misfire | `aSplitEdgeOverANonDelimitedSourceIsNeverFlaggedAsAFieldSeparatorCollision` |
| Non-colliding delimiter on a CSV source (ordinary usage) | yes, unchanged | `GraphImporterSplitDelimiterTest` + `GraphImporterIdTypesTest` (24 cases) |

Argued rather than fixed, with the evidence:

- **Standalone edge sources cannot declare a split edge.** `grep -n "splitEdge" GraphImporter.java` shows the method only on `VertexConfig`; `EdgeSourceConfig` has no equivalent. `grep -n "new EdgeDef("` shows every other construction site passing `split = false`. So every `isSplit` edge originates in the single `for (VertexSourceDef vsd) { for (EdgeDef ed : vsd.config.edges) }` loop this PR touches, where `vsd.source` is already in scope - one check covers the fluent API and the JSON config path alike, including self-referencing (deferred) split edges, which go through the same loop.
- **No false positive against quoted CSV.** `CsvRowSource.splitLine()` is documented "Simple CSV split (no quoting support - for quoted fields use Univocity)", so there is no quoting mechanism under which a delimiter-containing value could legitimately survive the source's own split.

### Known gaps

None. Every reachable entry point is fixed in this PR.

### Residual risk

- The legacy `CSVImporterFormat` (`format/CSVImporterFormat.java:739-740`) is a separate, older importer with its own settings parser, not reachable from `GraphImporter` and untouched here - already recorded as residual risk on #7270.
- #7267 (`CsvRowSource` passes its delimiter to `String.split`, which treats it as a **regex**) is still open and independent of this change. A regex-metacharacter separator such as `'|'` or `'.'` misbehaves in `splitLine()` itself; `fieldSeparator()` reports the configured character faithfully either way, so this check is correct regardless of how #7267 is resolved.

## Adversarial pass

Run by a subagent given only the issue text, the diff and the tree - deliberately not the reasoning above. It verified the API widening, the check's premise, the coverage argument and the tests (running them itself), and returned **no finding**: no corner case, uncovered call path, false comment claim, or dead code. Its one non-code note was that the analysis ledger belongs in this PR body rather than in a committed `docs/` file, which is why there is no tracking doc in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QU8yyPdj5LUm7yJ3dpJYj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graph import validation for CSV files by rejecting split-edge delimiters that conflict with the CSV field separator.
  * Added consistent validation for both fluent and JSON-based import configurations.
  * Preserved successful imports for JSONL sources, which do not use field separators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->