### PR TITLE
fix(#7267): CsvRowSource splits rows on the literal delimiter, not on a regex

### DIFF
--- a/docs/7267-csvrowsource-regex-delimiter.md
+++ b/docs/7267-csvrowsource-regex-delimiter.md
@@ -1,0 +1,225 @@
+# #7267 - `CsvRowSource` splits rows with a regex, so a metacharacter delimiter shreds or annihilates every row
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/7267
+
+## Root cause
+
+`integration/src/main/java/com/arcadedb/integration/importer/graph/CsvRowSource.java:96`
+
+```java
+return line.split(String.valueOf(delimiter), -1);
+```
+
+`String.split(String, int)`'s first argument is a **regular expression**. The delimiter is a `char` chosen by the
+operator, so any `char` that is a regex metacharacter is compiled as that metacharacter instead of as itself.
+
+## Reproduction (measured, not recalled)
+
+`"a<d>b<d>c".split(String.valueOf(d), -1)` on JDK 21:
+
+| delimiter | result | family |
+|---|---|---|
+| `;` `,` `]` `}` `-` | `[a, b, c]` | correct |
+| `\|` | `[a, \|, b, \|, c, ]` | **silent** - alternation of two empty branches, every char is its own field |
+| `.` | `[, , , , , ]` | **silent** - the row is annihilated |
+| `$` | `[a$b$c, ]` | **silent** - end-anchor, no split at all |
+| `^` | `[a^b^c]` | **silent** - start-anchor, no split at all |
+| `*` `+` `?` `{` | `PatternSyntaxException: Dangling meta character` / `Illegal repetition` | crash |
+| `(` `)` `[` | `PatternSyntaxException: Unclosed group` / `Unmatched closing ')'` / `Unclosed character class` | crash |
+| `\` | `PatternSyntaxException: Unescaped trailing backslash` | crash |
+
+The silent family is the one the issue is about: the header line is split into single characters, so every
+`record.get(attribute)` misses, and the import produces property-less vertices, or none at all, saying nothing.
+The crashing family is not benign either - a `PatternSyntaxException` mentions a regex the operator never wrote.
+
+## Completeness
+
+### Invariant
+
+**A `CsvRowSource` splits each line on the literal delimiter character it was given, for every one of the 65536
+possible `char` values, and never interprets that character as a regular expression.**
+
+### Every way to violate it
+
+```
+$ grep -rn "split(String.valueOf(" --include="*.java" . | grep -v /target/
+integration/src/main/java/com/arcadedb/integration/importer/graph/CsvRowSource.java:96:    return line.split(String.valueOf(delimiter), -1);
+```
+
+One hit in the whole tree: the reported line. Splitting is funnelled through the private `splitLine`, which both
+the header read and the per-row read call, so a single call site carries both.
+
+```
+$ grep -rn "\.split(" integration/src/main/java/
+.../ImportSecurityValidator.java:162:    for (final String dir : allowed.split(",")) {
+.../graph/GraphImporter.java:316:        final String[] parts = spec.split("=", 2);
+.../graph/GraphImporter.java:408:    final String[] parts = value.split(":");
+.../graph/CsvRowSource.java:96:    return line.split(String.valueOf(delimiter), -1);
+.../SourceDiscovery.java:396:          final String[] fields1 = line.toString().split(" ");
+.../SourceDiscovery.java:397:          final String[] fields2 = line2.toString().split(" ");
+.../format/CSVImporterFormat.java:150,410,570:  ....split(",")
+.../format/CSVImporterFormat.java:804:        final String[] headerColumns = header.split(",");
+.../format/JSONImporterFormat.java:418:      for (String tName : typeName.split(",")) {
+.../importer/OrientDBImporter.java:890:    for (final String pair : fieldTypes.split(",")) {
+.../exporter/ExporterSettings.java:82,84,86:   value.split(",")
+```
+
+Every other `.split(` in the module takes a **compile-time constant** that is not a regex metacharacter
+(`","`, `"="`, `":"`, `" "`). None of them can be reached by an operator-supplied character. Argued, not fixed.
+
+Constructors and factories that can carry a metacharacter delimiter into the class:
+
+```
+$ grep -n "CsvRowSource(\|static CsvRowSource from(" integration/src/main/java/com/arcadedb/integration/importer/graph/CsvRowSource.java
+41:  public CsvRowSource(final String filePath) {                                        // default ','
+45:  public CsvRowSource(final String filePath, final char delimiter, final int skipLines)
+51:  public static CsvRowSource from(final String dir, final String fileName)             // default ','
+55:  public static CsvRowSource from(final String dir, final String fileName, final char delimiter)
+```
+
+Config-driven construction:
+
+```
+$ grep -n "new CsvRowSource" -r integration/src/main/java/
+.../graph/GraphImporter.java:473:      return new CsvRowSource(filePath, delimiter.charAt(0), skipLines);
+```
+
+Sibling delimiter walkers in the same module (the `#7263` / `#7268` fixes) - already literal, `indexOf`-based:
+
+```
+$ grep -n "indexOf(delim" integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+1256:        pos = fieldVal.indexOf(delim, start);
+1321:      pos = fieldVal.indexOf(delimiter, start);
+```
+
+`CSVImporterFormat` hands its delimiter to Univocity as a `char` / `String` on `CsvFormat.setDelimiter`
+(lines 739-740, 867), which is a literal separator, not a pattern. Argued, not fixed.
+
+### Entry-point coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| JSON config `"delimiter": "\|"` -> `GraphImporter.createRecordSource` -> `new CsvRowSource(path, char, skipLines)` | yes | yes - `aJsonConfiguredPipeDelimiterImportsEveryProperty` |
+| `new CsvRowSource(path, delimiter, skipLines)` (public ctor) | yes | yes - `everyRegexMetacharacterSplitsOnTheLiteralCharacter`, `aPipeDelimitedImportThroughTheConstructorLoadsEveryProperty` |
+| `CsvRowSource.from(dir, file, delimiter)` (public factory) | yes | yes - `theThreeArgFactorySplitsOnTheLiteralCharacter` |
+| `new CsvRowSource(path)` / `from(dir, file)` - default `','` | yes (behaviour preserved) | yes - `theDefaultCommaDelimiterIsUnchanged`, plus the pre-existing `GraphImporterCSVTest` |
+| header line (same `splitLine`, one call site) | yes | yes - asserted inside every metacharacter case |
+| trailing / repeated empty fields (`split(..., -1)` semantics) | yes (preserved exactly) | yes - `emptyAndTrailingFieldsKeepTheirSplitMinusOneShape` |
+| `GraphImporter` split-edge walkers (`collectSplitKeys`, inline walker) | n/a - argued: already literal `indexOf` walks (#7263/#7268), evidence above | n/a |
+| `CSVImporterFormat` (Univocity) | n/a - argued: `CsvFormat.setDelimiter` takes a literal separator | n/a |
+| other `.split(` in `integration/src/main/java` | n/a - argued: all compile-time constants, none a metacharacter | n/a |
+
+No row is blank, and no row needed a follow-up issue.
+
+### Reachability
+
+`new CsvRowSource(...)` is constructed on a live path by `GraphImporter.createRecordSource`
+(`GraphImporter.java:473`), which every JSON-configured CSV source goes through, and directly by callers of the
+public constructor and factory - `GraphImporterCSVTest`, `GraphImporterArrayPropsTest`,
+`GraphImporterSplitDelimiterTest` and the StackOverflow/UberTrips importers all build one. `splitLine` runs once
+per header and once per data row of every such import. Nothing gates it behind a flag.
+
+### Residual risk
+
+`CsvRowSource` still has **no quoting support** - it is documented as "for quoted fields use Univocity" and a
+delimiter that appears inside a field value still splits that value. That is a separate, documented limitation
+of this class and not what #7267 reports; it is unchanged by this fix. Beyond that, the table above has no
+uncovered row.
+
+## Fix
+
+`splitLine` walks the line with `indexOf(char, from)` and fills a `String[]` directly:
+
+- **literal by construction** - a `char` compared with `==` cannot be a metacharacter;
+- **cheaper than the code it replaces** - `String.split` only takes its regex-free fast path for a single
+  *non-metacharacter* char; for `|`, `.`, `$` and friends it compiles a `Pattern` per call, i.e. per row of a
+  bulk import. The walk allocates the result array once and no `Pattern` ever;
+- **byte-identical output to `split(literal, -1)`** for every delimiter that worked before: one leading pass
+  counts the separators so the array is sized exactly, and trailing empty fields are kept.
+
+`java.util.regex.Pattern.quote` was rejected: `\Q;\E` is not a single character, so `String.split` would compile
+a `Pattern` on *every* row for *every* delimiter, including the default comma - a hot-path regression for the
+common case in exchange for correctness in the rare one.
+
+`com.arcadedb.utility.CodeUtils.split(String, char, int, int)` was rejected as the reuse candidate for two
+reasons: it drops the **trailing empty field** (`"a;b;"` answers `[a, b]`, where `split(";", -1)` answers
+`[a, b, ""]`), which would silently change behaviour for the delimiters that work today, and it returns a
+`List<String>` that would need an extra array copy per row.
+
+## Verification
+
+New test: `integration/src/test/java/com/arcadedb/integration/importer/Issue7267CsvRowSourceLiteralDelimiterTest.java`.
+
+**Before the fix** - 5 of its 7 tests fail, one per bug-carrying entry point:
+
+```
+[ERROR] Tests run: 7, Failures: 5, Errors: 0, Skipped: 0
+  everyRegexMetacharacterSplitsOnTheLiteralCharacter:121 [delimiter '|' ...] Expecting map: {} to contain only: ["lastName"="Miner", "firstName"="Jay", "id"="1"]
+  aMetacharacterDelimiterNeverRaisesARegexError            (PatternSyntaxException)
+  aPipeDelimitedImportThroughTheConstructorLoadsEveryProperty:166 expected: "Jay" but was: null
+  theThreeArgFactorySplitsOnTheLiteralCharacter:186 Expecting map: {} to contain entries: ["firstName"="Jay"]
+  aJsonConfiguredPipeDelimiterImportsEveryProperty
+```
+
+The two that pass before the fix are the two that assert behaviour must **not** change -
+`theDefaultCommaDelimiterIsUnchanged` and `emptyAndTrailingFieldsKeepTheirSplitMinusOneShape` - which is what a
+behaviour-preservation test is supposed to do.
+
+**After the fix:**
+
+```
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0 -- in Issue7267CsvRowSourceLiteralDelimiterTest
+```
+
+**No regressions** - the whole `integration` module, benchmark/vector/slow lanes excluded
+(`mvn -o -pl integration test -DexcludedGroups=benchmark,vector,slow`):
+
+```
+[INFO] Results:
+[INFO] Tests run: 270, Failures: 0, Errors: 0, Skipped: 9
+[INFO] BUILD SUCCESS
+```
+
+That run includes every existing CSV consumer of the changed method: `GraphImporterCSVTest`,
+`GraphImporterArrayPropsTest`, `GraphImporterSplitDelimiterTest`, `GraphImporterIdTypesTest`,
+`Issue6811CsvDelimiterOptionTest`, `Issue7266ImporterConfigValidationTest`.
+
+## Impact
+
+- Behaviour changes only for delimiters that were already broken. Every delimiter that produced correct fields
+  before produces byte-identical fields now, empty and trailing fields included.
+- Bulk imports get slightly cheaper across the board: no `Pattern` is compiled for any delimiter, where the old
+  code compiled one per row for every non-default separator that is a metacharacter.
+
+## Finding ledger
+
+- [x] 1. `CsvRowSource.splitLine` splits on a regex - fixed on all three entry points (JSON config, public
+      constructor, three-argument factory), 7 regression tests.
+
+## Adversarial pass
+
+The `Task` tool is disabled in this session, so the isolated subagent could not be spawned. The pass was run by
+hand against the same three inputs (issue body, diff, tree) and is recorded here in full rather than skipped.
+
+1. **"The rest threw" was false.** The test's `REGEX_METACHARACTERS` javadoc claimed every character except
+   `|`, `.`, `$`, `^` raised a `PatternSyntaxException`. `]` and `}` did not: they produced correct fields
+   before this fix. Evidence - `String.java:3691-3692` in the JDK 26 `src.zip` gates the regex-free fast path on
+   `regex.length() == 1 && ".$|()[{^?*+\\".indexOf(ch) == -1`, and `]` and `}` are absent from that set, which
+   matches the measured `']' -> [a, b, c]`. **Fixed here**: the javadoc now says which two are carried for
+   symmetry rather than as regressions, so nobody later reads the loop as fourteen reproduced bugs.
+2. **The performance sentence in `splitLine`'s javadoc was an unverified claim about the JDK.** Now verified
+   against `String.java:3684-3696` (same fast-path condition), which is exactly what it asserts. **Fixed here**
+   by proving it rather than by weakening it.
+3. **Is any construction of `CsvRowSource` outside the covered entry points?** No.
+   `grep -rn "new CsvRowSource(\|CsvRowSource.from(" --include="*.java" .` answers exactly one production site,
+   `GraphImporter.java:473`, plus the class's own two factories and test code; and
+   `grep -rln CsvRowSource` outside `integration/` answers nothing. **Not real** - the coverage table is complete.
+4. **Does the fix change `String.split(literal, -1)`'s answer for any line shape?** Walked by hand for the four
+   shapes that differ between splitters: `""` -> `[""]`, `"abc"` -> `["abc"]`, `";"` -> `["", ""]`,
+   `"a;;b;"` -> `["a", "", "b", ""]`. The counting pass and the walk scan with the identical
+   `indexOf(delimiter, pos + 1)` sequence, so the second loop can never see `-1`. **Not real.**
+5. **Does `indexOf(int)` mis-handle a surrogate delimiter?** No. `String.indexOf(int ch, int fromIndex)` routes
+   any `ch < Character.MIN_SUPPLEMENTARY_CODE_POINT` to a plain char scan, and a `char` argument always widens
+   to a value in that range. **Not real.**
+
+No finding was out of scope, so no follow-up issue was filed.

--- a/docs/7267-csvrowsource-regex-delimiter.md
+++ b/docs/7267-csvrowsource-regex-delimiter.md
@@ -296,3 +296,44 @@ answered:
    convention is the maintainer's call, not this PR's.
 
 `Tests run: 7, Failures: 0, Errors: 0, Skipped: 0` after both changes.
+
+### Cycle 4 - `41af0b66dd`
+
+`claude`: "No blocking issues found. This looks solid and ready to merge." No inline comments on this SHA from
+any reviewer. The only two remarks are explicitly re-raised "for visibility" and were both answered in earlier
+cycles - the doc's length against repo convention, and the second scan versus a per-row allocation. Nothing new
+was actionable, nothing was applied, and the working tree ended the cycle empty.
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/7286
+
+Commits:
+
+| SHA | What |
+|---|---|
+| `b0a498c846` | the fix, the 7 regression tests, this document |
+| `1d9c7a7bf2` | cycle 1: `REGEX_METACHARACTERS` -> `REGEX_SYNTAX_DELIMITERS` |
+| `c25e1547d9` | cycle 2: trimmed `splitLine`'s javadoc |
+| `41af0b66dd` | cycle 3: markdownlint MD040 fences; one assertion per claim in the empty-field test |
+
+## Deferred items
+
+None. No `review-deferred-*.md` notes file was produced in any of the four cycles: every review comment was
+either applied or answered with evidence in the cycle sections above. (`docs/review-deferred-47afd7da.md` in
+this directory belongs to PR #7210 / issue #6990 and was already on `main` before this branch existed.)
+
+Two things are the maintainer's call rather than deferred work, and are named here so they are not discovered
+in a diff stat:
+
+- Whether the per-issue `docs/<issue>-<name>.md` convention should continue at this length for small fixes.
+  Three reviews raised it; all three confirmed it matches current practice on `main` and none objected.
+- Whether CSV import is worth a benchmark. The performance claim this fix rests on - no `Pattern` compiled per
+  row - is proved from the JDK's fast-path condition, not measured; the count-then-fill pass was reasoned
+  about, not benchmarked, and there is no CSV-import benchmark in the tree to extend.
+
+## Final state
+
+`clean-approval` at cycle 4 of a maximum of 4.
+
+Every row of the coverage table is fixed and tested. No follow-up issue was needed, and none was filed.

--- a/docs/7267-csvrowsource-regex-delimiter.md
+++ b/docs/7267-csvrowsource-regex-delimiter.md
@@ -41,7 +41,7 @@ possible `char` values, and never interprets that character as a regular express
 
 ### Every way to violate it
 
-```
+```shell
 $ grep -rn "split(String.valueOf(" --include="*.java" . | grep -v /target/
 integration/src/main/java/com/arcadedb/integration/importer/graph/CsvRowSource.java:96:    return line.split(String.valueOf(delimiter), -1);
 ```
@@ -49,7 +49,7 @@ integration/src/main/java/com/arcadedb/integration/importer/graph/CsvRowSource.j
 One hit in the whole tree: the reported line. Splitting is funnelled through the private `splitLine`, which both
 the header read and the per-row read call, so a single call site carries both.
 
-```
+```shell
 $ grep -rn "\.split(" integration/src/main/java/
 .../ImportSecurityValidator.java:162:    for (final String dir : allowed.split(",")) {
 .../graph/GraphImporter.java:316:        final String[] parts = spec.split("=", 2);
@@ -69,7 +69,7 @@ Every other `.split(` in the module takes a **compile-time constant** that is no
 
 Constructors and factories that can carry a metacharacter delimiter into the class:
 
-```
+```shell
 $ grep -n "CsvRowSource(\|static CsvRowSource from(" integration/src/main/java/com/arcadedb/integration/importer/graph/CsvRowSource.java
 41:  public CsvRowSource(final String filePath) {                                        // default ','
 45:  public CsvRowSource(final String filePath, final char delimiter, final int skipLines)
@@ -79,14 +79,14 @@ $ grep -n "CsvRowSource(\|static CsvRowSource from(" integration/src/main/java/c
 
 Config-driven construction:
 
-```
+```shell
 $ grep -n "new CsvRowSource" -r integration/src/main/java/
 .../graph/GraphImporter.java:473:      return new CsvRowSource(filePath, delimiter.charAt(0), skipLines);
 ```
 
 Sibling delimiter walkers in the same module (the `#7263` / `#7268` fixes) - already literal, `indexOf`-based:
 
-```
+```shell
 $ grep -n "indexOf(delim" integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
 1256:        pos = fieldVal.indexOf(delim, start);
 1321:      pos = fieldVal.indexOf(delimiter, start);
@@ -152,7 +152,7 @@ New test: `integration/src/test/java/com/arcadedb/integration/importer/Issue7267
 
 **Before the fix** - 5 of its 7 tests fail, one per bug-carrying entry point:
 
-```
+```text
 [ERROR] Tests run: 7, Failures: 5, Errors: 0, Skipped: 0
   everyRegexMetacharacterSplitsOnTheLiteralCharacter:121 [delimiter '|' ...] Expecting map: {} to contain only: ["lastName"="Miner", "firstName"="Jay", "id"="1"]
   aMetacharacterDelimiterNeverRaisesARegexError            (PatternSyntaxException)
@@ -167,14 +167,14 @@ behaviour-preservation test is supposed to do.
 
 **After the fix:**
 
-```
+```text
 [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0 -- in Issue7267CsvRowSourceLiteralDelimiterTest
 ```
 
 **No regressions** - the whole `integration` module, benchmark/vector/slow lanes excluded
 (`mvn -o -pl integration test -DexcludedGroups=benchmark,vector,slow`):
 
-```
+```text
 [INFO] Results:
 [INFO] Tests run: 270, Failures: 0, Errors: 0, Skipped: 9
 [INFO] BUILD SUCCESS
@@ -272,3 +272,27 @@ The reviewer could not run Maven in its environment and said so. That gap is cov
 `integration` module was re-run after the trim - `Tests run: 270, Failures: 0, Errors: 0, Skipped: 9`.
 
 Again nothing deferred, so no `review-deferred-*.md` notes file was produced in this cycle either.
+
+### Cycle 3 - `c25e1547d9`
+
+Two reviewers this cycle. `claude`: "No blocking issues found", with the correctness trace repeated
+independently a third time and the `Pattern.quote` / `CodeUtils.split` rejections checked against the actual
+`CodeUtils` source rather than taken on trust. `coderabbitai` posted one inline finding. Two items applied, two
+answered:
+
+1. **`coderabbitai`, MD040 on `docs/7267-csvrowsource-regex-delimiter.md`** - eight fenced blocks carried no
+   language, which `markdownlint-cli2` flags. **Applied**: `shell` on the five grep/command blocks, `text` on
+   the three captured-output blocks.
+2. **`claude`, the `emptyAndTrailingFieldsKeepTheirSplitMinusOneShape` assertions are easy to misread** - a
+   `doesNotContainKey` there is about `CsvRecordReader.get` folding empty to null, not about the splitter
+   dropping a column. **Applied**: split into two assertions so each `.as()` describes one claim, and the
+   fold-to-null one says which behaviour it is testing.
+3. **The two-pass scan was reasoned about, not benchmarked.** **Skipped** - the reviewer's own conclusion is
+   "I doubt this is measurable", and there is no CSV-import benchmark in the tree to move. The claim the fix
+   actually rests on is not "two passes beat one" but "no `Pattern` is compiled per row", which is proved from
+   `String.java:3691-3692` rather than measured. Recorded here so the next person can see it was weighed.
+4. **The per-issue doc convention is worth confirming with the team.** **Skipped, and passed to the developer**
+   rather than argued: the evidence that it is current practice is in cycle 1, but whether the team *wants* the
+   convention is the maintainer's call, not this PR's.
+
+`Tests run: 7, Failures: 0, Errors: 0, Skipped: 0` after both changes.

--- a/docs/7267-csvrowsource-regex-delimiter.md
+++ b/docs/7267-csvrowsource-regex-delimiter.md
@@ -250,3 +250,25 @@ Nothing was deferred: every item was either applied or answered with evidence, s
 notes file was produced.
 
 Re-ran after the rename: `Tests run: 7, Failures: 0, Errors: 0, Skipped: 0`.
+
+### Cycle 2 - `1d9c7a7bf2`
+
+`claude` re-reviewed and traced the splitter by hand again, independently confirming the boundary shapes
+(leading/trailing/interior empties, delimiter as last character, zero-delimiter line) against
+`String.split(literal, -1)`, and confirming the scope claim - that `CsvRowSource` was the only regex-based
+splitter reachable with an operator-supplied delimiter. Verdict "looks good to merge". It also noted that the
+fix removes a class of untrusted-input-controls-a-regex risk, since a config-file delimiter could previously
+steer `Pattern` compilation. Two non-blocking points, neither a defect:
+
+1. **`splitLine`'s javadoc ran ~25 lines for a 15-line method**, with the per-delimiter blow-by-blow duplicated
+   from this document. **Applied**: trimmed to the three things a reader at the call site needs - that the
+   argument used to be a regex and must not become one again, one example from each failure family, and why
+   `Pattern.quote` is not the cheaper fix - with the full table left here and pointed to by name. This was the
+   one point both review cycles raised in some form, which is why it was acted on rather than argued.
+2. **The tracking doc is large relative to the diff.** Already answered in cycle 1 with the `git ls-tree`
+   evidence that per-issue docs are current repo practice; the reviewer explicitly registered "no objection".
+
+The reviewer could not run Maven in its environment and said so. That gap is covered here: the full
+`integration` module was re-run after the trim - `Tests run: 270, Failures: 0, Errors: 0, Skipped: 9`.
+
+Again nothing deferred, so no `review-deferred-*.md` notes file was produced in this cycle either.

--- a/docs/7267-csvrowsource-regex-delimiter.md
+++ b/docs/7267-csvrowsource-regex-delimiter.md
@@ -223,3 +223,30 @@ hand against the same three inputs (issue body, diff, tree) and is recorded here
    to a value in that range. **Not real.**
 
 No finding was out of scope, so no follow-up issue was filed.
+
+## Review cycles
+
+### Cycle 1 - `b0a498c846`
+
+`claude` reviewed on the PR's issue-comment surface. No blocking finding: correctness verified by hand against
+the same boundary shapes listed in the adversarial pass, the `char` -> `indexOf(int, int)` widening confirmed
+safe, and the three-entry-point claim confirmed against `GraphImporter.java:467-473`. Three non-blocking items:
+
+1. **`REGEX_METACHARACTERS` overclaims** - two of its fourteen entries were never broken, so the name reads
+   confusingly on first pass even though the javadoc says so. **Applied**: renamed to `REGEX_SYNTAX_DELIMITERS`,
+   which is what the array actually holds, and the javadoc now says why the name avoids "metacharacter".
+2. **A single-pass split with a growable `int[]` position buffer would scan each row once instead of twice.**
+   **Skipped, with reasoning** - the reviewer already scoped it as "not worth doing now", and it trades the one
+   thing the current shape is chosen for: a second heap allocation per row, against CLAUDE.md's
+   "lightweight on garbage collector" mantra, to save one branch-predictable `indexOf` scan of a line that is
+   typically a few hundred bytes. If CSV import ever measures as allocation-bound this is worth revisiting; it
+   is not a defect and is not tracked as one.
+3. **The tracking doc is detailed for a ~40-line fix.** **Skipped** - the reviewer answers this himself, and it
+   is verified: `git ls-tree -r --name-only origin/main -- docs/` lists `docs/7264-graphimporter-tx-leak-zero-count.md`,
+   `docs/7266-three-small-defects.md`, `docs/7225-unlearn-removed-peer-hosts.md` and two more, so one write-up
+   per issue is current repo practice, not a one-off here.
+
+Nothing was deferred: every item was either applied or answered with evidence, so no `review-deferred-*.md`
+notes file was produced.
+
+Re-ran after the rename: `Tests run: 7, Failures: 0, Errors: 0, Skipped: 0`.

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/CsvRowSource.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/CsvRowSource.java
@@ -29,7 +29,8 @@ import java.util.Map;
 /**
  * {@link GraphImporter.RecordSource} that reads CSV files with a header row.
  * Uses the first line as column names; subsequent lines are data records.
- * Supports configurable delimiter (default: comma).
+ * Supports configurable delimiter (default: comma). The delimiter is matched as a literal character, so any
+ * character is a usable field separator - {@code '|'} and {@code '.'} included (issue #7267).
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -91,9 +92,46 @@ public class CsvRowSource implements GraphImporter.RecordSource {
     }
   }
 
+  /**
+   * Splits a line on the delimiter as a LITERAL character, keeping every empty field - the shape
+   * {@code String.split(literal, -1)} answers, which the header/value zip in {@link #forEach} is written against.
+   * <p>
+   * Issue #7267: this used to be {@code line.split(String.valueOf(delimiter), -1)}, whose first argument is a
+   * <b>regular expression</b>. The delimiter is a character the operator chooses, so every one that happens to be a
+   * regex metacharacter did something other than separate fields, and never said which character was to blame:
+   * {@code '|'} is an alternation of two empty branches, so every character became its own field, separators
+   * included; {@code '.'} matched everything and annihilated the row; {@code '$'} and {@code '^'} are anchors and
+   * split nothing at all; {@code '*'}, {@code '+'}, {@code '?'}, {@code '('}, {@code ')'}, {@code '['}, {@code '{'}
+   * and {@code '\'} threw {@code PatternSyntaxException} about a pattern nobody wrote. The first four are the worse
+   * half: a header line cut into single characters means every {@code get(attribute)} misses, so the import produces
+   * vertices with no properties, or none, in silence.
+   * <p>
+   * Walking with {@code indexOf(char, from)} is literal by construction and also cheaper than what it replaces:
+   * {@code String.split} takes its regex-free fast path only for a single <i>non-metacharacter</i> char, and
+   * compiles a {@code Pattern} per call - that is, per row of a bulk import - for the others. One counting pass
+   * sizes the result array exactly, so a row costs one array and its substrings and no {@code Pattern} ever.
+   * {@code Pattern.quote} would have been the one-line fix and was rejected for the mirror-image reason: {@code \Q;\E}
+   * is not a single character, so it would compile a {@code Pattern} on every row for every delimiter, the default
+   * comma included.
+   * <p>
+   * Quoting is still unsupported, exactly as before - a delimiter inside a field value still separates fields. For
+   * quoted CSV use the Univocity-backed {@code CSVImporterFormat}.
+   */
   private String[] splitLine(final String line) {
-    // Simple CSV split (no quoting support — for quoted fields use Univocity)
-    return line.split(String.valueOf(delimiter), -1);
+    int fields = 1;
+    for (int pos = line.indexOf(delimiter); pos >= 0; pos = line.indexOf(delimiter, pos + 1))
+      ++fields;
+
+    final String[] values = new String[fields];
+    int start = 0;
+    for (int i = 0; i < fields - 1; ++i) {
+      final int pos = line.indexOf(delimiter, start);
+      values[i] = line.substring(start, pos);
+      start = pos + 1;
+    }
+    values[fields - 1] = line.substring(start);
+
+    return values;
   }
 
   private static class CsvRecordReader implements GraphImporter.RecordReader {

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/CsvRowSource.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/CsvRowSource.java
@@ -96,23 +96,18 @@ public class CsvRowSource implements GraphImporter.RecordSource {
    * Splits a line on the delimiter as a LITERAL character, keeping every empty field - the shape
    * {@code String.split(literal, -1)} answers, which the header/value zip in {@link #forEach} is written against.
    * <p>
-   * Issue #7267: this used to be {@code line.split(String.valueOf(delimiter), -1)}, whose first argument is a
-   * <b>regular expression</b>. The delimiter is a character the operator chooses, so every one that happens to be a
-   * regex metacharacter did something other than separate fields, and never said which character was to blame:
-   * {@code '|'} is an alternation of two empty branches, so every character became its own field, separators
-   * included; {@code '.'} matched everything and annihilated the row; {@code '$'} and {@code '^'} are anchors and
-   * split nothing at all; {@code '*'}, {@code '+'}, {@code '?'}, {@code '('}, {@code ')'}, {@code '['}, {@code '{'}
-   * and {@code '\'} threw {@code PatternSyntaxException} about a pattern nobody wrote. The first four are the worse
-   * half: a header line cut into single characters means every {@code get(attribute)} misses, so the import produces
-   * vertices with no properties, or none, in silence.
+   * Issue #7267: do not go back to {@code line.split(String.valueOf(delimiter), -1)}. Its first argument is a
+   * <b>regular expression</b>, and the delimiter is a character the operator chooses, so a metacharacter was read
+   * as itself only by accident - {@code '|'} made every character its own field, {@code '.'} annihilated the row,
+   * {@code '$'} and {@code '^'} split nothing at all, and eight more threw {@code PatternSyntaxException} about a
+   * pattern nobody wrote. The first four were the worse half, because a shredded header means every
+   * {@code get(attribute)} misses and the import yields property-less vertices in silence. The full table is in
+   * {@code docs/7267-csvrowsource-regex-delimiter.md}.
    * <p>
-   * Walking with {@code indexOf(char, from)} is literal by construction and also cheaper than what it replaces:
-   * {@code String.split} takes its regex-free fast path only for a single <i>non-metacharacter</i> char, and
-   * compiles a {@code Pattern} per call - that is, per row of a bulk import - for the others. One counting pass
-   * sizes the result array exactly, so a row costs one array and its substrings and no {@code Pattern} ever.
-   * {@code Pattern.quote} would have been the one-line fix and was rejected for the mirror-image reason: {@code \Q;\E}
-   * is not a single character, so it would compile a {@code Pattern} on every row for every delimiter, the default
-   * comma included.
+   * {@code indexOf} is also cheaper than what it replaces: {@code String.split} takes its regex-free fast path only
+   * for a single <i>non-metacharacter</i> char and compiles a {@code Pattern} per call - per row of a bulk import -
+   * for the rest. {@code Pattern.quote} was rejected for the mirror image of that reason: {@code \Q;\E} is not a
+   * single character, so it would compile a {@code Pattern} for every delimiter, the default comma included.
    * <p>
    * Quoting is still unsupported, exactly as before - a delimiter inside a field value still separates fields. For
    * quoted CSV use the Univocity-backed {@code CSVImporterFormat}.

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue7267CsvRowSourceLiteralDelimiterTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue7267CsvRowSourceLiteralDelimiterTest.java
@@ -68,7 +68,9 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 class Issue7267CsvRowSourceLiteralDelimiterTest {
 
   /**
-   * The characters a CSV delimiter can be that a regular expression does not read as themselves.
+   * Every character that carries syntactic meaning inside a regular expression and can be typed as a CSV
+   * delimiter. The name says "syntax", not "metacharacter", because two of the fourteen are neither broken nor
+   * misread on their own - see below.
    * <p>
    * {@code '|'}, {@code '.'}, {@code '$'} and {@code '^'} were the silent family; {@code '*'}, {@code '+'},
    * {@code '?'}, {@code '('}, {@code ')'}, {@code '['}, {@code '{'} and {@code '\'} threw. {@code ']'} and
@@ -77,7 +79,7 @@ class Issue7267CsvRowSourceLiteralDelimiterTest {
    * on JDK 26) and a lone closing bracket or brace is literal to {@code Pattern} anyway. Nothing here is claimed
    * to have been broken; the loop's claim is that all fourteen are correct now.
    */
-  private static final char[] REGEX_METACHARACTERS = { '|', '.', '$', '^', '*', '+', '?', '(', ')', '[', ']', '{', '}', '\\' };
+  private static final char[] REGEX_SYNTAX_DELIMITERS = { '|', '.', '$', '^', '*', '+', '?', '(', ')', '[', ']', '{', '}', '\\' };
 
   private static final String DB_PATH = "target/databases/issue7267-csv-literal-delimiter";
 
@@ -112,7 +114,7 @@ class Issue7267CsvRowSourceLiteralDelimiterTest {
    */
   @Test
   void everyRegexMetacharacterSplitsOnTheLiteralCharacter() throws Exception {
-    for (final char delimiter : REGEX_METACHARACTERS) {
+    for (final char delimiter : REGEX_SYNTAX_DELIMITERS) {
       final Path csv = writeCsv("meta-" + (int) delimiter + ".csv", delimiter,
           "id", "firstName", "lastName");
 
@@ -138,7 +140,7 @@ class Issue7267CsvRowSourceLiteralDelimiterTest {
    */
   @Test
   void aMetacharacterDelimiterNeverRaisesARegexError() {
-    for (final char delimiter : REGEX_METACHARACTERS)
+    for (final char delimiter : REGEX_SYNTAX_DELIMITERS)
       assertThatCode(() -> {
         final Path csv = writeCsv("nothrow-" + (int) delimiter + ".csv", delimiter, "id", "firstName", "lastName");
         readAll(new CsvRowSource(csv.toString(), delimiter, 0), "id");

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue7267CsvRowSourceLiteralDelimiterTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue7267CsvRowSourceLiteralDelimiterTest.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.integration.importer.graph.CsvRowSource;
+import com.arcadedb.integration.importer.graph.GraphImporter;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.FileUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Regression test for issue #7267.
+ * <p>
+ * {@link CsvRowSource} split each line with {@code line.split(String.valueOf(delimiter), -1)}, whose first
+ * argument is a <b>regular expression</b>. A delimiter that is a regex metacharacter therefore did something
+ * other than separate fields, in one of two families, neither of which names the delimiter as the culprit:
+ * <ul>
+ *   <li><b>silently wrong</b> - {@code '|'} is an alternation of two empty branches, so every character became
+ *       its own field, separators included; {@code '.'} matched everything and annihilated the row; {@code '$'}
+ *       and {@code '^'} are anchors and split nothing at all. A header line cut into single characters means
+ *       every {@code record.get(attribute)} misses, so the import produced property-less vertices, or none;</li>
+ *   <li><b>a crash about a regex nobody wrote</b> - {@code '*'}, {@code '+'}, {@code '?'}, {@code '('},
+ *       {@code ')'}, {@code '['}, {@code '{'} and {@code '\'} threw {@code PatternSyntaxException}.</li>
+ * </ul>
+ * Each test drives one of the entry points that can carry an operator-chosen delimiter into the class - the JSON
+ * configuration, the public constructor and the three-argument factory - because a fix applied at one of them
+ * would leave the others exactly as broken while a single-path test went green.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue7267CsvRowSourceLiteralDelimiterTest {
+
+  /**
+   * The characters a CSV delimiter can be that a regular expression does not read as themselves.
+   * <p>
+   * {@code '|'}, {@code '.'}, {@code '$'} and {@code '^'} were the silent family; {@code '*'}, {@code '+'},
+   * {@code '?'}, {@code '('}, {@code ')'}, {@code '['}, {@code '{'} and {@code '\'} threw. {@code ']'} and
+   * {@code '}'} are here for symmetry and worked before this fix as well - they are not in the set
+   * {@code String.split} excludes from its regex-free fast path ({@code ".$|()[{^?*+\"}, {@code String.java:3692}
+   * on JDK 26) and a lone closing bracket or brace is literal to {@code Pattern} anyway. Nothing here is claimed
+   * to have been broken; the loop's claim is that all fourteen are correct now.
+   */
+  private static final char[] REGEX_METACHARACTERS = { '|', '.', '$', '^', '*', '+', '?', '(', ')', '[', ']', '{', '}', '\\' };
+
+  private static final String DB_PATH = "target/databases/issue7267-csv-literal-delimiter";
+
+  @TempDir
+  Path tempDir;
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    database = new DatabaseFactory(DB_PATH).create();
+    database.transaction(() -> database.getSchema().createVertexType("Person"));
+  }
+
+  @AfterEach
+  void cleanup() {
+    if (database != null)
+      database.close();
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  // ───────────────────────────────────────────────────────────────────
+  //  Entry point 1: the public constructor
+  // ───────────────────────────────────────────────────────────────────
+
+  /**
+   * The whole defect in one loop: the same three-column file written with each metacharacter as its separator
+   * has to read back as the same three columns, whichever character was chosen. Header and data rows go through
+   * the same private splitter, so a header shredded into single characters shows up here as missing keys rather
+   * than as wrong values - which is why the assertion is on the record's own attributes and not on a field count.
+   */
+  @Test
+  void everyRegexMetacharacterSplitsOnTheLiteralCharacter() throws Exception {
+    for (final char delimiter : REGEX_METACHARACTERS) {
+      final Path csv = writeCsv("meta-" + (int) delimiter + ".csv", delimiter,
+          "id", "firstName", "lastName");
+
+      final List<Map<String, String>> rows = readAll(new CsvRowSource(csv.toString(), delimiter, 0),
+          "id", "firstName", "lastName");
+
+      assertThat(rows)
+          .as("delimiter '%s' must cut the file into rows, not into characters", delimiter)
+          .hasSize(2);
+      assertThat(rows.get(0))
+          .as("delimiter '%s' must separate fields on the literal character", delimiter)
+          .containsExactlyInAnyOrderEntriesOf(Map.of("id", "1", "firstName", "Jay", "lastName", "Miner"));
+      assertThat(rows.get(1))
+          .as("delimiter '%s' must separate fields on the literal character", delimiter)
+          .containsExactlyInAnyOrderEntriesOf(Map.of("id", "2", "firstName", "Ada", "lastName", "Lovelace"));
+    }
+  }
+
+  /**
+   * The crashing half of the defect, asserted as its own claim. {@code containsExactly} on the previous test
+   * would also have failed on a {@code PatternSyntaxException}, but it would have failed with a stack trace that
+   * says nothing about why - and "does not throw a regex error" is the promise a config file's author is owed.
+   */
+  @Test
+  void aMetacharacterDelimiterNeverRaisesARegexError() {
+    for (final char delimiter : REGEX_METACHARACTERS)
+      assertThatCode(() -> {
+        final Path csv = writeCsv("nothrow-" + (int) delimiter + ".csv", delimiter, "id", "firstName", "lastName");
+        readAll(new CsvRowSource(csv.toString(), delimiter, 0), "id");
+      })
+          .as("delimiter '%s' is a field separator, not a pattern the operator wrote", delimiter)
+          .doesNotThrowAnyException();
+  }
+
+  /**
+   * The pipe is not a hypothetical choice: it is the delimiter every {@code splitEdge} example in the tree uses,
+   * so an operator who already has pipe-delimited data reaches for it as the field separator too. This drives it
+   * through a whole import rather than through the row source alone, so the assertion is on what actually lands
+   * in the database - the shape of the failure the issue describes, vertices with no properties.
+   */
+  @Test
+  void aPipeDelimitedImportThroughTheConstructorLoadsEveryProperty() throws Exception {
+    final Path csv = writeCsv("people-ctor.csv", '|', "id", "firstName", "lastName");
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("Person", new CsvRowSource(csv.toString(), '|', 0), v -> {
+          v.id("id");
+          v.intProperty("id", "id");
+          v.property("firstName", "firstName");
+          v.property("lastName", "lastName");
+        })
+        .build()) {
+      importer.run();
+      assertThat(importer.getVertexCount()).isEqualTo(2);
+    }
+
+    assertPersonsLoaded();
+  }
+
+  // ───────────────────────────────────────────────────────────────────
+  //  Entry point 2: the three-argument factory
+  // ───────────────────────────────────────────────────────────────────
+
+  /**
+   * {@code CsvRowSource.from(dir, file, delimiter)} is a second public way in, and it is the one the JSON path
+   * does <b>not</b> use - a fix confined to {@code GraphImporter.createRecordSource} would leave it broken.
+   */
+  @Test
+  void theThreeArgFactorySplitsOnTheLiteralCharacter() throws Exception {
+    writeCsv("people-factory.csv", '|', "id", "firstName", "lastName");
+
+    final List<Map<String, String>> rows = readAll(
+        CsvRowSource.from(tempDir.toString(), "people-factory.csv", '|'),
+        "id", "firstName", "lastName");
+
+    assertThat(rows).hasSize(2);
+    assertThat(rows.get(0)).containsEntry("firstName", "Jay").containsEntry("lastName", "Miner");
+  }
+
+  // ───────────────────────────────────────────────────────────────────
+  //  Entry point 3: the JSON configuration
+  // ───────────────────────────────────────────────────────────────────
+
+  /**
+   * {@code "delimiter": "|"} on a vertex source reaches {@code new CsvRowSource(path, '|', skipLines)} through
+   * {@code GraphImporter.createRecordSource}. The single-character length check added by #7263 lets it through,
+   * as it should - a pipe is a legitimate field separator.
+   */
+  @Test
+  void aJsonConfiguredPipeDelimiterImportsEveryProperty() throws Exception {
+    writeCsv("people-json.csv", '|', "id", "firstName", "lastName");
+
+    final JSONObject config = new JSONObject().put("vertices", new JSONArray().put(new JSONObject()
+        .put("type", "Person")
+        .put("file", "people-json.csv")
+        .put("delimiter", "|")
+        .put("id", "id")
+        .put("properties", new JSONObject()
+            .put("id", "int:id")
+            .put("firstName", "firstName")
+            .put("lastName", "lastName"))));
+
+    try (final GraphImporter importer = GraphImporter.fromJSON(database, config, tempDir.toString())) {
+      importer.run();
+      assertThat(importer.getVertexCount()).isEqualTo(2);
+    }
+
+    assertPersonsLoaded();
+  }
+
+  // ───────────────────────────────────────────────────────────────────
+  //  Behaviour that must NOT change
+  // ───────────────────────────────────────────────────────────────────
+
+  /**
+   * The default comma, and every other delimiter that already worked, has to keep answering exactly what it
+   * answered before - this fix replaces the splitter for all of them, not only for the broken ones.
+   */
+  @Test
+  void theDefaultCommaDelimiterIsUnchanged() throws Exception {
+    writeCsv("people-default.csv", ',', "id", "firstName", "lastName");
+
+    for (final CsvRowSource source : new CsvRowSource[] {
+        new CsvRowSource(tempDir.resolve("people-default.csv").toString()),
+        CsvRowSource.from(tempDir.toString(), "people-default.csv") }) {
+
+      final List<Map<String, String>> rows = readAll(source, "id", "firstName", "lastName");
+      assertThat(rows).hasSize(2);
+      assertThat(rows.get(0)).containsEntry("id", "1").containsEntry("firstName", "Jay").containsEntry("lastName", "Miner");
+      assertThat(rows.get(1)).containsEntry("id", "2").containsEntry("firstName", "Ada").containsEntry("lastName", "Lovelace");
+    }
+  }
+
+  /**
+   * {@code split(literal, -1)} keeps every empty field, interior and trailing alike, and that shape is what the
+   * header/value zip in {@code forEach} is written against. Two consequences are observable from outside and are
+   * asserted here: an empty interior field does not shift the columns after it, and a trailing empty header name
+   * stays a column of its own rather than being dropped along with the value under it.
+   */
+  @Test
+  void emptyAndTrailingFieldsKeepTheirSplitMinusOneShape() throws Exception {
+    final Path csv = tempDir.resolve("empties.csv");
+    Files.writeString(csv, "id;firstName;lastName;\n1;;Miner;x\n2;Ada;;\n", StandardCharsets.UTF_8);
+
+    final List<Map<String, String>> rows = readAll(new CsvRowSource(csv.toString(), ';', 0),
+        "id", "firstName", "lastName", "");
+
+    assertThat(rows).hasSize(2);
+    assertThat(rows.get(0))
+        .as("an empty interior field must not shift the columns that follow it")
+        .containsEntry("id", "1").containsEntry("lastName", "Miner")
+        .doesNotContainKey("firstName");
+    assertThat(rows.get(0))
+        .as("a trailing empty header name is still a column, exactly as split(literal, -1) reports it")
+        .containsEntry("", "x");
+    assertThat(rows.get(1))
+        .as("trailing empty values read back as absent, the way CsvRecordReader folds empty to null")
+        .containsEntry("id", "2").containsEntry("firstName", "Ada")
+        .doesNotContainKey("lastName").doesNotContainKey("");
+  }
+
+  // ───────────────────────────────────────────────────────────────────
+  //  Helpers
+  // ───────────────────────────────────────────────────────────────────
+
+  /** Writes a two-row file whose header and values are joined by {@code delimiter}, and answers its path. */
+  private Path writeCsv(final String fileName, final char delimiter, final String... headers) throws Exception {
+    final String sep = String.valueOf(delimiter);
+    final String content = String.join(sep, headers) + "\n"
+        + "1" + sep + "Jay" + sep + "Miner" + "\n"
+        + "2" + sep + "Ada" + sep + "Lovelace" + "\n";
+    final Path file = tempDir.resolve(fileName);
+    Files.writeString(file, content, StandardCharsets.UTF_8);
+    return file;
+  }
+
+  /** Drains a row source into one map per record, reading only the attributes named. */
+  private static List<Map<String, String>> readAll(final GraphImporter.RecordSource source, final String... attributes)
+      throws Exception {
+    final List<Map<String, String>> rows = new ArrayList<>();
+    source.forEach(record -> {
+      final Map<String, String> row = new LinkedHashMap<>();
+      for (final String attribute : attributes) {
+        final String value = record.get(attribute);
+        if (value != null)
+          row.put(attribute, value);
+      }
+      rows.add(row);
+    });
+    return rows;
+  }
+
+  private void assertPersonsLoaded() {
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("sql", "SELECT FROM Person ORDER BY id")) {
+        assertThat(rs.hasNext()).isTrue();
+        final Result jay = rs.next();
+        assertThat(jay.<String>getProperty("firstName")).isEqualTo("Jay");
+        assertThat(jay.<String>getProperty("lastName")).isEqualTo("Miner");
+
+        assertThat(rs.hasNext()).isTrue();
+        final Result ada = rs.next();
+        assertThat(ada.<String>getProperty("firstName")).isEqualTo("Ada");
+        assertThat(ada.<String>getProperty("lastName")).isEqualTo("Lovelace");
+      }
+    });
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue7267CsvRowSourceLiteralDelimiterTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue7267CsvRowSourceLiteralDelimiterTest.java
@@ -264,8 +264,11 @@ class Issue7267CsvRowSourceLiteralDelimiterTest {
 
     assertThat(rows).hasSize(2);
     assertThat(rows.get(0))
-        .as("an empty interior field must not shift the columns that follow it")
-        .containsEntry("id", "1").containsEntry("lastName", "Miner")
+        .as("an empty interior field must not shift the columns that follow it - 'Miner' stays under 'lastName'")
+        .containsEntry("id", "1").containsEntry("lastName", "Miner");
+    assertThat(rows.get(0))
+        .as("'firstName' is absent because CsvRecordReader.get folds empty to null, not because the split "
+            + "dropped the column - the column landing is what the assertion above proves")
         .doesNotContainKey("firstName");
     assertThat(rows.get(0))
         .as("a trailing empty header name is still a column, exactly as split(literal, -1) reports it")


### PR DESCRIPTION
Closes #7267

## Summary

`CsvRowSource.splitLine` split every line with `line.split(String.valueOf(delimiter), -1)`, whose first argument is a **regular expression**. The delimiter is a character the operator chooses, so every one that happens to be a regex metacharacter did something other than separate fields, and nothing named the delimiter as the cause: `|` is an alternation of two empty branches and made every character its own field, separators included; `.` matched everything and annihilated the row; `$` and `^` are anchors and split nothing at all; and `*`, `+`, `?`, `(`, `)`, `[`, `{`, `\` threw `PatternSyntaxException` about a pattern nobody wrote. The first four are the worse half - a header line cut into single characters means every `record.get(attribute)` misses, so the import produces vertices with no properties, or none at all, in silence. The splitter now walks the line with `indexOf(char, from)`: literal by construction, and cheaper than what it replaces, because `String.split` takes its regex-free fast path only for a single **non**-metacharacter char (`String.java:3691`, gated on `".$|()[{^?*+\\".indexOf(ch) == -1`) and compiles a `Pattern` per row otherwise. One counting pass sizes the result array exactly, so the output is identical to `split(literal, -1)` for every delimiter that already worked, empty and trailing fields included. `Pattern.quote` was rejected for the mirror-image reason - `\Q;\E` is not a single character, so it would compile a `Pattern` on every row for **every** delimiter, the default comma included - and `CodeUtils.split(String, char, int, int)` was rejected as the reuse candidate because it drops the trailing empty field (`"a;b;"` answers `[a, b]`) and returns a `List` needing an extra array copy per row.

## Test plan

- [ ] `mvn -o -pl integration -am install -DskipTests && mvn -o -pl integration test -Dtest=Issue7267CsvRowSourceLiteralDelimiterTest` - 7 tests, all green. Reverting only `CsvRowSource.splitLine` turns 5 of them red (one per bug-carrying entry point); the 2 that stay green are the behaviour-preservation tests, which is what they are for.
- [ ] `mvn -o -pl integration test -DexcludedGroups=benchmark,vector,slow` - 270 tests, 0 failures, 9 skipped. Covers every existing CSV consumer of the changed method: `GraphImporterCSVTest`, `GraphImporterArrayPropsTest`, `GraphImporterSplitDelimiterTest`, `GraphImporterIdTypesTest`, `Issue6811CsvDelimiterOptionTest`, `Issue7266ImporterConfigValidationTest`.
- [ ] Manual: a pipe-delimited vertex file imported with `"delimiter": "|"` now lands with all its properties; before this change the same file produced property-less vertices and logged nothing.

## Coverage

Every path that can carry an operator-chosen delimiter into `CsvRowSource`:

| Entry point | Fixed | Test |
|---|---|---|
| JSON config `"delimiter": "\|"` -> `GraphImporter.createRecordSource` (`GraphImporter.java:473`) | yes | `aJsonConfiguredPipeDelimiterImportsEveryProperty` |
| `new CsvRowSource(path, delimiter, skipLines)` (public constructor) | yes | `everyRegexMetacharacterSplitsOnTheLiteralCharacter`, `aMetacharacterDelimiterNeverRaisesARegexError`, `aPipeDelimitedImportThroughTheConstructorLoadsEveryProperty` |
| `CsvRowSource.from(dir, file, delimiter)` (public factory) | yes | `theThreeArgFactorySplitsOnTheLiteralCharacter` |
| default `','` constructor / two-arg factory | yes (behaviour preserved) | `theDefaultCommaDelimiterIsUnchanged` |
| the header line (same private splitter, one call site) | yes | asserted inside every metacharacter case |
| `split(literal, -1)` empty/trailing-field shape | yes (preserved) | `emptyAndTrailingFieldsKeepTheirSplitMinusOneShape` |

`grep -rn "new CsvRowSource(\|CsvRowSource.from(" --include="*.java" .` answers exactly one production construction site, `GraphImporter.java:473`, plus the class's own factories and test code, and `CsvRowSource` is referenced nowhere outside the `integration` module - so the table is the whole surface.

Argued rather than fixed, with the evidence in `docs/7267-csvrowsource-regex-delimiter.md`:

- `GraphImporter`'s split-edge walkers already walk with literal `indexOf` (`GraphImporter.java:1256`, `:1321`, from #7263/#7268).
- `CSVImporterFormat` hands its delimiter to Univocity via `CsvFormat.setDelimiter`, a literal separator, not a pattern.
- Every other `.split(` in `integration/src/main/java` takes a compile-time constant (`","`, `"="`, `":"`, `" "`), none of them a metacharacter and none reachable by an operator-supplied character.

### Known gaps

None. No row of the coverage table needed a follow-up issue.

The one thing this does **not** change, because it is a different, already-documented limitation of the class and not what #7267 reports: `CsvRowSource` still has no quoting support, so a delimiter appearing inside a field value still separates fields. For quoted CSV the importer's Univocity-backed `CSVImporterFormat` is the path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvLhYByiYvAXzdZ9ZD5ekW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSV imports now treat selected delimiters as literal characters, including regex symbols such as `|`, `.`, `$`, and `*`.
  * Prevented incorrect field splitting and errors with special-character delimiters.
  * Empty and trailing fields continue to be preserved.

* **Tests**
  * Added coverage for CSV configuration and graph import workflows, including special-character and default comma delimiters.

* **Documentation**
  * Documented delimiter behavior, affected scenarios, and verification results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->