### PR TITLE
fix(#7272): five importer row loops resolve the transaction they opened

### DIFF
--- a/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
@@ -345,8 +345,10 @@ public class Neo4jImporter {
       final boolean[] txOpen = { false };
 
       // Vertices an intermediate commit already made durable. context.createdVertices counts every vertex the
-      // batch allocated, the ones still inside the transaction a failure rolls back included.
-      final long[] committedVertices = { 0 };
+      // batch allocated, the ones still inside the transaction a failure rolls back included. Seeded from the
+      // counter rather than from 0: the embedding constructor takes an ImporterContext from its caller, so a
+      // context that already carries durable vertices would otherwise be zeroed by the correction below.
+      final long[] committedVertices = { context.createdVertices.get() };
 
       // Whether the loop ran to its own trailing commit. Distinct from txOpen: a commit() that throws pops the
       // transaction in its own finally, so txOpen is already false there, yet the batch it failed to make

--- a/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
@@ -338,69 +338,110 @@ public class Neo4jImporter {
         .withCommitEvery(0)
         .build()) {
 
+      // Whether the transaction opened below is still the current one. Cleared right before every commit -
+      // LocalDatabase#commit() pops the transaction in a finally, so a commit that throws still leaves this
+      // method's transaction off the stack, and rolling back after that would discard the CALLER's instead
+      // (issue #7272).
+      final boolean[] txOpen = { false };
+
+      // Vertices an intermediate commit already made durable. context.createdVertices counts every vertex the
+      // batch allocated, the ones still inside the transaction a failure rolls back included.
+      final long[] committedVertices = { 0 };
+
       database.begin();
+      txOpen[0] = true;
 
-      readFileSimple(json -> {
-        lineNumber.incrementAndGet();
+      try {
+        readFileSimple(json -> {
+          lineNumber.incrementAndGet();
 
-        switch (json.getString("type")) {
-        case "node":
-          context.parsed.incrementAndGet();
-          ++totalVerticesParsed;
-          if (context.parsed.get() > 0 && context.parsed.get() % 1_000_000 == 0) {
-            final long elapsed = System.currentTimeMillis() - beginTimeVerticesCreation;
-            log("- Status update: created %,d vertices, skipped %,d edges (%,d vertices/sec)", context.createdVertices.get(),
-                context.skippedEdges.get(), context.createdVertices.get() / elapsed * 1000);
+          switch (json.getString("type")) {
+          case "node":
+            context.parsed.incrementAndGet();
+            ++totalVerticesParsed;
+            if (context.parsed.get() > 0 && context.parsed.get() % 1_000_000 == 0) {
+              final long elapsed = System.currentTimeMillis() - beginTimeVerticesCreation;
+              log("- Status update: created %,d vertices, skipped %,d edges (%,d vertices/sec)", context.createdVertices.get(),
+                  context.skippedEdges.get(), context.createdVertices.get() / elapsed * 1000);
+            }
+
+            final Pair<String, List<String>> type = typeNameFromLabels(json);
+            if (type == null) {
+              log("- found vertex in line %d without labels. Importing it as '%s'.", lineNumber.get(), ROOT_NODE_TYPE);
+              context.warnings.incrementAndGet();
+            }
+
+            final String typeName = type != null ? type.getFirst() : ROOT_NODE_TYPE;
+            final String id = json.getString("id");
+
+            try {
+              final Map<String, Object> props;
+              if (json.has("properties"))
+                props = setProperties(json.getJSONObject("properties"), schemaProperties.get(typeName));
+              else
+                props = new HashMap<>();
+              props.put("id", id);
+
+              final MutableVertex vertex = batch.createVertex(typeName, props);
+              final long packedRID = packRID(vertex.getIdentity());
+              putId(id, packedRID);
+              context.createdVertices.incrementAndGet();
+
+              incrementVerticesByType(typeName);
+            } catch (Exception e) {
+              error("- Error on saving vertex with id %s: %s", id, e.getMessage());
+              context.errors.incrementAndGet();
+            }
+
+            if (context.createdVertices.get() > 0 && context.createdVertices.get() % batchSize == 0) {
+              txOpen[0] = false;
+              database.commit();
+              committedVertices[0] = context.createdVertices.get();
+              database.begin();
+              txOpen[0] = true;
+            }
+
+            break;
+
+          case "relationship":
+            context.skippedEdges.incrementAndGet();
+            break;
           }
 
-          final Pair<String, List<String>> type = typeNameFromLabels(json);
-          if (type == null) {
-            log("- found vertex in line %d without labels. Importing it as '%s'.", lineNumber.get(), ROOT_NODE_TYPE);
-            context.warnings.incrementAndGet();
-          }
+          if (parsingCallback != null)
+            parsingCallback.call(json);
 
-          final String typeName = type != null ? type.getFirst() : ROOT_NODE_TYPE;
-          final String id = json.getString("id");
+          return null;
+        });
 
+        txOpen[0] = false;
+        if (database.isTransactionActive())
+          database.commit();
+      } finally {
+        // In the finally rather than in a catch so that an Error - an OutOfMemoryError is the one a large import
+        // can realistically raise - resolves the transaction too.
+        if (txOpen[0]) {
+          txOpen[0] = false;
           try {
-            final Map<String, Object> props;
-            if (json.has("properties"))
-              props = setProperties(json.getJSONObject("properties"), schemaProperties.get(typeName));
-            else
-              props = new HashMap<>();
-            props.put("id", id);
-
-            final MutableVertex vertex = batch.createVertex(typeName, props);
-            final long packedRID = packRID(vertex.getIdentity());
-            putId(id, packedRID);
-            context.createdVertices.incrementAndGet();
-
-            incrementVerticesByType(typeName);
-          } catch (Exception e) {
-            error("- Error on saving vertex with id %s: %s", id, e.getMessage());
-            context.errors.incrementAndGet();
+            database.rollback();
+          } catch (final Exception rollbackFailure) {
+            // Swallowed: a throw here would replace the failure the caller can actually act on with one about
+            // the cleanup, and would skip the counter correction below.
+            error("- Could not roll back after the vertex import failed: the transaction it opened may still be "
+                + "on the stack: %s", rollbackFailure.getMessage());
           }
 
-          if (context.createdVertices.get() > 0 && context.createdVertices.get() % batchSize == 0) {
-            database.commit();
-            database.begin();
-          }
+          // What the report calls "created" has to be what survived: leaving the counter at the number of
+          // vertices read would credit the import with the ones the rollback just took away.
+          final long readVertices = context.createdVertices.get();
+          context.createdVertices.set(committedVertices[0]);
 
-          break;
-
-        case "relationship":
-          context.skippedEdges.incrementAndGet();
-          break;
+          if (committedVertices[0] > 0)
+            log("- Vertex import failed after %,d vertices: the import is PARTIAL - %,d of them an earlier batch "
+                    + "commit made durable and they stay on the disk, the other %,d were rolled back", readVertices,
+                committedVertices[0], readVertices - committedVertices[0]);
         }
-
-        if (parsingCallback != null)
-          parsingCallback.call(json);
-
-        return null;
-      });
-
-      if (database.isTransactionActive())
-        database.commit();
+      }
     }
 
     final long elapsedInSecs = (System.currentTimeMillis() - context.startedOn) / 1000;
@@ -640,33 +681,53 @@ public class Neo4jImporter {
    */
   private void readFile(final Callable<Void, JSONObject> callback) throws IOException {
     database.begin();
+    // Whether the transaction just opened is still the current one - cleared right before the commit below so a
+    // rollback in the finally can never pop a transaction this method has already committed away, let alone the
+    // caller's own (issue #7272).
+    boolean txOpen = true;
 
-    try (InputStream inputStream = openInputStream()) {
-      try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, DatabaseFactory.getDefaultCharset()))) {
-        for (long lineNumber = 0; ; ++lineNumber) {
-          try {
-            final String line = reader.readLine();
-            if (line == null)
-              break;
+    try {
+      try (InputStream inputStream = openInputStream()) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, DatabaseFactory.getDefaultCharset()))) {
+          for (long lineNumber = 0; ; ++lineNumber) {
+            try {
+              final String line = reader.readLine();
+              if (line == null)
+                break;
 
-            final JSONObject json = new JSONObject(line);
-            final String type = json.getString("type");
-            if ("node".equals(type) || "relationship".equals(type))
-              callback.call(json);
-            else {
-              log("Invalid 'type' content on line %d of the input JSONL file. The line will be ignored. JSON: %s", lineNumber, line);
+              final JSONObject json = new JSONObject(line);
+              final String type = json.getString("type");
+              if ("node".equals(type) || "relationship".equals(type))
+                callback.call(json);
+              else {
+                log("Invalid 'type' content on line %d of the input JSONL file. The line will be ignored. JSON: %s", lineNumber, line);
+                context.errors.incrementAndGet();
+              }
+            } catch (final JSONException e) {
+              log("Error on parsing json on line %d of the input JSONL file. The line will be ignored.", lineNumber);
               context.errors.incrementAndGet();
             }
-          } catch (final JSONException e) {
-            log("Error on parsing json on line %d of the input JSONL file. The line will be ignored.", lineNumber);
-            context.errors.incrementAndGet();
           }
         }
       }
-    }
 
-    if (database.isTransactionActive())
-      database.commit();
+      txOpen = false;
+      if (database.isTransactionActive())
+        database.commit();
+    } finally {
+      // In the finally rather than in a catch so that an Error - an OutOfMemoryError is the one a large import
+      // can realistically raise - resolves the transaction too.
+      if (txOpen && database.isTransactionActive()) {
+        try {
+          database.rollback();
+        } catch (final Exception rollbackFailure) {
+          // Swallowed: a throw here would replace the failure the caller can actually act on - the I/O error that
+          // aborted the read - with one about the cleanup.
+          error("- Could not roll back after reading the input failed: the transaction it opened may still be on "
+              + "the stack: %s", rollbackFailure.getMessage());
+        }
+      }
+    }
   }
 
   /**

--- a/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
@@ -348,6 +348,11 @@ public class Neo4jImporter {
       // batch allocated, the ones still inside the transaction a failure rolls back included.
       final long[] committedVertices = { 0 };
 
+      // Whether the loop ran to its own trailing commit. Distinct from txOpen: a commit() that throws pops the
+      // transaction in its own finally, so txOpen is already false there, yet the batch it failed to make
+      // durable still has to come back off the counter.
+      boolean completed = false;
+
       database.begin();
       txOpen[0] = true;
 
@@ -417,6 +422,8 @@ public class Neo4jImporter {
         txOpen[0] = false;
         if (database.isTransactionActive())
           database.commit();
+        committedVertices[0] = context.createdVertices.get();
+        completed = true;
       } finally {
         // In the finally rather than in a catch so that an Error - an OutOfMemoryError is the one a large import
         // can realistically raise - resolves the transaction too.
@@ -430,7 +437,11 @@ public class Neo4jImporter {
             error("- Could not roll back after the vertex import failed: the transaction it opened may still be "
                 + "on the stack: %s", rollbackFailure.getMessage());
           }
+        }
 
+        // Outside the txOpen branch above, because a commit() that threw has already popped its own transaction
+        // and would otherwise leave the batch it failed to write counted as if it had survived.
+        if (!completed) {
           // What the report calls "created" has to be what survived: leaving the counter at the number of
           // vertices read would credit the import with the ones the rollback just took away.
           final long readVertices = context.createdVertices.get();

--- a/integration/src/main/java/com/arcadedb/integration/importer/OrientDBImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/OrientDBImporter.java
@@ -498,6 +498,11 @@ public class OrientDBImporter {
       // touched, the ones still inside the transaction a failure rolls back included.
       long committedDocuments = context.updatedDocuments.get();
 
+      // Whether the loop ran to its own trailing commit. Distinct from txOpen: a commit() that throws pops the
+      // transaction in its own finally, so txOpen is already false there, yet the batch it failed to make
+      // durable still has to come back off the counter.
+      boolean completed = false;
+
       try {
         for (RID rid : documentsWithLinksToUpdate) {
           final MutableDocument record = database.lookupByRID(rid, true).asDocument().modify();
@@ -521,6 +526,7 @@ public class OrientDBImporter {
         }
         txOpen = false;
         database.commit();
+        completed = true;
         logger.logLine(1, "- Updated LINKs in %,d records", context.updatedDocuments.get());
       } finally {
         // In the finally rather than in a catch so that an Error - an OutOfMemoryError is the one a large import
@@ -534,7 +540,11 @@ public class OrientDBImporter {
             logger.errorLine("- Could not roll back after the LINK update failed: the transaction it opened may still "
                 + "be on the stack: %s", rollbackFailure.getMessage());
           }
+        }
 
+        // Outside the txOpen branch above, because a commit() that threw has already popped its own transaction
+        // and would otherwise leave the batch it failed to write counted as if it had survived.
+        if (!completed) {
           // What the report calls "updated" has to be what survived: leaving the counter at the number of documents
           // touched would credit the import with the ones the rollback just took away.
           final long readDocuments = context.updatedDocuments.get();

--- a/integration/src/main/java/com/arcadedb/integration/importer/OrientDBImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/OrientDBImporter.java
@@ -489,26 +489,64 @@ public class OrientDBImporter {
       logger.logLine(1, "Updating LINKs in %,d documents...", documentsWithLinksToUpdate.size());
 
       database.begin();
+      // Whether the transaction just opened (or the one begun after a periodic commit below) is still the current
+      // one. Cleared right before every commit - which pops it in a finally even if it throws - so a rollback below
+      // can never pop a transaction this method has already committed away (issue #7272).
+      boolean txOpen = true;
 
-      for (RID rid : documentsWithLinksToUpdate) {
-        final MutableDocument record = database.lookupByRID(rid, true).asDocument().modify();
-        for (String pName : record.getPropertyNames()) {
-          final Object pValue = record.get(pName);
-          final RID converted = convertRIDs(pValue);
-          if (converted != null)
-            record.set(pName, converted);
+      // Documents an intermediate commit already made durable. context.updatedDocuments counts every document
+      // touched, the ones still inside the transaction a failure rolls back included.
+      long committedDocuments = context.updatedDocuments.get();
+
+      try {
+        for (RID rid : documentsWithLinksToUpdate) {
+          final MutableDocument record = database.lookupByRID(rid, true).asDocument().modify();
+          for (String pName : record.getPropertyNames()) {
+            final Object pValue = record.get(pName);
+            final RID converted = convertRIDs(pValue);
+            if (converted != null)
+              record.set(pName, converted);
+          }
+          record.save();
+
+          context.updatedDocuments.incrementAndGet();
+
+          if (context.updatedDocuments.get() > 0 && context.updatedDocuments.get() % batchSize == 0) {
+            txOpen = false;
+            database.commit();
+            committedDocuments = context.updatedDocuments.get();
+            database.begin();
+            txOpen = true;
+          }
         }
-        record.save();
+        txOpen = false;
+        database.commit();
+        logger.logLine(1, "- Updated LINKs in %,d records", context.updatedDocuments.get());
+      } finally {
+        // In the finally rather than in a catch so that an Error - an OutOfMemoryError is the one a large import
+        // can realistically raise - resolves the transaction too.
+        if (txOpen && database.isTransactionActive()) {
+          try {
+            database.rollback();
+          } catch (final Exception rollbackFailure) {
+            // Swallowed: a throw here would replace the failure the caller can actually act on with one about the
+            // cleanup, and would skip the counter correction below.
+            logger.errorLine("- Could not roll back after the LINK update failed: the transaction it opened may still "
+                + "be on the stack: %s", rollbackFailure.getMessage());
+          }
 
-        context.updatedDocuments.incrementAndGet();
+          // What the report calls "updated" has to be what survived: leaving the counter at the number of documents
+          // touched would credit the import with the ones the rollback just took away.
+          final long readDocuments = context.updatedDocuments.get();
+          context.updatedDocuments.set(committedDocuments);
 
-        if (context.updatedDocuments.get() > 0 && context.updatedDocuments.get() % batchSize == 0) {
-          database.commit();
-          database.begin();
+          if (committedDocuments > 0)
+            logger.logLine(1,
+                "- LINK update failed after %,d documents: the update is PARTIAL - %,d of them an earlier batch commit "
+                    + "made durable and they stay on the disk, the other %,d were rolled back", readDocuments,
+                committedDocuments, readDocuments - committedDocuments);
         }
       }
-      database.commit();
-      logger.logLine(1, "- Updated LINKs in %,d records", context.updatedDocuments.get());
     }
   }
 

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
@@ -588,29 +588,68 @@ public class CSVImporterFormat extends AbstractImporterFormat {
       // database.begin() nests rather than reusing an already-active transaction (see LocalDatabase#begin()), so a
       // caller's own pre-existing transaction is never touched by this method's own commits below.
       database.begin();
+      // Whether the transaction just opened (or the one begun after a periodic commit below) is still the current
+      // one. Cleared right before every commit - which pops it in a finally even if it throws - so a rollback below
+      // can never pop a transaction this method has already committed away, let alone the caller's own (issue #7272).
+      boolean txOpen = true;
+      // Edges an intermediate commit already made durable. context.createdEdges counts every edge
+      // createEdgeFromRow() creates, the ones still inside the transaction a failure rolls back included.
+      long committedEdges = context.createdEdges.get();
       int txCount = 0;
-      for (long line = 0; (row = csvParser.parseNext()) != null; ++line) {
-        context.parsed.incrementAndGet();
+      try {
+        for (long line = 0; (row = csvParser.parseNext()) != null; ++line) {
+          context.parsed.incrementAndGet();
 
-        if (skipEntries > 0 && line < skipEntries)
-          continue;
+          if (skipEntries > 0 && line < skipEntries)
+            continue;
 
-        try {
-          createEdgeFromRow(database, row, properties, from, to, context, settings);
-          txCount++;
-          if (txCount >= settings.commitEvery) {
-            database.commit();
-            database.begin();
-            txCount = 0;
+          try {
+            createEdgeFromRow(database, row, properties, from, to, context, settings);
+            txCount++;
+            if (txCount >= settings.commitEvery) {
+              txOpen = false;
+              database.commit();
+              committedEdges = context.createdEdges.get();
+              database.begin();
+              txOpen = true;
+              txCount = 0;
+            }
+          } catch (final Exception e) {
+            // Unlike loadDocuments/loadVertices, edge rows are always skipped-and-logged regardless of -onRowError:
+            // a "bad" edge row here is typically just an unresolved from/to vertex reference, expected during graph
+            // imports rather than a data-corruption case.
+            LogManager.instance().log(this, Level.SEVERE, "Error on parsing line %d", e, line);
           }
-        } catch (final Exception e) {
-          // Unlike loadDocuments/loadVertices, edge rows are always skipped-and-logged regardless of -onRowError: a
-          // "bad" edge row here is typically just an unresolved from/to vertex reference, expected during graph
-          // imports rather than a data-corruption case.
-          LogManager.instance().log(this, Level.SEVERE, "Error on parsing line %d", e, line);
+        }
+        txOpen = false;
+        database.commit();
+      } finally {
+        // A row-content failure is already caught and logged above without escaping; what reaches here is a
+        // source-level failure - typically csvParser.parseNext() itself throwing on a malformed row - that the loop
+        // never had a chance to catch.
+        if (txOpen && database.isTransactionActive()) {
+          try {
+            database.rollback();
+          } catch (final Exception rollbackFailure) {
+            // Swallowed: a throw here would replace the failure the caller can actually act on with one about the
+            // cleanup, and would skip the counter correction below.
+            LogManager.instance().log(this, Level.SEVERE,
+                "Could not roll back after the edge import failed: the transaction it opened may still be on the stack",
+                rollbackFailure);
+          }
+
+          // What the report calls "created" has to be what survived: leaving the counter at the number of edges
+          // read would credit the import with the ones the rollback just took away.
+          final long readEdges = context.createdEdges.get();
+          context.createdEdges.set(committedEdges);
+
+          if (committedEdges > 0)
+            LogManager.instance().log(this, Level.WARNING,
+                "Edge import failed after %,d edges: the import is PARTIAL - %,d of them an earlier batch commit made "
+                    + "durable and they stay on the disk, the other %,d were rolled back", null, readEdges,
+                committedEdges, readEdges - committedEdges);
         }
       }
-      database.commit();
 
     } catch (final IOException e) {
       throw new ImportException("Error on importing CSV", e);

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
@@ -610,19 +610,25 @@ public class CSVImporterFormat extends AbstractImporterFormat {
           try {
             createEdgeFromRow(database, row, properties, from, to, context, settings);
             txCount++;
-            if (txCount >= settings.commitEvery) {
-              txOpen = false;
-              database.commit();
-              committedEdges = context.createdEdges.get();
-              database.begin();
-              txOpen = true;
-              txCount = 0;
-            }
           } catch (final Exception e) {
             // Unlike loadDocuments/loadVertices, edge rows are always skipped-and-logged regardless of -onRowError:
             // a "bad" edge row here is typically just an unresolved from/to vertex reference, expected during graph
             // imports rather than a data-corruption case.
             LogManager.instance().log(this, Level.SEVERE, "Error on parsing line %d", e, line);
+          }
+
+          // Deliberately outside the per-row catch above: a commit failure is not a row error. Caught there it
+          // would be logged under a "parsing line N" message, and the loop would carry on with no transaction
+          // active - LocalDatabase#commit() pops in its own finally and the begin() below never runs - turning
+          // one failure into one more for every remaining row. Left to escape, it reaches the finally below,
+          // which corrects the counter and lets the real cause propagate.
+          if (txCount >= settings.commitEvery) {
+            txOpen = false;
+            database.commit();
+            committedEdges = context.createdEdges.get();
+            database.begin();
+            txOpen = true;
+            txCount = 0;
           }
         }
         txOpen = false;

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
@@ -595,6 +595,10 @@ public class CSVImporterFormat extends AbstractImporterFormat {
       // Edges an intermediate commit already made durable. context.createdEdges counts every edge
       // createEdgeFromRow() creates, the ones still inside the transaction a failure rolls back included.
       long committedEdges = context.createdEdges.get();
+      // Whether the loop ran to its own trailing commit. Distinct from txOpen: a commit() that throws pops the
+      // transaction in its own finally, so txOpen is already false there, yet the batch it failed to make
+      // durable still has to come back off the counter.
+      boolean completed = false;
       int txCount = 0;
       try {
         for (long line = 0; (row = csvParser.parseNext()) != null; ++line) {
@@ -623,6 +627,7 @@ public class CSVImporterFormat extends AbstractImporterFormat {
         }
         txOpen = false;
         database.commit();
+        completed = true;
       } finally {
         // A row-content failure is already caught and logged above without escaping; what reaches here is a
         // source-level failure - typically csvParser.parseNext() itself throwing on a malformed row - that the loop
@@ -637,7 +642,11 @@ public class CSVImporterFormat extends AbstractImporterFormat {
                 "Could not roll back after the edge import failed: the transaction it opened may still be on the stack",
                 rollbackFailure);
           }
+        }
 
+        // Outside the txOpen branch above, because a commit() that threw has already popped its own transaction
+        // and would otherwise leave the batch it failed to write counted as if it had survived.
+        if (!completed) {
           // What the report calls "created" has to be what survived: leaving the counter at the number of edges
           // read would credit the import with the ones the rollback just took away.
           final long readEdges = context.createdEdges.get();

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java
@@ -26,10 +26,12 @@ import com.arcadedb.integration.importer.ImporterContext;
 import com.arcadedb.integration.importer.ImporterSettings;
 import com.arcadedb.integration.importer.Parser;
 import com.arcadedb.integration.importer.SourceSchema;
+import com.arcadedb.log.LogManager;
 import com.univocity.parsers.common.AbstractParser;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.logging.Level;
 
 public class RDFImporterFormat extends CSVImporterFormat {
   private static final char[] STRING_CONTENT_SKIP = new char[] { '\'', '\'', '"', '"', '<', '>' };
@@ -44,11 +46,26 @@ public class RDFImporterFormat extends CSVImporterFormat {
       // BY DEFAULT SKIP THE FIRST LINE AS HEADER
       skipEntries = 1l;
 
+    // Whether this call is the one that opened the transaction it is about to use, as opposed to reusing one
+    // that predates it (see ImporterContext#callerTransactionActiveOnEntry) - a failure below must resolve only
+    // the transaction this call owns, never a caller's pre-existing one.
+    final boolean ownsTransaction = !context.callerTransactionActiveOnEntry;
+
+    // Whether a transaction this call owns is still the current one. Cleared right before every commit -
+    // LocalDatabase#commit() pops the transaction in a finally, so a commit that throws still leaves it off the
+    // stack - which keeps the rollback below from popping the caller's instead (issue #7272).
+    boolean txOpen = false;
+
+    // Edges an intermediate commit already made durable. context.createdEdges counts every edge created,
+    // the ones still inside the transaction a failure rolls back included.
+    long committedEdges = context.createdEdges.get();
+
     try (final InputStreamReader inputFileReader = new InputStreamReader(parser.getInputStream(), DatabaseFactory.getDefaultCharset())) {
       csvParser.beginParsing(inputFileReader);
 
       if (!database.isTransactionActive())
         database.begin();
+      txOpen = ownsTransaction;
 
       String[] row;
       for (long line = 0; (row = csvParser.parseNext()) != null; ++line) {
@@ -78,15 +95,45 @@ public class RDFImporterFormat extends CSVImporterFormat {
         context.parsed.incrementAndGet();
 
         if (context.parsed.get() % settings.commitEvery == 0) {
+          txOpen = false;
           database.commit();
+          committedEdges = context.createdEdges.get();
           database.begin();
+          txOpen = ownsTransaction;
         }
       }
 
+      txOpen = false;
       database.commit();
 
     } catch (final IOException e) {
       throw new ImportException("Error on importing CSV", e);
+    } finally {
+      // In a finally rather than in a catch: a malformed row (csvParser.parseNext() itself throwing) or a
+      // newEdgeByKeys() failure escapes uncaught otherwise, leaving the transaction opened above on the stack,
+      // and an Error - an OutOfMemoryError is the one a large import can realistically raise - would too.
+      if (txOpen && database.isTransactionActive()) {
+        try {
+          database.rollback();
+        } catch (final Exception rollbackFailure) {
+          // Swallowed: a throw here would replace the failure the caller can actually act on with one about the
+          // cleanup, and would skip the counter correction below.
+          LogManager.instance().log(this, Level.SEVERE,
+              "Could not roll back after the RDF import failed: the transaction it opened may still be on the stack",
+              rollbackFailure);
+        }
+
+        // What the report calls "created" has to be what survived: leaving the counter at the number of edges
+        // read would credit the import with the ones the rollback just took away.
+        final long readEdges = context.createdEdges.get();
+        context.createdEdges.set(committedEdges);
+
+        if (committedEdges > 0)
+          LogManager.instance().log(this, Level.WARNING,
+              "RDF import failed after %,d edges: the import is PARTIAL - %,d of them an earlier batch commit made "
+                  + "durable and they stay on the disk, the other %,d were rolled back", null, readEdges, committedEdges,
+              readEdges - committedEdges);
+      }
     }
   }
 

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java
@@ -46,9 +46,13 @@ public class RDFImporterFormat extends CSVImporterFormat {
       // BY DEFAULT SKIP THE FIRST LINE AS HEADER
       skipEntries = 1l;
 
-    // Whether this call is the one that opened the transaction it is about to use, as opposed to reusing one
-    // that predates it (see ImporterContext#callerTransactionActiveOnEntry) - a failure below must resolve only
-    // the transaction this call owns, never a caller's pre-existing one.
+    // Whether the transaction this method is about to use belongs to the import, as opposed to predating it.
+    // Not the same as "this call pushed it": in the CLI pipeline AbstractImporter.openDatabase() ends with a
+    // begin() that is deliberately left open for the whole import, so the begin() below finds one active and
+    // reuses it. Rolling that one back on failure is still right - the import aborts with it either way, and
+    // the alternative is AbstractImporter.closeDatabase() committing a half-finished import. What must never
+    // be rolled back is a transaction that predates the import, which is exactly what
+    // ImporterContext#callerTransactionActiveOnEntry records.
     final boolean ownsTransaction = !context.callerTransactionActiveOnEntry;
 
     // Whether a transaction this call owns is still the current one. Cleared right before every commit -

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java
@@ -60,6 +60,11 @@ public class RDFImporterFormat extends CSVImporterFormat {
     // the ones still inside the transaction a failure rolls back included.
     long committedEdges = context.createdEdges.get();
 
+    // Whether the loop ran to its own trailing commit. Distinct from txOpen: a commit() that throws pops the
+    // transaction in its own finally, so txOpen is already false there, yet the batch it failed to make
+    // durable still has to come back off the counter.
+    boolean completed = false;
+
     try (final InputStreamReader inputFileReader = new InputStreamReader(parser.getInputStream(), DatabaseFactory.getDefaultCharset())) {
       csvParser.beginParsing(inputFileReader);
 
@@ -94,17 +99,22 @@ public class RDFImporterFormat extends CSVImporterFormat {
         context.createdEdges.incrementAndGet();
         context.parsed.incrementAndGet();
 
-        if (context.parsed.get() % settings.commitEvery == 0) {
+        // Gated on ownsTransaction the same way JsonlImporterFormat.load() gates its own periodic commit: a
+        // transaction that predates this import is never ours to commit piecemeal, only to accumulate into and
+        // hand back to whoever owns it (issue #6561). That guard is also what makes the txOpen below
+        // unconditional - reached only when the begin() above pushed a transaction this call exclusively owns.
+        if (ownsTransaction && context.parsed.get() % settings.commitEvery == 0) {
           txOpen = false;
           database.commit();
           committedEdges = context.createdEdges.get();
           database.begin();
-          txOpen = ownsTransaction;
+          txOpen = true;
         }
       }
 
       txOpen = false;
       database.commit();
+      completed = true;
 
     } catch (final IOException e) {
       throw new ImportException("Error on importing CSV", e);
@@ -123,6 +133,13 @@ public class RDFImporterFormat extends CSVImporterFormat {
               rollbackFailure);
         }
 
+      }
+
+      // Outside the txOpen branch above, because a commit() that threw has already popped its own transaction
+      // and would otherwise leave the batch it failed to write counted as if it had survived. Gated on
+      // ownsTransaction for the same reason the rollback is: the edges accumulated into a caller's own
+      // transaction are the caller's to commit or discard, so their fate is not this method's to report on.
+      if (!completed && ownsTransaction) {
         // What the report calls "created" has to be what survived: leaving the counter at the number of edges
         // read would credit the import with the ones the rollback just took away.
         final long readEdges = context.createdEdges.get();

--- a/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterParseVerticesTransactionLeakTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterParseVerticesTransactionLeakTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7272, the entry point the issue's own grep did not name: {@code Neo4jImporter.parseVertices()} has the
+ * same shape as the four findings the issue lists - {@code database.begin()}, a row loop with a periodic
+ * {@code commit()}/{@code begin()} every {@code batchSize} vertices, and a trailing
+ * {@code if (database.isTransactionActive()) database.commit();} that an {@code IOException} escaping
+ * {@code readFileSimple()} skips, leaving the transaction it opened on the stack.
+ * <p>
+ * It also covers the issue's third suggested fix, the one about the progress report: {@code context.createdVertices}
+ * counts every vertex the batch allocated, so after a rollback it credits the import with vertices that are not on
+ * the disk. The counter has to come back to the value at the last successful commit.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Neo4jImporterParseVerticesTransactionLeakTest {
+
+  private static final String DB_PATH = "target/databases/neo4j-importer-parsevertices-tx-leak-test";
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    database = new DatabaseFactory(DB_PATH).create();
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Person").createProperty("id", Type.STRING);
+      database.getSchema().createDocumentType("Marker");
+    });
+  }
+
+  @AfterEach
+  void cleanup() {
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollbackAllNested();
+      if (database.isOpen())
+        database.drop();
+      database = null;
+    }
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  /**
+   * Delivers {@code failAfterBytes} bytes and then fails every further read, the shape {@code reader.readLine()}
+   * sees when the underlying source breaks. {@code InputStream#read(byte[], int, int)} swallows an
+   * {@link IOException} raised after at least one byte was read, so the first bulk read returns the whole prefix
+   * and only the read after it throws - which is what puts the failure past the batch commit below.
+   */
+  private static class FailingAfterInputStream extends InputStream {
+    private final byte[] data;
+    private final int    failAfterBytes;
+    private       int    pos;
+
+    FailingAfterInputStream(final byte[] data, final int failAfterBytes) {
+      this.data = data;
+      this.failAfterBytes = failAfterBytes;
+    }
+
+    @Override
+    public int read() throws IOException {
+      if (pos >= failAfterBytes)
+        throw new IOException("Simulated I/O failure mid-stream");
+      if (pos >= data.length)
+        return -1;
+      return data[pos++] & 0xff;
+    }
+
+    @Override
+    public boolean markSupported() {
+      return true;
+    }
+
+    @Override
+    public void mark(final int readLimit) {
+    }
+
+    @Override
+    public void reset() {
+      pos = 0;
+    }
+  }
+
+  private static void setField(final Neo4jImporter importer, final String name, final Object value) throws Exception {
+    final Field field = Neo4jImporter.class.getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(importer, value);
+  }
+
+  private static void invokeParseVertices(final Neo4jImporter importer) throws Throwable {
+    final Method method = Neo4jImporter.class.getDeclaredMethod("parseVertices");
+    method.setAccessible(true);
+    try {
+      method.invoke(importer);
+    } catch (final InvocationTargetException e) {
+      throw e.getCause();
+    }
+  }
+
+  private long countOf(final String typeName) {
+    return database.query("sql", "select count(*) as c from " + typeName).next().<Long>getProperty("c");
+  }
+
+  /**
+   * Three vertices with a batch size of two: the first two are committed by the periodic commit, the third is
+   * created into the transaction the failure then rolls back.
+   */
+  private Neo4jImporter importerFailingAfterThreeVertices(final ImporterContext context) throws Exception {
+    final Neo4jImporter importer = new Neo4jImporter(database, context);
+
+    final String lines = "{\"type\":\"node\",\"id\":\"1\",\"labels\":[\"Person\"]}\n"
+        + "{\"type\":\"node\",\"id\":\"2\",\"labels\":[\"Person\"]}\n"
+        + "{\"type\":\"node\",\"id\":\"3\",\"labels\":[\"Person\"]}\n";
+    final byte[] bytes = lines.getBytes(StandardCharsets.UTF_8);
+
+    setField(importer, "batchSize", 2);
+    setField(importer, "inputStream", new FailingAfterInputStream(bytes, bytes.length));
+    return importer;
+  }
+
+  @Test
+  void aFailedReadLeavesNoTransactionActive() throws Throwable {
+    final ImporterContext context = new ImporterContext();
+    final Neo4jImporter importer = importerFailingAfterThreeVertices(context);
+
+    assertThatThrownBy(() -> invokeParseVertices(importer)).isInstanceOf(IOException.class);
+
+    assertThat(database.isTransactionActive())
+        .as("the transaction parseVertices() opened must be resolved before the failure propagates")
+        .isFalse();
+    assertThat(countOf("Person"))
+        .as("only the batch the periodic commit made durable survives; the third vertex was rolled back")
+        .isEqualTo(2);
+  }
+
+  @Test
+  void aFailedReadReportsOnlyTheVerticesThatSurvived() throws Throwable {
+    final ImporterContext context = new ImporterContext();
+    final Neo4jImporter importer = importerFailingAfterThreeVertices(context);
+
+    assertThatThrownBy(() -> invokeParseVertices(importer)).isInstanceOf(IOException.class);
+
+    assertThat(context.createdVertices.get())
+        .as("the report must count what is on the disk, not the third vertex the rollback took away")
+        .isEqualTo(2);
+    assertThat(context.createdVertices.get())
+        .as("the counter and the durable row count must agree")
+        .isEqualTo(countOf("Person"));
+  }
+
+  @Test
+  void aFailedReadDoesNotShadowTheCallersOwnTransaction() throws Throwable {
+    final ImporterContext context = new ImporterContext();
+    final Neo4jImporter importer = importerFailingAfterThreeVertices(context);
+
+    database.begin();
+    database.newDocument("Marker").set("name", "caller").save();
+
+    assertThatThrownBy(() -> invokeParseVertices(importer)).isInstanceOf(IOException.class);
+
+    // The caller's own commit must land on its own transaction, not on the importer's abandoned nested one.
+    database.commit();
+
+    assertThat(database.isTransactionActive())
+        .as("one commit for the one transaction the caller opened must leave nothing active")
+        .isFalse();
+    assertThat(countOf("Marker"))
+        .as("the caller's own record must be what its commit made durable")
+        .isEqualTo(1);
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterParseVerticesTransactionLeakTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterParseVerticesTransactionLeakTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.integration.importer;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.exception.TransactionException;
 import com.arcadedb.schema.Type;
 import com.arcadedb.utility.FileUtils;
 
@@ -33,6 +34,7 @@ import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -206,4 +208,57 @@ class Neo4jImporterParseVerticesTransactionLeakTest {
         .as("the caller's own record must be what its commit made durable")
         .isEqualTo(1);
   }
+
+  /**
+   * The counterpart of the two commit-failure tests on the format classes, for the one site whose flags live in
+   * single-element arrays. {@code LocalDatabase.commit()} pops the transaction inside its own {@code finally},
+   * so a commit that throws leaves {@code txOpen[0]} already {@code false} and nothing to roll back - only the
+   * {@code completed} flag can still bring the counter back. Without it the batch the commit failed to write
+   * would stay counted as if it had survived.
+   * <p>
+   * The proxy fails the first commit, which is the periodic one after {@code batchSize} vertices, and leaves
+   * behind what a real commit failure leaves: the transaction gone and its records not durable.
+   */
+  private Database databaseWhoseFirstCommitFails() {
+    return (Database) Proxy.newProxyInstance(Database.class.getClassLoader(), new Class<?>[] { Database.class },
+        (proxy, method, args) -> {
+          if ("commit".equals(method.getName()) && (args == null || args.length == 0)) {
+            database.rollback();
+            throw new TransactionException("Simulated commit failure");
+          }
+          try {
+            return method.invoke(database, args);
+          } catch (final InvocationTargetException e) {
+            throw e.getCause();
+          }
+        });
+  }
+
+  @Test
+  void aFailedCommitReportsOnlyTheVerticesThatSurvived() throws Throwable {
+    final ImporterContext context = new ImporterContext();
+    final Neo4jImporter importer = new Neo4jImporter(databaseWhoseFirstCommitFails(), context);
+
+    // The input is fully readable: the only failure is the periodic commit after the second vertex.
+    final String lines = "{\"type\":\"node\",\"id\":\"1\",\"labels\":[\"Person\"]}\n"
+        + "{\"type\":\"node\",\"id\":\"2\",\"labels\":[\"Person\"]}\n"
+        + "{\"type\":\"node\",\"id\":\"3\",\"labels\":[\"Person\"]}\n";
+    final byte[] bytes = lines.getBytes(StandardCharsets.UTF_8);
+
+    setField(importer, "batchSize", 2);
+    setField(importer, "inputStream", new FailingAfterInputStream(bytes, bytes.length));
+
+    assertThatThrownBy(() -> invokeParseVertices(importer)).isInstanceOf(TransactionException.class);
+
+    assertThat(database.isTransactionActive())
+        .as("a failed commit still leaves its own transaction off the stack")
+        .isFalse();
+    assertThat(countOf("Person"))
+        .as("the failed commit made nothing durable")
+        .isZero();
+    assertThat(context.createdVertices.get())
+        .as("the report must not credit the import with the batch the failed commit never wrote")
+        .isZero();
+  }
+
 }

--- a/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterReadFileTransactionLeakTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterReadFileTransactionLeakTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.Callable;
+import com.arcadedb.utility.FileUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7272 (finding 4): {@code Neo4jImporter.readFile()} always begins its own transaction, reads the
+ * JSONL input inside a try-with-resources, and only resolves that transaction in the line right after it
+ * - {@code if (database.isTransactionActive()) database.commit();}. An {@code IOException} escaping
+ * {@code reader.readLine()} skips that line entirely, leaving the transaction opened above on the stack.
+ * <p>
+ * {@code readFile()} is private; it is invoked here via reflection on an importer built with the public
+ * {@code Neo4jImporter(Database, ImporterContext)} embedding constructor, with the private
+ * {@code inputStream} field swapped for a stream that fails mid-read.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Neo4jImporterReadFileTransactionLeakTest {
+
+  private static final String DB_PATH = "target/databases/neo4j-importer-readfile-tx-leak-test";
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    database = new DatabaseFactory(DB_PATH).create();
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Node");
+      database.getSchema().createDocumentType("Marker");
+    });
+  }
+
+  @AfterEach
+  void cleanup() {
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollbackAllNested();
+      if (database.isOpen())
+        database.drop();
+      database = null;
+    }
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  /**
+   * Fully readable up to {@code failAfterBytes}, then every further read throws {@link IOException} - the
+   * shape {@code reader.readLine()} sees when the underlying source breaks mid-line. Supports mark/reset
+   * trivially: {@code Neo4jImporter#openInputStream()} calls {@code reset()} once, before any read.
+   */
+  private static class FailingAfterInputStream extends InputStream {
+    private final byte[] data;
+    private final int    failAfterBytes;
+    private       int    pos;
+
+    FailingAfterInputStream(final byte[] data, final int failAfterBytes) {
+      this.data = data;
+      this.failAfterBytes = failAfterBytes;
+    }
+
+    @Override
+    public int read() throws IOException {
+      if (pos >= failAfterBytes)
+        throw new IOException("Simulated I/O failure mid-stream");
+      if (pos >= data.length)
+        return -1;
+      return data[pos++] & 0xff;
+    }
+
+    @Override
+    public boolean markSupported() {
+      return true;
+    }
+
+    @Override
+    public void mark(final int readLimit) {
+    }
+
+    @Override
+    public void reset() {
+      pos = 0;
+    }
+  }
+
+  private void setInputStream(final Neo4jImporter importer, final InputStream inputStream) throws Exception {
+    final Field field = Neo4jImporter.class.getDeclaredField("inputStream");
+    field.setAccessible(true);
+    field.set(importer, inputStream);
+  }
+
+  private void invokeReadFile(final Neo4jImporter importer, final Callable<Void, JSONObject> callback) throws Throwable {
+    final Method method = Neo4jImporter.class.getDeclaredMethod("readFile", Callable.class);
+    method.setAccessible(true);
+    try {
+      method.invoke(importer, callback);
+    } catch (final InvocationTargetException e) {
+      throw e.getCause();
+    }
+  }
+
+  private long countOf(final String typeName) {
+    return database.query("sql", "select count(*) as c from " + typeName).next().<Long>getProperty("c");
+  }
+
+  @Test
+  void aFailedReadLeavesNoTransactionActive() throws Throwable {
+    final Neo4jImporter importer = new Neo4jImporter(database, new ImporterContext());
+
+    final String line1 = "{\"type\":\"node\",\"id\":\"1\"}\n";
+    final String line2 = "{\"type\":\"node\",\"id\":\"2\"}\n";
+    final byte[] bytes = (line1 + line2).getBytes(StandardCharsets.UTF_8);
+    setInputStream(importer, new FailingAfterInputStream(bytes, line1.getBytes(StandardCharsets.UTF_8).length + 2));
+
+    final Callable<Void, JSONObject> callback = json -> {
+      database.newDocument("Node").set("marker", true).save();
+      return null;
+    };
+
+    assertThatThrownBy(() -> invokeReadFile(importer, callback)).isInstanceOf(IOException.class);
+
+    assertThat(database.isTransactionActive())
+        .as("the transaction readFile() opened must be resolved before the failure propagates")
+        .isFalse();
+    assertThat(countOf("Node"))
+        .as("the row read before the failure was never committed")
+        .isZero();
+  }
+
+  @Test
+  void aFailedReadDoesNotShadowTheCallersOwnTransaction() throws Throwable {
+    final Neo4jImporter importer = new Neo4jImporter(database, new ImporterContext());
+
+    final String line1 = "{\"type\":\"node\",\"id\":\"1\"}\n";
+    final String line2 = "{\"type\":\"node\",\"id\":\"2\"}\n";
+    final byte[] bytes = (line1 + line2).getBytes(StandardCharsets.UTF_8);
+    setInputStream(importer, new FailingAfterInputStream(bytes, line1.getBytes(StandardCharsets.UTF_8).length + 2));
+
+    final Callable<Void, JSONObject> callback = json -> {
+      database.newDocument("Node").set("marker", true).save();
+      return null;
+    };
+
+    database.begin();
+    database.newDocument("Marker").set("name", "caller").save();
+
+    assertThatThrownBy(() -> invokeReadFile(importer, callback)).isInstanceOf(IOException.class);
+
+    // The caller's own commit must land on its own transaction, not on the importer's abandoned nested one.
+    database.commit();
+
+    assertThat(database.isTransactionActive())
+        .as("one commit for the one transaction the caller opened must leave nothing active")
+        .isFalse();
+    assertThat(countOf("Marker"))
+        .as("the caller's own record must be what its commit made durable")
+        .isEqualTo(1);
+    assertThat(countOf("Node"))
+        .as("the importer's abandoned row must not ride out on the caller's commit")
+        .isZero();
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/importer/OrientDBImporterUpdateDocumentLinksTransactionLeakTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/OrientDBImporterUpdateDocumentLinksTransactionLeakTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.utility.FileUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7272 (finding 3): {@code OrientDBImporter.updateDocumentLinks()} opens a transaction, loops over
+ * {@code documentsWithLinksToUpdate}, and only commits at the very end - no {@code finally}. A failure
+ * mid-loop (here: {@code compressedRecordsRidMap} not yet populated, the state {@code run()} would be in
+ * before {@code createIndexes()}/schema-analysis errors surface) leaves that transaction on the stack.
+ * <p>
+ * {@code updateDocumentLinks()} is private and depends only on instance fields already reachable through
+ * the public embedding constructor, so it is invoked here via reflection rather than through the whole
+ * {@code run()} pipeline (which needs a full gzipped OrientDB export to reach this code path at all).
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class OrientDBImporterUpdateDocumentLinksTransactionLeakTest {
+
+  private static final String DB_PATH = "target/databases/orientdb-importer-updatelinks-tx-leak-test";
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    database = new DatabaseFactory(DB_PATH).create();
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Person");
+      database.getSchema().createDocumentType("Marker");
+    });
+  }
+
+  @AfterEach
+  void cleanup() {
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollbackAllNested();
+      if (database.isOpen())
+        database.drop();
+      database = null;
+    }
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void seedOneDocumentWithLinksToUpdate(final OrientDBImporter importer) throws Exception {
+    database.begin();
+    final RID personRid = database.newDocument("Person").set("link", new RID(9999, 9999)).save().getIdentity();
+    database.commit();
+
+    final Field field = OrientDBImporter.class.getDeclaredField("documentsWithLinksToUpdate");
+    field.setAccessible(true);
+    ((Set<RID>) field.get(importer)).add(personRid);
+  }
+
+  private void invokeUpdateDocumentLinks(final OrientDBImporter importer) throws Throwable {
+    final Method method = OrientDBImporter.class.getDeclaredMethod("updateDocumentLinks");
+    method.setAccessible(true);
+    try {
+      method.invoke(importer);
+    } catch (final InvocationTargetException e) {
+      throw e.getCause();
+    }
+  }
+
+  private long countOf(final String typeName) {
+    return database.query("sql", "select count(*) as c from " + typeName).next().<Long>getProperty("c");
+  }
+
+  @Test
+  void aFailedLinkUpdateLeavesNoTransactionActive() throws Exception {
+    final OrientDBImporter importer = new OrientDBImporter((DatabaseInternal) database, new ImporterSettings());
+    seedOneDocumentWithLinksToUpdate(importer);
+
+    // compressedRecordsRidMap is only populated inside run(); left null here, resolving the LINK property
+    // throws a NullPointerException - the kind of mid-loop failure the issue is about.
+    assertThatThrownBy(() -> invokeUpdateDocumentLinks(importer)).isInstanceOf(NullPointerException.class);
+
+    assertThat(database.isTransactionActive())
+        .as("the transaction updateDocumentLinks() opened must be resolved before the failure propagates")
+        .isFalse();
+  }
+
+  @Test
+  void aFailedLinkUpdateDoesNotShadowTheCallersOwnTransaction() throws Exception {
+    final OrientDBImporter importer = new OrientDBImporter((DatabaseInternal) database, new ImporterSettings());
+    seedOneDocumentWithLinksToUpdate(importer);
+
+    database.begin();
+    database.newDocument("Marker").set("name", "caller").save();
+
+    assertThatThrownBy(() -> invokeUpdateDocumentLinks(importer)).isInstanceOf(NullPointerException.class);
+
+    database.commit();
+
+    assertThat(database.isTransactionActive())
+        .as("one commit for the one transaction the caller opened must leave nothing active")
+        .isFalse();
+    assertThat(countOf("Marker"))
+        .as("the caller's own record must be what its commit made durable")
+        .isEqualTo(1);
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/importer/format/CSVImporterFormatLoadEdgesTransactionLeakTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/format/CSVImporterFormatLoadEdgesTransactionLeakTest.java
@@ -219,4 +219,36 @@ class CSVImporterFormatLoadEdgesTransactionLeakTest {
         .as("the report must not credit the import with the batch the failed commit never wrote")
         .isZero();
   }
+
+  @Test
+  void aFailedPeriodicCommitStopsTheImportInsteadOfBeingLoggedAsARowError() throws Exception {
+    final CSVImporterFormat format = new CSVImporterFormat();
+    final ImporterSettings settings = edgeSettings();
+    // One commit per row, so the failure below is a mid-loop commit rather than the trailing one.
+    settings.commitEvery = 1;
+    final SourceSchema sourceSchema = schemaFor(format, settings);
+    final ImporterContext context = new ImporterContext();
+
+    // Header plus two valid rows: the commit after the first row fails.
+    final Parser loadParser = csvParserOver("from,to\nv1,v2\nv2,v1\n");
+
+    assertThatThrownBy(
+        () -> format.load(sourceSchema, AnalyzedEntity.EntityType.EDGE, loadParser, databaseWhoseCommitFails(), context,
+            settings))
+        .isInstanceOf(TransactionException.class);
+
+    // The per-row catch swallows row failures and continues; a commit failure must not be swallowed with them.
+    // Were it, the loop would read the second row too - with no transaction active, since the failed commit
+    // popped it and the begin() after it never ran - and context.parsed would reach 3 rather than 2.
+    assertThat(context.parsed.get())
+        .as("the import must stop at the failed commit, not grind through the rest of the file without a transaction")
+        .isEqualTo(2);
+    assertThat(database.isTransactionActive())
+        .as("a failed commit still leaves its own transaction off the stack")
+        .isFalse();
+    assertThat(context.createdEdges.get())
+        .as("the report must not credit the import with the batch the failed commit never wrote")
+        .isZero();
+  }
+
 }

