### PR TITLE
fix: report the gremlin module's coverage from where its tests actually run

### DIFF
--- a/gremlin-it/pom.xml
+++ b/gremlin-it/pom.xml
@@ -213,4 +213,103 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- Coverage for the arcadedb-gremlin classes. The gremlin module skips its own tests
+             (antlr 4.13.2 vs 4.9.1 cannot share the unshaded test classpath), so the only JVM
+             that ever executes com.arcadedb.gremlin.* is this module's - and its execution data
+             used to be thrown away. jacoco:report only ever reports
+             ${project.build.outputDirectory}, which in this test-only module is empty, and the
+             goal exposes no classDirectories parameter to aim it somewhere else.
+
+             So put the classes there. JaCoCo keys execution data on the CRC64 of the class file,
+             so they have to be the same bytes the tests loaded, which came from the shaded
+             uber-jar. In practice maven-shade rewrites only the classes that actually reference
+             a relocated package - today exactly one, ArcadeDBGremlinSettings - and copies the
+             rest through verbatim. Hence two unpacks: the plain jar for the complete and
+             self-maintaining set of the module's own classes (the uber-jar would need a
+             hand-kept include list to keep its ~7,400 bundled third-party classes out), then the
+             uber-jar over the top of it for the rewritten ones. -->
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <version>${maven-dependency-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>unpack-gremlin-classes-for-jacoco</id>
+                                <!-- prepare-package, NOT an earlier phase: this module's output
+                                     directory is on its own test classpath, so classes unpacked
+                                     before the test phase would shadow the shaded jar the tests
+                                     are meant to exercise, and ShadedJarLayoutTest rightly fails
+                                     when they do. The report execution below moves to `package`
+                                     so it still runs after this. -->
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>com.arcadedb</groupId>
+                                            <artifactId>arcadedb-gremlin</artifactId>
+                                            <version>${project.parent.version}</version>
+                                            <type>jar</type>
+                                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                                            <includes>**/*.class</includes>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.arcadedb</groupId>
+                                            <artifactId>arcadedb-gremlin</artifactId>
+                                            <version>${project.parent.version}</version>
+                                            <classifier>shaded</classifier>
+                                            <type>jar</type>
+                                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                                            <!-- Ours only: everything under the relocation prefix
+                                                 is bundled third-party, not code to report on. -->
+                                            <includes>com/arcadedb/**/*.class</includes>
+                                            <excludes>com/arcadedb/gremlin/shaded/**</excludes>
+                                        </artifactItem>
+                                    </artifactItems>
+                                    <overWriteReleases>true</overWriteReleases>
+                                    <overWriteSnapshots>true</overWriteSnapshots>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <!-- Same id as the parent's, so this only moves the phase: the report
+                                 has to run after the unpack above, and the parent binds it to
+                                 prepare-package, the same phase. -->
+                            <execution>
+                                <id>report</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <!-- The unpacked classes are there for JaCoCo, not to be republished:
+                                 keep arcadedb-gremlin-it.jar empty so skipIfEmpty skips it. -->
+                            <excludes>
+                                <exclude>com/**</exclude>
+                                <exclude>org/**</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/gremlin/pom.xml
+++ b/gremlin/pom.xml
@@ -518,4 +518,26 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- This module runs no tests (see the surefire/failsafe skips above), so its JaCoCo
+             report is a phantom 0% over every class in src/main/java, and codecov publishes it
+             as the module's coverage. The classes are really exercised in arcadedb-gremlin-it,
+             which reports them from the shaded jar under the same profile id. Skip the agent and
+             the report here so the two do not contradict each other. -->
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
         <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
+        <maven-dependency-plugin.version>3.7.0</maven-dependency-plugin.version>
         <maven-central-publishing-plugin.version>0.11.0</maven-central-publishing-plugin.version>
         <license-maven-plugin.version>5.1.2</license-maven-plugin.version>
         <maven-install-plugin.version>3.1.4</maven-install-plugin.version>


### PR DESCRIPTION
## Problem

codecov reports near-zero coverage for `gremlin/src/main/java`. Neither of the two suspected causes is real:

- **Tests are not missing.** 59 test/IT classes for 41 main classes.
- **junit-vintage is not the cause.** JaCoCo is a JVM agent instrumenting at class load; it neither knows nor cares which JUnit engine drives the run. Vintage is present only because TinkerPop's `gremlin-test` structure suite is JUnit 4.

It is a build-topology artifact, in three parts:

1. `gremlin/pom.xml` sets `<skipTests>true</skipTests>` on both surefire and failsafe - engine antlr 4.13.2 and TinkerPop antlr 4.9.1 cannot share the unshaded test classpath. Under `-Pcoverage` the module still ran the agent over zero tests and emitted a **phantom 0% report over every class in the module**. That is the report codecov ingested.
2. The tests really run in `arcadedb-gremlin-it`, against the shaded uber-jar. That module has only `src/test`, so its `target/classes` is empty and `jacoco:report` analyzed nothing. The execution data in `gremlin-it/target/jacoco.exec` was collected and then discarded.
3. Nothing joined the two - there is no `report-aggregate` anywhere in the reactor.

## Fix

`jacoco:report` exposes **no `classDirectories` parameter** (confirmed against the 0.8.15 plugin descriptor); it only ever reports `${project.build.outputDirectory}`. So the classes have to be physically put there.

**Two unpacks, not one:**

- the **plain** jar carries exactly the module's own 77 classes, so it needs no hand-kept include list to keep the uber-jar's ~7,400 bundled third-party classes out of the bundle (a first attempt using only the uber-jar analyzed 7,526 classes);
- the **shaded** jar then overlays the classes maven-shade rewrote, so the bytes match what the JVM actually loaded and JaCoCo's CRC64 class ids resolve.

Shade copies a class through verbatim unless it actually references a relocated package, so today that overlay is exactly **one** class, `ArcadeDBGremlinSettings` - 76 of 77 are byte-identical between the two jars.

Two traps, both guarded with comments in the POM:

- **The unpack lands at `prepare-package`, not earlier.** This module's output directory is on its own test classpath, so classes unpacked before the `test` phase shadow the shaded jar the tests exist to exercise. `ShadedJarLayoutTest` caught this and failed - correctly. The jacoco `report` execution moves from `prepare-package` to `package` so it still runs after the unpack.
- **`arcadedb-gremlin-it.jar` must stay classless.** jar excludes keep it at metadata only (7 entries), so `skipIfEmpty` still skips it as before.

JaCoCo in the `gremlin` module is skipped under the same profile id, so the two reports cannot contradict each other. `report-integration` at `post-integration-test` reuses the same unpacked classes, which is after `prepare-package`, so the integration lane is covered by the same wiring.

## Result

`mvn -o clean verify -Pcoverage -pl gremlin,gremlin-it`:

- 399 tests, 0 failures, 0 errors
- bundle analyzes 73 classes over all **41** source files (previously: 0)
- **65.5% lines** (1571/2399), 54.5% branches, 47.8% complexity, 61.6% methods, 78.1% classes

Cross-checked against an independent reference report - the same exec data analyzed against `gremlin/target/classes` from a separate `jacoco:report` invocation - which agrees at 65.6% lines.

The build without `-Pcoverage` is unchanged: same 399 tests, no main jar for `gremlin-it`.

## Follow-up, not addressed here

`ArcadeEdgeCountFilterStep` now reports 0/28 lines even though `ArcadeEdgeCountFilterStepTest` runs 9 passing tests - the test may not be reaching the class it names. Worth a separate look; these are the numbers the fix makes visible for the first time.

The `-Pintegration` lane was not run locally: port 2480 was held by an unrelated long-running server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSU5gmp88CvQYTumM1SpSj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved code coverage reporting for the Gremlin integration module.
  - Excluded duplicate implementation classes from the generated module artifact.
  - Disabled redundant coverage processing in the Gremlin module.
  - Updated the Maven dependency plugin version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->