### PR TITLE
fix(#7281): the OTLP metrics and tracing plugins activate from their own enable flags

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -247,6 +247,10 @@ Check that:
 2. `META-INF/services/com.arcadedb.server.ServerPlugin` file exists
 3. Service file contains correct plugin class name
 4. Plugin class implements `ServerPlugin` interface
+5. The plugin is opted in - it is named in `arcadedb.server.plugins`, or it overrides
+   `ServerPlugin.isAutoDiscovered(ContextConfiguration)` to return `true`. Being on the class path is not by itself
+   enough: the default answer is `false`, so a plugin nobody asked for is found and then skipped (issue #7281).
+   Both loaders apply the same rule - a jar in `lib/plugins/` and one in `lib/` are asked the same question
 
 ### ClassNotFoundException
 
@@ -277,7 +281,10 @@ arcadedb.server.plugins=gremlin:com.arcadedb.server.gremlin.GremlinServerPlugin
 ### New Method (recommended)
 1. Place plugin JAR in `lib/plugins/`
 2. Include `META-INF/services` file
-3. No configuration needed
+3. Override `isAutoDiscovered(ContextConfiguration)` to return `true` - typically only when the plugin's own enable
+   setting is on, the way `OtlpMetricsPlugin` and `TracingPlugin` read their `arcadedb.serverMetrics.*` flags. A
+   plugin that keeps the default `false` still needs an `arcadedb.server.plugins` entry, which is what makes the
+   legacy method above the way to install a plugin you do not control
 
 ## Best Practices
 

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2788,8 +2788,13 @@ public enum GlobalConfiguration {
   private static synchronized void dumpConfigurationOrDefer() {
     // Synchronized on the same monitor as readConfiguration(), so "is a pass in flight?" is decided against a pass
     // that cannot start or finish while the question is being asked. It is reentrant for the callback's own caller
-    // (readConfiguration already holds it), and it makes an out-of-band write - SET SERVER SETTING, the MCP tool -
-    // wait for the in-flight pass and then dump the configuration that pass produced, rather than racing it.
+    // (readConfiguration already holds it), and a write from another thread waits for the in-flight pass and then
+    // dumps the configuration that pass produced, rather than racing it.
+    //
+    // "A write" here means a direct GlobalConfiguration.setValue()/reset() on this setting, which is the only way
+    // its callback runs: the ContextConfiguration overlay channels - a server configuration file, SET SERVER
+    // SETTING, the MCP set_server_setting tool - reach applyContextValue, which returns early for anything that is
+    // not SCOPE.SERVER, and this setting is SCOPE.JVM. That predates #7281 and is unchanged by it.
     if (readingConfiguration)
       dumpPending = true;
     else

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2748,9 +2748,13 @@ public enum GlobalConfiguration {
    * so a value the setting's type cannot read is reported and dropped instead of being coerced into whatever the
    * type's permissive parse makes of it - which for a {@code Boolean} was {@code false}, for every input (#7222).
    */
-  public static void readConfiguration() {
+  public static synchronized void readConfiguration() {
     String prop;
 
+    // Synchronized because the pass has state that spans it: readingConfiguration/dumpPending are JVM-wide, so two
+    // interleaved passes could clear the flag while the other is still walking values() and dump mid-pass - the very
+    // thing #7281 fixed. Today the only callers are this class's static initializer (single-threaded by class-init
+    // semantics) and tests, but a future "reload configuration" entry point must not have to rediscover that.
     readingConfiguration = true;
     try {
       for (final GlobalConfiguration config : values()) {

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -43,23 +43,13 @@ import java.util.logging.Level;
  */
 public enum GlobalConfiguration {
   // ENVIRONMENT
+  // The dump is DEFERRED while readConfiguration() is running (issue #7281). This is the first constant of the
+  // enum, so its callback used to fire while that pass was still walking values(), printing the compiled-in default
+  // of every setting declared after it - a reporter read `serverMetrics.tracing.enabled = false` out of the startup
+  // log while /api/v1/server correctly answered true for the same setting, and concluded the flag had been ignored.
   DUMP_CONFIG_AT_STARTUP("arcadedb.dumpConfigAtStartup", SCOPE.JVM, "Dumps the configuration at startup", Boolean.class, false,
       value -> {
-        //dumpConfiguration(System.out);
-
-        try {
-          final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-          dumpConfiguration(new PrintStream(buffer));
-          if (LogManager.instance() != null)
-            LogManager.instance().log(buffer, Level.WARNING, new String(buffer.toByteArray()));
-          else
-            System.out.println(new String(buffer.toByteArray()));
-
-          buffer.close();
-        } catch (IOException e) {
-          System.out.println("Error on printing initial configuration to log (error=" + e + ")");
-        }
-
+        dumpConfigurationOrDefer();
         return value;
       }),
 
@@ -1361,6 +1351,13 @@ public enum GlobalConfiguration {
       a system property or environment variable - and the setting keeps its default of true.""", Boolean.class,
       true),
 
+  SERVER_METRICS_OTLP_ENABLED("arcadedb.serverMetrics.otlp.enabled", SCOPE.SERVER,
+      "Enable pushing the server metrics to an OTLP endpoint, alongside (never replacing) the Prometheus scrape endpoint. Requires the optional metrics plugin on the classpath and arcadedb.serverMetrics to be true",
+      Boolean.class, false),
+
+  SERVER_METRICS_OTLP_ENDPOINT("arcadedb.serverMetrics.otlp.endpoint", SCOPE.SERVER, "OTLP metrics export endpoint",
+      String.class, "http://localhost:4317"),
+
   SERVER_METRICS_TRACING_ENABLED("arcadedb.serverMetrics.tracing.enabled", SCOPE.SERVER,
       "Enable OpenTelemetry distributed tracing (requires the optional tracing plugin on the classpath). Note: query/command spans include the statement text as the db.statement span attribute, which may contain sensitive data, so secure the OTLP collector endpoint",
       Boolean.class, false),
@@ -2410,6 +2407,12 @@ public enum GlobalConfiguration {
   private final        Set<Object>              allowed;
   public final static  String                   PREFIX = "arcadedb.";
   private static final Timer                    TIMER;
+  // Issue #7281: set for the duration of readConfiguration(), so DUMP_CONFIG_AT_STARTUP's callback can tell a
+  // startup pass that has not finished applying the other settings from a later write it can dump straight away.
+  // Left without an initializer on purpose: an enum's constants are constructed before any static field
+  // initializer runs, and these two have to read as false from the very first callback.
+  private static volatile boolean               readingConfiguration;
+  private static volatile boolean               dumpPending;
 
   public enum SCOPE {JVM, SERVER, DATABASE}
 
@@ -2748,16 +2751,60 @@ public enum GlobalConfiguration {
   public static void readConfiguration() {
     String prop;
 
-    for (final GlobalConfiguration config : values()) {
-      String source = "system property";
+    readingConfiguration = true;
+    try {
+      for (final GlobalConfiguration config : values()) {
+        String source = "system property";
 
-      prop = System.getProperty(config.key);
-      if (prop == null) {
-        prop = System.getenv(config.key);
-        source = "environment variable";
+        prop = System.getProperty(config.key);
+        if (prop == null) {
+          prop = System.getenv(config.key);
+          source = "environment variable";
+        }
+
+        config.applyConfigurationSource(prop, source);
       }
+    } finally {
+      readingConfiguration = false;
+    }
 
-      config.applyConfigurationSource(prop, source);
+    // Issue #7281: the dump describes the configuration this pass PRODUCED. Firing it from the callback, as the
+    // first constant of the enum, described the one the pass started from.
+    if (dumpPending) {
+      dumpPending = false;
+      dumpConfigurationToLog();
+    }
+  }
+
+  /**
+   * Dumps the configuration now, or marks it to be dumped by {@link #readConfiguration()} when that pass is the
+   * caller: mid-pass, every setting declared after {@code DUMP_CONFIG_AT_STARTUP} still holds its compiled-in
+   * default, so a dump taken there describes a configuration that never existed (issue #7281).
+   */
+  private static void dumpConfigurationOrDefer() {
+    if (readingConfiguration)
+      dumpPending = true;
+    else
+      dumpConfigurationToLog();
+  }
+
+  /**
+   * Writes {@link #dumpConfiguration(PrintStream)} to the log, or to stdout when the log is not up yet. A failure
+   * to print the configuration must never take the process down: this runs from a static initializer, where a throw
+   * becomes an {@code ExceptionInInitializerError}.
+   */
+  private static void dumpConfigurationToLog() {
+    try {
+      final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+      dumpConfiguration(new PrintStream(buffer));
+      if (LogManager.instance() != null)
+        LogManager.instance().log(buffer, Level.WARNING, new String(buffer.toByteArray()));
+      else
+        System.out.println(new String(buffer.toByteArray()));
+
+      buffer.close();
+    } catch (IOException e) {
+      System.out.println("Error on printing initial configuration to log (error=" + e + ")");
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2410,9 +2410,11 @@ public enum GlobalConfiguration {
   // Issue #7281: set for the duration of readConfiguration(), so DUMP_CONFIG_AT_STARTUP's callback can tell a
   // startup pass that has not finished applying the other settings from a later write it can dump straight away.
   // Left without an initializer on purpose: an enum's constants are constructed before any static field
-  // initializer runs, and these two have to read as false from the very first callback.
-  private static volatile boolean               readingConfiguration;
-  private static volatile boolean               dumpPending;
+  // initializer runs, and these two have to read as false from the very first callback. Not volatile: every read
+  // and every write happens inside readConfiguration() or dumpConfigurationOrDefer(), both synchronized on this
+  // class, which already carries the happens-before edge.
+  private static boolean                        readingConfiguration;
+  private static boolean                        dumpPending;
 
   public enum SCOPE {JVM, SERVER, DATABASE}
 

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2785,7 +2785,11 @@ public enum GlobalConfiguration {
    * caller: mid-pass, every setting declared after {@code DUMP_CONFIG_AT_STARTUP} still holds its compiled-in
    * default, so a dump taken there describes a configuration that never existed (issue #7281).
    */
-  private static void dumpConfigurationOrDefer() {
+  private static synchronized void dumpConfigurationOrDefer() {
+    // Synchronized on the same monitor as readConfiguration(), so "is a pass in flight?" is decided against a pass
+    // that cannot start or finish while the question is being asked. It is reentrant for the callback's own caller
+    // (readConfiguration already holds it), and it makes an out-of-band write - SET SERVER SETTING, the MCP tool -
+    // wait for the in-flight pass and then dump the configuration that pass produced, rather than racing it.
     if (readingConfiguration)
       dumpPending = true;
     else

--- a/engine/src/test/java/com/arcadedb/Issue7281StartupConfigDumpOrderTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue7281StartupConfigDumpOrderTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb;
+
+import com.arcadedb.log.LogManager;
+import com.arcadedb.log.Logger;
+import org.junit.jupiter.api.Test;
+
+import java.util.logging.Level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7281, second finding.
+ * <p>
+ * The startup dump fires from {@code DUMP_CONFIG_AT_STARTUP}'s own value callback, and that setting is the FIRST
+ * constant of the enum - so it used to run while {@link GlobalConfiguration#readConfiguration()} was still walking
+ * {@code values()}, printing the compiled-in DEFAULT of every setting declared after it. The reporter of #7281 read
+ * {@code arcadedb.serverMetrics.tracing.enabled = false} out of the startup log while {@code /api/v1/server}
+ * correctly answered {@code true} for the same setting, and reasonably concluded the flag had not been applied.
+ * <p>
+ * The dump has to describe the configuration that {@code readConfiguration()} produced, not the one it started from.
+ */
+class Issue7281StartupConfigDumpOrderTest {
+
+  /** A setting declared AFTER {@code DUMP_CONFIG_AT_STARTUP}, which is the whole point. */
+  private static final GlobalConfiguration LATER_SETTING = GlobalConfiguration.SERVER_METRICS_TRACING_ENDPOINT;
+  private static final String              CONFIGURED    = "http://otel-agent.issue7281:4317";
+
+  @Test
+  void theStartupDumpShowsTheValuesThatWereJustAppliedNotTheDefaults() {
+    final CapturingLogger captured = new CapturingLogger();
+    final Logger previousLogger = LogManager.instance().getLogger();
+    LogManager.instance().setLogger(captured);
+    try {
+      System.setProperty(GlobalConfiguration.DUMP_CONFIG_AT_STARTUP.getKey(), "true");
+      System.setProperty(LATER_SETTING.getKey(), CONFIGURED);
+
+      GlobalConfiguration.readConfiguration();
+
+      assertThat(captured.text()).contains(LATER_SETTING.getKey() + " = " + CONFIGURED);
+      assertThat(captured.text()).doesNotContain(LATER_SETTING.getKey() + " = " + LATER_SETTING.getDefValue());
+    } finally {
+      System.clearProperty(GlobalConfiguration.DUMP_CONFIG_AT_STARTUP.getKey());
+      System.clearProperty(LATER_SETTING.getKey());
+      // Reset while the capturing logger is still installed: resetting DUMP_CONFIG_AT_STARTUP runs its callback,
+      // which dumps, and the rest of the suite does not need that in its log.
+      GlobalConfiguration.DUMP_CONFIG_AT_STARTUP.reset();
+      LATER_SETTING.reset();
+      LogManager.instance().setLogger(previousLogger);
+    }
+  }
+
+  /**
+   * Turning the setting on outside {@code readConfiguration()} - a server configuration file, {@code SET SERVER
+   * SETTING}, the MCP tool - still dumps straight away: there is no in-flight pass to wait for.
+   */
+  @Test
+  void settingTheFlagAtRuntimeStillDumpsImmediately() {
+    final CapturingLogger captured = new CapturingLogger();
+    final Logger previousLogger = LogManager.instance().getLogger();
+    LogManager.instance().setLogger(captured);
+    try {
+      GlobalConfiguration.DUMP_CONFIG_AT_STARTUP.setValue(true);
+
+      assertThat(captured.text()).contains("ARCADEDB").contains(" configuration:");
+    } finally {
+      GlobalConfiguration.DUMP_CONFIG_AT_STARTUP.reset();
+      LogManager.instance().setLogger(previousLogger);
+    }
+  }
+
+  private static final class CapturingLogger implements Logger {
+    private final StringBuilder buffer = new StringBuilder();
+
+    String text() {
+      return buffer.toString();
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception, final String context,
+        final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5, final Object arg6,
+        final Object arg7, final Object arg8, final Object arg9, final Object arg10, final Object arg11, final Object arg12,
+        final Object arg13, final Object arg14, final Object arg15, final Object arg16, final Object arg17) {
+      append(message);
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception, final String context,
+        final Object... args) {
+      append(message);
+    }
+
+    @Override
+    public void flush() {
+      // NO-OP
+    }
+
+    private synchronized void append(final String message) {
+      if (message != null)
+        buffer.append(message).append('\n');
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/Issue7281StartupConfigDumpOrderTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue7281StartupConfigDumpOrderTest.java
@@ -68,8 +68,12 @@ class Issue7281StartupConfigDumpOrderTest {
   }
 
   /**
-   * Turning the setting on outside {@code readConfiguration()} - a server configuration file, {@code SET SERVER
-   * SETTING}, the MCP tool - still dumps straight away: there is no in-flight pass to wait for.
+   * Turning the setting on outside {@code readConfiguration()} still dumps straight away: there is no in-flight pass
+   * to wait for. That means a direct {@code setValue()} on the setting, which is the only channel that runs this
+   * setting's callback at all - the {@link ContextConfiguration} overlay writes (a server configuration file,
+   * {@code SET SERVER SETTING}, the MCP tool) go through {@code applyContextValue}, which returns early for
+   * anything that is not {@code SCOPE.SERVER}, and {@code DUMP_CONFIG_AT_STARTUP} is {@code SCOPE.JVM}. That is
+   * true before and after #7281; this test pins the behaviour the deferral had to preserve, not a new promise.
    */
   @Test
   void settingTheFlagAtRuntimeStillDumpsImmediately() {

--- a/metrics/src/main/java/com/arcadedb/metrics/otlp/OtlpMetricsPlugin.java
+++ b/metrics/src/main/java/com/arcadedb/metrics/otlp/OtlpMetricsPlugin.java
@@ -40,15 +40,23 @@ public class OtlpMetricsPlugin implements ServerPlugin {
   private OtlpMeterRegistry registry;
   private boolean           enabled;
 
+  /**
+   * The enable flag is the whole opt-in: a deployment that sets it does not also have to name this plugin in
+   * {@code arcadedb.server.plugins} (issue #7281). Before this, the flag governed what {@code configure()} did and
+   * nothing governed whether {@code configure()} ran, so setting it alone produced no exporter and no log line.
+   */
+  @Override
+  public boolean isAutoDiscovered(final ContextConfiguration configuration) {
+    return isEnabledBy(configuration);
+  }
+
   @Override
   public void configure(final ArcadeDBServer server, final ContextConfiguration configuration) {
-    final boolean metricsOn = configuration.getValueAsBoolean(GlobalConfiguration.SERVER_METRICS);
-    final boolean otlpOn = asBoolean(configuration.getValue("arcadedb.serverMetrics.otlp.enabled", (Object) Boolean.FALSE));
-    enabled = metricsOn && otlpOn;
+    enabled = isEnabledBy(configuration);
     if (!enabled)
       return;
 
-    final String endpoint = asString(configuration.getValue("arcadedb.serverMetrics.otlp.endpoint", (Object) "http://localhost:4317"));
+    final String endpoint = configuration.getValueAsString(GlobalConfiguration.SERVER_METRICS_OTLP_ENDPOINT);
     final OtlpConfig otlpConfig = key -> "otlp.url".equals(key) ? endpoint : null;
     registry = new OtlpMeterRegistry(otlpConfig, Clock.SYSTEM);
     Metrics.addRegistry(registry);
@@ -70,16 +78,11 @@ public class OtlpMetricsPlugin implements ServerPlugin {
   }
 
   /**
-   * Coerces a config value to a boolean. The value may be a {@link Boolean} (set programmatically /
-   * in tests) or a {@link String} (read from a config file or system property).
+   * The one reading of "OTLP is on", shared by the activation gate and by {@code configure()} so the two cannot
+   * disagree: the global metrics kill switch wins over the OTLP flag, exactly as it did before.
    */
-  private static boolean asBoolean(final Object value) {
-    if (value instanceof Boolean b)
-      return b;
-    return value != null && Boolean.parseBoolean(value.toString());
-  }
-
-  private static String asString(final Object value) {
-    return value != null ? value.toString() : null;
+  private static boolean isEnabledBy(final ContextConfiguration configuration) {
+    return configuration.getValueAsBoolean(GlobalConfiguration.SERVER_METRICS)
+        && configuration.getValueAsBoolean(GlobalConfiguration.SERVER_METRICS_OTLP_ENABLED);
   }
 }

--- a/metrics/src/main/java/com/arcadedb/metrics/prometheus/PrometheusMetricsPlugin.java
+++ b/metrics/src/main/java/com/arcadedb/metrics/prometheus/PrometheusMetricsPlugin.java
@@ -32,6 +32,12 @@ import io.undertow.server.handlers.PathHandler;
 import java.util.logging.Level;
 
 public class PrometheusMetricsPlugin implements ServerPlugin {
+  // Deliberately does NOT override isAutoDiscovered, unlike its OTLP and tracing siblings (issue #7281). Their
+  // enable flags default to false, so auto-discovery only honours something an operator asked for; this plugin's
+  // gate is arcadedb.serverMetrics, which defaults to TRUE, so the same change would publish /prometheus on every
+  // default server. What that endpoint exposes and who may read it is the subject of #7124 and #7222; changing its
+  // default exposure is a decision of its own, not a symmetry to restore.
+
 
   private PrometheusMeterRegistry registry;
   private boolean                 enabled;

--- a/metrics/src/main/java/com/arcadedb/metrics/prometheus/PrometheusMetricsPlugin.java
+++ b/metrics/src/main/java/com/arcadedb/metrics/prometheus/PrometheusMetricsPlugin.java
@@ -38,7 +38,6 @@ public class PrometheusMetricsPlugin implements ServerPlugin {
   // default server. What that endpoint exposes and who may read it is the subject of #7124 and #7222; changing its
   // default exposure is a decision of its own, not a symmetry to restore.
 
-
   private PrometheusMeterRegistry registry;
   private boolean                 enabled;
   private ContextConfiguration    configuration;

--- a/metrics/src/test/java/com/arcadedb/metrics/otlp/Issue7281OtlpPluginAutoDiscoveryTest.java
+++ b/metrics/src/test/java/com/arcadedb/metrics/otlp/Issue7281OtlpPluginAutoDiscoveryTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.metrics.otlp;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7281.
+ * <p>
+ * Setting {@code arcadedb.serverMetrics.otlp.enabled=true} was not enough to get the plugin running: the plugin did
+ * not override {@link com.arcadedb.server.ServerPlugin#isAutoDiscovered}, whose default is {@code false}, so
+ * {@code PluginManager} skipped the {@code ServiceLoader}-discovered instance unless the deployment ALSO named it in
+ * {@code arcadedb.server.plugins}. {@code configure()} was never called, which is why the reporter saw no OTLP log
+ * line at all while the setting read back correctly from {@code /api/v1/server}.
+ * <p>
+ * The two settings also gain a {@link GlobalConfiguration} entry here: they were read through the raw-string
+ * {@code getValue(String, default)} overload, so they worked as a {@code -D} but appeared in neither the startup
+ * dump nor {@code /api/v1/server} - the reporter's "There are no otlp settings".
+ */
+class Issue7281OtlpPluginAutoDiscoveryTest {
+
+  @AfterEach
+  void restoreTheSettings() {
+    GlobalConfiguration.SERVER_METRICS.reset();
+    GlobalConfiguration.SERVER_METRICS_OTLP_ENABLED.reset();
+    GlobalConfiguration.SERVER_METRICS_OTLP_ENDPOINT.reset();
+  }
+
+  @Test
+  void aServerThatNamesNoPluginDoesNotGetAnOtlpExporter() {
+    assertThat(new OtlpMetricsPlugin().isAutoDiscovered(new ContextConfiguration())).isFalse();
+  }
+
+  /**
+   * The {@code -D}/environment-variable channel: {@code readConfiguration()} stores the value on the enum, and an
+   * empty {@link ContextConfiguration} overlay reads straight through to it. This is the channel the Helm chart
+   * uses.
+   */
+  @Test
+  void theEnableFlagSetAsASystemPropertyIsEnoughToActivateThePlugin() {
+    GlobalConfiguration.SERVER_METRICS_OTLP_ENABLED.setValue(true);
+
+    assertThat(new OtlpMetricsPlugin().isAutoDiscovered(new ContextConfiguration())).isTrue();
+  }
+
+  /**
+   * The server-configuration-file channel: {@code fromJSON} writes into the {@link ContextConfiguration} overlay,
+   * which {@code PluginManager} is handed and which shadows the enum value.
+   */
+  @Test
+  void theEnableFlagSetInTheServerConfigurationIsEnoughToActivateThePlugin() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.setValue(GlobalConfiguration.SERVER_METRICS_OTLP_ENABLED.getKey(), true);
+
+    assertThat(new OtlpMetricsPlugin().isAutoDiscovered(cfg)).isTrue();
+  }
+
+  /**
+   * {@code arcadedb.serverMetrics=false} turns metrics off wholesale, and {@code configure()} already honours it.
+   * Auto-discovery has to agree with that gate, otherwise the plugin is installed only to do nothing.
+   */
+  @Test
+  void theGlobalMetricsKillSwitchAlsoKeepsThePluginOut() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.setValue(GlobalConfiguration.SERVER_METRICS.getKey(), false);
+    cfg.setValue(GlobalConfiguration.SERVER_METRICS_OTLP_ENABLED.getKey(), true);
+
+    assertThat(new OtlpMetricsPlugin().isAutoDiscovered(cfg)).isFalse();
+  }
+
+  /**
+   * Both OTLP settings are declared, so the startup dump and {@code /api/v1/server} - which both enumerate
+   * {@link GlobalConfiguration#values()} - list them like every other setting.
+   */
+  @Test
+  void bothOtlpSettingsAreDeclaredAndVisibleToTheSettingsApi() {
+    assertThat(GlobalConfiguration.findByKey("arcadedb.serverMetrics.otlp.enabled"))
+        .isSameAs(GlobalConfiguration.SERVER_METRICS_OTLP_ENABLED);
+    assertThat(GlobalConfiguration.findByKey("arcadedb.serverMetrics.otlp.endpoint"))
+        .isSameAs(GlobalConfiguration.SERVER_METRICS_OTLP_ENDPOINT);
+
+    assertThat(GlobalConfiguration.SERVER_METRICS_OTLP_ENABLED.getDefValue()).isEqualTo(Boolean.FALSE);
+    assertThat(GlobalConfiguration.SERVER_METRICS_OTLP_ENDPOINT.getDefValue()).isEqualTo("http://localhost:4317");
+    assertThat(GlobalConfiguration.SERVER_METRICS_OTLP_ENABLED.getScope()).isEqualTo(GlobalConfiguration.SCOPE.SERVER);
+    assertThat(GlobalConfiguration.SERVER_METRICS_OTLP_ENDPOINT.getScope()).isEqualTo(GlobalConfiguration.SCOPE.SERVER);
+  }
+
+  /**
+   * The endpoint keeps being read from the same key it was read from before it was declared, so an existing
+   * {@code -D arcadedb.serverMetrics.otlp.endpoint=...} deployment keeps working.
+   */
+  @Test
+  void theEndpointIsStillReadFromItsOriginalKey() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.setValue("arcadedb.serverMetrics.otlp.endpoint", "http://otel-agent.sf-infra:4317");
+
+    assertThat(cfg.getValueAsString(GlobalConfiguration.SERVER_METRICS_OTLP_ENDPOINT))
+        .isEqualTo("http://otel-agent.sf-infra:4317");
+  }
+}

--- a/metrics/src/test/java/com/arcadedb/metrics/otlp/Issue7281OtlpPluginAutoDiscoveryTest.java
+++ b/metrics/src/test/java/com/arcadedb/metrics/otlp/Issue7281OtlpPluginAutoDiscoveryTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.metrics.otlp;
 
 import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.metrics.prometheus.PrometheusMetricsPlugin;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -87,6 +88,22 @@ class Issue7281OtlpPluginAutoDiscoveryTest {
     cfg.setValue(GlobalConfiguration.SERVER_METRICS_OTLP_ENABLED.getKey(), true);
 
     assertThat(new OtlpMetricsPlugin().isAutoDiscovered(cfg)).isFalse();
+  }
+
+  /**
+   * Prometheus is excluded from auto-discovery ON PURPOSE, and this pins it so nobody restores the symmetry by
+   * mistake: its gate is {@code arcadedb.serverMetrics}, which defaults to TRUE, so an override here would publish
+   * {@code /prometheus} on every default server - a change to the default exposure of an endpoint whose
+   * authentication is the subject of #7124 and #7222, not a consequence of #7281.
+   */
+  @Test
+  void prometheusIsStillOptInEvenThoughMetricsAreOnByDefault() {
+    assertThat(GlobalConfiguration.SERVER_METRICS.getDefValue()).isEqualTo(Boolean.TRUE);
+
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.setValue(GlobalConfiguration.SERVER_METRICS.getKey(), true);
+
+    assertThat(new PrometheusMetricsPlugin().isAutoDiscovered(cfg)).isFalse();
   }
 
   /**

--- a/metrics/src/test/java/com/arcadedb/metrics/otlp/Issue7281OtlpPluginDiscoveryIT.java
+++ b/metrics/src/test/java/com/arcadedb/metrics/otlp/Issue7281OtlpPluginDiscoveryIT.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.metrics.otlp;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.ServerPlugin;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end half of issue #7281: a real server boot, driven only by the enable flag the Helm chart renders, with
+ * nothing named in {@code arcadedb.server.plugins}. This is the shape of the reporter's deployment, and before the
+ * fix {@code PluginManager} skipped the {@code ServiceLoader}-discovered plugin here even though the jar was on the
+ * classpath and the flag read back correctly from {@code /api/v1/server}.
+ */
+class Issue7281OtlpPluginDiscoveryIT extends BaseGraphServerTest {
+
+  @Override
+  protected int getServerCount() {
+    return 1;
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    config.setValue(GlobalConfiguration.SERVER_METRICS_OTLP_ENABLED.getKey(), true);
+    // This test never speaks HTTP - it asks the running server which plugins it installed. Give it a port range of
+    // its own so it neither contends with, nor is answered by, anything already listening on the default 2480-2489.
+    config.setValue(GlobalConfiguration.SERVER_HTTP_INCOMING_PORT, "2580-2589");
+  }
+
+  @Test
+  void theOtlpPluginIsInstalledWithoutAServerPluginsEntry() {
+    // The test is only meaningful while nothing names the plugin: otherwise the old code path would install it too.
+    assertThat(GlobalConfiguration.SERVER_PLUGINS.getValueAsString()).doesNotContain("Otlp");
+
+    assertThat(getServer(0).getPlugins())
+        .filteredOn(plugin -> plugin instanceof OtlpMetricsPlugin)
+        .hasSize(1);
+  }
+
+  @Test
+  void everyOtherPluginIsStillOptIn() {
+    // Auto-discovery is per-plugin and gated on that plugin's own flag: turning OTLP on must not drag in the
+    // Prometheus scrape endpoint, whose own gate (arcadedb.serverMetrics) defaults to true.
+    assertThat(getServer(0).getPlugins())
+        .extracting(ServerPlugin::getName)
+        .doesNotContain("PrometheusMetricsPlugin");
+  }
+}

--- a/metrics/src/test/java/com/arcadedb/metrics/otlp/Issue7281OtlpPluginDiscoveryIT.java
+++ b/metrics/src/test/java/com/arcadedb/metrics/otlp/Issue7281OtlpPluginDiscoveryIT.java
@@ -49,8 +49,10 @@ class Issue7281OtlpPluginDiscoveryIT extends BaseGraphServerTest {
 
   @Test
   void theOtlpPluginIsInstalledWithoutAServerPluginsEntry() {
-    // The test is only meaningful while nothing names the plugin: otherwise the old code path would install it too.
-    assertThat(GlobalConfiguration.SERVER_PLUGINS.getValueAsString()).doesNotContain("Otlp");
+    // The test is only meaningful while nothing names the plugin: otherwise the old code path would install it
+    // too. Read THIS server's configuration - the one PluginManager was handed - not the JVM-wide default.
+    assertThat(getServer(0).getConfiguration().getValueAsString(GlobalConfiguration.SERVER_PLUGINS))
+        .doesNotContain("Otlp");
 
     assertThat(getServer(0).getPlugins())
         .filteredOn(plugin -> plugin instanceof OtlpMetricsPlugin)

--- a/server/src/main/java/com/arcadedb/server/plugin/PluginManager.java
+++ b/server/src/main/java/com/arcadedb/server/plugin/PluginManager.java
@@ -195,15 +195,22 @@ public class PluginManager {
           continue;
         }
 
-        if (configuredPlugins.contains(name) ||
+        final boolean configured = configuredPlugins.contains(name) ||
             configuredPlugins.contains(pluginName) ||
-            configuredPlugins.contains(pluginInstance.getClass().getName())) {
+            configuredPlugins.contains(pluginInstance.getClass().getName());
+
+        // A jar in the plugins directory answers isAutoDiscovered the same way one on the main class path does
+        // (issue #7281). The two loaders differ in class isolation, not in what makes a plugin opt in, and
+        // ServerPlugin.isAutoDiscovered promises activation "on classpath presence alone" without qualifying which
+        // of the two the plugin arrived through - a promise this branch used to break for the plugins directory.
+        if (configured || pluginInstance.isAutoDiscovered(configuration)) {
           // Register the plugin
           plugins.put(name, descriptor);
           classLoaderMap.put(classLoader, descriptor);
           registered = true;
 
-          LogManager.instance().log(this, Level.INFO, "Loaded plugin: %s from %s", name, pluginJar.getName());
+          LogManager.instance().log(this, Level.INFO, "Loaded plugin: %s from %s%s", name, pluginJar.getName(),
+              !configured ? " (auto-discovered)" : "");
         } else {
           LogManager.instance().log(this, Level.INFO, "Skipping plugin: %s as not registered in configuration", name);
         }

--- a/server/src/test/java/com/arcadedb/server/plugin/Issue7281AutoDiscoveredPluginFromPluginsDirectoryTest.java
+++ b/server/src/test/java/com/arcadedb/server/plugin/Issue7281AutoDiscoveredPluginFromPluginsDirectoryTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.plugin;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.ServerPlugin;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Second half of issue #7281: {@link PluginManager} has two loaders, and only one of them used to ask a plugin
+ * whether it wants to be auto-discovered.
+ * <p>
+ * {@code discoverPluginsOnMainClassLoader} gates on {@code configured || isAutoDiscovered(configuration)}, while
+ * {@code loadPlugin} - the isolated-class-loader path for a jar dropped in {@code lib/plugins}, which
+ * {@code PLUGINS.md} documents as the supported way to add one - gated on the configuration entry alone. So the
+ * same jar that auto-installed from {@code lib} silently did nothing from {@code lib/plugins}, and
+ * {@link ServerPlugin#isAutoDiscovered} promised activation "on classpath presence alone" without saying that the
+ * promise held for only one of the two ways onto the classpath.
+ */
+class Issue7281AutoDiscoveredPluginFromPluginsDirectoryTest {
+
+  @TempDir
+  Path tempDir;
+
+  private PluginManager pluginManager;
+
+  @BeforeEach
+  void setup() {
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.SERVER_ROOT_PATH, tempDir.toString());
+    configuration.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, tempDir.resolve("databases").toString());
+    // Nothing is named: the plugin's own answer is the only thing that can install it.
+    configuration.setValue(GlobalConfiguration.SERVER_PLUGINS, "");
+
+    pluginManager = new PluginManager(new ArcadeDBServer(configuration), configuration);
+  }
+
+  @Test
+  void anAutoDiscoveredPluginInThePluginsDirectoryIsInstalledWithoutBeingNamed() throws Exception {
+    installJar("auto-discovered-plugin", AutoDiscoveredPlugin.class);
+
+    pluginManager.discoverPlugins();
+
+    assertThat(pluginManager.getPluginNames()).contains(AutoDiscoveredPlugin.class.getSimpleName());
+  }
+
+  /**
+   * The gate still is a gate: the default answer is {@code false}, and a plugin that keeps it stays opt-in.
+   */
+  @Test
+  void aPluginThatDoesNotAutoDiscoverIsStillSkipped() throws Exception {
+    installJar("opt-in-plugin", OptInPlugin.class);
+
+    pluginManager.discoverPlugins();
+
+    assertThat(pluginManager.getPluginNames()).doesNotContain(OptInPlugin.class.getSimpleName());
+  }
+
+  private void installJar(final String jarName, final Class<? extends ServerPlugin> pluginClass) throws Exception {
+    final Path pluginsDir = tempDir.resolve("lib/plugins");
+    Files.createDirectories(pluginsDir);
+
+    final File jarFile = pluginsDir.resolve(jarName + ".jar").toFile();
+    try (final JarOutputStream jar = new JarOutputStream(new FileOutputStream(jarFile))) {
+      final String classFileName = pluginClass.getName().replace('.', '/') + ".class";
+      jar.putNextEntry(new JarEntry(classFileName));
+      try (final InputStream is = getClass().getClassLoader().getResourceAsStream(classFileName)) {
+        assertThat(is).as("class bytes of %s", pluginClass.getName()).isNotNull();
+        is.transferTo(jar);
+      }
+      jar.closeEntry();
+
+      jar.putNextEntry(new JarEntry("META-INF/services/com.arcadedb.server.ServerPlugin"));
+      jar.write(pluginClass.getName().getBytes(StandardCharsets.UTF_8));
+      jar.closeEntry();
+    }
+  }
+
+  /** Mirrors what a distribution plugin does: it decides for itself, the way {@code MCPPlugin} does. */
+  public static class AutoDiscoveredPlugin implements ServerPlugin {
+    @Override
+    public boolean isAutoDiscovered(final ContextConfiguration configuration) {
+      return true;
+    }
+
+    @Override
+    public void startService() {
+      // NO-OP
+    }
+  }
+
+  public static class OptInPlugin implements ServerPlugin {
+    @Override
+    public void startService() {
+      // NO-OP
+    }
+  }
+}

--- a/tracing/src/main/java/com/arcadedb/tracing/TracingPlugin.java
+++ b/tracing/src/main/java/com/arcadedb/tracing/TracingPlugin.java
@@ -66,6 +66,16 @@ public class TracingPlugin implements ServerPlugin {
   private SdkTracerProvider             tracerProvider;
   private DeactivatableObservationHandler attachedHandler;
 
+  /**
+   * The enable flag is the whole opt-in: a deployment that sets it does not also have to name this plugin in
+   * {@code arcadedb.server.plugins} (issue #7281). Before this, the flag governed what {@code configure()} did and
+   * nothing governed whether {@code configure()} ran, so setting it alone produced no span and no log line.
+   */
+  @Override
+  public boolean isAutoDiscovered(final ContextConfiguration configuration) {
+    return configuration.getValueAsBoolean(GlobalConfiguration.SERVER_METRICS_TRACING_ENABLED);
+  }
+
   @Override
   public void configure(final ArcadeDBServer server, final ContextConfiguration configuration) {
     enabled = configuration.getValueAsBoolean(GlobalConfiguration.SERVER_METRICS_TRACING_ENABLED);

--- a/tracing/src/test/java/com/arcadedb/tracing/Issue7281TracingPluginAutoDiscoveryTest.java
+++ b/tracing/src/test/java/com/arcadedb/tracing/Issue7281TracingPluginAutoDiscoveryTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.tracing;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7281.
+ * <p>
+ * {@code arcadedb.serverMetrics.tracing.enabled=true} read back correctly from {@code /api/v1/server} and yet no
+ * span was ever exported: the plugin did not override
+ * {@link com.arcadedb.server.ServerPlugin#isAutoDiscovered}, whose default is {@code false}, so
+ * {@code PluginManager} installed it only for a deployment that ALSO named it in {@code arcadedb.server.plugins}.
+ * The enable flag governed what {@code configure()} did, and nothing governed whether {@code configure()} ran.
+ */
+class Issue7281TracingPluginAutoDiscoveryTest {
+
+  @AfterEach
+  void restoreTheSettings() {
+    GlobalConfiguration.SERVER_METRICS_TRACING_ENABLED.reset();
+  }
+
+  @Test
+  void tracingStaysOffOnAServerThatEnablesNothing() {
+    assertThat(new TracingPlugin().isAutoDiscovered(new ContextConfiguration())).isFalse();
+  }
+
+  /**
+   * The {@code -D}/environment-variable channel, which is the one the Helm chart renders.
+   */
+  @Test
+  void theEnableFlagSetAsASystemPropertyIsEnoughToActivateThePlugin() {
+    GlobalConfiguration.SERVER_METRICS_TRACING_ENABLED.setValue(true);
+
+    assertThat(new TracingPlugin().isAutoDiscovered(new ContextConfiguration())).isTrue();
+  }
+
+  /**
+   * The server-configuration-file channel: {@code fromJSON} writes into the {@link ContextConfiguration} overlay
+   * that {@code PluginManager} reads.
+   */
+  @Test
+  void theEnableFlagSetInTheServerConfigurationIsEnoughToActivateThePlugin() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.setValue(GlobalConfiguration.SERVER_METRICS_TRACING_ENABLED.getKey(), true);
+
+    assertThat(new TracingPlugin().isAutoDiscovered(cfg)).isTrue();
+  }
+}

--- a/tracing/src/test/java/com/arcadedb/tracing/Issue7281TracingPluginDiscoveryIT.java
+++ b/tracing/src/test/java/com/arcadedb/tracing/Issue7281TracingPluginDiscoveryIT.java
@@ -48,7 +48,9 @@ class Issue7281TracingPluginDiscoveryIT extends BaseGraphServerTest {
 
   @Test
   void theTracingPluginIsInstalledWithoutAServerPluginsEntry() {
-    assertThat(GlobalConfiguration.SERVER_PLUGINS.getValueAsString()).doesNotContain("Tracing");
+    // Read THIS server's configuration - the one PluginManager was handed - not the JVM-wide default.
+    assertThat(getServer(0).getConfiguration().getValueAsString(GlobalConfiguration.SERVER_PLUGINS))
+        .doesNotContain("Tracing");
 
     assertThat(getServer(0).getPlugins())
         .filteredOn(plugin -> plugin instanceof TracingPlugin)

--- a/tracing/src/test/java/com/arcadedb/tracing/Issue7281TracingPluginDiscoveryIT.java
+++ b/tracing/src/test/java/com/arcadedb/tracing/Issue7281TracingPluginDiscoveryIT.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.tracing;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end half of issue #7281 for tracing: a real server boot driven only by
+ * {@code arcadedb.serverMetrics.tracing.enabled}, with nothing named in {@code arcadedb.server.plugins}. The
+ * configured endpoint points nowhere on purpose - the plugin has to install regardless, exactly as
+ * {@link TracingBadEndpointIT} pins for the export path.
+ */
+class Issue7281TracingPluginDiscoveryIT extends BaseGraphServerTest {
+
+  @Override
+  protected int getServerCount() {
+    return 1;
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    config.setValue(GlobalConfiguration.SERVER_METRICS_TRACING_ENABLED.getKey(), true);
+    // This test never speaks HTTP - it asks the running server which plugins it installed. Give it a port range of
+    // its own so it neither contends with, nor is answered by, anything already listening on the default 2480-2489.
+    config.setValue(GlobalConfiguration.SERVER_HTTP_INCOMING_PORT, "2590-2599");
+  }
+
+  @Test
+  void theTracingPluginIsInstalledWithoutAServerPluginsEntry() {
+    assertThat(GlobalConfiguration.SERVER_PLUGINS.getValueAsString()).doesNotContain("Tracing");
+
+    assertThat(getServer(0).getPlugins())
+        .filteredOn(plugin -> plugin instanceof TracingPlugin)
+        .hasSize(1);
+  }
+}


### PR DESCRIPTION
Closes #7281

A 26.9.1 deployment set `arcadedb.serverMetrics.otlp.enabled=true` and `arcadedb.serverMetrics.tracing.enabled=true` through the Helm chart, watched `/api/v1/server` report both settings with the configured values, and got no exporter, no span and no log line. `PluginManager` activates a `ServiceLoader`-discovered plugin only when it is named in `arcadedb.server.plugins` **or** `ServerPlugin.isAutoDiscovered()` says so, that method defaults to `false`, and neither plugin overrode it - so the enable flag governed what `configure()` did while nothing governed whether `configure()` ran. Both plugins now return their own enable flag from `isAutoDiscovered`, sharing one expression with the `configure()` gate so a plugin cannot install and then do nothing. Two further defects the same report exposed are fixed alongside: the startup dump described the configuration `readConfiguration()` started from rather than the one it produced, and the two OTLP settings were not declared settings at all.

The plugin jars themselves were never the problem - verified against the published image:

```
$ docker run --rm --entrypoint sh arcadedata/arcadedb:26.9.1 -c 'ls /home/arcadedb/lib | grep -iE "tracing|metrics"'
arcadedb-metrics-26.9.1-shaded.jar
arcadedb-tracing-26.9.1-shaded.jar
$ ... unzip -p .../arcadedb-metrics-26.9.1-shaded.jar META-INF/services/com.arcadedb.server.ServerPlugin
com.arcadedb.metrics.prometheus.PrometheusMetricsPlugin
com.arcadedb.metrics.otlp.OtlpMetricsPlugin
```

## Findings and what each one does

| # | Finding | Fix |
|---|---|---|
| 1 | `OtlpMetricsPlugin` and `TracingPlugin` never activate from their own enable flags | `isAutoDiscovered()` override on both, returning the same predicate `configure()` gates on |
| 2 | The startup dump prints DEFAULTS for every setting declared after `DUMP_CONFIG_AT_STARTUP` - the FIRST constant of the enum, whose callback fired while `readConfiguration()` was still walking `values()`. This is why the reporter's log said `tracing.enabled = false` while `/api/v1/server` said `true` | the dump is deferred to the end of that pass; a write from anywhere else still dumps immediately |
| 3 | `arcadedb.serverMetrics.otlp.enabled` / `.endpoint` were read through the raw-string `ContextConfiguration` overload, so they worked as a `-D` but appeared in neither the dump nor `/api/v1/server` ("There are no `otlp` settings") | declared as `GlobalConfiguration` entries, read from the same keys as before |
| 4 | Found by the adversarial pass, below: `loadPlugin()` - the `lib/plugins` loader - never called `isAutoDiscovered` at all | same gate as the class-path loader |

## Completeness

The invariant for finding 1: *a distribution observability plugin whose own default-off enable flag is set activates from classpath presence alone, with no entry in `arcadedb.server.plugins`.*

Every `ServerPlugin` declared in a `META-INF/services` file was enumerated (`find . -name "com.arcadedb.server.ServerPlugin" -not -path "*/target/*"`), together with every `isAutoDiscovered` override (`grep -rn "isAutoDiscovered" --include="*.java" .`, 6 hits before this change, of which 2 were overrides: `RaftHAPlugin`, `MCPPlugin`).

| Entry point | Covered? | Test? |
|---|---|---|
| `-D`/env `serverMetrics.otlp.enabled` → `GlobalConfiguration` static → `isAutoDiscovered` | yes | yes |
| server config file / `ContextConfiguration` overlay, OTLP | yes | yes |
| `-D`/env `serverMetrics.tracing.enabled` | yes | yes |
| server config file overlay, tracing | yes | yes |
| a real server boot with nothing in `arcadedb.server.plugins` | yes | yes, one IT per module |
| `arcadedb.serverMetrics=false` must still keep OTLP off | yes | yes |
| the same jar loaded from `lib/plugins` instead of `lib` | yes (finding 4) | yes |
| runtime `SET SERVER SETTING` / MCP after startup | no - **argued**: `discoverPlugins()` is a one-shot startup pass (`ArcadeDBServer.java:310`). No plugin of any kind can be activated after it; not specific to these two |
| `PrometheusMetricsPlugin` (sibling; its gate `arcadedb.serverMetrics` defaults to **true**) | no - **argued**: auto-discovery would publish `/prometheus` on every default server. Flipping that default is a security-relevant change (cf. #7124, #7222), not this issue |
| `AutoBackupSchedulerPlugin` (sibling; gate is the presence of `config/backup.json`) | n/a - **argued**: already force-registered, `ArcadeDBServer.init()` prepends it to `SERVER_PLUGINS` (`ArcadeDBServer.java:1491`) |
| bolt / gremlin / postgres / mongo / redis / grpc | n/a - **argued**: none reads an enable flag in `configure()`; opting in by name is their contract and what the Helm chart already does |

For finding 3, the sibling grep `grep -rn 'getValue\(As[A-Za-z]*\)\?("arcadedb\.' --include="*.java" . | grep -v /target/ | grep -v /src/test/` returned exactly two hits in the whole main tree, both of them the two OTLP settings. No other main-source reader bypasses the enum.

For finding 2, `readConfiguration()` feeds the system property and the environment variable into the same `applyConfigurationSource` call, so the two channels are one code path; the property test covers both.

## Adversarial pass

One finding, verified and fixed here rather than deferred: `PluginManager` has two loaders and only `discoverPluginsOnMainClassLoader()` consulted `isAutoDiscovered`. `loadPlugin(File)`, the isolated-class-loader path for a jar in `<root>/lib/plugins` that `PLUGINS.md` documents as the supported way to add one, gated on the configuration entry alone - `grep -n "isAutoDiscovered" PluginManager.java` returned exactly one hit before this change. Today's distribution ships both jars in `lib`, so the reported bug is fixed either way; but `package/arcadedb-builder.sh:29` already lists `metrics` and `tracing` among `SHADED_MODULES`, and both the builder (lines 807-833) and all four assembly descriptors carry a commented-out `lib/plugins` routing next to the live `lib` one. Enabling it would have re-opened this issue verbatim.

## Test plan

- [x] `mvn -o -pl engine test -Dtest='Issue7281*,Issue7222*,Issue7124*,Issue6875*,Issue7121*,*ConfigurationTest,GlobalConfiguration*Test'` - 111/111
- [x] `mvn -o -pl metrics test` (full unit suite) - 27/27
- [x] `mvn -o -pl tracing test` (full unit suite) - 8/8
- [x] `mvn -o -pl server test -Dtest='Issue7281*,PluginManagerTest,ServerPluginAutoDiscoveryDefaultTest,Issue6852*,Issue7025*'` - 28/28
- [x] `mvn -o -pl server test -Dtest='CoreApiSpecTest,SecurityAdminApiSpecTest,RouteRecordingRoutingHandlerTest'` - 34/34
- [x] `mvn -o -pl mcp test -Dtest='MCPServerPluginTest,MCPStdioServerTest,MCPPluginDiscoveryTest'` - 152/152 (`MCPPlugin` is the one plugin already relying on `isAutoDiscovered`)
- [x] `mvn -o -pl metrics verify -DskipITs=false -Dit.test=Issue7281OtlpPluginDiscoveryIT` - 2/2
- [x] `mvn -o -pl tracing verify -DskipITs=false -Dit.test=Issue7281TracingPluginDiscoveryIT` - 1/1

Every new test was shown to fail without its fix, by reverting that fix alone:

- `Issue7281TracingPluginAutoDiscoveryTest` - 2 of 3 failed before the override existed; the default-off case passed, as it must.
- `Issue7281StartupConfigDumpOrderTest` - the ordering test failed; `settingTheFlagAtRuntimeStillDumpsImmediately` passed before and after, pinning behaviour the fix preserves.
- `Issue7281OtlpPluginDiscoveryIT` / `Issue7281TracingPluginDiscoveryIT` - with the override renamed away, the discovery method failed and the negative method still passed.
- `Issue7281AutoDiscoveredPluginFromPluginsDirectoryTest` - with the `loadPlugin` gate reverted, the positive case failed and the opt-in case still passed.

The two ITs give their server an HTTP port range of its own (2580-2589, 2590-2599) rather than the default 2480-2489: they never speak HTTP, so a server already listening on 2480 can neither block them nor answer for them.

## Coverage

Entry points this fix covers: the `-D`/environment-variable channel and the server-configuration-file channel for both `serverMetrics.otlp.enabled` and `serverMetrics.tracing.enabled`; the `arcadedb.serverMetrics` kill switch; a real server boot through `PluginManager` with an empty `arcadedb.server.plugins`; both `PluginManager` loaders; and the settings-visibility path shared by the startup dump and `/api/v1/server`.

**Known gaps:** None. Every row of the table above is fixed here or argued with evidence; nothing is deferred, so no follow-up issue was filed.

## Impact on the Helm chart

After this ships, the chart's existing `observability:` block is sufficient on its own and no `arcadedb.server.plugins` entry is needed. Charts pointed at 26.9.1 or older still need the plugins named explicitly - that workaround keeps working either way, since a named plugin is still installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxoxQvGbXSCmwyPfetnXHn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - OTLP metrics can be enabled and configured through dedicated server settings, including a customizable endpoint.
  - OTLP and tracing plugins are automatically activated when their metrics settings are enabled, without manual registration.
  - Automatically activated plugins are identified in server logs.
  - Plugin documentation now explains automatic discovery and opt-in behavior.

- **Bug Fixes**
  - Startup configuration logging now reflects values applied during configuration loading and preserves the correct dump order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->