--- a/integration/src/test/java/com/arcadedb/integration/importer/format/CSVImporterFormatLoadEdgesTransactionLeakTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/format/CSVImporterFormatLoadEdgesTransactionLeakTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer.format;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.integration.importer.AnalyzedEntity;
+import com.arcadedb.integration.importer.AnalyzedSchema;
+import com.arcadedb.integration.importer.ImporterContext;
+import com.arcadedb.integration.importer.ImporterSettings;
+import com.arcadedb.integration.importer.Parser;
+import com.arcadedb.integration.importer.Source;
+import com.arcadedb.integration.importer.SourceSchema;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import com.univocity.parsers.common.TextParsingException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7272 (finding 2): {@code CSVImporterFormat.loadEdges()} always begins its own transaction (it
+ * nests rather than reusing a caller's - see the comment above {@code database.begin()} in that method)
+ * and only catches {@code IOException}: a {@code RuntimeException} escaping {@code csvParser.parseNext()}
+ * (a malformed row, e.g. one exceeding {@code maxPropertySize}) leaves that nested transaction on the
+ * stack, shadowing whatever the caller had open.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class CSVImporterFormatLoadEdgesTransactionLeakTest {
+
+  private static final String DB_PATH = "target/databases/csv-loadedges-tx-leak-test";
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    database = new DatabaseFactory(DB_PATH).create();
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Node").createProperty("id", Type.STRING);
+      database.getSchema().getType("Node").getOrCreateTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, new String[] { "id" });
+      database.getSchema().createEdgeType("Relationship");
+      database.getSchema().createDocumentType("Marker");
+
+      database.newVertex("Node").set("id", "v1").save();
+      database.newVertex("Node").set("id", "v2").save();
+    });
+  }
+
+  @AfterEach
+  void cleanup() {
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollbackAllNested();
+      if (database.isOpen())
+        database.drop();
+      database = null;
+    }
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  private static Parser csvParserOver(final String content) throws Exception {
+    final byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+    final Source source = new Source("edges.csv", new ByteArrayInputStream(bytes), bytes.length, false, null, null);
+    return new Parser(source, 0);
+  }
+
+  private ImporterSettings edgeSettings() {
+    final ImporterSettings settings = new ImporterSettings();
+    settings.edgeTypeName = "Relationship";
+    settings.edgeFromField = "from";
+    settings.edgeToField = "to";
+    settings.typeIdProperty = "id";
+    settings.options.put("maxPropertySize", 5);
+    return settings;
+  }
+
+  private SourceSchema schemaFor(final CSVImporterFormat format, final ImporterSettings settings) throws Exception {
+    final Parser schemaParser = csvParserOver("from,to\nv1,v2\n");
+    return format.analyze(AnalyzedEntity.EntityType.EDGE, schemaParser, settings, new AnalyzedSchema(100));
+  }
+
+  private long countOf(final String typeName) {
+    return database.query("sql", "select count(*) as c from " + typeName).next().<Long>getProperty("c");
+  }
+
+  @Test
+  void aFailedRowLeavesNoTransactionActive() throws Exception {
+    final CSVImporterFormat format = new CSVImporterFormat();
+    final ImporterSettings settings = edgeSettings();
+    final SourceSchema sourceSchema = schemaFor(format, settings);
+    final ImporterContext context = new ImporterContext();
+
+    final Parser loadParser = csvParserOver("from,to\nv1,v2\nv1,TOOLONGVALUEHERE\n");
+
+    assertThatThrownBy(
+        () -> format.load(sourceSchema, AnalyzedEntity.EntityType.EDGE, loadParser, (DatabaseInternal) database, context, settings))
+        .isInstanceOf(TextParsingException.class);
+
+    assertThat(database.isTransactionActive())
+        .as("the nested transaction loadEdges() opened must be resolved before the failure propagates")
+        .isFalse();
+    assertThat(countOf("Relationship"))
+        .as("the edge parsed before the failure was never committed")
+        .isZero();
+    assertThat(context.createdEdges.get())
+        .as("the report must count what survived: the edge created before the failure was rolled back with it")
+        .isZero();
+  }
+
+  @Test
+  void aFailedRowDoesNotShadowTheCallersOwnTransaction() throws Exception {
+    final CSVImporterFormat format = new CSVImporterFormat();
+    final ImporterSettings settings = edgeSettings();
+    final SourceSchema sourceSchema = schemaFor(format, settings);
+    final ImporterContext context = new ImporterContext();
+
+    database.begin();
+    database.newDocument("Marker").set("name", "caller").save();
+
+    final Parser loadParser = csvParserOver("from,to\nv1,v2\nv1,TOOLONGVALUEHERE\n");
+
+    assertThatThrownBy(
+        () -> format.load(sourceSchema, AnalyzedEntity.EntityType.EDGE, loadParser, (DatabaseInternal) database, context, settings))
+        .isInstanceOf(TextParsingException.class);
+
+    // The caller's own commit must land on its own transaction, not on the importer's abandoned nested one.
+    database.commit();
+
+    assertThat(database.isTransactionActive())
+        .as("one commit for the one transaction the caller opened must leave nothing active")
+        .isFalse();
+    assertThat(countOf("Marker"))
+        .as("the caller's own record must be what its commit made durable")
+        .isEqualTo(1);
+    assertThat(countOf("Relationship"))
+        .as("the importer's abandoned edge must not ride out on the caller's commit")
+        .isZero();
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/importer/format/CSVImporterFormatLoadEdgesTransactionLeakTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/format/CSVImporterFormatLoadEdgesTransactionLeakTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.integration.importer.format;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.exception.TransactionException;
 import com.arcadedb.integration.importer.AnalyzedEntity;
 import com.arcadedb.integration.importer.AnalyzedSchema;
 import com.arcadedb.integration.importer.ImporterContext;
@@ -39,6 +40,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
 import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -162,6 +165,58 @@ class CSVImporterFormatLoadEdgesTransactionLeakTest {
         .isEqualTo(1);
     assertThat(countOf("Relationship"))
         .as("the importer's abandoned edge must not ride out on the caller's commit")
+        .isZero();
+  }
+
+  /**
+   * A {@code database.commit()} that fails is not the same failure as a row that throws, and the fix has to
+   * treat it separately: {@code LocalDatabase.commit()} pops the transaction inside its own {@code finally},
+   * so by the time the exception surfaces there is nothing left to roll back and the {@code txOpen} flag is
+   * already {@code false}. Hanging the counter correction off that flag would therefore leave the batch the
+   * commit failed to write counted as if it had survived.
+   * <p>
+   * The proxy below reproduces exactly that state - transaction resolved and its changes discarded, exception
+   * propagating out of {@code commit()} - by rolling back and then throwing in place of the real commit.
+   */
+  private DatabaseInternal databaseWhoseCommitFails() {
+    return (DatabaseInternal) Proxy.newProxyInstance(DatabaseInternal.class.getClassLoader(),
+        new Class<?>[] { DatabaseInternal.class }, (proxy, method, args) -> {
+          if ("commit".equals(method.getName()) && (args == null || args.length == 0)) {
+            // What a real commit failure leaves behind: the transaction gone, its records not durable.
+            database.rollback();
+            throw new TransactionException("Simulated commit failure");
+          }
+          try {
+            return method.invoke(database, args);
+          } catch (final InvocationTargetException e) {
+            throw e.getCause();
+          }
+        });
+  }
+
+  @Test
+  void aFailedCommitAlsoReportsOnlyTheEdgesThatSurvived() throws Exception {
+    final CSVImporterFormat format = new CSVImporterFormat();
+    final ImporterSettings settings = edgeSettings();
+    final SourceSchema sourceSchema = schemaFor(format, settings);
+    final ImporterContext context = new ImporterContext();
+
+    // The one data row is valid, so the loop completes and the only failure is the trailing commit itself.
+    final Parser loadParser = csvParserOver("from,to\nv1,v2\n");
+
+    assertThatThrownBy(
+        () -> format.load(sourceSchema, AnalyzedEntity.EntityType.EDGE, loadParser, databaseWhoseCommitFails(), context,
+            settings))
+        .isInstanceOf(TransactionException.class);
+
+    assertThat(database.isTransactionActive())
+        .as("a failed commit still leaves its own transaction off the stack")
+        .isFalse();
+    assertThat(countOf("Relationship"))
+        .as("the failed commit made nothing durable")
+        .isZero();
+    assertThat(context.createdEdges.get())
+        .as("the report must not credit the import with the batch the failed commit never wrote")
         .isZero();
   }
 }

