### PR TITLE
fix(#7291): the Query Profiler total covers the whole engine execution

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -494,6 +494,11 @@ public class CypherExecutionPlan {
       }
 
       @Override
+      public String getName() {
+        return "SubquerySeedRowStep";
+      }
+
+      @Override
       public String prettyPrint(final int depth, final int indent) {
         return "  ".repeat(Math.max(0, depth * indent)) + "+ SUBQUERY SEED ROW";
       }
@@ -1116,6 +1121,11 @@ public class CypherExecutionPlan {
       }
 
       @Override
+      public String getName() {
+        return "OptimizedMatchStep";
+      }
+
+      @Override
       public String prettyPrint(final int depth, final int indent) {
         return "  ".repeat(Math.max(0, depth * indent)) + "+ OPTIMIZED MATCH (physical operators)\n" +
             physicalPlan.explain();
@@ -1463,6 +1473,11 @@ public class CypherExecutionPlan {
           }
           consumed = true;
           return new IteratorResultSet(singleRow.iterator());
+        }
+
+        @Override
+        public String getName() {
+          return "DummyRowStep";
         }
 
         @Override
@@ -3191,6 +3206,11 @@ public class CypherExecutionPlan {
           }
           consumed = true;
           return new IteratorResultSet(singleRow.iterator());
+        }
+
+        @Override
+        public String getName() {
+          return "DummyRowStep";
         }
 
         @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -499,6 +499,11 @@ public class CypherExecutionPlan {
       }
 
       @Override
+      public String getType() {
+        return getName();
+      }
+
+      @Override
       public String prettyPrint(final int depth, final int indent) {
         return "  ".repeat(Math.max(0, depth * indent)) + "+ SUBQUERY SEED ROW";
       }
@@ -1126,6 +1131,11 @@ public class CypherExecutionPlan {
       }
 
       @Override
