### PR TITLE
fix: allow Docker login and build mode for attached releases

### DIFF
--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -467,7 +467,7 @@ jobs:
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Login to Docker Hub
-        if: ${{ github.event_name == 'release' }}
+        if: ${{ github.event_name == 'release' || inputs.attach_to_release }}
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -481,7 +481,7 @@ jobs:
           TAG="arcadedata/arcadedb:${{ steps.stage.outputs.version }}-native-${{ matrix.arch }}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           MODE="--load"
-          if [ "${{ github.event_name }}" = "release" ]; then
+          if [ "${{ github.event_name }}" = "release" || ${{ inputs.attach_to_release }} ]; then
             MODE="--push"
           fi
           docker buildx build --platform "linux/${{ matrix.arch }}" \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Docker image publishing can now be triggered during manual workflow runs when the release attachment option is enabled.
  - Manual builds without this option continue to load images locally rather than publishing them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->