--- a/integration/src/test/java/com/arcadedb/integration/importer/format/RDFImporterFormatTransactionLeakTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/format/RDFImporterFormatTransactionLeakTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer.format;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.integration.importer.ImporterContext;
+import com.arcadedb.integration.importer.ImporterSettings;
+import com.arcadedb.integration.importer.Parser;
+import com.arcadedb.integration.importer.Source;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import com.univocity.parsers.common.TextParsingException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7272 (finding 1): {@code RDFImporterFormat.load()} opens (or reuses) a transaction and never
+ * resolves it if a row throws - the only catch maps {@code IOException} to {@code ImportException} and
+ * does not roll back, so a {@code RuntimeException} escaping {@code csvParser.parseNext()} (a malformed
+ * row) leaves the transaction it opened active.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class RDFImporterFormatTransactionLeakTest {
+
+  private static final String DB_PATH = "target/databases/rdf-importer-tx-leak-test";
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    database = new DatabaseFactory(DB_PATH).create();
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Node").createProperty("id", Type.STRING);
+      database.getSchema().getType("Node").getOrCreateTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, new String[] { "id" });
+      database.getSchema().createEdgeType("Related");
+      database.getSchema().createDocumentType("Marker");
+    });
+  }
+
+  @AfterEach
+  void cleanup() {
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollbackAllNested();
+      if (database.isOpen())
+        database.drop();
+      database = null;
+    }
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  /**
+   * A row whose value exceeds {@code maxPropertySize} makes {@code csvParser.parseNext()} itself throw a
+   * {@link TextParsingException} (unchecked), outside the per-row work the loop otherwise wraps.
+   */
+  private static Parser rdfParser(final String content) throws Exception {
+    final byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+    final Source source = new Source("test.rdf", new ByteArrayInputStream(bytes), bytes.length, false, null, null);
+    return new Parser(source, 0);
+  }
+
+  private ImporterSettings settingsWithTinyMaxPropertySize() {
+    final ImporterSettings settings = new ImporterSettings();
+    settings.vertexTypeName = "Node";
+    settings.edgeTypeName = "Related";
+    settings.typeIdProperty = "id";
+    settings.options.put("maxPropertySize", 5);
+    return settings;
+  }
+
+  private long countOf(final String typeName) {
+    return database.query("sql", "select count(*) as c from " + typeName).next().<Long>getProperty("c");
+  }
+
+  @Test
+  void aFailedRowLeavesNoTransactionActiveWhenTheImporterOwnsIt() throws Exception {
+    final RDFImporterFormat format = new RDFImporterFormat();
+    final ImporterContext context = new ImporterContext();
+    context.callerTransactionActiveOnEntry = false;
+
+    final Parser parser = rdfParser("""
+        s,p,o
+        v1,rel,v2
+        v3,rel,TOOLONGVALUEHERE
+        """);
+
+    assertThatThrownBy(() -> format.load(null, null, parser, (DatabaseInternal) database, context, settingsWithTinyMaxPropertySize()))
+        .isInstanceOf(TextParsingException.class);
+
+    assertThat(database.isTransactionActive())
+        .as("the transaction load() opened for itself must be resolved before the failure propagates")
+        .isFalse();
+    assertThat(countOf("Node"))
+        .as("nothing must be durable: the only edge parsed before the failure was never committed")
+        .isZero();
+    assertThat(context.createdEdges.get())
+        .as("the report must count what survived: the edge created before the failure was rolled back with it")
+        .isZero();
+  }
+
+  @Test
+  void aFailedRowLeavesTheCallersOwnTransactionUntouched() throws Exception {
+    final RDFImporterFormat format = new RDFImporterFormat();
+    final ImporterContext context = new ImporterContext();
+    context.callerTransactionActiveOnEntry = true;
+
+    database.begin();
+    database.newDocument("Marker").set("name", "caller").save();
+
+    final Parser parser = rdfParser("""
+        s,p,o
+        v1,rel,v2
+        v3,rel,TOOLONGVALUEHERE
+        """);
+
+    assertThatThrownBy(() -> format.load(null, null, parser, (DatabaseInternal) database, context, settingsWithTinyMaxPropertySize()))
+        .isInstanceOf(TextParsingException.class);
+
+    assertThat(database.isTransactionActive())
+        .as("a transaction that predates the import is never the importer's to roll back")
+        .isTrue();
+
+    database.commit();
+
+    assertThat(countOf("Marker"))
+        .as("the caller's own pending work must survive a failure inside a transaction it owns")
+        .isEqualTo(1);
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/importer/format/RDFImporterFormatTransactionLeakTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/format/RDFImporterFormatTransactionLeakTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.integration.importer.format;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.exception.TransactionException;
 import com.arcadedb.integration.importer.ImporterContext;
 import com.arcadedb.integration.importer.ImporterSettings;
 import com.arcadedb.integration.importer.Parser;
@@ -36,6 +37,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
 import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -156,4 +159,88 @@ class RDFImporterFormatTransactionLeakTest {
         .as("the caller's own pending work must survive a failure inside a transaction it owns")
         .isEqualTo(1);
   }
+
+  /**
+   * The CLI pipeline's shape, which is not the same as either of the two above:
+   * {@code AbstractImporter.openDatabase()} ends with a {@code database.begin()} deliberately left open for the
+   * whole import, so {@code load()} finds a transaction already active and reuses it - while
+   * {@code callerTransactionActiveOnEntry} stays {@code false}, because that transaction belongs to the import
+   * and not to an external caller. A failing row must still resolve it: leaving it active is what let
+   * {@code AbstractImporter.closeDatabase()} commit a half-finished import.
+   */
+  @Test
+  void aFailedRowResolvesTheTransactionTheImportPipelineLeftOpen() throws Exception {
+    final RDFImporterFormat format = new RDFImporterFormat();
+    final ImporterContext context = new ImporterContext();
+    context.callerTransactionActiveOnEntry = false;
+
+    // What AbstractImporter.openDatabase() leaves behind before the format runs.
+    database.begin();
+
+    final Parser parser = rdfParser("""
+        s,p,o
+        v1,rel,v2
+        v3,rel,TOOLONGVALUEHERE
+        """);
+
+    assertThatThrownBy(() -> format.load(null, null, parser, (DatabaseInternal) database, context, settingsWithTinyMaxPropertySize()))
+        .isInstanceOf(TextParsingException.class);
+
+    assertThat(database.isTransactionActive())
+        .as("the import pipeline's own transaction is the import's to resolve, and a failure must resolve it")
+        .isFalse();
+    assertThat(countOf("Node"))
+        .as("nothing from the aborted import may survive to be committed by closeDatabase()")
+        .isZero();
+  }
+
+  /**
+   * A {@code database.commit()} that fails is a different path from a row that throws:
+   * {@code LocalDatabase.commit()} pops the transaction inside its own {@code finally}, so there is nothing
+   * left to roll back and the {@code txOpen} flag is already {@code false} - only the {@code completed} flag
+   * can still bring the counter back. The proxy reproduces that state exactly.
+   */
+  private DatabaseInternal databaseWhoseCommitFails() {
+    return (DatabaseInternal) Proxy.newProxyInstance(DatabaseInternal.class.getClassLoader(),
+        new Class<?>[] { DatabaseInternal.class }, (proxy, method, args) -> {
+          if ("commit".equals(method.getName()) && (args == null || args.length == 0)) {
+            // What a real commit failure leaves behind: the transaction gone, its records not durable.
+            database.rollback();
+            throw new TransactionException("Simulated commit failure");
+          }
+          try {
+            return method.invoke(database, args);
+          } catch (final InvocationTargetException e) {
+            throw e.getCause();
+          }
+        });
+  }
+
+  @Test
+  void aFailedCommitReportsOnlyTheEdgesThatSurvived() throws Exception {
+    final RDFImporterFormat format = new RDFImporterFormat();
+    final ImporterContext context = new ImporterContext();
+    context.callerTransactionActiveOnEntry = false;
+
+    // Every row is valid, so the loop completes and the only failure is the trailing commit itself.
+    final Parser parser = rdfParser("""
+        s,p,o
+        v1,rel,v2
+        """);
+
+    assertThatThrownBy(
+        () -> format.load(null, null, parser, databaseWhoseCommitFails(), context, settingsWithTinyMaxPropertySize()))
+        .isInstanceOf(TransactionException.class);
+
+    assertThat(database.isTransactionActive())
+        .as("a failed commit still leaves its own transaction off the stack")
+        .isFalse();
+    assertThat(countOf("Node"))
+        .as("the failed commit made nothing durable")
+        .isZero();
+    assertThat(context.createdEdges.get())
+        .as("the report must not credit the import with the batch the failed commit never wrote")
+        .isZero();
+  }
+
 }