+      public String getType() {
+        return getName();
+      }
+
+      @Override
       public String prettyPrint(final int depth, final int indent) {
         return "  ".repeat(Math.max(0, depth * indent)) + "+ OPTIMIZED MATCH (physical operators)\n" +
             physicalPlan.explain();
@@ -1475,9 +1485,17 @@ public class CypherExecutionPlan {
           return new IteratorResultSet(singleRow.iterator());
         }
 
+        // Both sites that build this step produce the same thing - one dummy row for a statement whose
+        // expressions stand on their own - so they deliberately share a name and aggregate together in the
+        // profiler's per-step statistics.
         @Override
         public String getName() {
           return "DummyRowStep";
+        }
+
+        @Override
+        public String getType() {
+          return getName();
         }
 
         @Override
@@ -3208,9 +3226,17 @@ public class CypherExecutionPlan {
           return new IteratorResultSet(singleRow.iterator());
         }
 
+        // Both sites that build this step produce the same thing - one dummy row for a statement whose
+        // expressions stand on their own - so they deliberately share a name and aggregate together in the
+        // profiler's per-step statistics.
         @Override
         public String getName() {
           return "DummyRowStep";
+        }
+
+        @Override
+        public String getType() {
+          return getName();
         }
 
         @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ForeachStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ForeachStep.java
@@ -310,6 +310,16 @@ public class ForeachStep extends AbstractExecutionStep {
       }
 
       @Override
+      public String getName() {
+        return "ForeachInputStep";
+      }
+
+      @Override
+      public String getType() {
+        return getName();
+      }
+
+      @Override
       public String prettyPrint(final int depth, final int indent) {
         return "  ".repeat(Math.max(0, depth * indent)) + "+ FOREACH INPUT";
       }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ExecutionStepInternal.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ExecutionStepInternal.java
@@ -100,6 +100,8 @@ public interface ExecutionStepInternal extends ExecutionStep {
       if (!name.isEmpty())
         return name;
     }
+    // Unreachable for any real step: the walk ends at Object, whose simple name is not empty. Kept so the method
+    // is total rather than relying on that being true of every classloader that ever produces a step class.
     return "ExecutionStep";
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ExecutionStepInternal.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ExecutionStepInternal.java
@@ -81,11 +81,26 @@ public interface ExecutionStepInternal extends ExecutionStep {
   }
 
   default String getName() {
-    return getClass().getSimpleName();
+    return simpleNameOf(getClass());
   }
 
   default String getType() {
-    return getClass().getSimpleName();
+    return simpleNameOf(getClass());
+  }
+
+  /**
+   * The step class' simple name, falling back to the first named ancestor for an anonymous step. {@code
+   * Class.getSimpleName()} answers the empty string for an anonymous class, and a step chain built out of anonymous
+   * steps (the OpenCypher plan builds several) therefore published nameless rows in the EXPLAIN/PROFILE plan and in
+   * Studio's Query Profiler step table (issue #7291).
+   */
+  static String simpleNameOf(final Class<?> stepClass) {
+    for (Class<?> c = stepClass; c != null; c = c.getSuperclass()) {
+      final String name = c.getSimpleName();
+      if (!name.isEmpty())
+        return name;
+    }
+    return "ExecutionStep";
   }
 
   default String getDescription() {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FilterNotMatchPatternStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FilterNotMatchPatternStep.java
@@ -130,6 +130,16 @@ public class FilterNotMatchPatternStep extends AbstractExecutionStep {
       private boolean executed = false;
 
       @Override
+      public String getName() {
+        return "NotMatchPatternInputStep";
+      }
+
+      @Override
+      public String getType() {
+        return getName();
+      }
+
+      @Override
       public ResultSet syncPull(final CommandContext context, final int nRecords) throws TimeoutException {
         final InternalResultSet result = new InternalResultSet();
         if (!executed) {

--- a/server/src/main/java/com/arcadedb/server/ServerDatabase.java
+++ b/server/src/main/java/com/arcadedb/server/ServerDatabase.java
@@ -515,8 +515,9 @@ public class ServerDatabase implements DatabaseInternal {
     final ServerQueryProfiler profiler = getProfiler();
     if (profiler == null || !profiler.isRecording())
       return wrapped.command(language, query, configuration, args);
+    final long beginNanos = System.nanoTime();
     final ResultSet rs = wrapped.command(language, query, configuration, args);
-    return new ProfilingResultSet(rs, profiler, wrapped.getName(), language, query);
+    return new ProfilingResultSet(rs, profiler, wrapped.getName(), language, query, beginNanos);
   }
 
   @Override
@@ -524,8 +525,9 @@ public class ServerDatabase implements DatabaseInternal {
     final ServerQueryProfiler profiler = getProfiler();
     if (profiler == null || !profiler.isRecording())
       return wrapped.command(language, query);
+    final long beginNanos = System.nanoTime();
     final ResultSet rs = wrapped.command(language, query);
-    return new ProfilingResultSet(rs, profiler, wrapped.getName(), language, query);
+    return new ProfilingResultSet(rs, profiler, wrapped.getName(), language, query, beginNanos);
   }
 
   @Override
@@ -533,8 +535,9 @@ public class ServerDatabase implements DatabaseInternal {
     final ServerQueryProfiler profiler = getProfiler();
     if (profiler == null || !profiler.isRecording())
       return wrapped.command(language, query, parameters);
+    final long beginNanos = System.nanoTime();
     final ResultSet rs = wrapped.command(language, query, parameters);
-    return new ProfilingResultSet(rs, profiler, wrapped.getName(), language, query);
+    return new ProfilingResultSet(rs, profiler, wrapped.getName(), language, query, beginNanos);
   }
 
   @Override
@@ -544,8 +547,9 @@ public class ServerDatabase implements DatabaseInternal {
       return wrapped.command(language, query, parameters);
     final Map<String, Object> profilingParams = new HashMap<>(parameters);
     profilingParams.put("$profileExecution", true);
+    final long beginNanos = System.nanoTime();
     final ResultSet rs = wrapped.command(language, query, profilingParams);
-    return new ProfilingResultSet(rs, profiler, wrapped.getName(), language, query);
+    return new ProfilingResultSet(rs, profiler, wrapped.getName(), language, query, beginNanos);
   }
 
   @Override
@@ -556,8 +560,9 @@ public class ServerDatabase implements DatabaseInternal {
       return wrapped.command(language, query, configuration, args);
     final Map<String, Object> profilingArgs = new HashMap<>(args);
     profilingArgs.put("$profileExecution", true);
+    final long beginNanos = System.nanoTime();
     final ResultSet rs = wrapped.command(language, query, configuration, profilingArgs);
-    return new ProfilingResultSet(rs, profiler, wrapped.getName(), language, query);
+    return new ProfilingResultSet(rs, profiler, wrapped.getName(), language, query, beginNanos);
   }
 
   @Deprecated
@@ -568,8 +573,9 @@ public class ServerDatabase implements DatabaseInternal {
       return wrapped.execute(language, script, params);
     final Map<String, Object> profilingParams = new HashMap<>(params);
     profilingParams.put("$profileExecution", true);
+    final long beginNanos = System.nanoTime();
     final ResultSet rs = wrapped.execute(language, script, profilingParams);
-    return new ProfilingResultSet(rs, profiler, wrapped.getName(), language, script);
+    return new ProfilingResultSet(rs, profiler, wrapped.getName(), language, script, beginNanos);
   }
 
   @Deprecated
@@ -578,8 +584,9 @@ public class ServerDatabase implements DatabaseInternal {
     final ServerQueryProfiler profiler = getProfiler();
     if (profiler == null || !profiler.isRecording())
       return wrapped.execute(language, script, args);
+    final long beginNanos = System.nanoTime();
     final ResultSet rs = wrapped.execute(language, script, args);
-    return new ProfilingResultSet(rs, profiler, wrapped.getName(), language, script);
+    return new ProfilingResultSet(rs, profiler, wrapped.getName(), language, script, beginNanos);
   }
 
   @Override
@@ -587,8 +594,9 @@ public class ServerDatabase implements DatabaseInternal {
     final ServerQueryProfiler profiler = getProfiler();
     if (profiler == null || !profiler.isRecording())
       return wrapped.query(language, query);
+    final long beginNanos = System.nanoTime();
     final ResultSet rs = wrapped.query(language, query);
-    return new ProfilingResultSet(rs, profiler, wrapped.getName(), language, query);
+    return new ProfilingResultSet(rs, profiler, wrapped.getName(), language, query, beginNanos);
   }
 
   @Override
@@ -596,8 +604,9 @@ public class ServerDatabase implements DatabaseInternal {
     final ServerQueryProfiler profiler = getProfiler();
     if (profiler == null || !profiler.isRecording())
       return wrapped.query(language, query, parameters);
+    final long beginNanos = System.nanoTime();
     final ResultSet rs = wrapped.query(language, query, parameters);
-    return new ProfilingResultSet(rs, profiler, wrapped.getName(), language, query);
+    return new ProfilingResultSet(rs, profiler, wrapped.getName(), language, query, beginNanos);
   }
 
   @Override
@@ -607,8 +616,9 @@ public class ServerDatabase implements DatabaseInternal {
       return wrapped.query(language, query, parameters);
     final Map<String, Object> profilingParams = new HashMap<>(parameters);
     profilingParams.put("$profileExecution", true);
+    final long beginNanos = System.nanoTime();
     final ResultSet rs = wrapped.query(language, query, profilingParams);
-    return new ProfilingResultSet(rs, profiler, wrapped.getName(), language, query);
+    return new ProfilingResultSet(rs, profiler, wrapped.getName(), language, query, beginNanos);
   }
 
   @Override

--- a/server/src/main/java/com/arcadedb/server/monitor/ProfilingResultSet.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/ProfilingResultSet.java
@@ -36,14 +36,24 @@ public class ProfilingResultSet implements ResultSet {
   private final long                 startNanos;
   private volatile boolean           recorded;
 
+  /**
+   * @param startNanos the {@link System#nanoTime()} reading taken <b>before</b> the query was handed to the engine.
+   *                   It cannot be taken here: by the time this wrapper is built the engine call has already
+   *                   returned, and everything a non-streaming plan does (every write statement, and every
+   *                   OpenCypher statement while the profiler is recording, because the profiler routes those
+   *                   through {@code CypherExecutionPlan.profile()} which drains the plan eagerly) has already
+   *                   happened. Starting the clock in this constructor therefore measured only the drain of an
+   *                   already-materialized iterator - a few microseconds - and Studio showed a query total far
+   *                   below its own step timings (issue #7291).
+   */
   public ProfilingResultSet(final ResultSet delegate, final ServerQueryProfiler profiler, final String database,
-      final String language, final String queryText) {
+      final String language, final String queryText, final long startNanos) {
     this.delegate = delegate;
     this.profiler = profiler;
     this.database = database;
     this.language = language;
     this.queryText = queryText;
-    this.startNanos = System.nanoTime();
+    this.startNanos = startNanos;
   }
 
   @Override

--- a/server/src/main/java/com/arcadedb/server/monitor/ServerQueryProfiler.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/ServerQueryProfiler.java
@@ -400,7 +400,9 @@ public class ServerQueryProfiler {
       final JSONObject step = stepsArray.getJSONObject(i);
       final String rawName = step.getString("name", "unknown");
       final String name = rawName.isBlank() ? "unknown" : rawName;
-      final long cost = step.getLong("cost", 0);
+      // Default to the same -1 the engine uses for "not calculated", so a plan that omits the field is classified
+      // as untimed rather than as a step that measurably took no time at all.
+      final long cost = step.getLong("cost", -1);
       stepCosts.computeIfAbsent(name, k -> new ArrayList<>()).add(cost);
 
       // Recurse into sub-steps

--- a/server/src/main/java/com/arcadedb/server/monitor/ServerQueryProfiler.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/ServerQueryProfiler.java
@@ -362,19 +362,33 @@ public class ServerQueryProfiler {
     final JSONArray result = new JSONArray();
     for (final Map.Entry<String, List<Long>> stepEntry : stepCosts.entrySet()) {
       final List<Long> costs = stepEntry.getValue();
-      final long[] costArray = costs.stream().mapToLong(Long::longValue).toArray();
-      Arrays.sort(costArray);
+
+      // A step reports cost -1 when it was never timed: per-step timing only runs when the command context has
+      // profiling on, which is not the case on every path that reaches the recorder. Summing that sentinel as if
+      // it were a duration turned "not measured" into a negative cost (issue #7291), so the statistics below are
+      // computed over the timed occurrences only, while executionCount still counts every occurrence.
+      final long[] costArray = costs.stream().mapToLong(Long::longValue).filter(c -> c >= 0).sorted().toArray();
 
       final JSONObject stepObj = new JSONObject();
       stepObj.put("name", stepEntry.getKey());
-      stepObj.put("executionCount", costArray.length);
+      stepObj.put("executionCount", costs.size());
+      stepObj.put("measuredCount", costArray.length);
 
-      final double totalCost = sumNanos(costArray) / 1_000_000.0;
-      stepObj.put("totalCostMs", round(totalCost));
-      stepObj.put("minCostMs", round(costArray[0] / 1_000_000.0));
-      stepObj.put("maxCostMs", round(costArray[costArray.length - 1] / 1_000_000.0));
-      stepObj.put("avgCostMs", round(totalCost / costArray.length));
-      stepObj.put("p99CostMs", round(percentile(costArray, 99) / 1_000_000.0));
+      if (costArray.length == 0) {
+        // Nothing timed: report zeros rather than a made-up cost.
+        stepObj.put("totalCostMs", 0d);
+        stepObj.put("minCostMs", 0d);
+        stepObj.put("maxCostMs", 0d);
+        stepObj.put("avgCostMs", 0d);
+        stepObj.put("p99CostMs", 0d);
+      } else {
+        final double totalCost = sumNanos(costArray) / 1_000_000.0;
+        stepObj.put("totalCostMs", round(totalCost));
+        stepObj.put("minCostMs", round(costArray[0] / 1_000_000.0));
+        stepObj.put("maxCostMs", round(costArray[costArray.length - 1] / 1_000_000.0));
+        stepObj.put("avgCostMs", round(totalCost / costArray.length));
+        stepObj.put("p99CostMs", round(percentile(costArray, 99) / 1_000_000.0));
+      }
 
       result.put(stepObj);
     }
@@ -384,7 +398,8 @@ public class ServerQueryProfiler {
   private void extractStepCosts(final JSONArray stepsArray, final Map<String, List<Long>> stepCosts) {
     for (int i = 0; i < stepsArray.length(); i++) {
       final JSONObject step = stepsArray.getJSONObject(i);
-      final String name = step.getString("name", "unknown");
+      final String rawName = step.getString("name", "unknown");
+      final String name = rawName.isBlank() ? "unknown" : rawName;
       final long cost = step.getLong("cost", 0);
       stepCosts.computeIfAbsent(name, k -> new ArrayList<>()).add(cost);
 

--- a/server/src/test/java/com/arcadedb/server/ServerQueryProfilerTest.java
+++ b/server/src/test/java/com/arcadedb/server/ServerQueryProfilerTest.java
@@ -609,6 +609,7 @@ class ServerQueryProfilerTest extends StaticBaseServerTest {
     plan.put("steps", new JSONArray()
         .put(new JSONObject().put("name", "TimedStep").put("cost", 4_000_000L))
         .put(new JSONObject().put("name", "UntimedStep").put("cost", -1L))
+        .put(new JSONObject().put("name", "NoCostStep"))
         .put(new JSONObject().put("name", "").put("cost", -1L)));
 
     profiler.recordQuery("testdb", "sql", "SELECT FROM Person", 10_000_000L, plan);
@@ -626,6 +627,11 @@ class ServerQueryProfilerTest extends StaticBaseServerTest {
     assertThat(untimed.getDouble("totalCostMs")).isEqualTo(0.0);
     assertThat(untimed.getDouble("minCostMs")).isEqualTo(0.0);
     assertThat(untimed.getDouble("p99CostMs")).isEqualTo(0.0);
+
+    // A plan that omits the field entirely is untimed too, not a step that measurably took no time at all.
+    final JSONObject noCost = findStep(steps, "NoCostStep");
+    assertThat(noCost.getInt("measuredCount")).isEqualTo(0);
+    assertThat(noCost.getDouble("totalCostMs")).isEqualTo(0.0);
 
     assertThat(findStep(steps, "unknown")).as("a blank step name must be labelled, not left empty").isNotNull();
   }

--- a/server/src/test/java/com/arcadedb/server/ServerQueryProfilerTest.java
+++ b/server/src/test/java/com/arcadedb/server/ServerQueryProfilerTest.java
@@ -35,7 +35,10 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -48,6 +51,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 class ServerQueryProfilerTest extends StaticBaseServerTest {
+  private static final String CONSISTENCY_QUERY = "UNWIND $data AS row"
+      + " MATCH (source:`Entity` {id: row.source_id})"
+      + " MATCH (target:`Entity` {id: row.target_id})"
+      + " MERGE (source)-[:`RELATES` {name: row.name}]->(target)";
+
   private ArcadeDBServer server;
 
   @BeforeEach
@@ -505,5 +513,137 @@ class ServerQueryProfilerTest extends StaticBaseServerTest {
       server.removeDatabase("profiler-pm-db1");
       server.removeDatabase("profiler-pm-db2");
     }
+  }
+
+  /**
+   * Issue #7291: the query total reported by the profiler must cover the whole engine execution, so it can never
+   * come out below the timings of the steps that ran inside it.
+   * <p>
+   * The wrapper that records the entry used to start its clock in its own constructor, which runs only after the
+   * engine call has returned. Everything a non-streaming plan does had already happened by then - and while the
+   * profiler is recording, an OpenCypher statement is always non-streaming, because the recorder asks for per-step
+   * timings and that routes the statement through the plan's profiling path, which drains it eagerly. The recorded
+   * total was therefore the cost of walking an already-materialized iterator: microseconds, next to step rows
+   * reporting seconds.
+   * <p>
+   * The assertions are relational rather than wall-clock bounds: the defect is an inconsistency between two numbers
+   * measured in the same run, so a GC pause moves both and cannot make this flake.
+   */
+  @Test
+  void queryTotalCoversTheStepsItContains() {
+    server.createDatabase("profiler-consistency-db", ComponentFile.MODE.READ_WRITE);
+    final ServerDatabase db = server.getDatabase("profiler-consistency-db");
+    try {
+      db.command("sql", "CREATE VERTEX TYPE Entity");
+      db.command("sql", "CREATE PROPERTY Entity.id STRING");
+      db.command("sql", "CREATE INDEX ON Entity (id) UNIQUE");
+      db.command("sql", "CREATE EDGE TYPE RELATES");
+      for (int i = 0; i < 20; i++)
+        db.command("sql", "INSERT INTO Entity SET id = '" + i + "'");
+
+      final List<Map<String, Object>> rows = new ArrayList<>();
+      for (int i = 0; i < 15; i++)
+        rows.add(Map.of("source_id", String.valueOf(i), "target_id", String.valueOf(i + 1), "name", "r" + i));
+      final Map<String, Object> params = Map.of("data", rows);
+
+      final ServerQueryProfiler profiler = server.getQueryProfiler();
+      profiler.start();
+      try {
+        for (int run = 0; run < 3; run++)
+          try (final ResultSet rs = db.command("cypher", CONSISTENCY_QUERY, params)) {
+            while (rs.hasNext())
+              rs.next();
+          }
+      } finally {
+        if (profiler.isRecording())
+          profiler.stop();
+      }
+
+      final JSONObject query = findQuery(profiler.getResults(), CONSISTENCY_QUERY);
+      assertThat(query).as("the profiled Cypher statement must be in the results").isNotNull();
+      assertThat(query.getInt("executionCount")).isEqualTo(3);
+
+      final JSONArray steps = query.getJSONArray("steps");
+      assertThat(steps.length()).as("the plan of a profiled Cypher statement must carry its steps").isGreaterThan(0);
+
+      double stepsTotalMs = 0;
+      double slowestStepMs = 0;
+      for (int i = 0; i < steps.length(); i++) {
+        final JSONObject step = steps.getJSONObject(i);
+
+        // A never-timed step reports the -1 "not calculated" sentinel; the aggregation must not sum it as a duration.
+        assertThat(step.getDouble("totalCostMs")).as("step %s total", step.getString("name")).isGreaterThanOrEqualTo(0);
+        assertThat(step.getDouble("minCostMs")).as("step %s min", step.getString("name")).isGreaterThanOrEqualTo(0);
+
+        // An anonymous step class has an empty simple name, which used to surface as a nameless row.
+        assertThat(step.getString("name")).as("every step row must be named").isNotBlank();
+
+        stepsTotalMs += step.getDouble("totalCostMs");
+        slowestStepMs = Math.max(slowestStepMs, step.getDouble("maxCostMs"));
+      }
+
+      assertThat(stepsTotalMs).as("the profiled run must have timed at least one step").isGreaterThan(0);
+
+      // The reported inconsistency, expressed exactly: the engine total is the wall time of the executions the steps
+      // ran inside, so it cannot be smaller than what those steps spent.
+      assertThat(query.getDouble("engineTotalTimeMs")).as("engine total vs. summed step cost").isGreaterThanOrEqualTo(stepsTotalMs);
+      assertThat(query.getDouble("totalTimeMs")).as("query total vs. summed step cost").isGreaterThanOrEqualTo(stepsTotalMs);
+      assertThat(query.getDouble("maxTimeMs")).as("slowest execution vs. slowest step").isGreaterThanOrEqualTo(slowestStepMs);
+    } finally {
+      db.getEmbedded().drop();
+      server.removeDatabase("profiler-consistency-db");
+    }
+  }
+
+  /**
+   * Issue #7291: a step the engine never timed reports cost -1 ("not calculated"). Summing that sentinel as a
+   * duration produced negative step costs, so it is excluded from the statistics while still being counted as an
+   * occurrence. A step whose class is anonymous has an empty simple name and must not surface as a nameless row.
+   */
+  @Test
+  void untimedAndUnnamedStepsAreReportedHonestly() {
+    final ServerQueryProfiler profiler = server.getQueryProfiler();
+    profiler.start();
+
+    final JSONObject plan = new JSONObject();
+    plan.put("steps", new JSONArray()
+        .put(new JSONObject().put("name", "TimedStep").put("cost", 4_000_000L))
+        .put(new JSONObject().put("name", "UntimedStep").put("cost", -1L))
+        .put(new JSONObject().put("name", "").put("cost", -1L)));
+
+    profiler.recordQuery("testdb", "sql", "SELECT FROM Person", 10_000_000L, plan);
+
+    final JSONArray steps = findQuery(profiler.stop(), "SELECT FROM Person").getJSONArray("steps");
+
+    final JSONObject timed = findStep(steps, "TimedStep");
+    assertThat(timed.getInt("executionCount")).isEqualTo(1);
+    assertThat(timed.getInt("measuredCount")).isEqualTo(1);
+    assertThat(timed.getDouble("totalCostMs")).isEqualTo(4.0);
+
+    final JSONObject untimed = findStep(steps, "UntimedStep");
+    assertThat(untimed.getInt("executionCount")).isEqualTo(1);
+    assertThat(untimed.getInt("measuredCount")).isEqualTo(0);
+    assertThat(untimed.getDouble("totalCostMs")).isEqualTo(0.0);
+    assertThat(untimed.getDouble("minCostMs")).isEqualTo(0.0);
+    assertThat(untimed.getDouble("p99CostMs")).isEqualTo(0.0);
+
+    assertThat(findStep(steps, "unknown")).as("a blank step name must be labelled, not left empty").isNotNull();
+  }
+
+  private static JSONObject findQuery(final JSONObject results, final String queryText) {
+    final JSONArray queries = results.getJSONArray("queries");
+    for (int i = 0; i < queries.length(); i++) {
+      final JSONObject query = queries.getJSONObject(i);
+      if (ServerQueryProfiler.normalizeQuery(queryText).equals(ServerQueryProfiler.normalizeQuery(query.getString("queryText"))))
+        return query;
+    }
+    return null;
+  }
+
+  private static JSONObject findStep(final JSONArray steps, final String name) {
+    for (int i = 0; i < steps.length(); i++)
+      if (name.equals(steps.getJSONObject(i).getString("name")))
+        return steps.getJSONObject(i);
+    return null;
   }
 }

--- a/studio/src/main/resources/static/js/studio-profiler.js
+++ b/studio/src/main/resources/static/js/studio-profiler.js
@@ -405,6 +405,13 @@ function profilerRenderQueryTable() {
   });
 }
 
+
+// A step the engine never timed reports occurrences but no measured sample. Showing its timings as 0 reads as
+// "instant" instead of "unknown", so the table says so in words and the chart leaves it out (issue #7291).
+function profilerIsStepUntimed(step) {
+  return step.measuredCount === 0 && step.executionCount > 0;
+}
+
 function profilerShowDetail(index) {
   var q = profilerData.queries[index];
   if (!q) return;
@@ -441,9 +448,7 @@ function profilerShowDetail(index) {
   jQuery("#profilerStepTable tbody").empty();
   for (var j = 0; j < steps.length; j++) {
     var s = steps[j];
-    // A step the engine never timed reports no measured sample. Showing its columns as 0 reads as
-    // "instant" instead of "unknown", so say so once rather than printing five zeros (issue #7291).
-    var untimed = s.measuredCount === 0 && s.executionCount > 0;
+    var untimed = profilerIsStepUntimed(s);
     var cells = untimed
       ? '<td colspan="5" class="text-muted" title="This step reports no timing: per-step timers only run when the engine is asked to profile the execution.">not timed</td>'
       : '<td>' + s.totalCostMs + '</td>' +
@@ -462,7 +467,7 @@ function profilerShowDetail(index) {
   jQuery("#profilerStepChart").empty();
   var timedSteps = [];
   for (var t = 0; t < steps.length; t++)
-    if (!(steps[t].measuredCount === 0 && steps[t].executionCount > 0))
+    if (!profilerIsStepUntimed(steps[t]))
       timedSteps.push(steps[t]);
   if (timedSteps.length > 0 && typeof ApexCharts !== "undefined") {
     var categories = [];

--- a/studio/src/main/resources/static/js/studio-profiler.js
+++ b/studio/src/main/resources/static/js/studio-profiler.js
@@ -457,19 +457,24 @@ function profilerShowDetail(index) {
     );
   }
 
-  // Step chart (horizontal bar)
+  // Step chart (horizontal bar). Only the timed steps are plotted: a step with no measured sample would
+  // otherwise draw a zero-length bar, which reads as "instant" and contradicts the "not timed" row above.
   jQuery("#profilerStepChart").empty();
-  if (steps.length > 0 && typeof ApexCharts !== "undefined") {
+  var timedSteps = [];
+  for (var t = 0; t < steps.length; t++)
+    if (!(steps[t].measuredCount === 0 && steps[t].executionCount > 0))
+      timedSteps.push(steps[t]);
+  if (timedSteps.length > 0 && typeof ApexCharts !== "undefined") {
     var categories = [];
     var avgData = [];
     var maxData = [];
-    for (var k = 0; k < steps.length; k++) {
-      categories.push(steps[k].name);
-      avgData.push(steps[k].avgCostMs);
-      maxData.push(steps[k].maxCostMs);
+    for (var k = 0; k < timedSteps.length; k++) {
+      categories.push(timedSteps[k].name);
+      avgData.push(timedSteps[k].avgCostMs);
+      maxData.push(timedSteps[k].maxCostMs);
     }
     var chart = new ApexCharts(document.querySelector("#profilerStepChart"), {
-      chart: { type: "bar", height: Math.max(150, steps.length * 40) },
+      chart: { type: "bar", height: Math.max(150, timedSteps.length * 40) },
       plotOptions: { bar: { horizontal: true, barHeight: "60%" } },
       series: [
         { name: "Avg (ms)", data: avgData },

--- a/studio/src/main/resources/static/js/studio-profiler.js
+++ b/studio/src/main/resources/static/js/studio-profiler.js
@@ -441,14 +441,19 @@ function profilerShowDetail(index) {
   jQuery("#profilerStepTable tbody").empty();
   for (var j = 0; j < steps.length; j++) {
     var s = steps[j];
+    // A step the engine never timed reports no measured sample. Showing its columns as 0 reads as
+    // "instant" instead of "unknown", so say so once rather than printing five zeros (issue #7291).
+    var untimed = s.measuredCount === 0 && s.executionCount > 0;
+    var cells = untimed
+      ? '<td colspan="5" class="text-muted" title="This step reports no timing: per-step timers only run when the engine is asked to profile the execution.">not timed</td>'
+      : '<td>' + s.totalCostMs + '</td>' +
+        '<td>' + s.minCostMs + '</td>' +
+        '<td>' + s.avgCostMs + '</td>' +
+        '<td>' + s.maxCostMs + '</td>' +
+        '<td>' + s.p99CostMs + '</td>';
     jQuery("#profilerStepTable tbody").append(
       '<tr><td>' + escapeHtml(s.name) + '</td>' +
-      '<td>' + s.executionCount + '</td>' +
-      '<td>' + s.totalCostMs + '</td>' +
-      '<td>' + s.minCostMs + '</td>' +
-      '<td>' + s.avgCostMs + '</td>' +
-      '<td>' + s.maxCostMs + '</td>' +
-      '<td>' + s.p99CostMs + '</td></tr>'
+      '<td>' + s.executionCount + '</td>' + cells + '</tr>'
     );
   }
 

--- a/studio/src/main/resources/static/profiler.html
+++ b/studio/src/main/resources/static/profiler.html
@@ -108,12 +108,16 @@
       <!-- Step chart -->
       <div id="profilerStepChart" style="min-height: 200px;"></div>
       <!-- Step table -->
+      <p class="text-muted mb-1" style="font-size: 0.8rem;">
+        Step timings are the time each step spent in its own work, summed over every occurrence of that step across
+        all the executions above. They are contained in the Engine total, never larger than it.
+      </p>
       <table id="profilerStepTable" class="table table-sm" style="width: 100%; font-size: 0.85rem;">
         <thead>
           <tr>
             <th>Step</th>
-            <th>Count</th>
-            <th>Total (ms)</th>
+            <th title="Occurrences of this step across all the executions of this statement">Count</th>
+            <th title="Time spent inside this step's own work, summed over all its occurrences">Total (ms)</th>
             <th>Min (ms)</th>
             <th>Avg (ms)</th>
             <th>Max (ms)</th>


### PR DESCRIPTION
Closes #7291.

## The report

Studio's Query Profiler showed, for one execution of a Bolt/OpenCypher statement:

- header: Total / Avg / Min / Max / P99 / Engine total, all **5.86 ms**
- steps: `MatchNodeStep` count 2, total **36,711.6 ms** (18.3 s each), `MergeStep` 8.99 ms, `UnwindStep` 0.09 ms

plus a nameless step row of zeros. The application-side request was observed to be slow, so the step timings were the honest half.

## Diagnosis

`ProfilingResultSet` took its `startNanos` in its own constructor. That constructor runs in `ServerDatabase` **after** `wrapped.command(...)` has already returned, so the clock started once the work was over for any plan that does not stream:

- every write statement materializes its results inside `execute()`;
- and while the profiler is recording, *every* OpenCypher statement is non-streaming - `ServerDatabase` injects `$profileExecution` to get per-step timings, which routes the statement through `CypherExecutionPlan.profile()`, and that drains the plan with `syncPull(ctx, Integer.MAX_VALUE)`.

What got recorded as the query's engine time was therefore the cost of walking an already-materialized iterator: microseconds, next to step rows reporting seconds. The HTTP path was unaffected (`PostCommandHandler` times the engine itself and `ProfilingResultSet` defers to that `QueryProfile`); Bolt, Postgres and direct `ServerDatabase` use were not.

Reproduced locally on the issue's query: header `totalTimeMs` **0.01 ms** across 3 executions whose step costs summed to **8.37 ms**. After the fix: **157.03 ms** vs. **9.24 ms** of step cost.

Two further defects made the step table read as impossible:

- `AbstractExecutionStep.cost` is `-1` until a step is actually timed ("not calculated"), and per-step timing only runs when the command context has profiling on - which is not true on every path that reaches the recorder. `aggregateSteps` summed that sentinel as a duration.
- `ExecutionStepInternal.getName()` returns `getClass().getSimpleName()`, which is the empty string for an anonymous class. The OpenCypher plan builds four anonymous steps, so the plan published nameless rows.

## Changes

- `ServerDatabase` takes `System.nanoTime()` **before** handing the query to the engine and passes it to `ProfilingResultSet`, on all ten `command`/`query`/`execute` overloads. The recorded total now spans the execution plus the caller's consumption of the rows.
- `ServerQueryProfiler.aggregateSteps` computes the cost statistics over the timed occurrences only and publishes `measuredCount` alongside `executionCount`; a step with nothing timed reports zeros rather than a fabricated negative cost. A blank step name is labelled `unknown`.
- The four anonymous OpenCypher steps name themselves (`SubquerySeedRowStep`, `DummyRowStep`, `OptimizedMatchStep`), and the default `getName()`/`getType()` fall back to the first named ancestor so a future anonymous step cannot regress this.
- Studio labels the step-timing model next to the table (step self-time, summed over occurrences, contained in the Engine total) and renders an untimed step as "not timed" instead of five zeros.

## Tests

`ServerQueryProfilerTest`:

- `queryTotalCoversTheStepsItContains` runs the issue's statement three times through `ServerDatabase` with the profiler recording and asserts `engineTotalTimeMs >= sum(step totalCostMs)`, `maxTimeMs >= slowest step`, no negative step cost and no blank step name. The assertions are relational rather than wall-clock bounds - both numbers come from the same run, so a GC pause moves both and cannot make this flake. Verified to fail on the pre-fix code with `[engine total vs. summed step cost]`.
- `untimedAndUnnamedStepsAreReportedHonestly` pins the sentinel and blank-name handling.

Green: `ServerQueryProfilerTest` (22), engine `com.arcadedb.query.opencypher.**` (1909), engine `com.arcadedb.query.sql.**` (2603).

Not run locally: the server HTTP ITs (`PostCommandHandlerProfileIT`), because port 2480 on this machine is held by an unrelated long-running process and every request answers 403. CI covers them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved query profiler timing to include the full query execution duration.
  - Added clearer execution-step names in profiling results.
  - Added explanations and tooltips for profiler step counts and timing totals.

- **Bug Fixes**
  - Profiling statistics now exclude unmeasured timing values from averages and percentiles while retaining execution counts.
  - Steps without timing data are shown as “not timed” and excluded from timing charts.
  - Unnamed profiling steps are labeled consistently as “unknown.”
  - Profiler reports zero-valued timing metrics when no measurements are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->