### PR TITLE
fix(#7250): a peer that stops being admitted loses its established Raft gRPC transport too

### DIFF
--- a/docs/7250-revoke-established-raft-transport.md
+++ b/docs/7250-revoke-established-raft-transport.md
@@ -1,0 +1,226 @@
+# Issue #7250 - unlearning a removed peer does not close its already-established Raft gRPC transport
+
+Follow-up to #7225 (itself a follow-up to #7132).
+
+## Problem
+
+`PeerAddressAllowlistFilter` gates inbound Raft gRPC connections at `ServerTransportFilter.transportReady`,
+which gRPC calls exactly once per transport. #7225 taught the filter to *unlearn* a host that left the Raft
+configuration, so a removed peer stops being **admitted**. Nothing revokes a transport that was already
+**established** when the removal happened: gRPC/HTTP-2 connections are long-lived and carry many RPCs, so a
+peer connected at the moment it was removed keeps that connection - and everything it can send on it - until
+one side closes it for an unrelated reason.
+
+The operator-facing claim was therefore "removing a peer revokes its ability to reconnect", not "removing a
+peer revokes its reach".
+
+## Root cause
+
+`ServerTransportFilter` is a one-shot admission gate and carries no handle to the transport it admitted:
+
+```
+$ grep -n "public" /tmp/ratis-tp-src/org/apache/ratis/thirdparty/io/grpc/ServerTransportFilter.java
+public abstract class ServerTransportFilter {
+  public Attributes transportReady(Attributes transportAttrs)
+  public void transportTerminated(Attributes transportAttrs)
+}
+```
+
+Nothing in the shaded gRPC public API hands out a `ServerTransport`, and `NettyServerBuilder` exposes no
+per-connection close either (checked every public method of
+`org/apache/ratis/thirdparty/io/grpc/netty/NettyServerBuilder.java`: `channelType`, `channelFactory`,
+`maxConnectionIdle`, `maxConnectionAge`, ... - all builder-wide, none targeted). Ratis sets none of the
+connection-age settings:
+
+```
+$ grep -n "maxConnectionIdle\|maxConnectionAge\|keepAlive\|permitKeepAlive" \
+    /tmp/ratis-grpc-src/org/apache/ratis/grpc/server/GrpcServicesImpl.java
+(no output)
+```
+
+So the socket itself cannot be closed from where the allowlist lives. What *can* be revoked is everything the
+socket is able to carry: every RPC on a gRPC server goes through the global `ServerInterceptor` chain
+(`ServerImpl` applies `builder.interceptors` to every call regardless of service registration order -
+`ServerImpl.java:669`), and an in-flight `ServerCall` can be closed.
+
+## Invariant established by the fix
+
+> An address the allowlist stops admitting also stops being able to run Raft gRPC RPCs on a transport it
+> established while it was admitted: in-flight RPCs are closed with `PERMISSION_DENIED` and every new RPC on
+> that transport is refused.
+
+## Completeness
+
+### Ways the admitted set can shrink (grep, not recall)
+
+```
+$ grep -n "allowedIps.set" ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java
+471:    allowedIps.set(Collections.unmodifiableSet(effective));
+```
+
+One writer. Every shrink therefore passes through `doResolve()`:
+
+```
+$ grep -rn "doResolve()\|resolveIfStale(" ha-raft/src/main
+PeerAddressAllowlistFilter.java:186:    doResolve();            # constructor
+PeerAddressAllowlistFilter.java:226:    resolveIfStale(missResolveFloor());   # isAllowed() miss path
+PeerAddressAllowlistFilter.java:315:      doResolve();          # learnPeerHosts
+PeerAddressAllowlistFilter.java:366:      doResolve();          # setMemberHosts
+PeerAddressAllowlistFilter.java:415:    doResolve();            # refresh()
+PeerAddressAllowlistFilter.java:431:    resolveIfStale(currentResolveFloor());   # proactiveRefresh()
+```
+
+Production callers of the mutators:
+
+```
+$ grep -rn "setMemberHosts\|learnPeerHosts\|proactiveRefresh" ha-raft/src/main/java --include="*.java" \
+    | grep -v PeerAddressAllowlistFilter.java
+RaftHAServer.java:4227:      filter.learnPeerHosts(List.of(serviceDomain));
+RaftHAServer.java:4272:    filter.proactiveRefresh();
+RaftHAServer.java:4320:    filter.setMemberHosts(committedHosts);
+```
+
+Same-shape siblings elsewhere in the tree - none:
+
+```
+$ grep -rn "ServerTransportFilter\|transportTerminated" --include="*.java" . | grep -v /target/
+ha-raft/.../PeerAddressAllowlistFilter.java        (this class)
+ha-raft/.../RaftGrpcServicesCustomizer.java        (installs it)
+```
+
+```
+$ grep -rn "ServerInterceptor\|addTransportFilter\|\.intercept(" --include="*.java" ha-raft/src/main
+RaftGrpcServicesCustomizer.java:44:      result = result.addTransportFilter(f);
+```
+
+No `ServerInterceptor` was installed on the Raft port before this change, so nothing competes with the new one.
+
+### Entry-point coverage table
+
+| # | Entry point that can shrink admission | Covered by fix? | Covered by a test? |
+|---|---|---|---|
+| 1 | `setMemberHosts` - peer removed from the Raft configuration (the reported case) | yes | yes - `aPeerRemovedFromTheRaftConfigurationLosesItsEstablishedTransport` |
+| 2 | `RaftHAServer.reconcileAllowlistMembership` - the production wiring of row 1 | yes | yes - `theProductionReconciliationRevokesTheRemovedPeersEstablishedTransport` |
+| 3 | `doResolve` via `proactiveRefresh()`/`refresh()` - a host's DNS record no longer carries the old IP | yes | yes - `aPeerWhoseAddressChangedLosesTheTransportOpenedOnTheOldAddress` |
+| 4 | `doResolve` via sticky-TTL expiry - last-known-good IPs age out | yes | yes - `aTransportHeldOpenOnAnExpiredStickyAddressIsRevoked` |
+| 5 | Startup fail-open window ending (quorum resolves, or the grace elapses) - a transport admitted while the filter was failing open | yes | yes - `aTransportAdmittedUnderTheStartupFailOpenIsRevokedOnceTheGraceEnds` |
+| 6 | `isAllowed` miss path (`resolveIfStale`) - same `doResolve` hook as rows 3-5 | yes | yes - covered by row 3, which drives revocation through `refresh()`, and by `aNewRpcOnARevokedTransportIsRefused` |
+| 7 | New RPCs started on an already-revoked transport | yes | yes - `aNewRpcOnARevokedTransportIsRefused` |
+| 8 | `learnPeerHosts` - **argued**: it only ever widens. It adds to `pinnedHosts` and re-resolves; `doResolve` rebuilds `effective` from `peerHosts | learned`, so a pin cannot remove an IP. The revocation sweep runs there anyway (same `doResolve` hook), so the claim is belt-and-braces rather than load-bearing. | n/a | n/a |
+| 9 | Loopback transports - **argued**: `transportReady` returns before the allow check for `address.isLoopbackAddress()`, so no session is ever created for one and nothing can revoke it. | n/a | yes - `aLoopbackTransportIsNeverTrackedAndNeverRevoked` |
+| 10 | The TCP/HTTP-2 socket itself stays open after revocation | **no** - filed as #7316 | n/a |
+
+### Residual risk
+
+Row 10 only. After a revocation the peer's socket remains connected until it or the kernel closes it: gRPC's
+public API offers no way to close one established transport, and Ratis configures neither `maxConnectionIdle`
+nor `maxConnectionAge` (grep above). What that socket can still *do* is nothing - every RPC on a gRPC server
+passes the global interceptor chain, and the interceptor refuses every call whose transport session is
+revoked - so the residue is a lingering idle connection (a resource cost), not reach. Filed as **#7316** so
+the reporter does not have to.
+
+Also unchanged, and out of scope here for the same reasons #7225 gave: the filter provides no peer identity
+and is explicitly not a substitute for mTLS (#3890), and gRPC authorization on the Raft port applies
+independently.
+
+## Changes
+
+| File | Change |
+|---|---|
+| `ha-raft/.../PeerTransportSession.java` | **new** - one admitted transport and the RPCs in flight on it; the handle `ServerTransportFilter` does not give out |
+| `ha-raft/.../RevocableServerCall.java` | **new** - `ServerCall` wrapper whose single-shot close is arbitrated between the handler and a revoking thread |
+| `ha-raft/.../PeerAllowlistCallInterceptor.java` | **new** - enforces the admission decision per RPC: refuses calls on a revoked session, registers the rest so a revocation can cut them |
+| `ha-raft/.../PeerAddressAllowlistFilter.java` | attaches a session to every admitted transport, drops it in `transportTerminated`, and sweeps the sessions at the end of `doResolve()` - the one writer of `allowedIps` - marking under the monitor and closing with it released |
+| `ha-raft/.../RaftGrpcServicesCustomizer.java` | installs interceptors as well as transport filters |
+| `ha-raft/.../RaftHAServer.java` | builds and publishes the interceptor next to the filter; `allowlistInterceptorForTest()` |
+| `engine/.../GlobalConfiguration.java` | `arcadedb.ha.peerAllowlist.enabled` now states the accurate operator-facing claim, including what is *not* revoked |
+| `ha-raft/src/test/.../Issue7250RevokesEstablishedTransportTest.java` | **new** - 12 tests, one per fixed row of the table plus the lifetime contract |
+
+### Design notes
+
+- **The socket is not the unit of revocation; the RPC is.** gRPC exposes no per-transport close, so the fix
+  works on the only surface it does expose. `ServerImpl` runs the builder's interceptors on every call
+  whatever order the services were registered in, so one interceptor covers ADMIN, CLIENT and SERVER - which
+  is the same reason one transport filter already did.
+- **Marking and closing are separated.** `doResolve()` holds the filter's monitor; closing a `ServerCall`
+  runs gRPC code. Flipping the session flag under the monitor is what stops the *next* RPC, and it is enough
+  to be correct; the in-flight ones are closed by `dispatchRevocations()` after the monitor is released, so
+  the filter's lock is never ordered against gRPC internals in two directions.
+- **The fail-open window is respected.** `admits()` reproduces `isAllowed`'s decision (minus its
+  re-resolution) rather than testing `allowedIps` alone, so a transport admitted while the filter was below
+  quorum is not cut until the grace window closes. Testing membership alone would have re-created the
+  self-inflicted startup partition #4471 and #4828 exist to prevent.
+- **Nothing outlives its transport.** The session set is cleared from `transportTerminated`, and a session
+  holds only calls in flight - the interceptor deregisters on `onComplete` and `onCancel`. Both are asserted.
+- **Cost on the hot path.** One `Attributes` lookup per RPC, and for a gated transport two small allocations
+  per RPC. Raft `appendEntries` is a long-lived stream, so on a follower this is per stream, not per entry.
+
+## Test results
+
+```
+$ mvn -o -pl ha-raft -Dtest=Issue7250RevokesEstablishedTransportTest test
+Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
+
+# with the revocation sweep in doResolve() disabled, to prove the tests can fail:
+Tests run: 14, Failures: 6, Errors: 0, Skipped: 0
+  aPeerRemovedFromTheRaftConfigurationLosesItsEstablishedTransport
+  aNewRpcOnARevokedTransportIsRefused
+  aPeerWhoseAddressChangedLosesTheTransportOpenedOnTheOldAddress
+  aTransportHeldOpenOnAnExpiredStickyAddressIsRevoked
+  aTransportAdmittedUnderTheStartupFailOpenIsRevokedOnceTheGraceEnds
+  theProductionReconciliationRevokesTheRemovedPeersEstablishedTransport
+
+$ mvn -o -pl ha-raft -DexcludedGroups=benchmark,slow,vector test
+Tests run: 1291, Failures: 0, Errors: 0, Skipped: 0
+
+# the allowlist's own history plus the classes that flaked on a later full run, re-run together:
+$ mvn -o -pl ha-raft -Dtest='PeerAddressAllowlistFilterTest,Issue7132AllowlistLearnsRuntimePeersTest,\
+    Issue7225AllowlistUnlearnsRemovedPeersTest,Issue7250RevokesEstablishedTransportTest,RaftHAServerTest,\
+    Issue3890RaftParametersPublicationTest,LeaveClusterTest,Issue7037SnapshotInstallSpaceCheckTest' test
+Tests run: 131, Failures: 0, Errors: 0, Skipped: 0
+
+$ mvn -o -pl engine -Dtest='*Configuration*Test' test
+Tests run: 105, Failures: 0, Errors: 0, Skipped: 0
+```
+
+## Reachability
+
+`arcadedb.ha.peerAllowlist.enabled` defaults to `true` (`GlobalConfiguration.java:2140`), so
+`installPeerAllowlist` runs on every HA server that has not turned the allowlist off, and it now constructs
+and publishes the interceptor on the same branch that constructs the filter. `RaftGrpcServicesCustomizer`
+passes it to `NettyServerBuilder.intercept`, and Ratis applies the customizer immediately before building
+the server (`GrpcServicesImpl.buildServer`: `customizer.customize(builder, types).build()`).
+`theProductionReconciliationRevokesTheRemovedPeersEstablishedTransport` drives the whole production path -
+`buildParameters` -> `installPeerAllowlist` -> `reconcileAllowlistMembership` -> revocation - rather than
+the filter in isolation.
+
+### A note on two flaky classes
+
+A later full-module run showed `LeaveClusterTest` (forked VM crash) and
+`Issue7037SnapshotInstallSpaceCheckTest`. Neither is this change:
+
+```
+$ lsof -nP -iTCP:2480 -sTCP:LISTEN
+java  14807 frank  262u  IPv6  TCP 127.0.0.1:2480 (LISTEN)
+java  93797 frank  263u  IPv6  TCP *:2480 (LISTEN)
+$ lsof -nP -iTCP:2434 -sTCP:LISTEN
+java  14807 frank  304u  IPv6  TCP *:2434 (LISTEN)
+```
+
+Two other JVMs held the fixed HA ports for the duration of that run. `Issue7037SnapshotInstallSpaceCheckTest`
+touches nothing in this diff either - it measures page-file sizes under `./target/databases` - and both classes
+pass in the 131-test run above, which was taken after the ports cleared.
+
+## Adversarial pass
+
+The orchestrator's independent subagent could not be spawned (the `Task` tool is disabled in this session), so
+this pass was self-performed and is **not** the independent read the process asks for - recorded here rather
+than presented as one. It still found five things, four of them fixed in this branch before the PR opened:
+
+| # | Finding | Disposition |
+|---|---|---|
+| 1 | **A transport could be admitted with nothing able to revoke it.** `transportReady` registered the session *after* `isAllowed()` returned, and `isAllowed()` can re-resolve; a reconciliation on another thread that swept in that window never saw the session, so the connection was admitted already un-revokable. | **Fixed** - the session is registered *before* the decision and removed again on the rejection path, and `transportReady` refuses a transport whose session was revoked while it was deciding. `aRejectedTransportIsRegisteredForTheRaceButNotLeftBehind` drives register/revoke/unregister on the rejection path. The concurrent half is correct by construction rather than by test: driving it would need a synchronisation hook in production code, and this doc says so rather than implying a test covers it. |
+| 2 | **A throwing handler leaked a call registration.** If `next.startCall` threw, neither `onComplete` nor `onCancel` would arrive, so the wrapper stayed in the session's live-call set - one dead entry per failed RPC on a connection that may live for days, walked by every later revocation. | **Fixed** - the interceptor deregisters and rethrows. Test: `aHandlerThatThrowsDoesNotLeaveTheCallRegistered`. |
+| 3 | **A rejected connection logged a revocation.** Consequence of fix 1: a session registered for the race and then swept produced "Revoked the established Raft gRPC transport of X" for a transport that was never admitted, next to the rejection line for the same address. | **Fixed** - the session carries an `admitted` flag set only when `transportReady` publishes it, and `dispatchRevocations` closes but does not log an unadmitted one. |
+| 4 | **`getSessions()` handed out the live mutable set.** A test hook that lets a caller corrupt the state it observes. | **Fixed** - returns an unmodifiable view. Test: `theSessionSetIsNotExposedForMutation`. |
+| 5 | **Revocation is terminal, and a DNS flap therefore forces a reconnect.** A peer whose name resolves elsewhere for one tick has its live transport cut and must reconnect rather than resuming. | **Not a defect - documented.** The sticky retention covers resolution *failure*, which is the transient case; an answer pointing somewhere else is a different pod. The outcome is a Ratis reconnect that the allowlist admits normally once DNS is right, and the alternative - un-revoking on a later resolution - would make a revocation only as durable as the least trustworthy answer in the window. Stated in `PeerTransportSession.revoke()`'s javadoc. |

--- a/docs/7250-revoke-established-raft-transport.md
+++ b/docs/7250-revoke-established-raft-transport.md
@@ -211,6 +211,10 @@ Two other JVMs held the fixed HA ports for the duration of that run. `Issue7037S
 touches nothing in this diff either - it measures page-file sizes under `./target/databases` - and both classes
 pass in the 131-test run above, which was taken after the ports cleared.
 
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/7319
+
 ## Adversarial pass
 
 The orchestrator's independent subagent could not be spawned (the `Task` tool is disabled in this session), so
@@ -251,3 +255,16 @@ comments rather than behaviour, and both applied:
 | `resolveIfStale`'s early return skips `dispatchRevocations()` as well as the resolution. Correct once traced - the thread that short-circuits enqueued nothing, and the one that ran `doResolve()` dispatches - but it is a genuine asymmetry with the other three dispatch sites and a later edit could break it silently. | **Applied** - the method now carries a javadoc paragraph stating why the early return is not a dropped revocation, and naming the two edits that would make it one. |
 | `PeerTransportSession.revoke()` is `synchronized` although its only caller already holds the filter's monitor, so the keyword is currently redundant and could suggest that is where the sweep's safety lives. | **Applied as a comment, not a removal.** Verified the claim - `grep -rn "\.revoke()" ha-raft/src` finds exactly one caller, `doResolve()`. Kept, because the return value is a promise this method makes and it should be this method that keeps it; the javadoc now says the keyword buys nothing today and why it is there anyway. |
 | Per-RPC cost is reasoned rather than measured; the concurrent register/revoke race is correct-by-construction rather than tested. | **No change** - both were already stated as such here rather than implied, which is what the review was acknowledging. |
+
+### Cycle 3 - `5a64d12` (clean)
+
+`claude` reviewed again: **no blocking issues**, nothing left from cycles 1 and 2, and no coverage gap. Static
+read once more. One optional note, deliberately not acted on:
+
+| Note | Disposition |
+|---|---|
+| `dispatchRevocations()` can log "Revoked the established Raft gRPC transport of X ... 0 in-flight RPC(s) closed" for a transport that terminated between the sweep enqueuing the session and the drain processing it - `transportTerminated` clears `liveCalls` but does not touch `pendingRevocations`. Log noise, not incorrect. The reviewer rated it "very low severity, probably not worth guarding against explicitly". | **Skipped, with the reasoning.** The guard is two lines (`!sessions.contains(session)` alongside the existing `!isAdmitted()` check) and would make the line accurate. It is not taken because it cannot be driven by a test: the window it closes is between an enqueue and a drain that happen microseconds apart on the same thread, and interleaving them would need a synchronisation hook in production code. That would add an unexercised branch to security-relevant code to improve the wording of a log line, against this repo's rule that new server-side code comes with a test - a worse trade than the noise. The window is real but narrow, the message is only ever emitted for a revocation that genuinely happened, and an operator reading it about a connection that has since dropped is told something true. |
+
+## Final state
+
+`clean-approval` after 3 review cycles. Merge remains the developer's.

--- a/docs/7250-revoke-established-raft-transport.md
+++ b/docs/7250-revoke-established-raft-transport.md
@@ -224,3 +224,18 @@ than presented as one. It still found five things, four of them fixed in this br
 | 3 | **A rejected connection logged a revocation.** Consequence of fix 1: a session registered for the race and then swept produced "Revoked the established Raft gRPC transport of X" for a transport that was never admitted, next to the rejection line for the same address. | **Fixed** - the session carries an `admitted` flag set only when `transportReady` publishes it, and `dispatchRevocations` closes but does not log an unadmitted one. |
 | 4 | **`getSessions()` handed out the live mutable set.** A test hook that lets a caller corrupt the state it observes. | **Fixed** - returns an unmodifiable view. Test: `theSessionSetIsNotExposedForMutation`. |
 | 5 | **Revocation is terminal, and a DNS flap therefore forces a reconnect.** A peer whose name resolves elsewhere for one tick has its live transport cut and must reconnect rather than resuming. | **Not a defect - documented.** The sticky retention covers resolution *failure*, which is the transient case; an answer pointing somewhere else is a different pod. The outcome is a Ratis reconnect that the allowlist admits normally once DNS is right, and the alternative - un-revoking on a later resolution - would make a revocation only as durable as the least trustworthy answer in the window. Stated in `PeerTransportSession.revoke()`'s javadoc. |
+
+## Review cycles
+
+### Cycle 1 - `8bd6dc5`
+
+`claude` reviewed and found **no blocking issues**; it read the concurrency-sensitive paths (register-before-decide,
+the interceptor's re-check, the lock discipline between `doResolve` and `dispatchRevocations`, and the single-shot
+close arbitration) and reported no correctness bug. It also noted it could not run Maven in its sandbox, so its
+read is static and CI is what confirms the suite. Three nits, all addressed:
+
+| Note | Disposition |
+|---|---|
+| The `arcadedb.ha.peerAllowlist.enabled` text reads awkwardly ("what an already established connection of its could still do"). | **Applied** - rewritten to "loses the reach an already-established connection still gave it". |
+| `getSessions()` returns an unmodifiable *view*, not a snapshot, so it still reflects concurrent change. | **Applied** - returns `Set.copyOf(sessions)`. The existing `theSessionSetIsNotExposedForMutation` still holds, since a copy is immutable too. |
+| The per-RPC wrapper and set add/remove apply to all inter-node Raft traffic; worth checking it does not add up under connection churn. | **Argued, with one change.** The interceptor adds three short-lived allocations per RPC on a gated transport: the `RevocableServerCall`, the forwarding listener, and the set node. gRPC allocates strictly more than that per RPC on its own - a `ServerCallImpl`, the `Metadata`, the stream and the listener chain - so the marginal cost is a fraction of a baseline the RPC already pays, and it is proportional to RPCs rather than to bytes or log entries, so a busy follower does not pay more per entry. That is a reasoning argument, not a measurement: no benchmark was run, and the doc says so rather than claiming one. The one thing worth changing was unrelated to the wrapper - the per-session live-call set defaulted to 16 slots for a connection that has a handful of RPCs in flight, and is now sized 4. |

--- a/docs/7250-revoke-established-raft-transport.md
+++ b/docs/7250-revoke-established-raft-transport.md
@@ -239,3 +239,15 @@ read is static and CI is what confirms the suite. Three nits, all addressed:
 | The `arcadedb.ha.peerAllowlist.enabled` text reads awkwardly ("what an already established connection of its could still do"). | **Applied** - rewritten to "loses the reach an already-established connection still gave it". |
 | `getSessions()` returns an unmodifiable *view*, not a snapshot, so it still reflects concurrent change. | **Applied** - returns `Set.copyOf(sessions)`. The existing `theSessionSetIsNotExposedForMutation` still holds, since a copy is immutable too. |
 | The per-RPC wrapper and set add/remove apply to all inter-node Raft traffic; worth checking it does not add up under connection churn. | **Argued, with one change.** The interceptor adds three short-lived allocations per RPC on a gated transport: the `RevocableServerCall`, the forwarding listener, and the set node. gRPC allocates strictly more than that per RPC on its own - a `ServerCallImpl`, the `Metadata`, the stream and the listener chain - so the marginal cost is a fraction of a baseline the RPC already pays, and it is proportional to RPCs rather than to bytes or log entries, so a busy follower does not pay more per entry. That is a reasoning argument, not a measurement: no benchmark was run, and the doc says so rather than claiming one. The one thing worth changing was unrelated to the wrapper - the per-session live-call set defaulted to 16 slots for a connection that has a handful of RPCs in flight, and is now sized 4. |
+
+### Cycle 2 - `d728df1`
+
+`claude` reviewed again and found **no blocking issues** and no coverage gap; it traced the same concurrency paths
+and confirmed the cycle-1 changes. Static read again - it could not run Maven either. Two notes, both about
+comments rather than behaviour, and both applied:
+
+| Note | Disposition |
+|---|---|
+| `resolveIfStale`'s early return skips `dispatchRevocations()` as well as the resolution. Correct once traced - the thread that short-circuits enqueued nothing, and the one that ran `doResolve()` dispatches - but it is a genuine asymmetry with the other three dispatch sites and a later edit could break it silently. | **Applied** - the method now carries a javadoc paragraph stating why the early return is not a dropped revocation, and naming the two edits that would make it one. |
+| `PeerTransportSession.revoke()` is `synchronized` although its only caller already holds the filter's monitor, so the keyword is currently redundant and could suggest that is where the sweep's safety lives. | **Applied as a comment, not a removal.** Verified the claim - `grep -rn "\.revoke()" ha-raft/src` finds exactly one caller, `doResolve()`. Kept, because the return value is a promise this method makes and it should be this method that keeps it; the javadoc now says the keyword buys nothing today and why it is there anyway. |
+| Per-RPC cost is reasoned rather than measured; the concurrent register/revoke race is correct-by-construction rather than tested. | **No change** - both were already stated as such here rather than implied, which is what the review was acknowledging. |

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2135,10 +2135,10 @@ public enum GlobalConfiguration {
       arcadedb.ha.k8s is set), plus the members of the live Raft configuration, which are picked up on \
       every health monitor tick so a peer that joined at runtime is admitted; on Kubernetes the headless \
       service behind arcadedb.ha.k8sSuffix is resolved too, so a StatefulSet scale-up pod can complete its \
-      auto-join. Loopback is always allowed. A host that stops being admitted also loses what an already \
-      established connection of its could still do: the Raft RPCs running on it are closed with a permission \
-      error and later ones are refused, though the connection itself stays open until the peer drops it. \
-      Does not provide peer identity or encryption: use mTLS on untrusted networks.""",
+      auto-join. Loopback is always allowed. A host that stops being admitted also loses the reach an \
+      already-established connection still gave it: the Raft RPCs running on that connection are closed with \
+      a permission error and later ones are refused, though the connection itself stays open until the peer \
+      drops it. Does not provide peer identity or encryption: use mTLS on untrusted networks.""",
       Boolean.class, true),
 
   HA_GRPC_ALLOWLIST_REFRESH_MS("arcadedb.ha.grpcAllowlistRefreshMs", SCOPE.SERVER,

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2135,8 +2135,10 @@ public enum GlobalConfiguration {
       arcadedb.ha.k8s is set), plus the members of the live Raft configuration, which are picked up on \
       every health monitor tick so a peer that joined at runtime is admitted; on Kubernetes the headless \
       service behind arcadedb.ha.k8sSuffix is resolved too, so a StatefulSet scale-up pod can complete its \
-      auto-join. Loopback is always allowed. Does not provide peer identity or encryption: use mTLS on \
-      untrusted networks.""",
+      auto-join. Loopback is always allowed. A host that stops being admitted also loses what an already \
+      established connection of its could still do: the Raft RPCs running on it are closed with a permission \
+      error and later ones are refused, though the connection itself stays open until the peer drops it. \
+      Does not provide peer identity or encryption: use mTLS on untrusted networks.""",
       Boolean.class, true),
 
   HA_GRPC_ALLOWLIST_REFRESH_MS("arcadedb.ha.grpcAllowlistRefreshMs", SCOPE.SERVER,

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java
@@ -311,9 +311,13 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
     return false;
   }
 
-  /** The transports currently admitted by this filter. Exposed for testing. */
+  /**
+   * A snapshot of the transports currently admitted by this filter. Exposed for testing, and a copy rather than an
+   * unmodifiable view of the live set so that a test reading it twice compares two stable values instead of racing
+   * a transport that connected in between.
+   */
   Set<PeerTransportSession> getSessions() {
-    return Collections.unmodifiableSet(sessions);
+    return Set.copyOf(sessions);
   }
 
   /** Returns an immutable snapshot of the currently allowed IPs. Exposed for testing. */

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java
@@ -36,7 +36,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.LongSupplier;
 import java.util.logging.Level;
@@ -97,6 +100,15 @@ import java.util.logging.Level;
  * Neither ever shadows a configured host: {@code serverList} is configuration, not membership, and removing
  * a host from it is a configuration change rather than something a Raft configuration commit can do.
  * <p>
+ * Unlearning a host stops it being <i>admitted</i>, and since issue #7250 it also revokes what an
+ * already-<i>established</i> transport of that host can still do. {@code ServerTransportFilter} is a one-shot
+ * admission gate and gRPC hands it no handle on the transport it admitted, so every transport this filter admits
+ * gets a {@link PeerTransportSession} stashed in its {@code Attributes}; a resolution that stops admitting the
+ * session's address revokes it, {@link PeerAllowlistCallInterceptor} then refuses every further RPC on it, and the
+ * RPCs already running on it are closed. The socket itself is not closed - gRPC's public API exposes no way to close
+ * one established transport - so the accurate operator-facing claim is that removing a peer revokes its reach, not
+ * that it drops its connection.
+ * <p>
  * This is NOT a substitute for mTLS: it does not authenticate peer identity and does not
  * encrypt the traffic. See GitHub issue #3890. The bounded startup fail-open is an acceptable
  * trade-off for that reason; set {@code startupGraceMs=0} to disable it.
@@ -106,6 +118,12 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
   // Minimum spacing between miss-triggered re-resolutions. Bounds DNS load under a connection flood
   // (at startup or from a non-peer) while letting the allowlist converge within ~1s.
   private static final long        MISS_RESOLVE_FLOOR_MS = 1_000L;
+
+  // The session this filter attaches to every transport it admits, so PeerAllowlistCallInterceptor can find it again
+  // on each RPC through ServerCall.getAttributes() - the transport attributes returned below are merged into it
+  // (issue #7250).
+  static final Attributes.Key<PeerTransportSession> TRANSPORT_SESSION =
+      Attributes.Key.create("com.arcadedb.server.ha.raft.PeerAddressAllowlistFilter.transportSession");
 
   // Hosts declared in arcadedb.ha.serverList. Immutable, and the ONLY ones the quorum/completeness
   // latches below count: they describe the configured cluster, which is what #4828 reasoned about.
@@ -147,6 +165,14 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
   // resolved hosts than there are configured ones (issue #7225). Also removes that message's unsynchronised
   // read of a plain HashMap.
   private volatile int                       resolvedPeerHosts;
+  // The transports this filter has admitted, so a host that stops being admitted can have its established
+  // transports revoked too (issue #7250). Entries are added by transportReady and removed by transportTerminated,
+  // so nothing here outlives the transport it describes.
+  private final Set<PeerTransportSession>    sessions           = ConcurrentHashMap.newKeySet();
+  // Sessions marked revoked by the last resolution and not yet cut. doResolve() runs under this object's monitor and
+  // must not call into gRPC while holding it, so it only flips the flag - which is what stops the NEXT RPC - and
+  // leaves the closing of the in-flight ones to dispatchRevocations() outside the lock.
+  private final Queue<PeerTransportSession>  pendingRevocations = new ConcurrentLinkedQueue<>();
 
   /**
    * Convenience form for a caller with no server configuration in reach - the tests; {@code RaftHAServer} passes
@@ -199,10 +225,43 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
     if (address.isLoopbackAddress())
       return attrs;
 
-    if (isAllowed(address.getHostAddress()))
-      return attrs;
+    final String ip = address.getHostAddress();
 
-    throw new SecurityException("Remote address '" + address.getHostAddress() + "' is not in the cluster peer allowlist");
+    // Register BEFORE deciding, not after (issue #7250). isAllowed() can re-resolve, and a reconciliation on another
+    // thread can revoke in the middle of it; a session added afterwards would be invisible to that sweep and the
+    // transport would be admitted with nothing left to revoke it. Registering first inverts the race into one this
+    // method can see and refuse: whatever happens while the decision runs, the session is either still admitted or
+    // has been marked revoked, and both are checked below.
+    final PeerTransportSession session = new PeerTransportSession(ip);
+    sessions.add(session);
+    final boolean allowed;
+    try {
+      allowed = isAllowed(ip);
+    } catch (final RuntimeException e) {
+      sessions.remove(session);
+      throw e;
+    }
+    if (!allowed || session.isRevoked()) {
+      sessions.remove(session);
+      throw new SecurityException("Remote address '" + ip + "' is not in the cluster peer allowlist");
+    }
+
+    session.markAdmitted();
+    return Attributes.newBuilder(attrs).set(TRANSPORT_SESSION, session).build();
+  }
+
+  /**
+   * Drops the session of a transport gRPC has torn down (issue #7250). This is the other half of the lifetime
+   * contract the session's javadoc states: without it {@link #sessions} would grow by one entry per connection for
+   * the life of the process, and the in-flight calls of a dead transport would be walked by every revocation.
+   */
+  @Override
+  public void transportTerminated(final Attributes attrs) {
+    final PeerTransportSession session = attrs == null ? null : attrs.get(TRANSPORT_SESSION);
+    if (session == null)
+      return;
+    sessions.remove(session);
+    session.forgetCalls();
   }
 
   /**
@@ -250,6 +309,11 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
             + "A peer removed from the Raft configuration is expected to appear here.",
         ip, allowedIps.get(), peerHosts, memberHosts, pinnedHosts);
     return false;
+  }
+
+  /** The transports currently admitted by this filter. Exposed for testing. */
+  Set<PeerTransportSession> getSessions() {
+    return Collections.unmodifiableSet(sessions);
   }
 
   /** Returns an immutable snapshot of the currently allowed IPs. Exposed for testing. */
@@ -314,6 +378,10 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
       // written to throttle away, and the connection it is meant to admit is usually already being retried.
       doResolve();
     }
+    // A pin only ever widens the allowlist, so this is expected to find nothing. It runs anyway because the
+    // re-resolution above went through the same doResolve() as every other path, and leaving one caller that can
+    // enqueue a revocation without draining it would strand an already-flipped session's in-flight RPCs.
+    dispatchRevocations();
     LogManager.instance().log(this, Level.FINE,
         "Raft gRPC peer allowlist pinned %d new host(s): %s", added.size(), added);
     return true;
@@ -365,6 +433,7 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
       // hosts, which is what actually evicts a departed peer's addresses.
       doResolve();
     }
+    dispatchRevocations();
     if (!dropped.isEmpty())
       LogManager.instance().log(this, Level.INFO,
           "Raft gRPC peer allowlist no longer admits %d host(s) that left the Raft configuration: %s",
@@ -412,7 +481,10 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
 
   /** Triggers an immediate DNS re-resolution. Exposed for testing. */
   void refresh() {
-    doResolve();
+    synchronized (this) {
+      doResolve();
+    }
+    dispatchRevocations();
   }
 
   /**
@@ -442,10 +514,13 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
   }
 
   /** Re-resolves only if at least {@code floor} ms have elapsed since the last resolution. */
-  private synchronized void resolveIfStale(final long floor) {
-    if (clock.getAsLong() - lastResolveMs < floor)
-      return; // another thread re-resolved recently; avoid a thundering herd under a connection flood
-    doResolve();
+  private void resolveIfStale(final long floor) {
+    synchronized (this) {
+      if (clock.getAsLong() - lastResolveMs < floor)
+        return; // another thread re-resolved recently; avoid a thundering herd under a connection flood
+      doResolve();
+    }
+    dispatchRevocations();
   }
 
   private synchronized void doResolve() {
@@ -475,6 +550,50 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
       everQuorumResolved = true;
     if (covered == peerHosts.size())
       everCompletelyResolved = true;
+
+    // Revoke the transports this resolution stopped admitting (issue #7250). Every way the allowed set can shrink -
+    // a peer leaving the Raft configuration, a peer's DNS record losing an address, a sticky last-known-good entry
+    // ageing out, the startup fail-open ending - lands here, because this is the only writer of allowedIps.
+    // Only the flag is flipped under the monitor; dispatchRevocations() does the gRPC work with it released.
+    for (final PeerTransportSession session : sessions)
+      if (!admits(session.getRemoteIp(), now) && session.revoke())
+        pendingRevocations.add(session);
+  }
+
+  /**
+   * Whether {@code ip} is admitted as of right now, reaching neither DNS nor the sticky retention. It is
+   * {@link #isAllowed}'s decision without the re-resolution that method triggers on a miss, and without its
+   * null-address case: it is only ever called for a session's address, which {@link #transportReady} obtained from a
+   * resolved {@link InetAddress} and is therefore never null. Called from inside {@link #doResolve()}, which has just
+   * rebuilt both inputs, so re-resolving here would be redundant as well as re-entrant.
+   */
+  private boolean admits(final String ip, final long now) {
+    if (allowedIps.get().contains(ip))
+      return true;
+    // The startup fail-open (#4471/#4828) admits an unmatched address while a quorum of configured peers has not
+    // resolved. A transport admitted under it must not be cut while it is still in force, or the fix would
+    // re-create the self-inflicted partition that window exists to prevent - it is revoked by the first resolution
+    // after the window closes, when this returns false.
+    return !everQuorumResolved && startupGraceMs > 0 && now - createdMs < startupGraceMs;
+  }
+
+  /**
+   * Cuts the RPCs in flight on the transports the last resolution revoked. Called with this object's monitor
+   * released: closing a {@code ServerCall} runs gRPC code, and holding the filter's lock across it would order this
+   * monitor above gRPC's internals on one path and below them on the {@code transportReady} path.
+   */
+  private void dispatchRevocations() {
+    PeerTransportSession session;
+    while ((session = pendingRevocations.poll()) != null) {
+      final int closed = session.closeLiveCalls();
+      if (!session.isAdmitted())
+        continue; // swept while transportReady was still deciding: it is being rejected, and that is logged there
+      LogManager.instance().log(this, Level.INFO,
+          "Revoked the established Raft gRPC transport of %s: the address is no longer in the peer allowlist. "
+              + "%d in-flight RPC(s) closed; every further RPC on that transport is refused. The connection itself "
+              + "stays open until the peer drops it - gRPC exposes no way to close one established transport.",
+          session.getRemoteIp(), closed);
+    }
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java
@@ -517,7 +517,16 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
     return Math.min(refreshIntervalMs, MISS_RESOLVE_FLOOR_MS);
   }
 
-  /** Re-resolves only if at least {@code floor} ms have elapsed since the last resolution. */
+  /**
+   * Re-resolves only if at least {@code floor} ms have elapsed since the last resolution.
+   * <p>
+   * The early return below skips {@link #dispatchRevocations()} as well as the resolution, which is deliberate and
+   * is the one asymmetry with this class's other three dispatch sites: a thread that finds the resolution still
+   * fresh performed none, so it has enqueued nothing, and the thread that actually ran {@code doResolve()} falls
+   * through the block and dispatches whatever that resolution revoked. Returning without dispatching is therefore
+   * not a dropped revocation - but moving the dispatch inside the synchronized block, or adding a second early
+   * return above it, would make it one.
+   */
   private void resolveIfStale(final long floor) {
     synchronized (this) {
       if (clock.getAsLong() - lastResolveMs < floor)

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAllowlistCallInterceptor.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAllowlistCallInterceptor.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.apache.ratis.thirdparty.io.grpc.ForwardingServerCallListener;
+import org.apache.ratis.thirdparty.io.grpc.Metadata;
+import org.apache.ratis.thirdparty.io.grpc.ServerCall;
+import org.apache.ratis.thirdparty.io.grpc.ServerCallHandler;
+import org.apache.ratis.thirdparty.io.grpc.ServerInterceptor;
+
+/**
+ * Enforces {@link PeerAddressAllowlistFilter}'s admission decision for the whole life of a transport rather than only
+ * at the moment it is established (issue #7250).
+ * <p>
+ * {@code ServerTransportFilter.transportReady} runs once per connection, and gRPC gives it no handle on the
+ * connection, so #7225's unlearning of a removed peer stopped that peer from <i>reconnecting</i> and left an
+ * already-open HTTP/2 connection - and every RPC it can still carry - untouched. This interceptor closes that window
+ * from the only surface gRPC does expose: every RPC on the server passes the interceptor chain
+ * ({@code ServerImpl} applies the builder's interceptors to every call regardless of service registration order), so
+ * a transport whose {@link PeerTransportSession} has been revoked can be refused per call.
+ * <p>
+ * It also registers each call with its session, which is what lets a revocation cut the RPCs that are already
+ * running - a Raft {@code appendEntries} stream is long-lived, so refusing only new calls would revoke nothing on a
+ * connected follower.
+ * <p>
+ * Calls with no session in their attributes are passed straight through. That is not a hole: the filter creates no
+ * session for a loopback connection (it returns before the allowlist check) nor for a transport whose remote address
+ * gRPC did not report, and both are addresses the filter itself admits unconditionally.
+ */
+final class PeerAllowlistCallInterceptor implements ServerInterceptor {
+
+  @Override
+  public <Q, R> ServerCall.Listener<Q> interceptCall(final ServerCall<Q, R> call, final Metadata headers,
+      final ServerCallHandler<Q, R> next) {
+    final PeerTransportSession session = call.getAttributes().get(PeerAddressAllowlistFilter.TRANSPORT_SESSION);
+    if (session == null)
+      return next.startCall(call, headers);
+
+    if (session.isRevoked())
+      return refuse(call);
+
+    final RevocableServerCall<Q, R> revocable = new RevocableServerCall<>(call);
+    session.register(revocable);
+    // Re-read after registering: a revocation that ran between the check above and the registration has already
+    // walked the call set, so without this the call would start on a transport that is no longer admitted.
+    if (session.isRevoked()) {
+      session.unregister(revocable);
+      revocable.closeAsRevoked();
+      return new NoOpListener<>();
+    }
+
+    final ServerCall.Listener<Q> delegate;
+    try {
+      delegate = next.startCall(revocable, headers);
+    } catch (final RuntimeException | Error e) {
+      // The handler never started, so neither onComplete nor onCancel will arrive to deregister the call. Without
+      // this the session would keep one dead entry per failed RPC for the life of the connection.
+      session.unregister(revocable);
+      throw e;
+    }
+
+    return new ForwardingServerCallListener.SimpleForwardingServerCallListener<>(delegate) {
+      @Override
+      public void onComplete() {
+        session.unregister(revocable);
+        super.onComplete();
+      }
+
+      @Override
+      public void onCancel() {
+        session.unregister(revocable);
+        super.onCancel();
+      }
+    };
+  }
+
+  private static <Q, R> ServerCall.Listener<Q> refuse(final ServerCall<Q, R> call) {
+    call.close(PeerTransportSession.REVOKED, new Metadata());
+    return new NoOpListener<>();
+  }
+
+  /**
+   * Listener for a call that was refused before the handler ever saw it. Declared rather than an anonymous subclass
+   * so both refusal paths return the same thing.
+   */
+  private static final class NoOpListener<Q> extends ServerCall.Listener<Q> {
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerTransportSession.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerTransportSession.java
@@ -52,8 +52,9 @@ final class PeerTransportSession {
 
   private final String                             remoteIp;
   // The calls in flight on this transport. Concurrent because the interceptor registers and deregisters from gRPC
-  // handler threads while a reconciliation thread may be closing them.
-  private final Set<RevocableServerCall<?, ?>>     liveCalls = ConcurrentHashMap.newKeySet();
+  // handler threads while a reconciliation thread may be closing them. Sized for the handful a Raft connection
+  // actually has in flight rather than the default 16, since there is one of these per open connection.
+  private final Set<RevocableServerCall<?, ?>>     liveCalls = ConcurrentHashMap.newKeySet(4);
   private volatile boolean                         revoked;
   // Set once transportReady has decided to admit this transport. A session is registered BEFORE that decision, so
   // that a concurrent revocation cannot miss it, which means a rejected connection can be swept too; this flag is

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerTransportSession.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerTransportSession.java
@@ -87,6 +87,12 @@ final class PeerTransportSession {
    * Marks this transport revoked. Idempotent, and the return value is what keeps a repeated reconciliation from
    * logging - and re-walking the call set of - a transport that was already cut.
    * <p>
+   * The {@code synchronized} makes the check-and-set atomic in this object rather than in its caller. It buys
+   * nothing today: {@code grep -rn "\.revoke()" ha-raft/src} finds one caller,
+   * {@code PeerAddressAllowlistFilter.doResolve()}, which already runs under that filter's monitor. It is here so
+   * that the guarantee this method's return value advertises belongs to this method, and a second caller does not
+   * have to discover that it was really the filter's lock all along.
+   * <p>
    * <b>Revocation is terminal for this transport, deliberately.</b> Nothing un-revokes a session when its address
    * becomes admissible again, so a peer whose name resolved elsewhere for one tick reconnects rather than resuming
    * on the connection it had - which Ratis does on its own, and which the allowlist then admits normally. The

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerTransportSession.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerTransportSession.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.apache.ratis.thirdparty.io.grpc.Status;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * One inbound Raft gRPC transport that {@link PeerAddressAllowlistFilter} admitted, and the RPCs currently running on
+ * it (issue #7250).
+ * <p>
+ * {@code ServerTransportFilter} is a one-shot admission gate: it is consulted when a transport is established and
+ * never again, and it is handed no reference to the transport it admitted. So #7225 could make a removed peer stop
+ * being <i>admitted</i> but could not make one that was already <i>connected</i> stop talking. This object is the
+ * missing handle. The filter creates one per admitted transport, stashes it in the transport {@link
+ * org.apache.ratis.thirdparty.io.grpc.Attributes}, and {@link PeerAllowlistCallInterceptor} finds it again on every
+ * RPC through {@code ServerCall.getAttributes()} - which is where the transport attributes are merged in.
+ * <p>
+ * <b>Lifetime.</b> The filter holds sessions in a set it clears from {@code transportTerminated}, and a session holds
+ * only the calls currently in flight - the interceptor deregisters each one when it completes or is cancelled. So
+ * neither the session nor a call outlives its transport, which is the part the issue asked to design carefully.
+ * <p>
+ * <b>What a revocation actually revokes.</b> gRPC's public API hands out no way to close one established transport
+ * (checked across {@code ServerTransportFilter} and every public method of {@code NettyServerBuilder}), so the socket
+ * stays connected until one side drops it. What is revoked is everything the socket can carry: in-flight calls are
+ * closed with {@link #REVOKED} and every subsequent call on the transport is refused by the interceptor, which sits
+ * in the server-wide interceptor chain that every RPC passes.
+ */
+final class PeerTransportSession {
+
+  /** Status a revoked peer sees, on the in-flight RPCs and on every one it starts afterwards. */
+  static final Status REVOKED = Status.PERMISSION_DENIED
+      .withDescription("The Raft gRPC peer allowlist no longer admits this address");
+
+  private final String                             remoteIp;
+  // The calls in flight on this transport. Concurrent because the interceptor registers and deregisters from gRPC
+  // handler threads while a reconciliation thread may be closing them.
+  private final Set<RevocableServerCall<?, ?>>     liveCalls = ConcurrentHashMap.newKeySet();
+  private volatile boolean                         revoked;
+  // Set once transportReady has decided to admit this transport. A session is registered BEFORE that decision, so
+  // that a concurrent revocation cannot miss it, which means a rejected connection can be swept too; this flag is
+  // what keeps such a session out of the revocation log, where it would report a revocation of something that was
+  // never admitted (the rejection itself is already logged by isAllowed).
+  private volatile boolean                         admitted;
+
+  PeerTransportSession(final String remoteIp) {
+    this.remoteIp = remoteIp;
+  }
+
+  String getRemoteIp() {
+    return remoteIp;
+  }
+
+  boolean isRevoked() {
+    return revoked;
+  }
+
+  /** Called by {@code transportReady} once it has decided to admit this transport, and never unset. */
+  void markAdmitted() {
+    admitted = true;
+  }
+
+  boolean isAdmitted() {
+    return admitted;
+  }
+
+  /**
+   * Marks this transport revoked. Idempotent, and the return value is what keeps a repeated reconciliation from
+   * logging - and re-walking the call set of - a transport that was already cut.
+   * <p>
+   * <b>Revocation is terminal for this transport, deliberately.</b> Nothing un-revokes a session when its address
+   * becomes admissible again, so a peer whose name resolved elsewhere for one tick reconnects rather than resuming
+   * on the connection it had - which Ratis does on its own, and which the allowlist then admits normally. The
+   * alternative, letting a later DNS answer undo a revocation, would make the revocation only as durable as the
+   * least trustworthy resolution in the window, and this class exists to revoke.
+   *
+   * @return true when this invocation is the one that flipped the session from live to revoked
+   */
+  synchronized boolean revoke() {
+    if (revoked)
+      return false;
+    revoked = true;
+    return true;
+  }
+
+  void register(final RevocableServerCall<?, ?> call) {
+    liveCalls.add(call);
+  }
+
+  void unregister(final RevocableServerCall<?, ?> call) {
+    liveCalls.remove(call);
+  }
+
+  /**
+   * Closes every RPC currently in flight on this transport. Removing before closing rather than after keeps the set
+   * from being walked twice for the same call when a handler completes concurrently.
+   *
+   * @return how many calls this invocation actually closed
+   */
+  int closeLiveCalls() {
+    int closed = 0;
+    for (final RevocableServerCall<?, ?> call : liveCalls) {
+      liveCalls.remove(call);
+      if (call.closeAsRevoked())
+        closed++;
+    }
+    return closed;
+  }
+
+  /** Drops the call references without touching them; the transport is gone, so there is nothing left to close. */
+  void forgetCalls() {
+    liveCalls.clear();
+  }
+
+  /** How many RPCs are currently in flight on this transport. Exposed for testing. */
+  int getLiveCallCount() {
+    return liveCalls.size();
+  }
+
+  @Override
+  public String toString() {
+    return "PeerTransportSession{remoteIp=" + remoteIp + ", admitted=" + admitted + ", revoked=" + revoked
+        + ", liveCalls=" + liveCalls.size() + "}";
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGrpcServicesCustomizer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGrpcServicesCustomizer.java
@@ -19,22 +19,34 @@
 package com.arcadedb.server.ha.raft;
 
 import org.apache.ratis.grpc.server.GrpcServices;
+import org.apache.ratis.thirdparty.io.grpc.ServerInterceptor;
 import org.apache.ratis.thirdparty.io.grpc.ServerTransportFilter;
 import org.apache.ratis.thirdparty.io.grpc.netty.NettyServerBuilder;
 
 import java.util.EnumSet;
 
 /**
- * {@link GrpcServices.Customizer} that installs the configured server-side transport filters
+ * {@link GrpcServices.Customizer} that installs the configured server-side transport filters and call interceptors
  * on the Ratis Netty gRPC server builder. Ratis 3.2.2 routes all service types (ADMIN, CLIENT,
  * SERVER) through the same listener, so one customizer covers every inbound RPC.
+ * <p>
+ * A transport filter gates a connection once, when it is established; an interceptor is consulted on every RPC. The
+ * peer allowlist needs both (issue #7250): the filter to refuse a connection, the interceptor to revoke one that was
+ * established before its address stopped being admitted. Interceptors registered on the builder are server-wide -
+ * {@code ServerImpl} applies them to every call whatever order the services were added in - so the two are installed
+ * together here rather than per service.
  */
 final class RaftGrpcServicesCustomizer implements GrpcServices.Customizer {
 
-  private final ServerTransportFilter[] filters;
+  private static final ServerTransportFilter[] NO_FILTERS      = new ServerTransportFilter[0];
+  private static final ServerInterceptor[]     NO_INTERCEPTORS = new ServerInterceptor[0];
 
-  RaftGrpcServicesCustomizer(final ServerTransportFilter... filters) {
-    this.filters = filters == null ? new ServerTransportFilter[0] : filters;
+  private final ServerTransportFilter[] filters;
+  private final ServerInterceptor[]     interceptors;
+
+  RaftGrpcServicesCustomizer(final ServerTransportFilter[] filters, final ServerInterceptor[] interceptors) {
+    this.filters = filters == null ? NO_FILTERS : filters;
+    this.interceptors = interceptors == null ? NO_INTERCEPTORS : interceptors;
   }
 
   @Override
@@ -42,6 +54,8 @@ final class RaftGrpcServicesCustomizer implements GrpcServices.Customizer {
     NettyServerBuilder result = builder;
     for (final ServerTransportFilter f : filters)
       result = result.addTransportFilter(f);
+    for (final ServerInterceptor i : interceptors)
+      result = result.intercept(i);
     return result;
   }
 }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -57,6 +57,8 @@ import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.storage.RaftStorage;
 import org.apache.ratis.thirdparty.com.codahale.metrics.MetricRegistry;
 import org.apache.ratis.thirdparty.com.codahale.metrics.Timer;
+import org.apache.ratis.thirdparty.io.grpc.ServerInterceptor;
+import org.apache.ratis.thirdparty.io.grpc.ServerTransportFilter;
 import org.apache.ratis.util.LifeCycle;
 import org.apache.ratis.util.TimeDuration;
 
@@ -250,6 +252,9 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   // Inbound Raft gRPC peer allowlist, recreated on each Ratis (re)start. Periodically refreshed by the
   // health monitor tick so a returned peer's new pod IP is admitted proactively (issue #4696).
   private volatile PeerAddressAllowlistFilter allowlistFilter;
+  // Installed alongside allowlistFilter and null for exactly the same reasons (issue #7250): the two are the
+  // connection-time and the per-RPC half of one decision.
+  private volatile PeerAllowlistCallInterceptor allowlistInterceptor;
   // Ratis transport parameters (gRPC TLS conf and the inbound-allowlist services customizer) built by
   // buildParameters() on each Ratis (re)start. Kept so refreshRaftClient() can rebuild the leader's
   // self-client with the SAME transport configuration: a client built with an empty Parameters would
@@ -4169,6 +4174,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   // raftParameters becomes visible - the property this method exists to get right.
   Parameters buildParameters(final ContextConfiguration configuration) {
     this.allowlistFilter = null;
+    this.allowlistInterceptor = null;
     final Parameters parameters = new Parameters();
 
     // mTLS first: it is the cryptographic peer identity the allowlist below cannot provide. Throws a
@@ -4226,8 +4232,14 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     if (serviceDomain != null)
       filter.learnPeerHosts(List.of(serviceDomain));
 
+    // The filter gates a connection once, when it is established. The interceptor enforces the same decision on
+    // every RPC, which is what revokes a transport already open when its address stopped being admitted (#7250):
+    // it reads the session the filter attached to the transport and refuses the call when that session is revoked.
+    final PeerAllowlistCallInterceptor interceptor = new PeerAllowlistCallInterceptor();
     this.allowlistFilter = filter;
-    GrpcConfigKeys.Server.setServicesCustomizer(parameters, new RaftGrpcServicesCustomizer(filter));
+    this.allowlistInterceptor = interceptor;
+    GrpcConfigKeys.Server.setServicesCustomizer(parameters, new RaftGrpcServicesCustomizer(
+        new ServerTransportFilter[] { filter }, new ServerInterceptor[] { interceptor }));
   }
 
   /**
@@ -4251,6 +4263,11 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   /** Package-private test hook: the inbound Raft gRPC peer allowlist, or null when disabled. */
   PeerAddressAllowlistFilter allowlistFilterForTest() {
     return allowlistFilter;
+  }
+
+  /** Package-private test hook: the per-RPC half of the peer allowlist (issue #7250), or null when disabled. */
+  PeerAllowlistCallInterceptor allowlistInterceptorForTest() {
+    return allowlistInterceptor;
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RevocableServerCall.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RevocableServerCall.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.log.LogManager;
+import org.apache.ratis.thirdparty.io.grpc.ForwardingServerCall;
+import org.apache.ratis.thirdparty.io.grpc.Metadata;
+import org.apache.ratis.thirdparty.io.grpc.ServerCall;
+import org.apache.ratis.thirdparty.io.grpc.Status;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+
+/**
+ * A {@link ServerCall} that a third party - {@link PeerTransportSession#closeLiveCalls()} - may terminate while the
+ * handler owning it is still running, used to cut the in-flight Raft RPCs of a peer whose transport has just been
+ * revoked (issue #7250).
+ * <p>
+ * The wrapper exists for exactly one reason: {@code ServerCall.close} is single-shot ({@code ServerCallImpl} throws
+ * {@code IllegalStateException} on a second call) and the revoking thread is not the thread running the handler, so
+ * without a shared latch the two race to close the same call. Every close the handler performs goes through
+ * {@link #close(Status, Metadata)} because the handler is handed <i>this</i> object rather than the delegate, so the
+ * {@link AtomicBoolean} below arbitrates both directions with one CAS.
+ * <p>
+ * {@code ServerCall} is documented as not thread-safe, and this class does not make it so: it makes exactly one
+ * additional caller safe against the handler, which is what a revocation needs. A close the delegate performs on its
+ * own - the gRPC runtime aborting the stream, say - bypasses the latch, so {@link #closeAsRevoked()} still guards its
+ * delegate call with a try/catch rather than trusting the CAS to be the whole story.
+ */
+final class RevocableServerCall<Q, R> extends ForwardingServerCall.SimpleForwardingServerCall<Q, R> {
+
+  private final AtomicBoolean closed = new AtomicBoolean();
+
+  RevocableServerCall(final ServerCall<Q, R> delegate) {
+    super(delegate);
+  }
+
+  @Override
+  public void close(final Status status, final Metadata trailers) {
+    if (closed.compareAndSet(false, true))
+      super.close(status, trailers);
+  }
+
+  /**
+   * Closes this call on behalf of a revocation, unless it is already closed.
+   *
+   * @return true when this invocation is the one that closed the call
+   */
+  boolean closeAsRevoked() {
+    if (!closed.compareAndSet(false, true))
+      return false;
+    try {
+      super.close(PeerTransportSession.REVOKED, new Metadata());
+      return true;
+    } catch (final RuntimeException e) {
+      // The delegate was already finished by the gRPC runtime without passing through close(Status, Metadata)
+      // above. Nothing to revoke, and nothing an operator can act on: the RPC is over either way.
+      LogManager.instance().log(this, Level.FINE,
+          "Raft gRPC call was already terminated when its transport was revoked: %s", e.toString());
+      return false;
+    }
+  }
+
+  /** Whether this call has been closed through this wrapper. Exposed for testing. */
+  boolean isClosed() {
+    return closed.get();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7250RevokesEstablishedTransportTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7250RevokesEstablishedTransportTest.java
@@ -1,0 +1,518 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.thirdparty.io.grpc.Attributes;
+import org.apache.ratis.thirdparty.io.grpc.Grpc;
+import org.apache.ratis.thirdparty.io.grpc.Metadata;
+import org.apache.ratis.thirdparty.io.grpc.MethodDescriptor;
+import org.apache.ratis.thirdparty.io.grpc.ServerCall;
+import org.apache.ratis.thirdparty.io.grpc.ServerCallHandler;
+import org.apache.ratis.thirdparty.io.grpc.Status;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for issue #7250, a follow-up to #7225.
+ * <p>
+ * #7225 made the allowlist unlearn a host that left the Raft configuration, so a removed peer stopped being
+ * <i>admitted</i>. It did not touch one that was already <i>connected</i>: {@code ServerTransportFilter.transportReady}
+ * runs once per transport and gRPC hands it no reference to the transport it admitted, so a peer connected at the
+ * moment it was removed kept that HTTP/2 connection - and everything it could send on it - until one side dropped it.
+ * <p>
+ * The filter now attaches a {@link PeerTransportSession} to every transport it admits, revokes the sessions whose
+ * address a resolution stopped admitting, and {@link PeerAllowlistCallInterceptor} enforces that per RPC: in-flight
+ * calls are closed with {@code PERMISSION_DENIED} and later ones are refused. What is NOT closed is the socket -
+ * gRPC's public API offers no way to close one established transport - which is the residual risk the tracking doc
+ * records.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue7250RevokesEstablishedTransportTest {
+
+  private static final Metadata NO_HEADERS = new Metadata();
+
+  // ---------------------------------------------------------------------------
+  // Row 1: the reported case - a peer removed from the Raft configuration
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void aPeerRemovedFromTheRaftConfigurationLosesItsEstablishedTransport() throws UnknownHostException {
+    final AtomicLong clock = new AtomicLong(0);
+    final PeerAddressAllowlistFilterTest.FakeResolver dns = new PeerAddressAllowlistFilterTest.FakeResolver();
+    dns.table.put("arcadedb-0", List.of("10.1.13.1"));
+    dns.table.put("arcadedb-3", List.of("10.1.13.4"));
+    final PeerAddressAllowlistFilter filter = new PeerAddressAllowlistFilter(List.of("arcadedb-0"), 30_000L, 0L,
+        300_000L, clock::get, dns);
+    final PeerAllowlistCallInterceptor interceptor = new PeerAllowlistCallInterceptor();
+
+    // Scale-up: pod 3 joins and connects. A long-lived appendEntries stream is running on that transport.
+    filter.setMemberHosts(List.of("arcadedb-0", "arcadedb-3"));
+    final Attributes transport = admit(filter, "10.1.13.4");
+    final RecordingServerCall stream = startCall(interceptor, transport);
+    assertThat(stream.closedStatus()).as("an admitted peer's RPC runs").isNull();
+
+    // Scale-down: the health monitor tick reports the smaller membership.
+    filter.setMemberHosts(List.of("arcadedb-0"));
+
+    assertThat(filter.isAllowed("10.1.13.4")).as("#7225: the removed peer can no longer connect").isFalse();
+    assertThat(stream.closedStatus()).as("#7250: and the RPC it already had running is cut")
+        .isEqualTo(Status.Code.PERMISSION_DENIED);
+  }
+
+  /** Row 7: after a revocation, an RPC started on the same still-open transport is refused. */
+  @Test
+  void aNewRpcOnARevokedTransportIsRefused() throws UnknownHostException {
+    final AtomicLong clock = new AtomicLong(0);
+    final PeerAddressAllowlistFilterTest.FakeResolver dns = new PeerAddressAllowlistFilterTest.FakeResolver();
+    dns.table.put("peerA", List.of("10.0.0.1"));
+    dns.table.put("gone", List.of("10.0.0.9"));
+    final PeerAddressAllowlistFilter filter = new PeerAddressAllowlistFilter(List.of("peerA"), 30_000L, 0L, 300_000L,
+        clock::get, dns);
+    final PeerAllowlistCallInterceptor interceptor = new PeerAllowlistCallInterceptor();
+
+    filter.setMemberHosts(List.of("gone"));
+    final Attributes transport = admit(filter, "10.0.0.9");
+    filter.setMemberHosts(List.of());
+
+    final AtomicInteger handlerInvocations = new AtomicInteger();
+    final RecordingServerCall refused = new RecordingServerCall(transport);
+    interceptor.interceptCall(refused, NO_HEADERS, countingHandler(handlerInvocations));
+
+    assertThat(refused.closedStatus()).isEqualTo(Status.Code.PERMISSION_DENIED);
+    assertThat(handlerInvocations)
+        .as("a refused call must never reach the Raft service handler on the other side of the interceptor")
+        .hasValue(0);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Row 3: the peer's DNS record no longer carries the address it connected from
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void aPeerWhoseAddressChangedLosesTheTransportOpenedOnTheOldAddress() throws UnknownHostException {
+    final AtomicLong clock = new AtomicLong(0);
+    final PeerAddressAllowlistFilterTest.FakeResolver dns = new PeerAddressAllowlistFilterTest.FakeResolver();
+    dns.table.put("peerA", List.of("10.0.0.1"));
+    final PeerAddressAllowlistFilter filter = new PeerAddressAllowlistFilter(List.of("peerA"), 30_000L, 0L, 0L,
+        clock::get, dns);
+    final PeerAllowlistCallInterceptor interceptor = new PeerAllowlistCallInterceptor();
+
+    final Attributes transport = admit(filter, "10.0.0.1");
+    final RecordingServerCall stream = startCall(interceptor, transport);
+
+    // The pod is recreated with a new IP; the name now resolves elsewhere. Whoever still holds the old address is
+    // not the peer any more.
+    dns.table.put("peerA", List.of("10.0.0.2"));
+    clock.addAndGet(60_000L);
+    filter.proactiveRefresh();
+
+    assertThat(filter.getAllowedIps()).contains("10.0.0.2").doesNotContain("10.0.0.1");
+    assertThat(stream.closedStatus()).isEqualTo(Status.Code.PERMISSION_DENIED);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Row 4: the sticky last-known-good retention expiring
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void aTransportHeldOpenOnAnExpiredStickyAddressIsRevoked() throws UnknownHostException {
+    final AtomicLong clock = new AtomicLong(0);
+    final PeerAddressAllowlistFilterTest.FakeResolver dns = new PeerAddressAllowlistFilterTest.FakeResolver();
+    dns.table.put("peerA", List.of("10.0.0.1"));
+    final PeerAddressAllowlistFilter filter = new PeerAddressAllowlistFilter(List.of("peerA"), 1_000L, 0L, 10_000L,
+        clock::get, dns);
+    final PeerAllowlistCallInterceptor interceptor = new PeerAllowlistCallInterceptor();
+
+    final Attributes transport = admit(filter, "10.0.0.1");
+    final RecordingServerCall stream = startCall(interceptor, transport);
+
+    // DNS stops answering for the peer. Inside the sticky window the transport keeps its access, which is the whole
+    // point of the retention: a transient outage must not partition a live cluster.
+    dns.table.remove("peerA");
+    clock.addAndGet(5_000L);
+    filter.refresh();
+    assertThat(stream.closedStatus()).as("a sticky entry still covers the address").isNull();
+
+    // Past the retention the address is nobody's any more.
+    clock.addAndGet(20_000L);
+    filter.refresh();
+    assertThat(filter.getAllowedIps()).doesNotContain("10.0.0.1");
+    assertThat(stream.closedStatus()).isEqualTo(Status.Code.PERMISSION_DENIED);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Row 5: a transport admitted while the filter was failing open at startup
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void aTransportAdmittedUnderTheStartupFailOpenIsRevokedOnceTheGraceEnds() throws UnknownHostException {
+    final AtomicLong clock = new AtomicLong(0);
+    final PeerAddressAllowlistFilterTest.FakeResolver dns = new PeerAddressAllowlistFilterTest.FakeResolver();
+    // peerA does not resolve yet: below quorum, so the filter fails open (issues #4471/#4828).
+    final PeerAddressAllowlistFilter filter = new PeerAddressAllowlistFilter(List.of("peerA"), 1_000L, 60_000L, 0L,
+        clock::get, dns);
+    final PeerAllowlistCallInterceptor interceptor = new PeerAllowlistCallInterceptor();
+
+    final Attributes transport = admit(filter, "10.0.0.55");
+    final RecordingServerCall stream = startCall(interceptor, transport);
+
+    // Still inside the grace window and still below quorum: cutting the transport here would re-create exactly the
+    // self-inflicted partition the fail-open exists to prevent.
+    clock.addAndGet(10_000L);
+    filter.refresh();
+    assertThat(stream.closedStatus()).as("the fail-open window must keep admitting what it admitted").isNull();
+
+    // The peer resolves, the quorum latch trips and the fail-open ends. 10.0.0.55 was never a peer.
+    dns.table.put("peerA", List.of("10.0.0.1"));
+    clock.addAndGet(10_000L);
+    filter.refresh();
+
+    assertThat(filter.isQuorumResolved()).isTrue();
+    assertThat(stream.closedStatus()).isEqualTo(Status.Code.PERMISSION_DENIED);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Row 9 and the lifetime contract
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void aLoopbackTransportIsNeverTrackedAndNeverRevoked() throws UnknownHostException {
+    final AtomicLong clock = new AtomicLong(0);
+    final PeerAddressAllowlistFilterTest.FakeResolver dns = new PeerAddressAllowlistFilterTest.FakeResolver();
+    dns.table.put("peerA", List.of("10.0.0.1"));
+    final PeerAddressAllowlistFilter filter = new PeerAddressAllowlistFilter(List.of("peerA"), 30_000L, 0L, 0L,
+        clock::get, dns);
+    final PeerAllowlistCallInterceptor interceptor = new PeerAllowlistCallInterceptor();
+
+    final Attributes transport = filter.transportReady(remoteAttributes("127.0.0.1"));
+    assertThat(transport.get(PeerAddressAllowlistFilter.TRANSPORT_SESSION))
+        .as("loopback is admitted before the allowlist is consulted, so it gets no session").isNull();
+    assertThat(filter.getSessions()).isEmpty();
+
+    final AtomicInteger handlerInvocations = new AtomicInteger();
+    final RecordingServerCall call = new RecordingServerCall(transport);
+    interceptor.interceptCall(call, NO_HEADERS, countingHandler(handlerInvocations));
+
+    // Every membership shrink there is, and the loopback call is still running.
+    filter.setMemberHosts(List.of());
+    filter.refresh();
+    assertThat(handlerInvocations).hasValue(1);
+    assertThat(call.closedStatus()).isNull();
+  }
+
+  /**
+   * The session is registered before the admission decision is taken, so that a revocation racing that decision
+   * cannot miss it. This pins the other half of that ordering: the rejection path has to take the session back out
+   * again, and the miss-triggered re-resolution inside {@code isAllowed} sweeps it on the way through - so the
+   * rejected connection walks the whole register/revoke/unregister path, not just the throw.
+   */
+  @Test
+  void aRejectedTransportIsRegisteredForTheRaceButNotLeftBehind() {
+    final AtomicLong clock = new AtomicLong(0);
+    final PeerAddressAllowlistFilterTest.FakeResolver dns = new PeerAddressAllowlistFilterTest.FakeResolver();
+    dns.table.put("peerA", List.of("10.0.0.1"));
+    final PeerAddressAllowlistFilter filter = new PeerAddressAllowlistFilter(List.of("peerA"), 30_000L, 0L, 0L,
+        clock::get, dns);
+
+    assertThatThrownBy(() -> filter.transportReady(remoteAttributes("192.168.7.7")))
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("192.168.7.7");
+    assertThat(filter.getSessions()).as("a transport that was never admitted must not be tracked").isEmpty();
+  }
+
+  /** {@code getSessions()} is a test hook, and a test hook that hands out the live set is a way to corrupt it. */
+  @Test
+  void theSessionSetIsNotExposedForMutation() throws UnknownHostException {
+    final AtomicLong clock = new AtomicLong(0);
+    final PeerAddressAllowlistFilterTest.FakeResolver dns = new PeerAddressAllowlistFilterTest.FakeResolver();
+    dns.table.put("peerA", List.of("10.0.0.1"));
+    final PeerAddressAllowlistFilter filter = new PeerAddressAllowlistFilter(List.of("peerA"), 30_000L, 0L, 0L,
+        clock::get, dns);
+    admit(filter, "10.0.0.1");
+
+    assertThatThrownBy(() -> filter.getSessions().clear()).isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  /**
+   * A handler that throws before the RPC starts leaves no {@code onComplete} or {@code onCancel} to deregister the
+   * call, so the interceptor has to do it itself - otherwise a long-lived connection accumulates one dead entry per
+   * failed RPC, and every later revocation walks them.
+   */
+  @Test
+  void aHandlerThatThrowsDoesNotLeaveTheCallRegistered() throws UnknownHostException {
+    final AtomicLong clock = new AtomicLong(0);
+    final PeerAddressAllowlistFilterTest.FakeResolver dns = new PeerAddressAllowlistFilterTest.FakeResolver();
+    dns.table.put("peerA", List.of("10.0.0.1"));
+    final PeerAddressAllowlistFilter filter = new PeerAddressAllowlistFilter(List.of("peerA"), 30_000L, 0L, 0L,
+        clock::get, dns);
+    final PeerAllowlistCallInterceptor interceptor = new PeerAllowlistCallInterceptor();
+
+    final Attributes transport = admit(filter, "10.0.0.1");
+    final PeerTransportSession session = transport.get(PeerAddressAllowlistFilter.TRANSPORT_SESSION);
+
+    assertThatThrownBy(() -> interceptor.interceptCall(new RecordingServerCall(transport), NO_HEADERS,
+        (call, headers) -> {
+          throw new IllegalStateException("the Raft service refused to start this RPC");
+        })).isInstanceOf(IllegalStateException.class);
+
+    assertThat(session.getLiveCallCount()).isZero();
+  }
+
+  @Test
+  void aTerminatedTransportIsForgottenSoTheSessionSetDoesNotGrowForever() throws UnknownHostException {
+    final AtomicLong clock = new AtomicLong(0);
+    final PeerAddressAllowlistFilterTest.FakeResolver dns = new PeerAddressAllowlistFilterTest.FakeResolver();
+    dns.table.put("peerA", List.of("10.0.0.1"));
+    final PeerAddressAllowlistFilter filter = new PeerAddressAllowlistFilter(List.of("peerA"), 30_000L, 0L, 0L,
+        clock::get, dns);
+    final PeerAllowlistCallInterceptor interceptor = new PeerAllowlistCallInterceptor();
+
+    final Attributes transport = admit(filter, "10.0.0.1");
+    final PeerTransportSession session = transport.get(PeerAddressAllowlistFilter.TRANSPORT_SESSION);
+    startCall(interceptor, transport);
+    assertThat(filter.getSessions()).hasSize(1);
+    assertThat(session.getLiveCallCount()).isEqualTo(1);
+
+    filter.transportTerminated(transport);
+
+    assertThat(filter.getSessions()).isEmpty();
+    assertThat(session.getLiveCallCount()).as("a dead transport's calls must not be walked by later revocations")
+        .isZero();
+  }
+
+  @Test
+  void aCompletedRpcIsDeregisteredFromItsSession() throws UnknownHostException {
+    final AtomicLong clock = new AtomicLong(0);
+    final PeerAddressAllowlistFilterTest.FakeResolver dns = new PeerAddressAllowlistFilterTest.FakeResolver();
+    dns.table.put("peerA", List.of("10.0.0.1"));
+    final PeerAddressAllowlistFilter filter = new PeerAddressAllowlistFilter(List.of("peerA"), 30_000L, 0L, 0L,
+        clock::get, dns);
+    final PeerAllowlistCallInterceptor interceptor = new PeerAllowlistCallInterceptor();
+
+    final Attributes transport = admit(filter, "10.0.0.1");
+    final PeerTransportSession session = transport.get(PeerAddressAllowlistFilter.TRANSPORT_SESSION);
+
+    final ServerCall.Listener<byte[]> listener = interceptor.interceptCall(new RecordingServerCall(transport),
+        NO_HEADERS, countingHandler(new AtomicInteger()));
+    assertThat(session.getLiveCallCount()).isEqualTo(1);
+    listener.onComplete();
+    assertThat(session.getLiveCallCount()).isZero();
+
+    final ServerCall.Listener<byte[]> cancelled = interceptor.interceptCall(new RecordingServerCall(transport),
+        NO_HEADERS, countingHandler(new AtomicInteger()));
+    assertThat(session.getLiveCallCount()).isEqualTo(1);
+    cancelled.onCancel();
+    assertThat(session.getLiveCallCount()).isZero();
+  }
+
+  /**
+   * A revocation and the handler's own completion race for the single-shot {@code ServerCall.close}. The wrapper has
+   * to arbitrate, or one of the two throws {@code IllegalStateException} inside gRPC.
+   */
+  @Test
+  void aCallTheHandlerAlreadyClosedIsNotClosedTwiceByARevocation() throws UnknownHostException {
+    final AtomicLong clock = new AtomicLong(0);
+    final PeerAddressAllowlistFilterTest.FakeResolver dns = new PeerAddressAllowlistFilterTest.FakeResolver();
+    dns.table.put("gone", List.of("10.0.0.9"));
+    dns.table.put("peerA", List.of("10.0.0.1"));
+    final PeerAddressAllowlistFilter filter = new PeerAddressAllowlistFilter(List.of("peerA"), 30_000L, 0L, 0L,
+        clock::get, dns);
+    final PeerAllowlistCallInterceptor interceptor = new PeerAllowlistCallInterceptor();
+
+    filter.setMemberHosts(List.of("gone"));
+    final Attributes transport = admit(filter, "10.0.0.9");
+
+    final RecordingServerCall raw = new RecordingServerCall(transport);
+    final List<ServerCall<byte[], byte[]>> handed = new ArrayList<>();
+    interceptor.interceptCall(raw, NO_HEADERS, (call, headers) -> {
+      handed.add(call);
+      return new ServerCall.Listener<>() {
+      };
+    });
+    // The handler finishes the RPC normally, exactly as a completing appendEntries would.
+    handed.getFirst().close(Status.OK, new Metadata());
+    assertThat(raw.closes).isEqualTo(1);
+
+    filter.setMemberHosts(List.of());
+
+    assertThat(raw.closes).as("the revocation must not close a call the handler already finished").isEqualTo(1);
+    assertThat(raw.closedStatus()).isEqualTo(Status.Code.OK);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Row 2: the production wiring in RaftHAServer
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void theProductionReconciliationRevokesTheRemovedPeersEstablishedTransport() throws UnknownHostException {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_SERVER_LIST, "127.0.0.1:2434:2480");
+    config.setValue(GlobalConfiguration.HA_PEER_ALLOWLIST_STARTUP_GRACE_MS, 0L);
+
+    final ArcadeDBServer arcadeServer = mock(ArcadeDBServer.class);
+    when(arcadeServer.getServerName()).thenReturn("arcadedb-0");
+    final RaftHAServer server = new RaftHAServer(arcadeServer, config);
+    server.buildParameters(config);
+
+    final PeerAddressAllowlistFilter filter = server.allowlistFilterForTest();
+    final PeerAllowlistCallInterceptor interceptor = server.allowlistInterceptorForTest();
+    assertThat(filter).isNotNull();
+    assertThat(interceptor).as("the per-RPC half of the allowlist is installed with the filter").isNotNull();
+
+    // A peer joins at runtime and connects; its host is a literal address so it needs no DNS.
+    server.reconcileAllowlistMembership(List.of(peer("arcadedb-1", "10.20.30.40:2434")));
+    assertThat(filter.isAllowed("10.20.30.40")).isTrue();
+    final Attributes transport = admit(filter, "10.20.30.40");
+    final RecordingServerCall stream = startCall(interceptor, transport);
+
+    // DELETE /api/v1/cluster/peer/{id}: the next tick carries the committed configuration without it.
+    server.reconcileAllowlistMembership(List.of(peer("arcadedb-0", "127.0.0.1:2434")));
+
+    assertThat(filter.isAllowed("10.20.30.40")).isFalse();
+    assertThat(stream.closedStatus()).as("removing a peer revokes its reach, not only its ability to reconnect")
+        .isEqualTo(Status.Code.PERMISSION_DENIED);
+  }
+
+  @Test
+  void aDisabledAllowlistInstallsNeitherHalf() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_SERVER_LIST, "127.0.0.1:2434:2480");
+    config.setValue(GlobalConfiguration.HA_PEER_ALLOWLIST_ENABLED, false);
+
+    final ArcadeDBServer arcadeServer = mock(ArcadeDBServer.class);
+    when(arcadeServer.getServerName()).thenReturn("arcadedb-0");
+    final RaftHAServer server = new RaftHAServer(arcadeServer, config);
+    server.buildParameters(config);
+
+    assertThat(server.allowlistFilterForTest()).isNull();
+    assertThat(server.allowlistInterceptorForTest()).isNull();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private static RaftPeer peer(final String id, final String address) {
+    return RaftPeer.newBuilder().setId(RaftPeerId.valueOf(id)).setAddress(address).build();
+  }
+
+  /** The transport attributes gRPC hands {@code transportReady} for a connection from {@code ip}. */
+  private static Attributes remoteAttributes(final String ip) throws UnknownHostException {
+    return Attributes.newBuilder()
+        .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, new InetSocketAddress(InetAddress.getByName(ip), 51_234)).build();
+  }
+
+  /** Runs a connection from {@code ip} through the filter and returns the effective transport attributes. */
+  private static Attributes admit(final PeerAddressAllowlistFilter filter, final String ip)
+      throws UnknownHostException {
+    final Attributes effective = filter.transportReady(remoteAttributes(ip));
+    assertThat(effective.get(PeerAddressAllowlistFilter.TRANSPORT_SESSION))
+        .as("an admitted transport carries the handle a revocation needs").isNotNull();
+    return effective;
+  }
+
+  /** Starts one long-lived RPC on {@code transport} and returns the underlying call, to inspect how it ends. */
+  private static RecordingServerCall startCall(final PeerAllowlistCallInterceptor interceptor,
+      final Attributes transport) {
+    final RecordingServerCall call = new RecordingServerCall(transport);
+    interceptor.interceptCall(call, NO_HEADERS, countingHandler(new AtomicInteger()));
+    return call;
+  }
+
+  /** A handler that counts its invocations and never finishes the call, standing in for a live Raft stream. */
+  private static ServerCallHandler<byte[], byte[]> countingHandler(final AtomicInteger invocations) {
+    return (call, headers) -> {
+      invocations.incrementAndGet();
+      return new ServerCall.Listener<>() {
+      };
+    };
+  }
+
+  /**
+   * A {@link ServerCall} that records how it was finished. {@code ServerCall} is an abstract class with no
+   * final methods, so the real thing can be stood in for without a mocking framework - and without a gRPC server.
+   */
+  private static final class RecordingServerCall extends ServerCall<byte[], byte[]> {
+    private final Attributes attributes;
+    private       Status     closedWith;
+    private       int        closes;
+
+    private RecordingServerCall(final Attributes attributes) {
+      this.attributes = attributes;
+    }
+
+    private Status.Code closedStatus() {
+      return closedWith == null ? null : closedWith.getCode();
+    }
+
+    @Override
+    public void request(final int numMessages) {
+      // no flow control in this stub
+    }
+
+    @Override
+    public void sendHeaders(final Metadata headers) {
+      // no headers in this stub
+    }
+
+    @Override
+    public void sendMessage(final byte[] message) {
+      // no messages in this stub
+    }
+
+    @Override
+    public void close(final Status status, final Metadata trailers) {
+      closes++;
+      closedWith = status;
+    }
+
+    @Override
+    public boolean isCancelled() {
+      return false;
+    }
+
+    @Override
+    public Attributes getAttributes() {
+      return attributes;
+    }
+
+    @Override
+    public MethodDescriptor<byte[], byte[]> getMethodDescriptor() {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
Closes #7250

## Summary

#7225 made the Raft gRPC allowlist unlearn a host that left the Raft configuration, so a removed peer stopped
being *admitted*. It did not touch one that was already *connected*: `ServerTransportFilter.transportReady` runs
once per transport and gRPC hands it no reference to the transport it admitted, so a peer connected at the moment
it was removed kept that HTTP/2 connection - and everything it could send on it - until one side dropped it for an
unrelated reason. `PeerAddressAllowlistFilter` now attaches a `PeerTransportSession` to every transport it admits
and drops it in `transportTerminated`; the sweep at the end of `doResolve()` - the only writer of `allowedIps`, so
every way the admitted set can shrink lands there - revokes the sessions whose address it stopped admitting; and
`PeerAllowlistCallInterceptor` enforces that per RPC, closing the calls in flight with `PERMISSION_DENIED` and
refusing every later one. The operator-facing claim `arcadedb.ha.peerAllowlist.enabled` makes is updated to match,
including what is *not* revoked: gRPC's public API exposes no way to close one established transport, so the socket
stays connected until the peer drops it.

## Test plan

- [ ] `mvn -o -pl ha-raft -Dtest=Issue7250RevokesEstablishedTransportTest test` - 14 tests, one per fixed row of
      the coverage table plus the session lifetime contract.
- [ ] Revert the revocation sweep at the end of `PeerAddressAllowlistFilter.doResolve()` and re-run: 6 of the 14
      must fail. They did - the run is transcribed in the tracking doc, so the tests are known to be able to fail.
- [ ] `mvn -o -pl ha-raft -DexcludedGroups=benchmark,slow,vector test` - 1291 tests, no regressions.
- [ ] `mvn -o -pl engine -Dtest='*Configuration*Test' test` - 105 tests; the only engine change is the
      `arcadedb.ha.peerAllowlist.enabled` description.
- [ ] Manually: remove a peer with `DELETE /api/v1/cluster/peer/{id}` while it is streaming, and confirm the
      receiving node logs `Revoked the established Raft gRPC transport of <ip>` and that the peer's RPCs end with
      `PERMISSION_DENIED` rather than continuing.

## Coverage

Entry points that can shrink the admitted set, and therefore have to revoke an established transport. All four
shrink paths converge on `doResolve()`, which is why one hook covers them:

| Entry point | Fixed | Test |
|---|---|---|
| `setMemberHosts` - peer removed from the Raft configuration (the reported case) | yes | `aPeerRemovedFromTheRaftConfigurationLosesItsEstablishedTransport` |
| `RaftHAServer.reconcileAllowlistMembership` - the production wiring of the above | yes | `theProductionReconciliationRevokesTheRemovedPeersEstablishedTransport` |
| `proactiveRefresh()`/`refresh()` - the peer's DNS record no longer carries the address | yes | `aPeerWhoseAddressChangedLosesTheTransportOpenedOnTheOldAddress` |
| Sticky last-known-good expiry | yes | `aTransportHeldOpenOnAnExpiredStickyAddressIsRevoked` |
| The startup fail-open window ending (quorum resolves, or the grace elapses) | yes | `aTransportAdmittedUnderTheStartupFailOpenIsRevokedOnceTheGraceEnds` |
| New RPCs on an already-revoked transport | yes | `aNewRpcOnARevokedTransportIsRefused` |
| `learnPeerHosts` | n/a - only ever widens; the sweep runs there anyway | - |
| Loopback transports | n/a - `transportReady` returns before the allowlist check, so no session exists | `aLoopbackTransportIsNeverTrackedAndNeverRevoked` |

The fail-open row is the one that constrains the design: revocation reproduces `isAllowed`'s decision rather than
testing `allowedIps` alone, so a transport admitted while the filter was below quorum is not cut until the window
closes. Cutting it earlier would re-create the self-inflicted startup partition #4471 and #4828 exist to prevent.

### Known gaps

- **#7316** - a revoked peer keeps its TCP/HTTP-2 connection open. gRPC exposes no per-transport close and Ratis
  configures neither `maxConnectionIdle` nor `maxConnectionAge`, so the socket lingers. What it can carry is
  nothing - every RPC on a gRPC server passes the server-wide interceptor chain, and the interceptor refuses every
  call on a revoked session - so the residue is an idle connection, not reach. Filed with two sketched fixes.

## Notes

- **Marking and closing are separated.** `doResolve()` holds the filter's monitor; closing a `ServerCall` runs
  gRPC code. Flipping the session flag under the monitor is what stops the *next* RPC and is enough to be correct;
  `dispatchRevocations()` closes the in-flight ones with the monitor released, so the filter's lock is never
  ordered against gRPC internals in two directions.
- **The session is registered before the admission decision, not after.** `isAllowed()` can re-resolve, and a
  reconciliation on another thread can revoke during it; a session added afterwards would be invisible to that
  sweep and the transport would be admitted already un-revokable. `transportReady` removes it again on the
  rejection path and refuses a transport whose session was revoked while it was deciding.
- **Nothing outlives its transport**, which is the part the issue asked to design carefully: the session set is
  cleared from `transportTerminated`, and a session holds only calls in flight - the interceptor deregisters on
  `onComplete`, on `onCancel`, and when the handler throws before the RPC starts. All three are asserted.
- **Cost on the hot path**: one `Attributes` lookup per RPC, and two small allocations per RPC on a gated
  transport. Raft `appendEntries` is a long-lived stream, so on a follower that is per stream, not per entry.
- Full analysis, the greps behind the coverage table, and the self-performed adversarial pass (the independent
  subagent could not be spawned in this session - recorded as such rather than presented as independent) are in
  `docs/7250-revoke-established-raft-transport.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExK43vNXCF5WGoHu6CtDiy