### PR DESCRIPTION
Closes #7272

`LocalDatabase.begin()` pushes a **nested** `TransactionContext` when one is already active, and
`commit()`/`rollback()` pop whatever is on top. Four importer entry points opened a transaction before a row
loop and resolved it only on the success path, so an exception escaping the loop left that transaction on the
stack - and the caller's own next `commit()` popped the importer's instead of its own. This fixes all four,
plus a fifth of the identical shape that the completeness sweep found in the same class.

Each site now (1) tracks whether the transaction it pushed is still current, cleared right *before* every
commit because `LocalDatabase.commit()` pops inside a `finally` and a commit that throws still leaves the
transaction off the stack; (2) rolls back in a `finally` rather than a `catch`, so an `Error` resolves it too,
with the rollback itself wrapped so a failure there cannot replace the exception the caller can actually act
on; and (3) resets the progress counter to its value at the last successful commit, so a partial import
reports what survived rather than what it read - the issue's third suggested fix, using the same
`context.created*.set(...)` idiom `JSONImporterFormat.parseRecords` already uses.

## Coverage

| Entry point | Fixed | Test |
|---|---|---|
| `RDFImporterFormat.load` | yes | `RDFImporterFormatTransactionLeakTest` |
| `CSVImporterFormat.loadEdges` | yes | `CSVImporterFormatLoadEdgesTransactionLeakTest` |
| `OrientDBImporter.updateDocumentLinks` | yes | `OrientDBImporterUpdateDocumentLinksTransactionLeakTest` |
| `Neo4jImporter.readFile` (drives `syncSchema`) | yes | `Neo4jImporterReadFileTransactionLeakTest` |
| `Neo4jImporter.parseVertices` - **not named by the issue** | yes | `Neo4jImporterParseVerticesTransactionLeakTest` |

The sweep was `grep -rn "database\.begin()\|database\.commit()\|database\.rollback()"` over
`integration/src/main/java/com/arcadedb/integration/importer/` - 70 hits across 9 files. The rest classify as:

- **Already fixed:** `CSVImporterFormat.loadDocuments`/`loadVertices` (`rollbackIfOwned`),
  `JSONImporterFormat.parseRecords`, `GraphImporter.processVertexSource` (#7264 / PR #7270).
- **Not the same defect, with evidence:** `Neo4jImporter.parseEdges` never calls `database.begin()` - it
  delegates the cadence to `GraphBatch.withCommitEvery(batchSize)`, so there is no manually-opened transaction
  to leak. `AbstractImporter.openDatabase` is not a row loop: its `begin()`/`commit()` pair brackets schema
  creation and its trailing `begin()` is deliberately left open for the import phases, resolved by
  `Importer.java:93` / `closeDatabase()`.

### Known gaps

- **#7288** (filed with this PR) - `RDFImporterFormat.load` increments `context.parsed` twice per row, so with
  the default one-line header skip the value at the `% commitEvery` check is always odd and the default
  `commitEvery = 5000` never divides it: the mid-loop commit **never fires**, and an RDF import is one
  transaction whatever `-commitEvery` says. The issue also covers the missing `context.parsed.set(0)` on entry
  that every sibling format performs, and the fact that `load()` commits a caller-supplied transaction early.
  Deliberately out of scope here: this PR only makes sure the importer *resolves* the transaction it opened,
  it does not change when anything commits.
- `JsonlImporterFormat` - out of scope, tracked by #6561.

Nothing else is left unaccounted for.

## Test plan

- [x] `mvn -o -pl integration -am install -DskipTests` - compiles clean across the reactor.
- [x] `mvn -o -pl integration test` - **275 unit tests, 0 failures** (272 on `main`, +3 from the new
      `parseVertices` class).
- [x] `mvn -o -pl integration verify -DskipITs=false -Dit.test=CSVImporterIT,Neo4jImporterIT,Neo4jImporterLabelCharactersIT,OrientDBImporterIT,JSONImporterIT,JsonLImporterIT,XMLImporterIT,SQLLocalImporterIT`
      - **51 integration tests, 0 failures**, covering every importer touched.
- [x] **Every assertion proved able to fail**, by reverting only the code it covers:
  - the four production files reverted to `main`: 7 of 8 original tests fail. The 8th
    (`aFailedRowLeavesTheCallersOwnTransactionUntouched`) is a guard against the fix over-reaching into a
    caller's transaction - it must pass on both sides, and does.
  - `Neo4jImporter.java` alone reverted: all 3 `parseVertices` tests fail.
  - only the `context.created*.set(...)` lines neutralized: the three counter assertions fail.

That last check caught a defect in this branch's own first draft: the RDF fixture's header row was `header`,
six characters against a `maxCharsPerColumn` of 5, so `parseNext()` threw on line 0 and the test never reached
the edge-creation branch its Javadoc described. It now uses an `s,p,o` header and declares the `Related` edge
type, so the valid row really does create an edge before the malformed one aborts the load.

`OrientDBImporterUpdateDocumentLinksTransactionLeakTest` deliberately carries no counter assertion:
`convertRIDs()` throws before `context.updatedDocuments.incrementAndGet()` on the first document, so both the
pre- and post-fix value are 0 and an assertion there would pass for the wrong reason. The other three classes
are what prove the counter restore does something.

## Review round 1 (`782d980` -> `b6724e5`)

Both correctness findings were real and are fixed; the maintainability note is deliberately not taken.

**1. Counter correction was skipped when `commit()` itself threw.** Correct, and the diagnosis was exact:
`txOpen` is cleared *before* `commit()` precisely because `LocalDatabase.commit()` pops in its own `finally`,
so a failing commit left the correction unreachable and the batch it never wrote still counted. Rollback
eligibility and counter correction are now two flags rather than one - a `completed` flag drives the
correction, so it runs whether the loop threw or the commit did. New regression test
`aFailedCommitAlsoReportsOnlyTheEdgesThatSurvived` drives a commit that fails the way a real one does
(transaction resolved, changes discarded, exception out of `commit()`), and it fails if the correction is
put back behind `txOpen`.

**2. `RDFImporterFormat`'s `txOpen = ownsTransaction` after the mid-loop `begin()`.** Also correct that the
assignment was wrong, though `txOpen = true` on its own would have traded the dormant leak for a different
problem: when the caller's transaction is the last one on the stack, `commit()` does not pop it and the
following `begin()` re-begins *that same context*, so rolling it back would leave the caller with no active
transaction and its next `commit()` throwing. The real defect is one line earlier - the method should not be
committing a transaction it does not own at all. The mid-loop commit is now gated on `ownsTransaction`, the
same guard `JsonlImporterFormat.load()` applies for the same reason (#6561: "a caller-managed transaction is
never ours to commit piecemeal, only to accumulate into and hand back"). That removes the dormant leak, makes
the `txOpen = true` assignment unconditional and correct, and as a side effect settles the
"commits a caller-supplied transaction early" wart that #7288 lists. The trailing commit stays as it is:
changing it is a behaviour change for the default path and belongs in #7288.

**3. Shared helper for the four sites - not taken, with reasons.** The scaffolding looks duplicated but the
four sites differ in every axis a helper would have to abstract: the logger (`LogManager` in the two formats,
`ConsoleLogger` in `OrientDBImporter`, the private `log`/`error` pair in `Neo4jImporter`), the counter field,
whether the flags are captured by a lambda (`Neo4jImporter.parseVertices` needs `boolean[]`/`long[]`, the
others use plain locals), and whether ownership is unconditional or gated on
`callerTransactionActiveOnEntry`. A helper taking four callbacks plus a counter accessor would be longer than
what it folds and would hide the one thing a reader of these loops needs to see - where exactly the flag is
cleared relative to the commit. Left explicit, with the reasoning in a comment at each site.

## Review round 2 (`b6724e5` -> `d2aaf9f`)

**1. `parseVertices` seeded `committedVertices` from `0`** while the other four sites seed from the counter's
current value - flagged independently by both reviewers, and correct. The embedding constructor takes an
`ImporterContext` from its caller, so a context already carrying durable vertices would be zeroed by the
correction instead of left at its true baseline. Now `{ context.createdVertices.get() }`.

**2. `loadEdges`' periodic commit sat inside the per-row `catch`.** CodeRabbit marked this "addressed in
b6724e5"; that marker is wrong. Round 1 fixed the counter half only, and the control-flow half was still
live: a `commit()` that throws was caught and logged under an "Error on parsing line N" message, and the loop
carried on with **no transaction active** - `commit()` pops in its own `finally` and the `begin()` after it
never runs - so every remaining row failed too and the operator saw a wall of row errors instead of the
commit failure. The periodic commit is now outside the per-row catch, so the real cause escapes to the
`finally` that corrects the counter and propagates. New test
`aFailedPeriodicCommitStopsTheImportInsteadOfBeingLoggedAsARowError` pins it: with the commit back inside the
catch, `context.parsed` reaches 3 instead of 2 because the loop reads the row after the failure.

Unit suite is now **277 tests, 0 failures**; the 51 importer ITs stay green.

## Review round 3 (`d2aaf9f` -> `6163359`)

**1. `ownsTransaction` does not mean "this call pushed the transaction".** Correct, and the mechanism was
described exactly: `AbstractImporter.openDatabase()` ends with a `begin()` deliberately left open for the whole
import, so in the CLI pipeline `RDFImporterFormat.load()` finds one active and reuses it while
`callerTransactionActiveOnEntry` is still `false`. The *behaviour* is right - rolling that transaction back on
failure is what stops `closeDatabase()` from committing a half-finished import - but the comment claimed
something narrower than the code does. Rewritten to state the real distinction: a transaction belonging to the
import, versus one that predates it.

**Answering the review's question directly: no.** The 51 ITs do not cover a failing RDF import through the
full `Importer` pipeline, because **there is no RDF integration test in the module at all** -
`RDFImporterFormatTransactionLeakTest` is the only RDF coverage that exists. Rather than leave that implicit,
`aFailedRowResolvesTheTransactionTheImportPipelineLeftOpen` now drives exactly the CLI shape described
(transaction already active, `callerTransactionActiveOnEntry` false, row fails).

**2. Test asymmetry: RDF had no commit-failure test.** Fixed - `aFailedCommitReportsOnlyTheEdgesThatSurvived`
mirrors `loadEdges`'. Both new tests fail against `main`.

**3.** The `boolean[]`/`long[]` wrapping nit needed no action; noted as deliberate.

Unit suite is now **279 tests, 0 failures**; the 51 importer ITs stay green.

## Review round 4 (`6163359` -> `24490c8`)

One finding, and it was a fair one: the `completed`-flag fix from round 1 was pinned for `loadEdges` and for
`RDFImporterFormat`, but `parseVertices`' three tests all drive a failing *read*, where `txOpen[0]` is still
`true` when the `finally` runs - the rollback branch, not the branch the flag exists for. So the flag was
untested at the one site where it is wrapped in single-element arrays.
`aFailedCommitReportsOnlyTheVerticesThatSurvived` now fails the periodic commit instead, through the same
`Proxy` pattern as the other two, and it was verified load-bearing rather than copied: putting the correction
back behind the flag the rollback branch uses makes the new test fail while the other three still pass.

The review's second point (RDF's trailing commit still unconditional) was explicitly not a new finding and
stays with #7288, which is the scope boundary this PR has held since round 1.

Final state: **280 unit tests, 0 failures**; 51 importer ITs green. Every commit-failure and row-failure path
at all five sites now has a test that fails without its fix.

## CI on `24490c8`

**32 checks pass**, including `build-and-package`, `lint`, `unit-tests`, `integration-tests`,
`slow-unit-tests`, `vector-unit-tests`, CodeQL and every e2e lane.

`ha-integration-tests` fails (and `CI Status` rolls that up). **It is red on `main` for the same reason and
is not caused by this PR** - verified rather than assumed: run 34282456547 on `main` fails
`Issue5569SlotMergeDeleteRaftIT.mergedDeletesReplicateIntact` with the identical
`AssertionError: Update returned null: record=0 seq=28`, alongside `RaftHARandomCrashIT` and
`RaftPriorityRejoinIT`. All three are `ha-raft` consensus tests; `ha-raft`'s only link to this PR's module is a
`test`-scoped dependency on `arcadedb-integration` for the "backup database" SQL command, which touches no
importer. Tracked as #5668.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvLhYByiYvAXzdZ9ZD5ekW
