### PR TITLE
feat(#7304): the gRPC admin service exposes the control plane, through the implementation HTTP runs

### DIFF
--- a/docs/7304-grpc-control-plane.md
+++ b/docs/7304-grpc-control-plane.md
@@ -1,0 +1,258 @@
+# #7304 - gRPC control plane: database lifecycle, backup, security and profiler RPCs
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/7304
+Branch: `feat/7304-grpc-control-plane-admin-service`
+
+## Correction to the issue's premise
+
+The issue says `ArcadeDbService` "has no control-plane operation of any kind". That is true of
+`ArcadeDbService`, but the proto already carries a second service:
+
+```
+$ sed -n '/^service ArcadeDbAdminService/,/^}/p' grpc/src/main/proto/arcadedb-server.proto | grep -o 'rpc [A-Za-z]*'
+rpc Ping
+rpc GetServerInfo
+rpc ListDatabases
+rpc ExistsDatabase
+rpc CreateDatabase
+rpc DropDatabase
+rpc GetDatabaseInfo
+rpc CreateUser
+rpc DeleteUser
+```
+
+So `ArcadeDbAdminService` exists with 9 RPCs, of which `CreateUser` and `DeleteUser` are declared
+but answer `UNIMPLEMENTED` at runtime
+(`ArcadeDbGrpcAdminService.createUser`/`deleteUser`, before this change). The issue's keyword
+counts are accurate and unchanged by that:
+
+```
+$ for k in backup health cluster profil; do printf "%-8s %s\n" "$k" "$(grep -ic "$k" grpc/src/main/proto/arcadedb-server.proto)"; done
+backup   0
+health   0
+cluster  0
+profil   0
+```
+
+The real gap is therefore narrower than "no control plane" and wider than "a few RPCs": database
+lifecycle is half-covered, and backup / security / profiler / probes / settings / server events
+are absent entirely.
+
+## Invariant
+
+**Every exchange-free control-plane operation the HTTP layer exposes is reachable over gRPC, and
+both protocols reach it through one implementation, gated by the same root-user check.**
+
+"Exchange-free" is the boundary of this PR: the three HTTP operations that stream progress over
+the `HttpServerExchange` (restore backup, restore database, import database) need a
+server-streaming RPC design of their own and are filed as follow-ups rather than half-adapted.
+
+## Completeness
+
+### Enumeration (commands run in this session)
+
+```
+$ grep -n 'private static final String [A-Z_]* *=' server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+LIST_DATABASES SHUTDOWN CREATE_DATABASE DROP_DATABASE CLOSE_DATABASE OPEN_DATABASE
+CREATE_USER DROP_USER CONNECT_CLUSTER DISCONNECT_CLUSTER SET_DATABASE_SETTING
+SET_SERVER_SETTING GET_SERVER_EVENTS ALIGN_DATABASE GET_BACKUP_CONFIG SET_BACKUP_CONFIG
+LIST_BACKUPS TRIGGER_BACKUP RESTORE_BACKUP DELETE_BACKUP RESTORE_DATABASE IMPORT_DATABASE
+PROFILER                                                              (23 commands)
+
+$ grep -n '"/server/\|"/health"\|"/ready"\|"/databases"\|"/exists/\|"/progress/\|"/login"\|"/logout"\|"/sessions"' server/src/main/java/com/arcadedb/server/http/HttpServer.java
+/databases /exists/{db} /progress/{db} /login /logout /sessions /ready /health
+/server/api-tokens {GET,POST,DELETE}  /server/users {GET,POST,PUT,DELETE}
+/server/groups {GET,POST,DELETE}                                      (18 routes)
+
+$ grep -rn "checkRootUser" server/src/main/java/com/arcadedb/server/http/handler/ | wc -l
+14      # one definition in AbstractServerHttpHandler + 13 call sites
+
+$ grep -rn 'requireServerAdmin\|"root"' grpcw/src/main/java/
+ArcadeDbGrpcAdminService.java:122,152  (createDatabase, dropDatabase)
+ArcadeDbGrpcAdminService.java:297-298  (definition, mirrors checkRootUser)
+```
+
+### Entry-point coverage table
+
+| HTTP control-plane entry point | gRPC RPC | Disposition | Test |
+|---|---|---|---|
+| `list databases`, `GET /databases` | `ListDatabases` | pre-existing RPC, **narrowed here** to the caller's authorized databases | yes |
+| `GET /exists/{db}` | `ExistsDatabase` | pre-existing | pre-existing |
+| `create database` | `CreateDatabase` | pre-existing | pre-existing |
+| `drop database` | `DropDatabase` | pre-existing | pre-existing |
+| `GET /server` | `GetServerInfo` | pre-existing RPC, `databases_count` **narrowed here** | covered by the `ListDatabases` filter test |
+| `GET /server` (per-database view) | `GetDatabaseInfo` | pre-existing RPC, **gated here** on the caller's grant | yes |
+| `open database` | `OpenDatabase` | fixed here | yes |
+| `close database` | `CloseDatabase` | fixed here | yes |
+| `align database` | `AlignDatabase` | fixed here | yes |
+| `set server setting` | `SetServerSetting` | fixed here | yes |
+| `set database setting` | `SetDatabaseSetting` | fixed here | yes |
+| `get backup config` | `GetBackupConfig` | fixed here | yes |
+| `set backup config` | `SetBackupConfig` | fixed here | yes |
+| `list backups` | `ListBackups` | fixed here | yes |
+| `trigger backup` | `TriggerBackup` | fixed here | yes |
+| `delete backup` | `DeleteBackup` | fixed here | yes |
+| `profiler start/stop/reset/results/list/load` | `ProfilerStart/Stop/Reset/Results/List/Load` | fixed here | yes |
+| `create user`, `POST /server/users` | `CreateUser` (was `UNIMPLEMENTED`) | fixed here | yes |
+| leader forwarding of create/drop database and user | leader gate on the four RPCs | fixed here | yes (HA, 3 nodes) |
+| `drop user`, `DELETE /server/users` | `DeleteUser` (was `UNIMPLEMENTED`) | fixed here | yes |
+| `GET /server/users` | `ListUsers` | fixed here | yes |
+| `get server events` | `GetServerEvents` | fixed here | yes |
+| `shutdown` | `Shutdown` | fixed here | yes (authz only; a test may not stop the JVM) |
+| `disconnect cluster` | `DisconnectCluster` | fixed here | yes (authz + non-HA rejection) |
+| `GET /health` | `Health` | fixed here | yes |
+| `GET /ready` | `Ready` | fixed here | yes |
+| `connect cluster` | none | **argued** | - |
+| `restore backup` | none | **filed** #7308 | - |
+| `restore database` | none | **filed** #7308 | - |
+| `import database` | none | **filed** #7308 | - |
+| `PUT /server/users` (update) | none | **filed** #7309 | - |
+| `GET/POST/DELETE /server/groups` | none | **filed** #7309 | - |
+| `GET/POST/DELETE /server/api-tokens` | none | **filed** #7309 | - |
+| `GET /progress/{db}` | none | **filed** #7310 | - |
+| `POST /login`, `POST /logout`, `GET /sessions` | none | **argued** | - |
+
+### Arguments
+
+- **`connect cluster`** - the HTTP implementation has no behaviour to adapt. It is a single
+  `throw new CommandExecutionException("Connect cluster operation is not supported by the current
+  HA implementation...")` (`PostServerCommandHandler.connectCluster`, lines 829-834). Adding a
+  gRPC RPC would reproduce an unconditional error, not an operation.
+- **`POST /login` / `POST /logout` / `GET /sessions`** - HTTP sessions exist because HTTP is
+  stateless per request and the browser needs a bearer token. gRPC authenticates every admin RPC
+  from the `DatabaseCredentials` on the request body, enforced centrally in
+  `GrpcAuthInterceptor.authenticateAdminRequest`. There is no gRPC session to create, destroy, or
+  list. `GET /sessions` as a *read-only administrative view of HTTP sessions* is a real gap and is
+  filed with the discovery group (#7310).
+
+## Design
+
+`PostServerCommandHandler` held the control-plane semantics as ~450 lines of private methods
+returning `ExecutionResponse`. Reimplementing them in the gRPC service is exactly the drift the
+issue warns against, so they move to a new shared class instead:
+
+`server/src/main/java/com/arcadedb/server/ServerControlPlane.java`
+
+- constructed from an `ArcadeDBServer`, with no HTTP types on its surface;
+- returns `JSONObject`/`JSONArray`/void and throws, so each protocol maps errors its own way;
+- `PostServerCommandHandler` keeps command-string parsing, leader forwarding, the
+  `ExecutionResponse` status mapping, and the three exchange-bound operations, and delegates the
+  semantics.
+
+`ArcadeDbGrpcAdminService` gains the RPCs, each a thin adapter over the same object, gated by the
+existing `requireServerAdmin` (the mirror of HTTP's `checkRootUser`) and, for the four operations
+HTTP forwards to the leader, by `requireLeader` (see the adversarial pass below).
+
+Two things deliberately did NOT move into the shared class, because they are properties of the
+transport rather than of the operation: the `http.*` metric counters, and leader routing.
+
+`Health` and `Ready` are unauthenticated on HTTP (`isRequireAuthentication()` returns `false` on
+both handlers), so `GrpcAuthInterceptor` exempts those two method names from the admin
+authentication choke point to keep the two protocols' probe semantics equal - a probe that needs
+credentials is not usable by a Kubernetes probe.
+
+## What the tests caught
+
+`ProfilerList` first modelled a saved run as a bare file name (`repeated string file_names`). The
+gRPC test passed while the profiler directory was empty and failed the moment a run existed:
+`ServerQueryProfiler.listSavedRuns` returns `{fileName, size, lastModified}` objects, not strings,
+so the adapter raised `JSONArray[0] is not a string`. The proto now carries `ProfilerRunInfo` and
+the test stops a recording first so the listing is non-empty when its shape is asserted - an
+empty-list assertion could not have failed.
+
+## Adversarial pass
+
+The orchestrator's Phase 1.5 spawns an uninvolved subagent to write the follow-up issue it would
+file against this patch. The `Task` tool is disabled in this session, so that pass was run by the
+author instead - weaker, and recorded as such. Four findings, all fixed here:
+
+1. **The leader gate was not reproduced.** The HTTP handler forwards create/drop database and
+   create/drop user to the leader (`PostServerCommandHandler.forwardToLeaderIfReplica`), so those
+   commands never run on a follower. The gRPC admin service ran them wherever the call landed,
+   which would have taken `createUserClusterWide` into `HAServerPlugin.replicateSecurityUsers` on a
+   follower - a state the HTTP path cannot reach. The issue named this explicitly ("leader proxying
+   via `LeaderProxy` ... must be reproduced rather than assumed"). gRPC has no request proxy, so the
+   gate is the refusal this transport already uses for `graphBatchLoad` (#6091/#6183):
+   `ServerIsNotTheLeaderException` routed through `GrpcErrorMapper`, so the answer is
+   `FAILED_PRECONDITION` carrying the leader address on the `LeaderRedirectProtocol` trailers.
+   Driven against a real 3-node cluster by `Issue7304GrpcAdminLeaderRoutingIT`, with a
+   leader-succeeds positive control and a read-only RPC that must still answer on a follower - a
+   gate that refused everywhere would otherwise pass.
+2. **gRPC admin calls were inflating the HTTP metrics.** Moving the operations into
+   `ServerControlPlane` took the `Metrics.counter("http.*")` increments with them, so a gRPC
+   `TriggerBackup` would have incremented `http.trigger-backup`. The counters are back on the HTTP
+   side of the split (`PostServerCommandHandler.count`); gRPC admin calls are counted per method by
+   `GrpcMetricsInterceptor`, as they already were.
+3. **`ListDatabases` and `GetDatabaseInfo` disclosed more over gRPC than over HTTP.** Listing is
+   the one control-plane read that is not root-only, so on HTTP the gate is the answer's contents:
+   `list databases` and `GET /api/v1/databases` both narrow it through
+   `filterAuthorizedDatabases`. The gRPC `ListDatabases` handed every authenticated caller every
+   database name on the server, `GetDatabaseInfo` reported the schema shape and record counts of
+   any database to any account, and `GetServerInfo.databases_count` counted them all. All three now
+   narrow to the caller through the same filter, which moved to `ServerControlPlane` with
+   `AbstractServerHttpHandler.filterAuthorizedDatabases` delegating to it. `ExistsDatabase` is
+   deliberately left unfiltered, matching the note `GetExistsDatabaseHandler` carries about its own
+   HTTP counterpart. Pre-existing RPCs, but this is the parity the issue asks for.
+4. **`CreateUser` could only make an ungranted account.** `CreateUserRequest` carried `user`,
+   `password` and a `role` the security model has no concept of, while the HTTP `create user`
+   document carries a `databases` map of per-database groups - which is where a user's authority
+   actually comes from. The request now carries that map, `role` is marked deprecated rather than
+   silently ignored, and `RemoteGrpcServer.createUser` has an overload for it.
+
+## Contract surfaces
+
+1. **Proto** - `grpc/src/main/proto/arcadedb-server.proto`
+2. **OpenAPI** - no new HTTP route is introduced, so no spec contributor changes; the existing
+   routes these RPCs mirror are already described. `OpenApiSpecGenerationIT` is run to prove it.
+3. **Client** - `grpc-client/.../RemoteGrpcServer.java` gains a method per new RPC.
+
+## Verification
+
+Every suite below was run in this session, on a machine where an unrelated ArcadeDB server has been
+listening on `*:2480` for days. That matters, because the `server`-module HTTP tests bind port 2480
+too and some of them build their URLs as `localhost:2480`:
+
+```
+$ lsof -nP -iTCP:2480 -sTCP:LISTEN     # with no test running
+java 93797 *:2480
+
+$ curl -s -o /dev/null -w '%{http_code} (remote %{remote_ip})\n' http://localhost:2480/api/v1/server
+401 (remote ::1)
+$ curl -s -o /dev/null -w '%{http_code} (remote %{remote_ip})\n' http://127.0.0.1:2480/api/v1/server
+401 (remote 127.0.0.1)
+```
+
+`localhost` resolves to `::1` and reaches that server; the test server binds `127.0.0.1:2480`
+alongside it. So a test that posts to `localhost:2480` is answered by a server that has none of the
+fixture's state, which reads as an assertion about a value that was never stored - or, in
+`Issue6753ConcurrentBackupIT`, as `expected 409 but was 200`, a coordinator with no backup in
+progress because it is a different process's coordinator.
+
+The same suites were therefore run against pristine `main` to establish that an intercepted run
+fails there identically, and each suite was retried until it ran in a window where it was not
+intercepted. Counts are from those runs.
+
+| Suite | Result |
+|---|---|
+| `grpcw` unit tests | green (211) |
+| `server` unit tests | green (954) |
+| `server` control-plane ITs (`PostServerCommandHandlerIT`, `Issue6875SetServerSettingHttpIT`, `Issue7124BooleanSettingHttpIT`, `BackupApiCommandsIT`, `BackupRestoreDeleteApiIT`, `Issue6753ConcurrentBackupIT`, `RestoreImportSecurityDurabilityIT`, `HealthProbesIT`, `UngatedHandlerCrossDatabaseIT`, `HTTPGraphIT`, `OpenApiSpecGenerationIT`) | green (85) |
+| `grpcw` admin ITs, including the new `Issue7304GrpcControlPlaneIT`, `Issue7304GrpcControlPlaneAuthorizationIT` and the 3-node `Issue7304GrpcAdminLeaderRoutingIT` | green (136) |
+| `grpc-client` ITs, including the new `Issue7304RemoteGrpcServerControlPlaneIT` | green (25) |
+
+`Issue7304GrpcAdminLeaderRoutingIT` inherits `BaseRaftHATest`'s teardown, which compares every
+node's copy of the database after each test method. That comparison was seen to fail once, as
+`Types: DB1 7 <> DB2 8`, on a machine running several builds at once - a follower one schema entry
+behind at the moment `checkDatabasesAreIdentical` looked, after
+`waitForReplicationIsCompleted` had given up its 30 s budget. It is not an assertion this test
+makes, and no test method here writes a type. Measured afterwards: the class passed 3 of 3 runs in
+isolation, and the pre-existing `Issue6183FollowerCommandRoutingIT` on the same fixture passed 3 of
+3 alongside it. The class was then reduced from four test methods to two, halving the number of
+three-node cluster restarts (51 s to 28 s) without dropping an assertion, which halves the exposure
+to it.
+
+## Residual risk
+
+Listed in the table above as **filed**: restore/import (#7308), user update + groups + API
+tokens (#7309), and progress/sessions discovery (#7310). Nothing else in the HTTP control plane
+is uncovered.

--- a/docs/7304-grpc-control-plane.md
+++ b/docs/7304-grpc-control-plane.md
@@ -1,7 +1,9 @@
 # #7304 - gRPC control plane: database lifecycle, backup, security and profiler RPCs
 
 Issue: https://github.com/ArcadeData/arcadedb/issues/7304
+PR: https://github.com/ArcadeData/arcadedb/pull/7324
 Branch: `feat/7304-grpc-control-plane-admin-service`
+Final state: clean approval on cycle 2. The merge is the developer's.
 
 ## Correction to the issue's premise
 
@@ -307,6 +309,24 @@ Codacy reported 5 new "avoid throwing raw exception types" against 5 solved. Fou
 purpose: converting them to `CommandExecutionException` would change the HTTP error body's
 `exception` field and, through the mapping above, would have made a failed backup report as a
 precondition failure over gRPC. The fifth was `RemoteGrpcServer`, fixed by (3).
+
+### Cycle 2 - `5753212`
+
+Both cycle-1 findings confirmed fixed, and the two changes the review had not raised confirmed as
+well: "No new issues found in this incremental diff." Two observations, neither actionable:
+
+- the reviewer noted the `mapped.getMessage() == null || isBlank()` fallback to `RemoteException` in
+  `RemoteGrpcServer.call` is unreachable in practice, because `GrpcClientErrorMapper.toException`
+  always derives a message from the status description or the status code name. Correct, and it is
+  kept as a defensive guard: it costs one branch and it is what stops a future mapper change from
+  handing a caller an exception with no message at all.
+- it could not run Maven in that session, so cycle 2 is a diff-level read rather than a compiled
+  one. The suites listed above were run locally against exactly `5753212`.
+
+Codacy went from 5 new "avoid throwing raw exception types" to 4, the remaining ones being the
+verbatim-moved backup throws argued about in cycle 1.
+
+No deferred items: nothing in either review was left unaddressed or unanswered.
 
 ## Residual risk
 

--- a/docs/7304-grpc-control-plane.md
+++ b/docs/7304-grpc-control-plane.md
@@ -77,7 +77,7 @@ ArcadeDbGrpcAdminService.java:297-298  (definition, mirrors checkRootUser)
 | HTTP control-plane entry point | gRPC RPC | Disposition | Test |
 |---|---|---|---|
 | `list databases`, `GET /databases` | `ListDatabases` | pre-existing RPC, **narrowed here** to the caller's authorized databases | yes |
-| `GET /exists/{db}` | `ExistsDatabase` | pre-existing | pre-existing |
+| `GET /exists/{db}` | `ExistsDatabase` | pre-existing RPC, **gated here** on the caller's grant | yes |
 | `create database` | `CreateDatabase` | pre-existing | pre-existing |
 | `drop database` | `DropDatabase` | pre-existing | pre-existing |
 | `GET /server` | `GetServerInfo` | pre-existing RPC, `databases_count` **narrowed here** | covered by the `ListDatabases` filter test |
@@ -190,9 +190,9 @@ author instead - weaker, and recorded as such. Four findings, all fixed here:
    database name on the server, `GetDatabaseInfo` reported the schema shape and record counts of
    any database to any account, and `GetServerInfo.databases_count` counted them all. All three now
    narrow to the caller through the same filter, which moved to `ServerControlPlane` with
-   `AbstractServerHttpHandler.filterAuthorizedDatabases` delegating to it. `ExistsDatabase` is
-   deliberately left unfiltered, matching the note `GetExistsDatabaseHandler` carries about its own
-   HTTP counterpart. Pre-existing RPCs, but this is the parity the issue asks for.
+   `AbstractServerHttpHandler.filterAuthorizedDatabases` delegating to it. `ExistsDatabase` was left
+   unfiltered at first, on a misreading of `GetExistsDatabaseHandler` that review cycle 1 below
+   corrected. Pre-existing RPCs, but this is the parity the issue asks for.
 4. **`CreateUser` could only make an ungranted account.** `CreateUserRequest` carried `user`,
    `password` and a `role` the security model has no concept of, while the HTTP `create user`
    document carries a `databases` map of per-database groups - which is where a user's authority
@@ -250,6 +250,63 @@ isolation, and the pre-existing `Issue6183FollowerCommandRoutingIT` on the same 
 3 alongside it. The class was then reduced from four test methods to two, halving the number of
 three-node cluster restarts (51 s to 28 s) without dropping an assertion, which halves the exposure
 to it.
+
+## Review cycles
+
+### Cycle 1 - `f65ff26`
+
+The scheduled `claude-review` run for this commit completed successfully (18 turns, 9 permission
+denials) and posted nothing, so a review was requested explicitly with an `@claude` comment. Two
+findings, both correct, both fixed:
+
+1. **The `http.*` counters moved from "after this command's validation" to "before it".** The first
+   attempt wrote `count("http.create-user").createUser(...)`, and Java evaluates the receiver before
+   the argument - so the counter fired before the JSON was parsed, let alone before the shared
+   password policy ran. Every one of these counters used to sit inside the moved method, past that
+   method's own validation, so a command rejected for an empty database name or a password the
+   policy refuses was never counted. The chained form silently turned nine of them from successes
+   into attempts, in a PR that claimed the split changed no behaviour. Each command now has a small
+   wrapper in the handler that runs the shared implementation and increments afterwards.
+   `connect cluster` is the one exception and says so: it always throws, so there is no success to
+   count after, which is what the moved implementation did too.
+2. **`ExistsDatabase` disclosed the existence of databases the caller has no grant on.** The first
+   attempt left it unfiltered and this document claimed that as parity with
+   `GetExistsDatabaseHandler`. That was a misreading of the handler's comment, which explains why it
+   does not build the whole authorized set to answer a one-name question - not that it skips
+   authorization:
+
+   ```java
+   final boolean existsDatabase = server.getDatabaseNames().contains(requested)
+       && (user == null || user.canAccessToDatabase(requested));
+   ```
+
+   The gRPC RPC carried only the first conjunct, so any account could enumerate over gRPC the
+   database names HTTP hides from it - the same disclosure this PR narrows for `ListDatabases`,
+   `GetDatabaseInfo` and `GetServerInfo`, missed on the fourth RPC. It now carries both, with
+   `existsDatabaseAnswersFalseForADatabaseTheCallerMayNotAccess` covering it: the granted database
+   still reads `true`, the ungranted one reads `false`, and it cannot be told apart from a name that
+   does not exist at all.
+
+Two more changes went into the same commit that the review did not raise, one from the Codacy report
+and one from reading it:
+
+3. `RemoteGrpcServer` wrapped every admin failure in a bare `RuntimeException` carrying a rendered
+   message. It now goes through `GrpcClientErrorMapper`, the mapper the data plane already uses, so a
+   follower's leader refusal arrives as a `ServerIsNotTheLeaderException` holding the leader's
+   address from the trailers rather than a string with that address thrown away - which was the whole
+   point of adding those trailers.
+4. The gRPC service mapped every `CommandExecutionException` to `FAILED_PRECONDITION`. That is right
+   for "HA is not enabled" and "connect cluster is unsupported", and wrong for a backup archive that
+   could not be deleted, which is a server-side fault. A new
+   `ServerControlPlane.OperationNotAvailableException` (a `CommandExecutionException` subtype, so the
+   HTTP status stays 500) now carries the first meaning, and everything else stays `INTERNAL`.
+
+Codacy reported 5 new "avoid throwing raw exception types" against 5 solved. Four are the
+`RuntimeException` throws inside `executeImmediateBackup` and `listBackups`, moved verbatim out of
+`PostServerCommandHandler` - the same ones Codacy counts as solved there. They are left alone on
+purpose: converting them to `CommandExecutionException` would change the HTTP error body's
+`exception` field and, through the mapping above, would have made a failed backup report as a
+precondition failure over gRPC. The fifth was `RemoteGrpcServer`, fixed by (3).
 
 ## Residual risk
 

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
@@ -18,13 +18,47 @@
  */
 package com.arcadedb.remote.grpc;
 
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.grpc.AlignDatabaseRequest;
 import com.arcadedb.server.grpc.ArcadeDbAdminServiceGrpc;
 import com.arcadedb.server.grpc.ArcadeDbServiceGrpc;
+import com.arcadedb.server.grpc.BackupInfo;
+import com.arcadedb.server.grpc.CloseDatabaseRequest;
 import com.arcadedb.server.grpc.CreateDatabaseRequest;
+import com.arcadedb.server.grpc.CreateUserRequest;
 import com.arcadedb.server.grpc.DatabaseCredentials;
+import com.arcadedb.server.grpc.DeleteBackupRequest;
+import com.arcadedb.server.grpc.DeleteUserRequest;
+import com.arcadedb.server.grpc.DisconnectClusterRequest;
 import com.arcadedb.server.grpc.DropDatabaseRequest;
+import com.arcadedb.server.grpc.GetBackupConfigRequest;
+import com.arcadedb.server.grpc.GetBackupConfigResponse;
+import com.arcadedb.server.grpc.GetServerEventsRequest;
+import com.arcadedb.server.grpc.GetServerEventsResponse;
+import com.arcadedb.server.grpc.HealthRequest;
+import com.arcadedb.server.grpc.ListBackupsRequest;
+import com.arcadedb.server.grpc.ListBackupsResponse;
 import com.arcadedb.server.grpc.ListDatabasesRequest;
 import com.arcadedb.server.grpc.ListDatabasesResponse;
+import com.arcadedb.server.grpc.ListUsersRequest;
+import com.arcadedb.server.grpc.OpenDatabaseRequest;
+import com.arcadedb.server.grpc.ProfilerDocumentResponse;
+import com.arcadedb.server.grpc.ProfilerListRequest;
+import com.arcadedb.server.grpc.ProfilerLoadRequest;
+import com.arcadedb.server.grpc.ProfilerResetRequest;
+import com.arcadedb.server.grpc.ProfilerRunInfo;
+import com.arcadedb.server.grpc.ProfilerResultsRequest;
+import com.arcadedb.server.grpc.ProfilerStartRequest;
+import com.arcadedb.server.grpc.ProfilerStopRequest;
+import com.arcadedb.server.grpc.ReadyRequest;
+import com.arcadedb.server.grpc.ReadyResponse;
+import com.arcadedb.server.grpc.SetBackupConfigRequest;
+import com.arcadedb.server.grpc.SetDatabaseSettingRequest;
+import com.arcadedb.server.grpc.SetServerSettingRequest;
+import com.arcadedb.server.grpc.ShutdownRequest;
+import com.arcadedb.server.grpc.TriggerBackupRequest;
+import com.arcadedb.server.grpc.UserGroups;
+import com.arcadedb.server.grpc.UserInfo;
 import io.grpc.CallCredentials;
 import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
@@ -44,21 +78,26 @@ import javax.annotation.PreDestroy;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Minimal server-scope gRPC wrapper (HTTP RemoteServer equivalent), implemented
- * ONLY with RPCs present in your current proto.
+ * Server-scope gRPC client: the {@code RemoteServer} of this transport, one method per RPC of
+ * {@code ArcadeDbAdminService}.
  * <p>
- * Features: - listDatabases() - existsDatabase(name) via listDatabases() -
- * createDatabase(name, type) - createDatabaseIfMissing(name, type) -
- * dropDatabase(name, force?) // 'force' only if defined in your proto;
- * otherwise ignored
+ * It covers the discovery and database-lifecycle RPCs, and, since issue #7304, the rest of the
+ * control plane: settings, backup, users, the query profiler, server events, shutdown, cluster
+ * disconnect, and the two container probes. What it does not cover is what the proto does not carry
+ * either - restore and import (#7308), groups and API tokens (#7309), progress and sessions
+ * (#7310).
  * <p>
- * Add more methods later when you extend the proto (ping, serverInfo, user
- * mgmt, etc.).
+ * Every method carries the credentials this instance was built with in the request body, except
+ * {@link #health()} and {@link #ready()}: their requests have no credentials field, and the server
+ * exempts those two methods from the admin authentication gate, so a probe works whatever this
+ * instance was constructed with. (The shared stub still sends this instance's call credentials as
+ * headers on every call, probes included; the server does not read them for the admin service.)
  */
 public class RemoteGrpcServer implements AutoCloseable {
 
@@ -301,6 +340,198 @@ public class RemoteGrpcServer implements AutoCloseable {
     } catch (StatusException e) {
       throw new RuntimeException("Failed to drop database: " + e.getMessage(), e);
     }
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Control plane (issue #7304). Each method is one RPC of ArcadeDbAdminService; every one of them
+  // reaches the same com.arcadedb.server.ServerControlPlane the HTTP control plane reaches, so the
+  // behaviour matches RemoteServer's over HTTP.
+  // -------------------------------------------------------------------------------------------
+
+  /**
+   * Opens a database on the server, loading it if it was closed.
+   */
+  public void openDatabase(final String database) {
+    call("open database", stub -> stub.openDatabase(
+        OpenDatabaseRequest.newBuilder().setCredentials(buildCredentials()).setName(database).build()));
+  }
+
+  /**
+   * Closes a database on the server and removes it from the server's cache. The files stay on disk.
+   */
+  public void closeDatabase(final String database) {
+    call("close database", stub -> stub.closeDatabase(
+        CloseDatabaseRequest.newBuilder().setCredentials(buildCredentials()).setName(database).build()));
+  }
+
+  public void alignDatabase(final String database) {
+    call("align database", stub -> stub.alignDatabase(
+        AlignDatabaseRequest.newBuilder().setCredentials(buildCredentials()).setName(database).build()));
+  }
+
+  public void setServerSetting(final String key, final String value) {
+    call("set server setting", stub -> stub.setServerSetting(
+        SetServerSettingRequest.newBuilder().setCredentials(buildCredentials()).setKey(key).setValue(value).build()));
+  }
+
+  public void setDatabaseSetting(final String database, final String key, final String value) {
+    call("set database setting", stub -> stub.setDatabaseSetting(
+        SetDatabaseSettingRequest.newBuilder().setCredentials(buildCredentials()).setDatabase(database).setKey(key)
+            .setValue(value).build()));
+  }
+
+  /**
+   * Creates a server user with no grants beyond the server default.
+   */
+  public void createUser(final String user, final String password) {
+    createUser(user, password, Map.of());
+  }
+
+  /**
+   * Creates a server user holding {@code databases} - a database name (or {@code "*"}) to the list of
+   * groups the user holds on it, the same shape the HTTP {@code create user} document carries.
+   */
+  public void createUser(final String user, final String password, final Map<String, List<String>> databases) {
+    final CreateUserRequest.Builder request = CreateUserRequest.newBuilder().setCredentials(buildCredentials())
+        .setUser(user).setPassword(password);
+    databases.forEach((database, groups) -> request.putDatabases(database,
+        UserGroups.newBuilder().addAllGroups(groups).build()));
+
+    call("create user", stub -> stub.createUser(request.build()));
+  }
+
+  public void dropUser(final String user) {
+    call("drop user", stub -> stub.deleteUser(
+        DeleteUserRequest.newBuilder().setCredentials(buildCredentials()).setUser(user).build()));
+  }
+
+  /**
+   * The server's users, as {@code name -> (database -> groups)}. Password hashes are never returned.
+   */
+  public List<UserInfo> listUsers() {
+    return call("list users", stub -> stub.listUsers(
+        ListUsersRequest.newBuilder().setCredentials(buildCredentials()).build())).getUsersList();
+  }
+
+  public GetBackupConfigResponse getBackupConfig() {
+    return call("get backup config", stub -> stub.getBackupConfig(
+        GetBackupConfigRequest.newBuilder().setCredentials(buildCredentials()).build()));
+  }
+
+  public void setBackupConfig(final JSONObject config) {
+    call("set backup config", stub -> stub.setBackupConfig(
+        SetBackupConfigRequest.newBuilder().setCredentials(buildCredentials()).setConfigJson(config.toString()).build()));
+  }
+
+  public List<BackupInfo> listBackups(final String database) {
+    return call("list backups", stub -> stub.listBackups(
+        ListBackupsRequest.newBuilder().setCredentials(buildCredentials()).setDatabase(database).build())).getBackupsList();
+  }
+
+  /**
+   * Runs a full backup inline and returns the archive path.
+   */
+  public String triggerBackup(final String database) {
+    return call("trigger backup", stub -> stub.triggerBackup(
+        TriggerBackupRequest.newBuilder().setCredentials(buildCredentials()).setDatabase(database).build())).getBackupFile();
+  }
+
+  public void deleteBackup(final String database, final String fileName) {
+    call("delete backup", stub -> stub.deleteBackup(
+        DeleteBackupRequest.newBuilder().setCredentials(buildCredentials()).setDatabase(database).setFileName(fileName)
+            .build()));
+  }
+
+  /**
+   * Starts the query profiler. {@code timeoutSeconds} of 0 records until {@link #profilerStop()}.
+   */
+  public void profilerStart(final int timeoutSeconds) {
+    call("profiler start", stub -> stub.profilerStart(
+        ProfilerStartRequest.newBuilder().setCredentials(buildCredentials()).setTimeoutSeconds(timeoutSeconds).build()));
+  }
+
+  public JSONObject profilerStop() {
+    return profilerDocument(call("profiler stop", stub -> stub.profilerStop(
+        ProfilerStopRequest.newBuilder().setCredentials(buildCredentials()).build())));
+  }
+
+  public void profilerReset() {
+    call("profiler reset", stub -> stub.profilerReset(
+        ProfilerResetRequest.newBuilder().setCredentials(buildCredentials()).build()));
+  }
+
+  public JSONObject profilerResults() {
+    return profilerDocument(call("profiler results", stub -> stub.profilerResults(
+        ProfilerResultsRequest.newBuilder().setCredentials(buildCredentials()).build())));
+  }
+
+  /**
+   * The profiler runs saved on the server, newest first.
+   */
+  public List<ProfilerRunInfo> profilerList() {
+    return call("profiler list", stub -> stub.profilerList(
+        ProfilerListRequest.newBuilder().setCredentials(buildCredentials()).build())).getRunsList();
+  }
+
+  public JSONObject profilerLoad(final String fileName) {
+    return profilerDocument(call("profiler load", stub -> stub.profilerLoad(
+        ProfilerLoadRequest.newBuilder().setCredentials(buildCredentials()).setFileName(fileName).build())));
+  }
+
+  public GetServerEventsResponse getServerEvents(final String fileName) {
+    return call("get server events", stub -> stub.getServerEvents(
+        GetServerEventsRequest.newBuilder().setCredentials(buildCredentials()).setFileName(fileName).build()));
+  }
+
+  /**
+   * Stops the server that answers this call, or - when {@code serverName} is not empty - the named
+   * HA peer. The local shutdown is scheduled a second out server-side, so this call returns before
+   * the process exits.
+   */
+  public void shutdown(final String serverName) {
+    call("shutdown", stub -> stub.shutdown(
+        ShutdownRequest.newBuilder().setCredentials(buildCredentials()).setServerName(serverName).build()));
+  }
+
+  public void disconnectCluster() {
+    call("disconnect cluster", stub -> stub.disconnectCluster(
+        DisconnectClusterRequest.newBuilder().setCredentials(buildCredentials()).build()));
+  }
+
+  /**
+   * Liveness probe. Needs no credentials, like {@code GET /api/v1/health}.
+   */
+  public boolean health() {
+    return call("health", stub -> stub.health(HealthRequest.newBuilder().build())).getOk();
+  }
+
+  /**
+   * Readiness probe. Needs no credentials, like {@code GET /api/v1/ready}. A node that is not ready
+   * is a successful answer carrying {@code ready=false} and the reason, not an error.
+   */
+  public ReadyResponse ready() {
+    return call("ready", stub -> stub.ready(ReadyRequest.newBuilder().build()));
+  }
+
+  private static JSONObject profilerDocument(final ProfilerDocumentResponse response) {
+    return new JSONObject(response.getResultsJson());
+  }
+
+  /**
+   * Runs one admin RPC under the default deadline, reporting a failure the way the pre-existing
+   * admin methods of this class do.
+   */
+  private <T> T call(final String operation, final AdminCall<T> body) {
+    try {
+      return body.run(withDeadline(adminServiceBlockingV2Stub(), defaultTimeoutMs));
+    } catch (final StatusException e) {
+      throw new RuntimeException("Failed to " + operation + ": " + e.getMessage(), e);
+    }
+  }
+
+  @FunctionalInterface
+  private interface AdminCall<T> {
+    T run(ArcadeDbAdminServiceGrpc.ArcadeDbAdminServiceBlockingV2Stub stub) throws StatusException;
   }
 
   public String endpoint() {

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.remote.grpc;
 
+import com.arcadedb.remote.RemoteException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.grpc.AlignDatabaseRequest;
 import com.arcadedb.server.grpc.ArcadeDbAdminServiceGrpc;
@@ -518,14 +519,25 @@ public class RemoteGrpcServer implements AutoCloseable {
   }
 
   /**
-   * Runs one admin RPC under the default deadline, reporting a failure the way the pre-existing
-   * admin methods of this class do.
+   * Runs one admin RPC under the default deadline and turns a failure into the typed ArcadeDB
+   * exception the server raised, through the same {@link GrpcClientErrorMapper} the data plane uses.
+   * <p>
+   * The mapper, not a wrapped {@code RuntimeException}, is what makes the control plane's leader
+   * refusal actionable: a follower answers {@code FAILED_PRECONDITION} with the leader's address on
+   * the {@link com.arcadedb.server.grpc.LeaderRedirectProtocol} trailers, and the mapper rebuilds a
+   * {@code ServerIsNotTheLeaderException} carrying that address. Flattening the status to a message
+   * string would throw the address away, which is the one thing the caller needs (issue #7304).
+   *
+   * @param operation the operation name, used only when the failure carries no description of its own
    */
   private <T> T call(final String operation, final AdminCall<T> body) {
     try {
       return body.run(withDeadline(adminServiceBlockingV2Stub(), defaultTimeoutMs));
     } catch (final StatusException e) {
-      throw new RuntimeException("Failed to " + operation + ": " + e.getMessage(), e);
+      final RuntimeException mapped = GrpcClientErrorMapper.toException(e);
+      if (mapped.getMessage() == null || mapped.getMessage().isBlank())
+        throw new RemoteException("Failed to " + operation, e);
+      throw mapped;
     }
   }
 

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue7304RemoteGrpcServerControlPlaneIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue7304RemoteGrpcServerControlPlaneIT.java
@@ -19,6 +19,7 @@
 package com.arcadedb.remote.grpc;
 
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.remote.RemoteException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.BaseGraphServerTest;
 import com.arcadedb.server.grpc.UserInfo;
@@ -157,11 +158,19 @@ class Issue7304RemoteGrpcServerControlPlaneIT extends BaseGraphServerTest {
 
   /**
    * Outside HA the operation cannot run, and the client surfaces that rather than swallowing it.
+   * <p>
+   * The type matters as much as the message: admin failures go through
+   * {@code GrpcClientErrorMapper}, the same mapper the data plane uses, rather than being wrapped in
+   * a bare {@code RuntimeException} carrying only a rendered string. That is what lets a follower's
+   * leader refusal arrive as a {@code ServerIsNotTheLeaderException} holding the leader's address
+   * from the trailers instead of losing it.
    */
   @Test
-  void disconnectClusterWithoutHaIsReported() {
+  void disconnectClusterWithoutHaIsReportedThroughTheSharedErrorMapper() {
     assertThatThrownBy(() -> server.disconnectCluster())
-        .isInstanceOf(RuntimeException.class)
-        .hasMessageContaining("High Availability");
+        .isInstanceOf(RemoteException.class)
+        .hasMessageContaining("High Availability")
+        // The server's own description, not a "Failed to disconnect cluster" wrapper around it.
+        .hasMessageContaining("-Darcadedb.ha.enabled=true");
   }
 }

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue7304RemoteGrpcServerControlPlaneIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue7304RemoteGrpcServerControlPlaneIT.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.grpc.UserInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7304: the control plane reached {@code ArcadeDbAdminService} but nothing in
+ * {@link RemoteGrpcServer}, and an RPC no client can call is one nobody can use. This drives each
+ * new client method against a live server, so the proto, the service and the client are proved to
+ * agree rather than only to compile.
+ */
+class Issue7304RemoteGrpcServerControlPlaneIT extends BaseGraphServerTest {
+
+  private RemoteGrpcServer server;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GRPC:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void connect() {
+    server = new RemoteGrpcServer("localhost", 50051, "root", DEFAULT_PASSWORD_FOR_TESTS, true, List.of());
+  }
+
+  @AfterEach
+  void disconnect() {
+    if (server != null) {
+      server.close();
+      server = null;
+    }
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+  }
+
+  @Test
+  void closeAndOpenDatabaseRoundTrip() {
+    final String database = "client7304_lifecycle";
+    server.createDatabaseIfMissing(database);
+
+    server.closeDatabase(database);
+    assertThat(getServer(0).getDatabaseNames()).doesNotContain(database);
+
+    server.openDatabase(database);
+    assertThat(getServer(0).getDatabaseNames()).contains(database);
+  }
+
+  @Test
+  void settingsAreStoredCoerced() {
+    final GlobalConfiguration setting = GlobalConfiguration.TX_RETRIES;
+    final Object previous = getServer(0).getConfiguration().getValue(setting);
+    try {
+      server.setServerSetting(setting.getKey(), "9");
+      assertThat(getServer(0).getConfiguration().getValueAsInteger(setting)).isEqualTo(9);
+
+      server.setDatabaseSetting(getDatabaseName(), setting.getKey(), "5");
+      assertThat(getServer(0).getDatabase(getDatabaseName()).getConfiguration().getValueAsInteger(setting)).isEqualTo(5);
+    } finally {
+      getServer(0).getConfiguration().setValue(setting.getKey(), previous);
+    }
+  }
+
+  @Test
+  void userManagementRoundTrip() {
+    final String user = "client7304user";
+    try {
+      server.createUser(user, "client7304password", Map.of(getDatabaseName(), List.of("admin")));
+      assertThat(getServer(0).getSecurity().existsUser(user)).isTrue();
+
+      final List<UserInfo> users = server.listUsers();
+      assertThat(users).extracting(UserInfo::getName).contains(user);
+
+      final UserInfo created = users.stream().filter(u -> user.equals(u.getName())).findFirst().orElseThrow();
+      assertThat(created.getDatabasesMap().get(getDatabaseName()).getGroupsList()).contains("admin");
+
+      server.dropUser(user);
+      assertThat(getServer(0).getSecurity().existsUser(user)).isFalse();
+    } finally {
+      if (getServer(0).getSecurity().existsUser(user))
+        getServer(0).getSecurity().dropUser(user);
+    }
+  }
+
+  @Test
+  void backupConfigRoundTripAndListing() {
+    server.setBackupConfig(new JSONObject().put("backupDirectory", "backups7304client"));
+
+    assertThat(new JSONObject(server.getBackupConfig().getConfigJson()).getString("backupDirectory"))
+        .isEqualTo("backups7304client");
+
+    // Auto-backup is not running in this fixture, so the listing is empty rather than absent.
+    assertThat(server.listBackups(getDatabaseName())).isEmpty();
+  }
+
+  @Test
+  void profilerRoundTrip() {
+    server.profilerReset();
+    server.profilerStart(0);
+
+    assertThat(server.profilerResults()).isNotNull();
+    assertThat(server.profilerStop()).isNotNull();
+
+    // Stopping saves the run, so the listing reports it with its file metadata.
+    assertThat(server.profilerList()).isNotEmpty();
+    assertThat(server.profilerList().getFirst().getFileName()).startsWith("profiler-run-");
+    assertThat(server.profilerLoad(server.profilerList().getFirst().getFileName())).isNotNull();
+
+    server.profilerReset();
+  }
+
+  @Test
+  void serverEventsAreReadable() {
+    assertThat(server.getServerEvents("").getEventsJson()).startsWith("[");
+  }
+
+  /**
+   * The probe methods build a request with no credentials field at all - the field the admin
+   * interceptor authenticates from - so they exercise the server-side exemption from the client.
+   * That the exemption holds for a caller with no credentials whatsoever is asserted on the server
+   * side, by {@code Issue7304GrpcControlPlaneAuthorizationIT}, with a raw stub.
+   */
+  @Test
+  void probesAnswerWithNoCredentialsInTheRequest() {
+    assertThat(server.health()).isTrue();
+    assertThat(server.ready().getReady()).isTrue();
+    assertThat(server.ready().getReason()).isEmpty();
+  }
+
+  /**
+   * Outside HA the operation cannot run, and the client surfaces that rather than swallowing it.
+   */
+  @Test
+  void disconnectClusterWithoutHaIsReported() {
+    assertThatThrownBy(() -> server.disconnectCluster())
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("High Availability");
+  }
+}

--- a/grpc/src/main/proto/arcadedb-server.proto
+++ b/grpc/src/main/proto/arcadedb-server.proto
@@ -600,6 +600,26 @@ message GraphBatchResult {
 // Admin service
 // -----------------------------------------------------------------------------
 
+// The control plane. Every RPC here reaches the same implementation the HTTP control plane reaches
+// (com.arcadedb.server.ServerControlPlane), so the two protocols cannot drift apart on what an
+// administrative operation does - see issue #7304.
+//
+// Authentication is enforced centrally by GrpcAuthInterceptor from the 'credentials' field every
+// request carries, before the call reaches a handler. Health and Ready are exempt from it, exactly
+// as GET /health and GET /ready are unauthenticated over HTTP, so a container orchestrator can probe
+// the node without credentials.
+//
+// Authorization on top of that is per RPC, and mirrors what the HTTP counterpart of each operation
+// requires:
+//   - Ping, GetServerInfo, ListDatabases, ExistsDatabase and GetDatabaseInfo need only a valid
+//     account, as GET /api/v1/databases and GET /api/v1/server do;
+//   - every other RPC needs the server-admin (root) principal, the gate POST /api/v1/server and the
+//     /api/v1/server/* routes apply through checkRootUser.
+//
+// Leader routing: CreateDatabase, DropDatabase, CreateUser and DeleteUser are refused on a follower
+// with FAILED_PRECONDITION and the leader's address on the arcadedb-leader-* trailers. That is this
+// transport's equivalent of the HTTP handler forwarding those four commands to the leader; gRPC has
+// no request proxy, so the caller redirects itself.
 service ArcadeDbAdminService {
   rpc Ping           (PingRequest)           returns (PingResponse);
   rpc GetServerInfo  (GetServerInfoRequest)  returns (GetServerInfoResponse);
@@ -608,11 +628,43 @@ service ArcadeDbAdminService {
   rpc ExistsDatabase (ExistsDatabaseRequest) returns (ExistsDatabaseResponse);
   rpc CreateDatabase (CreateDatabaseRequest) returns (CreateDatabaseResponse);
   rpc DropDatabase   (DropDatabaseRequest)   returns (DropDatabaseResponse);
+  rpc OpenDatabase   (OpenDatabaseRequest)   returns (OpenDatabaseResponse);
+  rpc CloseDatabase  (CloseDatabaseRequest)  returns (CloseDatabaseResponse);
+  rpc AlignDatabase  (AlignDatabaseRequest)  returns (AlignDatabaseResponse);
 
   rpc GetDatabaseInfo (GetDatabaseInfoRequest) returns (GetDatabaseInfoResponse);
 
   rpc CreateUser     (CreateUserRequest)     returns (CreateUserResponse);
   rpc DeleteUser     (DeleteUserRequest)     returns (DeleteUserResponse);
+  rpc ListUsers      (ListUsersRequest)      returns (ListUsersResponse);
+
+  // settings
+  rpc SetServerSetting   (SetServerSettingRequest)   returns (SetServerSettingResponse);
+  rpc SetDatabaseSetting (SetDatabaseSettingRequest) returns (SetDatabaseSettingResponse);
+
+  // backup
+  rpc GetBackupConfig (GetBackupConfigRequest) returns (GetBackupConfigResponse);
+  rpc SetBackupConfig (SetBackupConfigRequest) returns (SetBackupConfigResponse);
+  rpc ListBackups     (ListBackupsRequest)     returns (ListBackupsResponse);
+  rpc TriggerBackup   (TriggerBackupRequest)   returns (TriggerBackupResponse);
+  rpc DeleteBackup    (DeleteBackupRequest)    returns (DeleteBackupResponse);
+
+  // query profiler
+  rpc ProfilerStart   (ProfilerStartRequest)   returns (ProfilerStateResponse);
+  rpc ProfilerStop    (ProfilerStopRequest)    returns (ProfilerDocumentResponse);
+  rpc ProfilerReset   (ProfilerResetRequest)   returns (ProfilerStateResponse);
+  rpc ProfilerResults (ProfilerResultsRequest) returns (ProfilerDocumentResponse);
+  rpc ProfilerList    (ProfilerListRequest)    returns (ProfilerListResponse);
+  rpc ProfilerLoad    (ProfilerLoadRequest)    returns (ProfilerDocumentResponse);
+
+  // server lifecycle and cluster
+  rpc GetServerEvents   (GetServerEventsRequest)   returns (GetServerEventsResponse);
+  rpc Shutdown          (ShutdownRequest)          returns (ShutdownResponse);
+  rpc DisconnectCluster (DisconnectClusterRequest) returns (DisconnectClusterResponse);
+
+  // probes - unauthenticated, see the service comment
+  rpc Health (HealthRequest) returns (HealthResponse);
+  rpc Ready  (ReadyRequest)  returns (ReadyResponse);
 }
 
 message PingRequest {
@@ -685,7 +737,14 @@ message CreateUserRequest {
   DatabaseCredentials credentials = 1; // admin creds
   string user     = 2;
   string password = 3;
-  string role     = 4; // optional, depending on your model
+  // Deprecated and ignored: the server's security model grants authority through per-database groups
+  // (the 'databases' map below), not through a single server-wide role. Kept so the field number is
+  // not reused.
+  string role     = 4 [deprecated = true];
+  // The groups the new user holds per database, the same map the HTTP "create user" document carries
+  // under "databases". Absent means no grants beyond the server default. The key "*" applies to every
+  // database, as it does over HTTP.
+  map<string, UserGroups> databases = 5;
 }
 message CreateUserResponse {
   bool success = 1;
@@ -699,4 +758,228 @@ message DeleteUserRequest {
 message DeleteUserResponse {
   bool success = 1;
   string message = 2;
+}
+
+// -----------------------------------------------------------------------------
+// Control plane: database lifecycle beyond create/drop
+// -----------------------------------------------------------------------------
+
+message OpenDatabaseRequest {
+  DatabaseCredentials credentials = 1;
+  string name = 2;
+}
+message OpenDatabaseResponse {}
+
+message CloseDatabaseRequest {
+  DatabaseCredentials credentials = 1;
+  string name = 2;
+}
+message CloseDatabaseResponse {}
+
+message AlignDatabaseRequest {
+  DatabaseCredentials credentials = 1;
+  string name = 2;
+}
+message AlignDatabaseResponse {}
+
+// -----------------------------------------------------------------------------
+// Control plane: settings
+// -----------------------------------------------------------------------------
+
+// key and value are separate fields here, so - unlike the HTTP "set server setting <key> <value>"
+// command, which splits on the first space - a value containing a space needs no quoting. Both
+// transports then run the same coercion, so a DECLARED setting accepts and refuses the same values
+// on either one.
+message SetServerSettingRequest {
+  DatabaseCredentials credentials = 1;
+  string key   = 2;
+  string value = 3;
+}
+message SetServerSettingResponse {}
+
+message SetDatabaseSettingRequest {
+  DatabaseCredentials credentials = 1;
+  string database = 2;
+  string key      = 3;
+  string value    = 4;
+}
+message SetDatabaseSettingResponse {}
+
+// -----------------------------------------------------------------------------
+// Control plane: security
+// -----------------------------------------------------------------------------
+
+// The groups a user holds on one database.
+message UserGroups {
+  repeated string groups = 1;
+}
+
+// A user as the control plane reports it. Password hashes are never included.
+message UserInfo {
+  string name = 1;
+  map<string, UserGroups> databases = 2;
+}
+
+message ListUsersRequest {
+  DatabaseCredentials credentials = 1;
+}
+message ListUsersResponse {
+  repeated UserInfo users = 1;
+}
+
+// -----------------------------------------------------------------------------
+// Control plane: backup
+// -----------------------------------------------------------------------------
+
+message GetBackupConfigRequest {
+  DatabaseCredentials credentials = 1;
+}
+message GetBackupConfigResponse {
+  // false when the auto-backup plugin is not running; a config may still be present, saved but not
+  // yet in effect, in which case 'message' says so.
+  bool   enabled     = 1;
+  // AutoBackupConfig as a JSON document. Empty when no configuration exists. It is carried as JSON
+  // rather than as proto fields because it is the same free-form document the config file holds, and
+  // a second declaration of its shape here would be one more thing to keep in step with it.
+  string config_json = 2;
+  string message     = 3;
+}
+
+message SetBackupConfigRequest {
+  DatabaseCredentials credentials = 1;
+  // AutoBackupConfig as a JSON document - the same object POST /api/v1/server takes under "config".
+  string config_json = 2;
+}
+message SetBackupConfigResponse {}
+
+message BackupInfo {
+  string file_name        = 1;
+  int64  size_bytes       = 2;
+  int64  last_modified_ms = 3;
+  // ISO-8601 local date-time parsed out of the archive name, empty when the name does not carry one.
+  string timestamp        = 4;
+}
+
+message ListBackupsRequest {
+  DatabaseCredentials credentials = 1;
+  string database = 2;
+}
+message ListBackupsResponse {
+  string              database   = 1;
+  repeated BackupInfo backups    = 2;
+  // Retention-manager totals; both are 0 when no retention manager is running.
+  int64               total_size  = 3;
+  int64               total_count = 4;
+}
+
+message TriggerBackupRequest {
+  DatabaseCredentials credentials = 1;
+  string database = 2;
+}
+message TriggerBackupResponse {
+  // Absolute path of the archive that was written.
+  string backup_file = 1;
+}
+
+message DeleteBackupRequest {
+  DatabaseCredentials credentials = 1;
+  string database  = 2;
+  // A plain archive file name inside the database's backup directory. Path separators and traversal
+  // sequences are refused.
+  string file_name = 3;
+}
+message DeleteBackupResponse {}
+
+// -----------------------------------------------------------------------------
+// Control plane: query profiler
+// -----------------------------------------------------------------------------
+
+message ProfilerStartRequest {
+  DatabaseCredentials credentials = 1;
+  // Seconds after which recording stops on its own. 0 records until ProfilerStop.
+  int32 timeout_seconds = 2;
+}
+message ProfilerStopRequest {
+  DatabaseCredentials credentials = 1;
+}
+message ProfilerResetRequest {
+  DatabaseCredentials credentials = 1;
+}
+message ProfilerResultsRequest {
+  DatabaseCredentials credentials = 1;
+}
+message ProfilerListRequest {
+  DatabaseCredentials credentials = 1;
+}
+message ProfilerLoadRequest {
+  DatabaseCredentials credentials = 1;
+  string file_name = 2;
+}
+
+message ProfilerStateResponse {
+  bool recording = 1;
+}
+
+// A profiler run. The document's shape is the profiler's own and changes with it, so it travels as
+// JSON rather than as a proto schema that would have to be revised in step.
+message ProfilerDocumentResponse {
+  string results_json = 1;
+}
+
+// One saved profiler run on disk, as ServerQueryProfiler.listSavedRuns reports it.
+message ProfilerRunInfo {
+  string file_name        = 1;
+  int64  size_bytes       = 2;
+  int64  last_modified_ms = 3;
+}
+
+message ProfilerListResponse {
+  // Newest first, the order the profiler lists them in.
+  repeated ProfilerRunInfo runs = 1;
+}
+
+// -----------------------------------------------------------------------------
+// Control plane: server lifecycle and cluster
+// -----------------------------------------------------------------------------
+
+message GetServerEventsRequest {
+  DatabaseCredentials credentials = 1;
+  // Empty reads the current event file.
+  string file_name = 2;
+}
+message GetServerEventsResponse {
+  // JSON array of event objects.
+  string          events_json = 1;
+  repeated string files       = 2;
+}
+
+message ShutdownRequest {
+  DatabaseCredentials credentials = 1;
+  // Empty shuts down the server that receives the call; otherwise the named HA peer.
+  string server_name = 2;
+}
+message ShutdownResponse {}
+
+message DisconnectClusterRequest {
+  DatabaseCredentials credentials = 1;
+}
+message DisconnectClusterResponse {}
+
+// -----------------------------------------------------------------------------
+// Control plane: probes
+// -----------------------------------------------------------------------------
+
+// Liveness, the equivalent of GET /api/v1/health. Unauthenticated: reaching the handler is the
+// whole answer, and a probe that needs credentials is not usable as a container liveness probe.
+message HealthRequest {}
+message HealthResponse {
+  bool ok = 1;
+}
+
+// Readiness, the equivalent of GET /api/v1/ready. Unauthenticated for the same reason as Health.
+message ReadyRequest {}
+message ReadyResponse {
+  bool ready = 1;
+  // Why the node is not ready; empty when it is.
+  string reason = 2;
 }

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
@@ -25,7 +25,13 @@ import com.arcadedb.index.Index;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.VertexType;
+import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.HAServerPlugin;
+import com.arcadedb.server.ServerControlPlane;
 import com.arcadedb.server.ServerDatabase;
 import com.arcadedb.server.ServerPlugin;
 import com.arcadedb.server.http.HttpServer;
@@ -34,11 +40,11 @@ import com.arcadedb.server.security.ServerSecurityUser;
 import com.arcadedb.server.security.credential.CredentialsValidator;
 import io.grpc.Status;
 import io.grpc.StatusException;
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -49,11 +55,18 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
 
   private final ArcadeDBServer       server;
   private final CredentialsValidator credentialsValidator;
+  /**
+   * The transport-independent control plane, shared with the HTTP {@code POST /api/v1/server}
+   * handler so the two protocols run one implementation of each administrative operation rather than
+   * two that can drift (issue #7304).
+   */
+  private final ServerControlPlane   controlPlane;
 
   public ArcadeDbGrpcAdminService(final ArcadeDBServer server, CredentialsValidator credentialsValidator) {
 
     this.server = Objects.requireNonNull(server, "server");
     this.credentialsValidator = Objects.requireNonNull(credentialsValidator, "credentialsValidator");
+    this.controlPlane = new ServerControlPlane(this.server);
   }
 
   // ------------------------------------------------------------------------------------
@@ -73,7 +86,7 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
   @Override
   public void getServerInfo(final GetServerInfoRequest req, final StreamObserver<GetServerInfoResponse> resp) {
     respond(resp, "getServerInfo", () -> {
-      authenticate(req.getCredentials());
+      final ServerSecurityUser user = authenticate(req.getCredentials());
 
       final String version = getServerVersion();
       final long startMs = getServerStartMs();
@@ -83,8 +96,10 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
       final int grpcPort = getGrpcPort();
       final int binaryPort = getBinaryPort();
 
-      final List<String> dbNames = new ArrayList<>(getDatabaseNames());
-      final int dbCount = dbNames.size();
+      // Counted over the databases this caller may access, as GET /api/v1/server reports them
+      // (issue #7304): the total would otherwise tell an unprivileged caller how many databases it
+      // cannot see.
+      final int dbCount = controlPlane.listAuthorizedDatabases(user).size();
 
       return GetServerInfoResponse.newBuilder().setVersion(version)
           .setEdition("CE") // adjust if you expose edition
@@ -93,12 +108,18 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
     });
   }
 
+  /**
+   * Lists the databases the caller is allowed to see. Listing is the one control-plane read that is
+   * not root-only, so the answer is narrowed to the caller instead - the same filter
+   * {@code list databases} and {@code GET /api/v1/databases} apply over HTTP. Before issue #7304
+   * this RPC answered every authenticated caller with every database name on the server.
+   */
   @Override
   public void listDatabases(final ListDatabasesRequest req, final StreamObserver<ListDatabasesResponse> resp) {
     respond(resp, "listDatabases", () -> {
-      authenticate(req.getCredentials());
+      final ServerSecurityUser user = authenticate(req.getCredentials());
 
-      final ArrayList<String> names = new ArrayList<>(getDatabaseNames());
+      final ArrayList<String> names = new ArrayList<>(controlPlane.listAuthorizedDatabases(user));
       names.sort(String.CASE_INSENSITIVE_ORDER);
 
       return ListDatabasesResponse.newBuilder().addAllDatabases(names).build();
@@ -120,6 +141,7 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
   public void createDatabase(final CreateDatabaseRequest req, final StreamObserver<CreateDatabaseResponse> resp) {
     respond(resp, "createDatabase", () -> {
       requireServerAdmin(authenticate(req.getCredentials()));
+      requireLeader("CreateDatabase");
 
       final String name = req.getName(); // DB name in proto
       final String type = req.getType(); // "graph" or "document" (logical)
@@ -150,6 +172,7 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
   public void dropDatabase(final DropDatabaseRequest req, final StreamObserver<DropDatabaseResponse> resp) {
     respond(resp, "dropDatabase", () -> {
       requireServerAdmin(authenticate(req.getCredentials()));
+      requireLeader("DropDatabase");
 
       final String name = req.getName();
 
@@ -163,9 +186,16 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
   @Override
   public void getDatabaseInfo(final GetDatabaseInfoRequest req, final StreamObserver<GetDatabaseInfoResponse> resp) {
     respond(resp, "getDatabaseInfo", () -> {
-      authenticate(req.getCredentials());
+      final ServerSecurityUser user = authenticate(req.getCredentials());
 
       final String name = req.getName();
+
+      // Schema shape and record counts are database content, so the caller has to be granted the
+      // database - the same rule that decides whether GET /api/v1/server reports it (issue #7304).
+      // The answer is NOT_FOUND rather than PERMISSION_DENIED so it is the one an unauthorized
+      // caller already gets for a name that does not exist.
+      if (user != null && !user.canAccessToDatabase(name))
+        throw Status.NOT_FOUND.withDescription("Database not found: " + name).asException();
 
       if (!containsDatabaseIgnoreCase(name))
         throw Status.NOT_FOUND.withDescription("Database not found: " + name).asException();
@@ -213,22 +243,352 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
     });
   }
 
+  /**
+   * Creates a server user with the per-database groups the request carries, which is the same document
+   * the HTTP {@code create user} command takes. The deprecated {@code role} field is ignored: the
+   * security model has no server-wide role, only groups held per database.
+   */
   @Override
-  public void createUser(CreateUserRequest req, StreamObserver<CreateUserResponse> resp) {
-    // User management via gRPC is not yet implemented
-    // Users should be managed via configuration files or HTTP API
-    resp.onError(Status.UNIMPLEMENTED
-        .withDescription("User management via gRPC is not yet implemented. Use HTTP API or configuration files.")
-        .asException());
+  public void createUser(final CreateUserRequest req, final StreamObserver<CreateUserResponse> resp) {
+    respond(resp, "createUser", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+      requireLeader("CreateUser");
+
+      final JSONObject user = new JSONObject().put("name", req.getUser()).put("password", req.getPassword());
+      if (!req.getDatabasesMap().isEmpty()) {
+        final JSONObject databases = new JSONObject();
+        req.getDatabasesMap().forEach((database, groups) -> databases.put(database, new JSONArray(groups.getGroupsList())));
+        user.put("databases", databases);
+      }
+      controlPlane.createUser(user);
+
+      return CreateUserResponse.newBuilder().setSuccess(true).setMessage("User '" + req.getUser() + "' created").build();
+    });
   }
 
   @Override
-  public void deleteUser(DeleteUserRequest req, StreamObserver<DeleteUserResponse> resp) {
-    // User management via gRPC is not yet implemented
-    // Users should be managed via configuration files or HTTP API
-    resp.onError(Status.UNIMPLEMENTED
-        .withDescription("User management via gRPC is not yet implemented. Use HTTP API or configuration files.")
-        .asException());
+  public void deleteUser(final DeleteUserRequest req, final StreamObserver<DeleteUserResponse> resp) {
+    respond(resp, "deleteUser", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+      requireLeader("DeleteUser");
+
+      controlPlane.dropUser(req.getUser());
+
+      return DeleteUserResponse.newBuilder().setSuccess(true).setMessage("User '" + req.getUser() + "' dropped").build();
+    });
+  }
+
+  @Override
+  public void listUsers(final ListUsersRequest req, final StreamObserver<ListUsersResponse> resp) {
+    respond(resp, "listUsers", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      final ListUsersResponse.Builder builder = ListUsersResponse.newBuilder();
+      final JSONArray users = controlPlane.listUsers();
+      for (int i = 0; i < users.length(); i++) {
+        final JSONObject user = users.getJSONObject(i);
+        final UserInfo.Builder info = UserInfo.newBuilder().setName(user.getString("name"));
+
+        // The grants are a database-name -> group-name-array map. An entry of any other shape is
+        // skipped rather than raised: GetUsersHandler copies this document verbatim without looking
+        // inside it, so a deployment carrying something unexpected here still reads its user list
+        // over HTTP, and must over gRPC too.
+        final JSONObject databases = user.getJSONObject("databases");
+        for (final String database : databases.keySet()) {
+          if (!(databases.get(database) instanceof final JSONArray groupNames))
+            continue;
+          final UserGroups.Builder groups = UserGroups.newBuilder();
+          for (int g = 0; g < groupNames.length(); g++)
+            groups.addGroups(String.valueOf(groupNames.get(g)));
+          info.putDatabases(database, groups.build());
+        }
+        builder.addUsers(info.build());
+      }
+      return builder.build();
+    });
+  }
+
+  // ------------------------------------------------------------------------------------
+  // Database lifecycle beyond create/drop
+  // ------------------------------------------------------------------------------------
+
+  @Override
+  public void openDatabase(final OpenDatabaseRequest req, final StreamObserver<OpenDatabaseResponse> resp) {
+    respond(resp, "openDatabase", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      controlPlane.openDatabase(req.getName());
+      return OpenDatabaseResponse.newBuilder().build();
+    });
+  }
+
+  @Override
+  public void closeDatabase(final CloseDatabaseRequest req, final StreamObserver<CloseDatabaseResponse> resp) {
+    respond(resp, "closeDatabase", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      controlPlane.closeDatabase(req.getName());
+      return CloseDatabaseResponse.newBuilder().build();
+    });
+  }
+
+  @Override
+  public void alignDatabase(final AlignDatabaseRequest req, final StreamObserver<AlignDatabaseResponse> resp) {
+    respond(resp, "alignDatabase", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      controlPlane.alignDatabase(req.getName());
+      return AlignDatabaseResponse.newBuilder().build();
+    });
+  }
+
+  // ------------------------------------------------------------------------------------
+  // Settings
+  // ------------------------------------------------------------------------------------
+
+  @Override
+  public void setServerSetting(final SetServerSettingRequest req, final StreamObserver<SetServerSettingResponse> resp) {
+    respond(resp, "setServerSetting", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      controlPlane.setServerSetting(req.getKey(), req.getValue());
+      return SetServerSettingResponse.newBuilder().build();
+    });
+  }
+
+  @Override
+  public void setDatabaseSetting(final SetDatabaseSettingRequest req, final StreamObserver<SetDatabaseSettingResponse> resp) {
+    respond(resp, "setDatabaseSetting", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      controlPlane.setDatabaseSetting(req.getDatabase(), req.getKey(), req.getValue());
+      return SetDatabaseSettingResponse.newBuilder().build();
+    });
+  }
+
+  // ------------------------------------------------------------------------------------
+  // Backup
+  // ------------------------------------------------------------------------------------
+
+  @Override
+  public void getBackupConfig(final GetBackupConfigRequest req, final StreamObserver<GetBackupConfigResponse> resp) {
+    respond(resp, "getBackupConfig", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      final JSONObject config = controlPlane.getBackupConfig();
+      final Object configDocument = config.get("config");
+
+      return GetBackupConfigResponse.newBuilder()
+          .setEnabled(config.getBoolean("enabled", false))
+          .setConfigJson(configDocument instanceof JSONObject document ? document.toString() : "")
+          .setMessage(config.getString("message", ""))
+          .build();
+    });
+  }
+
+  @Override
+  public void setBackupConfig(final SetBackupConfigRequest req, final StreamObserver<SetBackupConfigResponse> resp) {
+    respond(resp, "setBackupConfig", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      if (req.getConfigJson().isBlank())
+        throw new IllegalArgumentException("Missing 'config_json' in request");
+
+      controlPlane.setBackupConfig(new JSONObject(req.getConfigJson()));
+      return SetBackupConfigResponse.newBuilder().build();
+    });
+  }
+
+  @Override
+  public void listBackups(final ListBackupsRequest req, final StreamObserver<ListBackupsResponse> resp) {
+    respond(resp, "listBackups", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      final JSONObject result = controlPlane.listBackups(req.getDatabase());
+      final ListBackupsResponse.Builder builder = ListBackupsResponse.newBuilder()
+          .setDatabase(result.getString("database", req.getDatabase()))
+          .setTotalSize(result.getLong("totalSize", 0L))
+          .setTotalCount(result.getLong("totalCount", 0L));
+
+      final JSONArray backups = result.getJSONArray("backups");
+      for (int i = 0; i < backups.length(); i++) {
+        final JSONObject backup = backups.getJSONObject(i);
+        final Object timestamp = backup.get("timestamp");
+        builder.addBackups(BackupInfo.newBuilder()
+            .setFileName(backup.getString("fileName", ""))
+            .setSizeBytes(backup.getLong("size", 0L))
+            .setLastModifiedMs(backup.getLong("lastModified", 0L))
+            .setTimestamp(timestamp instanceof String isoTimestamp ? isoTimestamp : "")
+            .build());
+      }
+      return builder.build();
+    });
+  }
+
+  @Override
+  public void triggerBackup(final TriggerBackupRequest req, final StreamObserver<TriggerBackupResponse> resp) {
+    respond(resp, "triggerBackup", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      final JSONObject result = controlPlane.triggerBackup(req.getDatabase());
+      return TriggerBackupResponse.newBuilder().setBackupFile(result.getString("backupFile", "")).build();
+    });
+  }
+
+  @Override
+  public void deleteBackup(final DeleteBackupRequest req, final StreamObserver<DeleteBackupResponse> resp) {
+    respond(resp, "deleteBackup", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      controlPlane.deleteBackup(req.getDatabase(), req.getFileName());
+      return DeleteBackupResponse.newBuilder().build();
+    });
+  }
+
+  // ------------------------------------------------------------------------------------
+  // Query profiler
+  // ------------------------------------------------------------------------------------
+
+  @Override
+  public void profilerStart(final ProfilerStartRequest req, final StreamObserver<ProfilerStateResponse> resp) {
+    respond(resp, "profilerStart", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      controlPlane.profilerStart(req.getTimeoutSeconds());
+      return ProfilerStateResponse.newBuilder().setRecording(true).build();
+    });
+  }
+
+  @Override
+  public void profilerStop(final ProfilerStopRequest req, final StreamObserver<ProfilerDocumentResponse> resp) {
+    respond(resp, "profilerStop", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      return ProfilerDocumentResponse.newBuilder().setResultsJson(controlPlane.profilerStop().toString()).build();
+    });
+  }
+
+  @Override
+  public void profilerReset(final ProfilerResetRequest req, final StreamObserver<ProfilerStateResponse> resp) {
+    respond(resp, "profilerReset", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      controlPlane.profilerReset();
+      return ProfilerStateResponse.newBuilder().setRecording(false).build();
+    });
+  }
+
+  @Override
+  public void profilerResults(final ProfilerResultsRequest req, final StreamObserver<ProfilerDocumentResponse> resp) {
+    respond(resp, "profilerResults", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      return ProfilerDocumentResponse.newBuilder().setResultsJson(controlPlane.profilerResults().toString()).build();
+    });
+  }
+
+  @Override
+  public void profilerList(final ProfilerListRequest req, final StreamObserver<ProfilerListResponse> resp) {
+    respond(resp, "profilerList", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      final ProfilerListResponse.Builder builder = ProfilerListResponse.newBuilder();
+      final JSONArray runs = controlPlane.profilerList();
+      for (int i = 0; i < runs.length(); i++) {
+        final JSONObject run = runs.getJSONObject(i);
+        builder.addRuns(ProfilerRunInfo.newBuilder()
+            .setFileName(run.getString("fileName", ""))
+            .setSizeBytes(run.getLong("size", 0L))
+            .setLastModifiedMs(run.getLong("lastModified", 0L))
+            .build());
+      }
+      return builder.build();
+    });
+  }
+
+  @Override
+  public void profilerLoad(final ProfilerLoadRequest req, final StreamObserver<ProfilerDocumentResponse> resp) {
+    respond(resp, "profilerLoad", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      return ProfilerDocumentResponse.newBuilder()
+          .setResultsJson(controlPlane.profilerLoad(req.getFileName()).toString()).build();
+    });
+  }
+
+  // ------------------------------------------------------------------------------------
+  // Server lifecycle and cluster
+  // ------------------------------------------------------------------------------------
+
+  @Override
+  public void getServerEvents(final GetServerEventsRequest req, final StreamObserver<GetServerEventsResponse> resp) {
+    respond(resp, "getServerEvents", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      final JSONObject result = controlPlane.getServerEvents(req.getFileName());
+      final GetServerEventsResponse.Builder builder = GetServerEventsResponse.newBuilder()
+          .setEventsJson(result.getJSONArray("events").toString());
+
+      final JSONArray files = result.getJSONArray("files");
+      for (int i = 0; i < files.length(); i++)
+        builder.addFiles(files.getString(i));
+
+      return builder.build();
+    });
+  }
+
+  /**
+   * Stops this server, or the named HA peer. The local branch is asynchronous - the shared
+   * implementation schedules the stop a second out - so the response is written before the JVM exits
+   * rather than the call failing with the connection.
+   */
+  @Override
+  public void shutdown(final ShutdownRequest req, final StreamObserver<ShutdownResponse> resp) {
+    respond(resp, "shutdown", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      controlPlane.shutdownServer(req.getServerName());
+      return ShutdownResponse.newBuilder().build();
+    });
+  }
+
+  @Override
+  public void disconnectCluster(final DisconnectClusterRequest req, final StreamObserver<DisconnectClusterResponse> resp) {
+    respond(resp, "disconnectCluster", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      controlPlane.disconnectCluster();
+      return DisconnectClusterResponse.newBuilder().build();
+    });
+  }
+
+  // ------------------------------------------------------------------------------------
+  // Probes
+  // ------------------------------------------------------------------------------------
+
+  /**
+   * Liveness. Unauthenticated, like {@code GET /api/v1/health}: {@link GrpcAuthInterceptor} exempts
+   * this method from the admin authentication choke point so an orchestrator can probe the node
+   * without credentials. It answers the same way whatever the server's status is - reaching here
+   * proves the process is live, and a node still warming up must not be killed.
+   */
+  @Override
+  public void health(final HealthRequest req, final StreamObserver<HealthResponse> resp) {
+    respond(resp, "health", () -> HealthResponse.newBuilder().setOk(controlPlane.isLive()).build());
+  }
+
+  /**
+   * Readiness. Unauthenticated for the same reason as {@link #health}. Unlike the HTTP probe, which
+   * answers 503, this returns {@code ready=false} with the reason rather than an error status: a
+   * not-ready node is a successful answer to "are you ready", and a gRPC health checker reads the
+   * payload.
+   */
+  @Override
+  public void ready(final ReadyRequest req, final StreamObserver<ReadyResponse> resp) {
+    respond(resp, "ready", () -> {
+      final String reason = controlPlane.notReadyReason();
+      return ReadyResponse.newBuilder().setReady(reason == null).setReason(reason == null ? "" : reason).build();
+    });
   }
 
   // ------------------------------------------------------------------------------------
@@ -240,7 +600,7 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
    * the same {@code responded} guard {@link ArcadeDbGrpcService} carries inline, applied by {@link GrpcUnaryCall}.
    * {@code operation} prefixes the description of an unexpected failure, as the inline catch blocks used to.
    */
-  private static <T> void respond(final StreamObserver<T> resp, final String operation, final GrpcUnaryCall.Body<T> body) {
+  private <T> void respond(final StreamObserver<T> resp, final String operation, final GrpcUnaryCall.Body<T> body) {
     GrpcUnaryCall.respond(resp, body, e -> toStatus(operation, e));
   }
 
@@ -249,13 +609,41 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
    * NOT_FOUND of {@code getDatabaseInfo}) is sent as it is; the authorization exception is checked before the
    * authentication one because it is the more specific outcome, not because of any inheritance between the two.
    */
-  private static StatusException toStatus(final String operation, final Exception e) {
+  private StatusException toStatus(final String operation, final Exception e) {
     if (e instanceof StatusException se)
       return se;
+    // A leader-only operation refused on a follower. Routed through the shared mapper so the answer carries the
+    // LeaderRedirectProtocol trailers (issue #6183) and a client can redirect itself, rather than reading prose:
+    // gRPC has no equivalent of the HTTP handler's forwardToLeaderIfReplica, which proxies the request body to
+    // the leader, so naming the leader is how this transport reproduces that gate.
+    if (e instanceof ServerIsNotTheLeaderException) {
+      final StatusRuntimeException mapped = GrpcErrorMapper.toStatusRuntimeException(e, operation, ha());
+      return new StatusException(mapped.getStatus(), mapped.getTrailers());
+    }
     if (e instanceof AdminAuthorizationException)
       return Status.PERMISSION_DENIED.withDescription(e.getMessage()).asException();
     if (e instanceof SecurityException)
       return Status.UNAUTHENTICATED.withDescription(e.getMessage()).asException();
+    // ServerSecurityException does NOT extend java.lang.SecurityException, so it reaches here rather
+    // than the arm above. Authentication failures never do - authenticate() converts those to a plain
+    // SecurityException - so what is left is a security policy refusing the operation's arguments,
+    // such as the shared credentials validator rejecting a short password on createUser. The HTTP
+    // control plane answers that 403 (AbstractServerHttpHandler.isSecurityFailure treats the two
+    // exception types alike), and PERMISSION_DENIED is the status that says the same thing.
+    if (e instanceof ServerSecurityException)
+      return Status.PERMISSION_DENIED.withDescription(e.getMessage()).asException();
+    // A backup already running for the same database is HTTP's 409 on the other transport: the request
+    // is well formed and authorized, and retrying once the other run finishes is the fix.
+    if (e instanceof ServerControlPlane.BackupInProgressException)
+      return Status.ABORTED.withDescription(e.getMessage()).asException();
+    // A rejected argument must not read as a server fault: an empty database name, an unparseable
+    // setting value or a backup file name outside the backup directory are all the caller's to fix.
+    if (e instanceof IllegalArgumentException)
+      return Status.INVALID_ARGUMENT.withDescription(e.getMessage()).asException();
+    // The operation cannot run in the server's current state - HA not enabled, connect cluster
+    // unsupported - rather than having failed while running.
+    if (e instanceof CommandExecutionException)
+      return Status.FAILED_PRECONDITION.withDescription(e.getMessage()).asException();
     return Status.INTERNAL.withDescription(operation + ": " + e.getMessage()).asException();
   }
 
@@ -294,6 +682,30 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
    * proves identity only; without this gate any valid account could create or drop any database.
    * Mirrors the HTTP {@code PostServerCommandHandler} which restricts server administration to root.
    */
+  /**
+   * Refuses an operation that may only run on the cluster leader when this node is a follower.
+   * <p>
+   * The HTTP control plane forwards these same commands - create/drop database and create/drop user, the set
+   * {@code PostServerCommandHandler.execute} hands to {@code forwardToLeaderIfReplica} - by proxying the request
+   * to the leader. gRPC has no such proxy, so the equivalent gate is a refusal that names the leader, which is
+   * the pattern {@code graphBatchLoad} already established on this transport (issues #6091 and #6183). Without
+   * it, {@code createUserClusterWide} would reach {@code HAServerPlugin.replicateSecurityUsers} on a follower,
+   * which is exactly the state the HTTP path never gets into.
+   * <p>
+   * A server with HA inactive is always allowed: there is no leader to be, and {@code getHA()} is null.
+   */
+  private void requireLeader(final String rpc) {
+    final HAServerPlugin ha = ha();
+    if (ha != null && !ha.isLeader())
+      throw new ServerIsNotTheLeaderException(rpc + " must run on the cluster leader and this server is not it",
+          ha.getLeaderAddress());
+  }
+
+  /** This server's HA plugin, or null when HA is inactive: the source of the leader address on a refusal. */
+  private HAServerPlugin ha() {
+    return server.getHA();
+  }
+
   private void requireServerAdmin(final ServerSecurityUser user) {
     if (user == null || !"root".equals(user.getName()))
       throw new AdminAuthorizationException("User is not authorized to execute server administration commands");

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
@@ -25,7 +25,6 @@ import com.arcadedb.index.Index;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.VertexType;
-import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
@@ -126,14 +125,24 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
     });
   }
 
+  /**
+   * Whether the named database exists <i>and the caller may access it</i>. Both conjuncts, because
+   * that is the predicate {@code GET /api/v1/exists/{database}} applies: {@code GetExistsDatabaseHandler}
+   * skips the batch {@code filterAuthorizedDatabases} helper only to avoid building a whole authorized
+   * set to answer one yes/no, and evaluates {@code canAccessToDatabase} for the single name instead.
+   * Without the second conjunct this RPC lets any account enumerate the names of databases it has no
+   * grant on, which is the disclosure {@link #listDatabases} and {@link #getDatabaseInfo} were narrowed
+   * to close.
+   */
   @Override
   public void existsDatabase(final ExistsDatabaseRequest req, final StreamObserver<ExistsDatabaseResponse> resp) {
     respond(resp, "existsDatabase", () -> {
-      authenticate(req.getCredentials());
+      final ServerSecurityUser user = authenticate(req.getCredentials());
 
       final String name = req.getName(); // proto should define 'name' for the DB
+      final boolean exists = containsDatabaseIgnoreCase(name) && (user == null || user.canAccessToDatabase(name));
 
-      return ExistsDatabaseResponse.newBuilder().setExists(containsDatabaseIgnoreCase(name)).build();
+      return ExistsDatabaseResponse.newBuilder().setExists(exists).build();
     });
   }
 
@@ -640,9 +649,11 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
     // setting value or a backup file name outside the backup directory are all the caller's to fix.
     if (e instanceof IllegalArgumentException)
       return Status.INVALID_ARGUMENT.withDescription(e.getMessage()).asException();
-    // The operation cannot run in the server's current state - HA not enabled, connect cluster
-    // unsupported - rather than having failed while running.
-    if (e instanceof CommandExecutionException)
+    // The operation cannot run in this server's configuration at all - HA not enabled, connect
+    // cluster unsupported - rather than having been attempted and failed. Only that subtype: a plain
+    // CommandExecutionException from here means the operation ran and failed (a backup archive that
+    // could not be deleted), which is INTERNAL, not a precondition the caller can satisfy.
+    if (e instanceof ServerControlPlane.OperationNotAvailableException)
       return Status.FAILED_PRECONDITION.withDescription(e.getMessage()).asException();
     return Status.INTERNAL.withDescription(operation + ": " + e.getMessage()).asException();
   }

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java
@@ -33,6 +33,7 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 
+import java.util.Set;
 import java.util.logging.Level;
 
 /**
@@ -49,6 +50,14 @@ class GrpcAuthInterceptor implements ServerInterceptor {
       Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
   private static final Metadata.Key<String> DATABASE_HEADER      =
       Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+  /**
+   * Admin methods that are reachable without credentials. Matched on the full method name so a
+   * future RPC whose name merely starts with "Health" is not exempted by accident.
+   */
+  private static final Set<String> UNAUTHENTICATED_ADMIN_METHODS = Set.of(
+      ArcadeDbAdminServiceGrpc.getHealthMethod().getFullMethodName(),
+      ArcadeDbAdminServiceGrpc.getReadyMethod().getFullMethodName());
+
   private final        ServerSecurity          security;
   private final        boolean                 securityEnabled;
   private final        HttpAuthSessionManager  authSessionManager;
@@ -77,6 +86,17 @@ class GrpcAuthInterceptor implements ServerInterceptor {
         methodName.startsWith("grpc.reflection.")) {
       return next.startCall(call, headers);
     }
+
+    // The two container probes, exempt for the same reason the HTTP ones are: GetHealthHandler and
+    // GetReadyHandler both return false from isRequireAuthentication(), so an orchestrator can probe
+    // the node without holding server credentials. Requiring credentials here would leave a gRPC-only
+    // deployment unable to express a liveness or readiness probe at all (issue #7304).
+    //
+    // Neither answer discloses anything an unauthenticated caller could not already establish by
+    // opening the port: Health is constant, and Ready reports only whether this node is serving and,
+    // when it is not, which of the three published readiness gates it is behind.
+    if (UNAUTHENTICATED_ADMIN_METHODS.contains(methodName))
+      return next.startCall(call, headers);
 
     // Admin service: enforce authentication centrally from the request-body credentials instead of
     // trusting every RPC to authenticate itself. This is the central authentication choke point: a

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7304GrpcAdminLeaderRoutingIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7304GrpcAdminLeaderRoutingIT.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ha.raft.BaseRaftHATest;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+/**
+ * Issue #7304: the HTTP control plane forwards create/drop database and create/drop user to the
+ * leader ({@code PostServerCommandHandler.forwardToLeaderIfReplica}), so those commands never run on
+ * a follower. gRPC has no request-proxying equivalent, and before this change its admin service ran
+ * them wherever the call landed - which would have taken {@code createUserClusterWide} into
+ * {@code HAServerPlugin.replicateSecurityUsers} on a follower.
+ * <p>
+ * The gRPC gate is therefore a refusal that names the leader, the pattern {@code graphBatchLoad}
+ * established on this transport (issues #6091, #6183). This test drives it against a real follower:
+ * the refusal must be FAILED_PRECONDITION and must carry the leader address in the
+ * {@link LeaderRedirectProtocol} trailers, and the same call against the leader must still succeed -
+ * without that positive control, a gate that refused everywhere would pass.
+ */
+@Tag("slow")
+class Issue7304GrpcAdminLeaderRoutingIT extends BaseRaftHATest {
+
+  private static final int BASE_RAFT_PORT = 2434;
+  private static final int BASE_HTTP_PORT = 2480;
+  private static final int BASE_GRPC_PORT = 51141;
+
+  private ManagedChannel channel;
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Override
+  protected String getServerAddresses() {
+    final StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < getServerCount(); i++) {
+      if (i > 0)
+        sb.append(",");
+      sb.append("localhost:{raft:").append(BASE_RAFT_PORT + i)
+          .append(",http:").append(BASE_HTTP_PORT + i)
+          .append(",grpc:").append(BASE_GRPC_PORT + i).append("}");
+    }
+    return sb.toString();
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+
+    final String serverName = config.getValueAsString(GlobalConfiguration.SERVER_NAME);
+    final int index = Integer.parseInt(serverName.substring(serverName.lastIndexOf('_') + 1));
+
+    config.setValue("arcadedb.grpc.enabled", "true");
+    config.setValue(GlobalConfiguration.GRPC_PORT.getKey(), String.valueOf(BASE_GRPC_PORT + index));
+    config.setValue("arcadedb.grpc.host", "localhost");
+    config.setValue("arcadedb.grpc.reflection.enabled", "false");
+    config.setValue("arcadedb.grpc.health.enabled", "false");
+
+    final String existingPlugins = config.getValueAsString(GlobalConfiguration.SERVER_PLUGINS);
+    final String pluginEntry = "GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin";
+    if (existingPlugins == null || existingPlugins.isEmpty())
+      config.setValue(GlobalConfiguration.SERVER_PLUGINS, pluginEntry);
+    else if (!existingPlugins.contains(pluginEntry))
+      config.setValue(GlobalConfiguration.SERVER_PLUGINS, existingPlugins + "," + pluginEntry);
+  }
+
+  @AfterEach
+  void closeChannelAfterEach() {
+    closeChannel();
+  }
+
+  /**
+   * A blocking admin stub aimed at one node. Every call here is blocking and has returned by the time
+   * the next stub is asked for, so the previous channel is closed rather than left behind - a test
+   * that dials two nodes would otherwise leak the first one past the {@code @AfterEach}, which can
+   * only see the last.
+   */
+  private ArcadeDbAdminServiceGrpc.ArcadeDbAdminServiceBlockingStub adminStubOn(final int serverIndex) {
+    closeChannel();
+    channel = ManagedChannelBuilder.forTarget("localhost:" + (BASE_GRPC_PORT + serverIndex)).usePlaintext().build();
+    return ArcadeDbAdminServiceGrpc.newBlockingStub(channel).withDeadlineAfter(30, TimeUnit.SECONDS);
+  }
+
+  private void closeChannel() {
+    if (channel != null) {
+      channel.shutdown();
+      try {
+        channel.awaitTermination(5, TimeUnit.SECONDS);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      channel = null;
+    }
+  }
+
+  private static DatabaseCredentials root() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  private int anyFollowerOf(final int leaderIndex) {
+    for (int i = 0; i < getServerCount(); i++)
+      if (i != leaderIndex)
+        return i;
+    throw new IllegalStateException("At least one follower must exist");
+  }
+
+  /**
+   * Both leader-only mutations, in one cluster: gRPC has no request proxy, so a follower answers
+   * FAILED_PRECONDITION and names the leader on the {@link LeaderRedirectProtocol} trailers instead
+   * of running the work where the call happened to land. Nothing may be written on any node on the
+   * way to the refusal.
+   * <p>
+   * The two RPCs share a test because each method of this class restarts a three-node cluster, and
+   * the assertions are the same gate seen through two entry points rather than two behaviours.
+   */
+  @Test
+  void leaderOnlyAdminRpcsAreRefusedOnAFollowerAndNameTheLeader() {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+    waitForAllServers();
+
+    final int followerIndex = anyFollowerOf(leaderIndex);
+    final String user = "issue7304leaderuser";
+    final String database = "issue7304_follower_db";
+
+    final StatusRuntimeException userRefusal = catchStatus(() -> adminStubOn(followerIndex).createUser(
+        CreateUserRequest.newBuilder().setCredentials(root()).setUser(user).setPassword("issue7304password").build()));
+
+    assertThat(userRefusal.getStatus().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
+    assertThat(userRefusal.getTrailers()).isNotNull();
+    assertThat(userRefusal.getTrailers().get(LeaderRedirectProtocol.LEADER_HTTP_ADDRESS))
+        .as("the refusal must name where to go instead").isNotBlank();
+
+    final StatusRuntimeException databaseRefusal = catchStatus(() -> adminStubOn(followerIndex).createDatabase(
+        CreateDatabaseRequest.newBuilder().setCredentials(root()).setName(database).setType("document").build()));
+
+    assertThat(databaseRefusal.getStatus().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
+    assertThat(databaseRefusal.getTrailers().get(LeaderRedirectProtocol.LEADER_HTTP_ADDRESS)).isNotBlank();
+
+    for (int i = 0; i < getServerCount(); i++) {
+      assertThat(getServer(i).getSecurity().existsUser(user))
+          .as("server %d must not hold a user the follower refused to create", i).isFalse();
+      assertThat(getServer(i).existsDatabase(database))
+          .as("server %d must not hold a database the follower refused to create", i).isFalse();
+    }
+  }
+
+  /**
+   * The two controls the refusals need to mean anything: a gate that refused on every node, or one
+   * that had widened to reads, would satisfy the test above and fail this one.
+   * <p>
+   * Reading the control plane is leader-agnostic on both transports - {@code GET /databases} answers
+   * from whichever node is asked - so {@code ListDatabases} must still answer on a follower.
+   */
+  @Test
+  void theSameCallSucceedsOnTheLeaderWhileReadsStillAnswerOnAFollower() {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).isGreaterThanOrEqualTo(0);
+    waitForAllServers();
+
+    final String user = "issue7304leaderokuser";
+    adminStubOn(leaderIndex).createUser(CreateUserRequest.newBuilder().setCredentials(root())
+        .setUser(user).setPassword("issue7304password").build());
+
+    assertThat(getServer(leaderIndex).getSecurity().existsUser(user)).isTrue();
+
+    final ListDatabasesResponse response = adminStubOn(anyFollowerOf(leaderIndex))
+        .listDatabases(ListDatabasesRequest.newBuilder().setCredentials(root()).build());
+
+    assertThat(response.getDatabasesList()).contains(getDatabaseName());
+  }
+
+  private static StatusRuntimeException catchStatus(final Runnable call) {
+    return catchThrowableOfType(StatusRuntimeException.class, call::run);
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7304GrpcControlPlaneAuthorizationIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7304GrpcControlPlaneAuthorizationIT.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.security.ServerSecurity;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7304: the control plane is the surface where a missing authorization check costs the most,
+ * so every RPC the issue added is asserted here to enforce the same root-user gate that
+ * {@code PostServerCommandHandler} enforces through {@code checkRootUser}.
+ * <p>
+ * The RPCs are exercised as a table rather than as one test method each: the point of the assertion
+ * is that <em>no</em> RPC is missing its gate, and a table makes adding an RPC without adding its row
+ * the visible omission. A new control-plane RPC belongs in {@link #mutatingCalls()}.
+ * <p>
+ * Two callers are used: an authenticated non-root user (must be denied with
+ * {@code PERMISSION_DENIED}) and a caller with an invalid password (must be denied with
+ * {@code UNAUTHENTICATED}, by the central interceptor, before the handler runs at all).
+ */
+public class Issue7304GrpcControlPlaneAuthorizationIT extends BaseGraphServerTest {
+
+  private static final int    GRPC_PORT    = 50051;
+  private static final String ALLOWED_DB   = "allowed7304db";
+  private static final String LIMITED_USER = "limited7304";
+  private static final String LIMITED_PASS = "limited7304pass";
+
+  private ManagedChannel                                            channel;
+  private ArcadeDbAdminServiceGrpc.ArcadeDbAdminServiceBlockingStub adminStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void setupUserAndChannel() {
+    final ServerSecurity security = getServer(0).getSecurity();
+
+    getServer(0).getOrCreateDatabase(ALLOWED_DB);
+
+    if (!security.existsUser(LIMITED_USER)) {
+      final JSONObject config = new JSONObject();
+      config.put("name", LIMITED_USER);
+      config.put("password", security.encodePassword(LIMITED_PASS));
+      config.put("databases", new JSONObject().put(ALLOWED_DB, new JSONArray().put("admin")));
+      security.createUser(config);
+    }
+
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    adminStub = ArcadeDbAdminServiceGrpc.newBlockingStub(channel);
+  }
+
+  @AfterEach
+  void teardown() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private static DatabaseCredentials limited() {
+    return DatabaseCredentials.newBuilder().setUsername(LIMITED_USER).setPassword(LIMITED_PASS).build();
+  }
+
+  private static DatabaseCredentials wrongPassword() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword("not-the-root-password").build();
+  }
+
+  /**
+   * Every control-plane RPC added by #7304 that changes server or database state, plus the reads that
+   * are root-only on HTTP. Keyed by RPC name so a failure names the RPC that is missing its gate.
+   */
+  private Map<String, Consumer<DatabaseCredentials>> mutatingCalls() {
+    final Map<String, Consumer<DatabaseCredentials>> calls = new LinkedHashMap<>();
+
+    calls.put("OpenDatabase",
+        c -> adminStub.openDatabase(OpenDatabaseRequest.newBuilder().setCredentials(c).setName(ALLOWED_DB).build()));
+    calls.put("CloseDatabase",
+        c -> adminStub.closeDatabase(CloseDatabaseRequest.newBuilder().setCredentials(c).setName(ALLOWED_DB).build()));
+    calls.put("AlignDatabase",
+        c -> adminStub.alignDatabase(AlignDatabaseRequest.newBuilder().setCredentials(c).setName(ALLOWED_DB).build()));
+
+    calls.put("SetServerSetting", c -> adminStub.setServerSetting(SetServerSettingRequest.newBuilder().setCredentials(c)
+        .setKey(GlobalConfiguration.SERVER_METRICS_PROMETHEUS_REQUIRE_AUTHENTICATION.getKey()).setValue("false").build()));
+    calls.put("SetDatabaseSetting", c -> adminStub.setDatabaseSetting(SetDatabaseSettingRequest.newBuilder().setCredentials(c)
+        .setDatabase(ALLOWED_DB).setKey(GlobalConfiguration.DATE_TIME_IMPLEMENTATION.getKey())
+        .setValue("java.time.LocalDateTime").build()));
+
+    calls.put("GetBackupConfig",
+        c -> adminStub.getBackupConfig(GetBackupConfigRequest.newBuilder().setCredentials(c).build()));
+    calls.put("SetBackupConfig", c -> adminStub.setBackupConfig(SetBackupConfigRequest.newBuilder().setCredentials(c)
+        .setConfigJson(new JSONObject().put("backupDirectory", "backups7304auth").toString()).build()));
+    calls.put("ListBackups",
+        c -> adminStub.listBackups(ListBackupsRequest.newBuilder().setCredentials(c).setDatabase(ALLOWED_DB).build()));
+    calls.put("TriggerBackup",
+        c -> adminStub.triggerBackup(TriggerBackupRequest.newBuilder().setCredentials(c).setDatabase(ALLOWED_DB).build()));
+    calls.put("DeleteBackup", c -> adminStub.deleteBackup(DeleteBackupRequest.newBuilder().setCredentials(c)
+        .setDatabase(ALLOWED_DB).setFileName("anything-backup-20260101.zip").build()));
+
+    calls.put("CreateUser", c -> adminStub.createUser(CreateUserRequest.newBuilder().setCredentials(c)
+        .setUser("escalated7304").setPassword("escalated7304pass").build()));
+    calls.put("DeleteUser",
+        c -> adminStub.deleteUser(DeleteUserRequest.newBuilder().setCredentials(c).setUser("root").build()));
+    calls.put("ListUsers", c -> adminStub.listUsers(ListUsersRequest.newBuilder().setCredentials(c).build()));
+
+    calls.put("ProfilerStart",
+        c -> adminStub.profilerStart(ProfilerStartRequest.newBuilder().setCredentials(c).setTimeoutSeconds(1).build()));
+    calls.put("ProfilerStop", c -> adminStub.profilerStop(ProfilerStopRequest.newBuilder().setCredentials(c).build()));
+    calls.put("ProfilerReset", c -> adminStub.profilerReset(ProfilerResetRequest.newBuilder().setCredentials(c).build()));
+    calls.put("ProfilerResults",
+        c -> adminStub.profilerResults(ProfilerResultsRequest.newBuilder().setCredentials(c).build()));
+    calls.put("ProfilerList", c -> adminStub.profilerList(ProfilerListRequest.newBuilder().setCredentials(c).build()));
+    calls.put("ProfilerLoad", c -> adminStub.profilerLoad(
+        ProfilerLoadRequest.newBuilder().setCredentials(c).setFileName("anything.json").build()));
+
+    calls.put("GetServerEvents",
+        c -> adminStub.getServerEvents(GetServerEventsRequest.newBuilder().setCredentials(c).setFileName("").build()));
+    calls.put("DisconnectCluster",
+        c -> adminStub.disconnectCluster(DisconnectClusterRequest.newBuilder().setCredentials(c).build()));
+    // Empty server name is the LOCAL shutdown. It must be denied before it is scheduled: were the
+    // gate missing, this row would stop the JVM the rest of the suite runs in.
+    calls.put("Shutdown",
+        c -> adminStub.shutdown(ShutdownRequest.newBuilder().setCredentials(c).setServerName("").build()));
+
+    return calls;
+  }
+
+  @TestFactory
+  Stream<DynamicTest> everyControlPlaneRpcDeniesAnAuthenticatedNonRootCaller() {
+    return mutatingCalls().entrySet().stream().map(entry -> DynamicTest.dynamicTest(
+        entry.getKey() + " denies a non-root caller",
+        () -> assertThatThrownBy(() -> entry.getValue().accept(limited()))
+            .isInstanceOf(StatusRuntimeException.class)
+            .hasMessageContaining("PERMISSION_DENIED")));
+  }
+
+  @TestFactory
+  Stream<DynamicTest> everyControlPlaneRpcDeniesAnInvalidPassword() {
+    return mutatingCalls().entrySet().stream().map(entry -> DynamicTest.dynamicTest(
+        entry.getKey() + " denies an invalid password",
+        () -> assertThatThrownBy(() -> entry.getValue().accept(wrongPassword()))
+            .isInstanceOf(StatusRuntimeException.class)
+            .hasMessageContaining("UNAUTHENTICATED")));
+  }
+
+  /**
+   * The denials above must be denials and nothing else: none of them may have changed server state
+   * on the way to the error.
+   */
+  @Test
+  void aDeniedCallerChangedNothing() {
+    mutatingCalls().values().forEach(call -> {
+      try {
+        call.accept(limited());
+      } catch (final StatusRuntimeException expected) {
+        // asserted by the factories above
+      }
+    });
+
+    assertThat(getServer(0).getSecurity().existsUser("root")).isTrue();
+    assertThat(getServer(0).getSecurity().existsUser("escalated7304")).isFalse();
+    assertThat(getServer(0).getDatabaseNames()).contains(ALLOWED_DB);
+    assertThat(getServer(0).getStatus()).isEqualTo(com.arcadedb.server.ArcadeDBServer.STATUS.ONLINE);
+  }
+
+  /**
+   * Listing is not root-only on either transport, so the gate on it is the answer's contents: HTTP
+   * filters {@code list databases} and {@code GET /api/v1/databases} by what the caller may access,
+   * and gRPC must too. Before #7304 this RPC handed every authenticated caller every database name
+   * on the server.
+   */
+  @Test
+  void listDatabasesShowsANonRootCallerOnlyWhatItMayAccess() {
+    final ListDatabasesResponse limitedView = adminStub.listDatabases(
+        ListDatabasesRequest.newBuilder().setCredentials(limited()).build());
+
+    assertThat(limitedView.getDatabasesList()).containsExactly(ALLOWED_DB);
+    assertThat(limitedView.getDatabasesList()).doesNotContain(getDatabaseName());
+
+    // The positive control: root, which may access everything, still sees the database the limited
+    // caller does not - so the assertion above is about the filter and not about an empty server.
+    final ListDatabasesResponse rootView = adminStub.listDatabases(ListDatabasesRequest.newBuilder()
+        .setCredentials(DatabaseCredentials.newBuilder().setUsername("root")
+            .setPassword(DEFAULT_PASSWORD_FOR_TESTS).build())
+        .build());
+    assertThat(rootView.getDatabasesList()).contains(ALLOWED_DB, getDatabaseName());
+  }
+
+  /**
+   * Schema shape and record counts are database content, so a caller with no grant on the database
+   * gets the answer it gets for a name that does not exist.
+   */
+  @Test
+  void getDatabaseInfoHidesADatabaseTheCallerMayNotAccess() {
+    assertThatThrownBy(() -> adminStub.getDatabaseInfo(
+        GetDatabaseInfoRequest.newBuilder().setCredentials(limited()).setName(getDatabaseName()).build()))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("NOT_FOUND");
+
+    // ... and still answers for the database it was granted.
+    assertThat(adminStub.getDatabaseInfo(
+        GetDatabaseInfoRequest.newBuilder().setCredentials(limited()).setName(ALLOWED_DB).build()).getDatabase())
+        .isEqualTo(ALLOWED_DB);
+  }
+
+  /**
+   * The two probes are the deliberate exception: they answer an unauthenticated caller, because a
+   * container orchestrator holds no server credentials. Asserted here, next to the gate they are
+   * exempt from, so the exemption cannot be widened without this test being read.
+   */
+  @Test
+  void theProbesAreTheOnlyRpcsThatAnswerWithoutCredentials() {
+    assertThat(adminStub.health(HealthRequest.newBuilder().build()).getOk()).isTrue();
+    assertThat(adminStub.ready(ReadyRequest.newBuilder().build()).getReady()).isTrue();
+
+    // A request with no credentials at all is stopped by the central interceptor for everything else.
+    assertThatThrownBy(() -> adminStub.listUsers(ListUsersRequest.newBuilder().build()))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("UNAUTHENTICATED");
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7304GrpcControlPlaneAuthorizationIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7304GrpcControlPlaneAuthorizationIT.java
@@ -225,6 +225,36 @@ public class Issue7304GrpcControlPlaneAuthorizationIT extends BaseGraphServerTes
   }
 
   /**
+   * {@code ExistsDatabase} answers the same predicate {@code GET /api/v1/exists/{database}} answers:
+   * installed AND accessible to the caller. {@code GetExistsDatabaseHandler} evaluates
+   * {@code canAccessToDatabase} for the single name rather than building the whole authorized set,
+   * which is a cost decision, not a decision to skip authorization - so a database the caller has no
+   * grant on reads as absent on both transports, not as present.
+   */
+  @Test
+  void existsDatabaseAnswersFalseForADatabaseTheCallerMayNotAccess() {
+    // The database is really there ...
+    assertThat(getServer(0).existsDatabase(getDatabaseName())).isTrue();
+
+    // ... and root sees it.
+    assertThat(adminStub.existsDatabase(ExistsDatabaseRequest.newBuilder()
+        .setCredentials(DatabaseCredentials.newBuilder().setUsername("root")
+            .setPassword(DEFAULT_PASSWORD_FOR_TESTS).build())
+        .setName(getDatabaseName()).build()).getExists()).isTrue();
+
+    // The limited caller, which holds no grant on it, must not be able to tell it apart from a name
+    // that does not exist at all.
+    assertThat(adminStub.existsDatabase(ExistsDatabaseRequest.newBuilder().setCredentials(limited())
+        .setName(getDatabaseName()).build()).getExists()).isFalse();
+    assertThat(adminStub.existsDatabase(ExistsDatabaseRequest.newBuilder().setCredentials(limited())
+        .setName("no_such_database_7304").build()).getExists()).isFalse();
+
+    // And it still sees the one it was granted.
+    assertThat(adminStub.existsDatabase(ExistsDatabaseRequest.newBuilder().setCredentials(limited())
+        .setName(ALLOWED_DB).build()).getExists()).isTrue();
+  }
+
+  /**
    * Schema shape and record counts are database content, so a caller with no grant on the database
    * gets the answer it gets for a name that does not exist.
    */

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7304GrpcControlPlaneIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7304GrpcControlPlaneIT.java
@@ -1,0 +1,466 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7304: the gRPC admin service exposed database create/drop and nothing else of the control
+ * plane, so a gRPC-only deployment had to keep the HTTP port open purely for administration.
+ * <p>
+ * One test per control-plane group added by that change, each driving the operation through its own
+ * gRPC entry point rather than through the shared implementation directly - a test that called
+ * {@code ServerControlPlane} would pass against a proto whose RPC was never wired up.
+ * <p>
+ * Authorization is the subject of {@link Issue7304GrpcControlPlaneAuthorizationIT}; this class runs
+ * as {@code root} throughout, except for the two probes, which deliberately carry no credentials.
+ */
+public class Issue7304GrpcControlPlaneIT extends BaseGraphServerTest {
+
+  private static final int GRPC_PORT = 50051;
+
+  private ManagedChannel                                            channel;
+  private ArcadeDbAdminServiceGrpc.ArcadeDbAdminServiceBlockingStub adminStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    adminStub = ArcadeDbAdminServiceGrpc.newBlockingStub(channel);
+  }
+
+  @AfterEach
+  void teardownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private DatabaseCredentials root() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Database lifecycle
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  void closeDatabaseRemovesItFromTheServerAndOpenDatabaseBringsItBack() {
+    final String database = "grpc7304_lifecycle";
+    getServer(0).getOrCreateDatabase(database);
+    assertThat(getServer(0).getDatabaseNames()).contains(database);
+
+    adminStub.closeDatabase(CloseDatabaseRequest.newBuilder().setCredentials(root()).setName(database).build());
+    assertThat(getServer(0).getDatabaseNames()).doesNotContain(database);
+
+    adminStub.openDatabase(OpenDatabaseRequest.newBuilder().setCredentials(root()).setName(database).build());
+    assertThat(getServer(0).getDatabaseNames()).contains(database);
+  }
+
+  @Test
+  void openDatabaseWithAnEmptyNameIsARejectedArgumentAndNotAServerFault() {
+    assertThatThrownBy(() -> adminStub.openDatabase(
+        OpenDatabaseRequest.newBuilder().setCredentials(root()).setName("").build()))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("INVALID_ARGUMENT");
+  }
+
+  /**
+   * Aligning is an HA operation: {@code LocalDatabase.align} refuses with "Align Database not
+   * supported" on a standalone server, which is what this fixture is. The assertion is therefore that
+   * the RPC reaches the SQL command and reports its refusal, rather than answering UNIMPLEMENTED the
+   * way the RPC did not exist at all before - the wiring is what is under test, and the aligning
+   * itself is covered in HA by {@code RaftServerDatabaseAlignIT}.
+   */
+  @Test
+  void alignDatabaseReachesTheSqlCommandWhichRefusesOutsideHa() {
+    assertThatThrownBy(() -> adminStub.alignDatabase(
+        AlignDatabaseRequest.newBuilder().setCredentials(root()).setName(getDatabaseName()).build()))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("Align Database not supported");
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Settings
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  void setServerSettingStoresACoercedValue() {
+    final GlobalConfiguration setting = GlobalConfiguration.SERVER_METRICS_PROMETHEUS_REQUIRE_AUTHENTICATION;
+    try {
+      adminStub.setServerSetting(SetServerSettingRequest.newBuilder().setCredentials(root())
+          .setKey(setting.getKey()).setValue("false").build());
+
+      assertThat(getServer(0).getConfiguration().getValueAsBoolean(setting)).isFalse();
+
+      adminStub.setServerSetting(SetServerSettingRequest.newBuilder().setCredentials(root())
+          .setKey(setting.getKey()).setValue("TRUE").build());
+
+      assertThat(getServer(0).getConfiguration().getValueAsBoolean(setting)).isTrue();
+    } finally {
+      getServer(0).getConfiguration().setValue(setting.getKey(), null);
+    }
+  }
+
+  /**
+   * The strict coercion of issue #7124 has to be on this transport too: a boolean typo that read as
+   * {@code false} is how the Prometheus endpoint was once published unauthenticated by a 200.
+   */
+  @Test
+  void setServerSettingRefusesAValueTheSettingsTypeCannotRead() {
+    final GlobalConfiguration setting = GlobalConfiguration.SERVER_METRICS_PROMETHEUS_REQUIRE_AUTHENTICATION;
+
+    assertThatThrownBy(() -> adminStub.setServerSetting(SetServerSettingRequest.newBuilder().setCredentials(root())
+        .setKey(setting.getKey()).setValue("ture").build()))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("INVALID_ARGUMENT");
+
+    assertThat(getServer(0).getConfiguration().getValueAsBoolean(setting)).isTrue();
+  }
+
+  @Test
+  void setDatabaseSettingStoresACoercedValueOnTheNamedDatabase() {
+    final GlobalConfiguration setting = GlobalConfiguration.TX_RETRIES;
+    final Object previous = getServer(0).getDatabase(getDatabaseName()).getConfiguration().getValue(setting);
+    try {
+      adminStub.setDatabaseSetting(SetDatabaseSettingRequest.newBuilder().setCredentials(root())
+          .setDatabase(getDatabaseName()).setKey(setting.getKey()).setValue("7").build());
+
+      // Coerced to the setting's declared type, not stored as the string "7".
+      assertThat(getServer(0).getDatabase(getDatabaseName()).getConfiguration().getValueAsInteger(setting)).isEqualTo(7);
+    } finally {
+      getServer(0).getDatabase(getDatabaseName()).getConfiguration().setValue(setting.getKey(), previous);
+    }
+  }
+
+  @Test
+  void setDatabaseSettingRefusesAValueTheSettingsTypeCannotRead() {
+    final GlobalConfiguration setting = GlobalConfiguration.TX_RETRIES;
+
+    assertThatThrownBy(() -> adminStub.setDatabaseSetting(SetDatabaseSettingRequest.newBuilder().setCredentials(root())
+        .setDatabase(getDatabaseName()).setKey(setting.getKey()).setValue("not-a-number").build()))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("INVALID_ARGUMENT");
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Security
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  void createUserListUsersAndDeleteUserRoundTrip() {
+    final String user = "grpc7304user";
+    try {
+      adminStub.createUser(CreateUserRequest.newBuilder().setCredentials(root())
+          .setUser(user).setPassword("grpc7304password").build());
+
+      assertThat(getServer(0).getSecurity().existsUser(user)).isTrue();
+
+      final ListUsersResponse users = adminStub.listUsers(ListUsersRequest.newBuilder().setCredentials(root()).build());
+      assertThat(users.getUsersList()).extracting(UserInfo::getName).contains(user, "root");
+
+      adminStub.deleteUser(DeleteUserRequest.newBuilder().setCredentials(root()).setUser(user).build());
+      assertThat(getServer(0).getSecurity().existsUser(user)).isFalse();
+    } finally {
+      if (getServer(0).getSecurity().existsUser(user))
+        getServer(0).getSecurity().dropUser(user);
+    }
+  }
+
+  /**
+   * A user's authority is the groups it holds per database, so a create that cannot carry them can
+   * only make an ungranted account. The grants the request names must reach the stored user, and
+   * {@code ListUsers} must report them back.
+   */
+  @Test
+  void createUserCarriesThePerDatabaseGroupsAndListUsersReportsThem() {
+    final String user = "grpc7304granted";
+    try {
+      adminStub.createUser(CreateUserRequest.newBuilder().setCredentials(root())
+          .setUser(user).setPassword("grpc7304password")
+          .putDatabases(getDatabaseName(), UserGroups.newBuilder().addGroups("admin").build())
+          .build());
+
+      final UserInfo created = adminStub.listUsers(ListUsersRequest.newBuilder().setCredentials(root()).build())
+          .getUsersList().stream().filter(u -> user.equals(u.getName())).findFirst().orElseThrow();
+
+      assertThat(created.getDatabasesMap()).containsKey(getDatabaseName());
+      assertThat(created.getDatabasesMap().get(getDatabaseName()).getGroupsList()).contains("admin");
+    } finally {
+      if (getServer(0).getSecurity().existsUser(user))
+        getServer(0).getSecurity().dropUser(user);
+    }
+  }
+
+  /**
+   * The RPC used to answer {@code UNIMPLEMENTED} and told callers to use the HTTP API. It now runs
+   * the same credentials policy the REST create-user path runs, so a short password is refused here
+   * exactly as it is there - and with the same meaning: HTTP answers that refusal 403
+   * ({@code PostServerCommandHandlerIT.createUserRejectsShortPassword}), whose gRPC equivalent is
+   * PERMISSION_DENIED.
+   */
+  @Test
+  void createUserAppliesTheSharedCredentialsPolicy() {
+    assertThatThrownBy(() -> adminStub.createUser(CreateUserRequest.newBuilder().setCredentials(root())
+        .setUser("grpc7304short").setPassword("short").build()))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("PERMISSION_DENIED")
+        .hasMessageContaining("User password too short");
+
+    assertThat(getServer(0).getSecurity().existsUser("grpc7304short")).isFalse();
+  }
+
+  @Test
+  void deleteUserOfAnUnknownPrincipalIsARejectedArgument() {
+    assertThatThrownBy(() -> adminStub.deleteUser(
+        DeleteUserRequest.newBuilder().setCredentials(root()).setUser("grpc7304nobody").build()))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("INVALID_ARGUMENT");
+  }
+
+  @Test
+  void listUsersNeverCarriesAPasswordHash() {
+    final ListUsersResponse users = adminStub.listUsers(ListUsersRequest.newBuilder().setCredentials(root()).build());
+
+    assertThat(users.getUsersList()).isNotEmpty();
+    // UserInfo has no password field at all; this asserts the serialized message carries no hash
+    // under any name, which is what a client would actually receive.
+    assertThat(users.toString()).doesNotContain(getServer(0).getSecurity().getUser("root").getPassword());
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Backup
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  void backupConfigWrittenOverGrpcIsReadBackOverGrpc() {
+    final GetBackupConfigResponse before = adminStub.getBackupConfig(
+        GetBackupConfigRequest.newBuilder().setCredentials(root()).build());
+    assertThat(before.getEnabled()).isFalse();
+
+    final JSONObject config = new JSONObject().put("backupDirectory", "backups7304").put("enabled", false);
+    adminStub.setBackupConfig(SetBackupConfigRequest.newBuilder().setCredentials(root())
+        .setConfigJson(config.toString()).build());
+
+    final GetBackupConfigResponse after = adminStub.getBackupConfig(
+        GetBackupConfigRequest.newBuilder().setCredentials(root()).build());
+
+    // The plugin is not running in this fixture, so the config is saved but not in effect - the same
+    // answer GET "get backup config" gives over HTTP in that state.
+    assertThat(after.getEnabled()).isFalse();
+    assertThat(new JSONObject(after.getConfigJson()).getString("backupDirectory")).isEqualTo("backups7304");
+    assertThat(after.getMessage()).contains("restart");
+  }
+
+  /**
+   * The backup directory is validated before anything is written, and the rejection reaches the
+   * caller as a bad argument rather than as a server fault - a path outside the server root is the
+   * traversal this check exists to stop.
+   */
+  @Test
+  void setBackupConfigRefusesABackupDirectoryOutsideTheServerRoot() {
+    final JSONObject config = new JSONObject().put("backupDirectory", "../../escaped7304");
+
+    assertThatThrownBy(() -> adminStub.setBackupConfig(SetBackupConfigRequest.newBuilder().setCredentials(root())
+        .setConfigJson(config.toString()).build()))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("INVALID_ARGUMENT");
+  }
+
+  @Test
+  void setBackupConfigRefusesAnEmptyDocument() {
+    assertThatThrownBy(() -> adminStub.setBackupConfig(
+        SetBackupConfigRequest.newBuilder().setCredentials(root()).setConfigJson("").build()))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("INVALID_ARGUMENT");
+  }
+
+  @Test
+  void listBackupsAnswersAnEmptyListWhenAutoBackupIsNotRunning() {
+    final ListBackupsResponse response = adminStub.listBackups(
+        ListBackupsRequest.newBuilder().setCredentials(root()).setDatabase(getDatabaseName()).build());
+
+    assertThat(response.getDatabase()).isEqualTo(getDatabaseName());
+    assertThat(response.getBackupsList()).isEmpty();
+  }
+
+  @Test
+  void listBackupsWithAnEmptyDatabaseNameIsARejectedArgument() {
+    assertThatThrownBy(() -> adminStub.listBackups(
+        ListBackupsRequest.newBuilder().setCredentials(root()).setDatabase("").build()))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("INVALID_ARGUMENT");
+  }
+
+  /**
+   * The archive name is validated before the backup directory is even resolved, so a name carrying a
+   * traversal sequence is refused whether or not auto-backup is configured.
+   */
+  @Test
+  void deleteBackupRefusesAFileNameThatLeavesTheBackupDirectory() {
+    assertThatThrownBy(() -> adminStub.deleteBackup(DeleteBackupRequest.newBuilder().setCredentials(root())
+        .setDatabase(getDatabaseName()).setFileName("../../etc/passwd").build()))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("INVALID_ARGUMENT");
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Query profiler
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  void profilerRecordsAQueryAndStopReturnsTheRun() {
+    adminStub.profilerReset(ProfilerResetRequest.newBuilder().setCredentials(root()).build());
+
+    final ProfilerStateResponse started = adminStub.profilerStart(
+        ProfilerStartRequest.newBuilder().setCredentials(root()).setTimeoutSeconds(0).build());
+    assertThat(started.getRecording()).isTrue();
+
+    try (final var rs = getServer(0).getDatabase(getDatabaseName()).query("sql", "select from " + VERTEX1_TYPE_NAME)) {
+      rs.stream().count();
+    }
+
+    final ProfilerDocumentResponse results = adminStub.profilerResults(
+        ProfilerResultsRequest.newBuilder().setCredentials(root()).build());
+    assertThat(new JSONObject(results.getResultsJson())).isNotNull();
+
+    final ProfilerDocumentResponse stopped = adminStub.profilerStop(
+        ProfilerStopRequest.newBuilder().setCredentials(root()).build());
+    assertThat(new JSONObject(stopped.getResultsJson())).isNotNull();
+
+    // Reset leaves the profiler not recording, which is the state the RPC reports back.
+    final ProfilerStateResponse reset = adminStub.profilerReset(
+        ProfilerResetRequest.newBuilder().setCredentials(root()).build());
+    assertThat(reset.getRecording()).isFalse();
+  }
+
+  /**
+   * A saved run is a document on disk, not a bare name: {@code listSavedRuns} reports file name, size
+   * and modification time for each. Stopping a recording first makes the list non-empty, so the
+   * mapping of those fields is asserted rather than only the empty case - the shape only shows up
+   * once there is a run to report.
+   */
+  @Test
+  void profilerListAnswersTheSavedRunsWithTheirFileMetadata() {
+    adminStub.profilerStart(ProfilerStartRequest.newBuilder().setCredentials(root()).setTimeoutSeconds(0).build());
+    adminStub.profilerStop(ProfilerStopRequest.newBuilder().setCredentials(root()).build());
+
+    final ProfilerListResponse response = adminStub.profilerList(
+        ProfilerListRequest.newBuilder().setCredentials(root()).build());
+
+    assertThat(response.getRunsList()).isNotEmpty();
+    assertThat(response.getRunsList()).allSatisfy(run -> {
+      assertThat(run.getFileName()).startsWith("profiler-run-").endsWith(".json");
+      assertThat(run.getSizeBytes()).isPositive();
+      assertThat(run.getLastModifiedMs()).isPositive();
+    });
+
+    // And the run the list names can be loaded back by that name.
+    final ProfilerDocumentResponse loaded = adminStub.profilerLoad(ProfilerLoadRequest.newBuilder().setCredentials(root())
+        .setFileName(response.getRuns(0).getFileName()).build());
+    assertThat(new JSONObject(loaded.getResultsJson())).isNotNull();
+  }
+
+  @Test
+  void profilerLoadOfAnUnknownRunFails() {
+    assertThatThrownBy(() -> adminStub.profilerLoad(ProfilerLoadRequest.newBuilder().setCredentials(root())
+        .setFileName("grpc7304-no-such-run.json").build()))
+        .isInstanceOf(StatusRuntimeException.class);
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Server lifecycle and cluster
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  void getServerEventsReturnsTheCurrentEventFile() {
+    final GetServerEventsResponse response = adminStub.getServerEvents(
+        GetServerEventsRequest.newBuilder().setCredentials(root()).setFileName("").build());
+
+    // events_json is a JSON array; parsing it is the assertion that the RPC did not hand back a
+    // rendering of some other shape.
+    assertThat(new com.arcadedb.serializer.json.JSONArray(response.getEventsJson())).isNotNull();
+  }
+
+  /**
+   * HA is off in this fixture, so the operation cannot run - and that is a precondition failure, not
+   * a server fault and not a bad argument.
+   */
+  @Test
+  void disconnectClusterWithoutHaFailsThePrecondition() {
+    assertThatThrownBy(() -> adminStub.disconnectCluster(
+        DisconnectClusterRequest.newBuilder().setCredentials(root()).build()))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("FAILED_PRECONDITION");
+  }
+
+  /**
+   * Shutting down a named peer needs HA. The local shutdown - an empty server name - is exercised
+   * only by {@link Issue7304GrpcControlPlaneAuthorizationIT}, which proves an unauthorized caller
+   * cannot reach it; a test may not stop the JVM the rest of the suite runs in.
+   */
+  @Test
+  void shutdownOfANamedPeerWithoutHaFailsThePrecondition() {
+    assertThatThrownBy(() -> adminStub.shutdown(
+        ShutdownRequest.newBuilder().setCredentials(root()).setServerName("someOtherNode").build()))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("FAILED_PRECONDITION");
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Probes
+  // -------------------------------------------------------------------------------------------
+
+  /**
+   * Both probes must answer without credentials, exactly as {@code GET /api/v1/health} and
+   * {@code GET /api/v1/ready} do. A probe that needs a password is one a container orchestrator
+   * cannot use, which is the whole reason they are exempt from the admin authentication gate.
+   */
+  @Test
+  void healthAnswersWithoutCredentials() {
+    assertThat(adminStub.health(HealthRequest.newBuilder().build()).getOk()).isTrue();
+  }
+
+  @Test
+  void readyAnswersWithoutCredentialsAndReportsAServingNode() {
+    final ReadyResponse response = adminStub.ready(ReadyRequest.newBuilder().build());
+
+    assertThat(response.getReady()).isTrue();
+    assertThat(response.getReason()).isEmpty();
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -1,0 +1,727 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.backup.AutoBackupConfig;
+import com.arcadedb.server.backup.AutoBackupSchedulerPlugin;
+import com.arcadedb.server.backup.BackupCoordinator;
+import com.arcadedb.server.backup.BackupRetentionManager;
+import com.arcadedb.server.monitor.ServerQueryProfiler;
+import com.arcadedb.server.security.ServerSecurity;
+import com.arcadedb.server.security.ServerSecurityUser;
+import com.arcadedb.utility.FileUtils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.Timer;
+import java.util.TimerTask;
+
+/**
+ * The server's control plane: the administrative operations that do not depend on the transport
+ * that asked for them.
+ * <p>
+ * Every method here used to be a private method of
+ * {@code com.arcadedb.server.http.handler.PostServerCommandHandler}, reachable only by parsing a
+ * {@code POST /server} command string. It moved so that gRPC's {@code ArcadeDbAdminService} runs
+ * the same code rather than a second implementation of the same semantics (issue #7304): the two
+ * protocols differ in how a caller names an operation and how a failure is reported, not in what
+ * the operation does.
+ * <p>
+ * What stayed behind in the HTTP handler is what is genuinely HTTP: parsing the command string,
+ * forwarding a write to the leader, mapping a result to a status code, and the three operations
+ * that stream progress over the {@code HttpServerExchange} itself (restore backup, restore
+ * database, import database - tracked for gRPC in issue #7308).
+ * <p>
+ * <b>This class performs no authorization, and no leader routing.</b> Each transport supplies both:
+ * HTTP through {@code AbstractServerHttpHandler.checkRootUser} and
+ * {@code PostServerCommandHandler.forwardToLeaderIfReplica}, gRPC through
+ * {@code ArcadeDbGrpcAdminService}'s {@code requireServerAdmin} and {@code requireLeader}. Adding a
+ * caller means adding both gates.
+ * <p>
+ * <b>It also emits no metrics.</b> The {@code http.*} counters these operations carried stayed with
+ * the HTTP handler, because they count HTTP requests; folding gRPC admin traffic into them would
+ * have been invisible in a dashboard. gRPC counts its admin calls per method in
+ * {@code GrpcMetricsInterceptor}.
+ */
+public class ServerControlPlane {
+  private final ArcadeDBServer server;
+
+  public ServerControlPlane(final ArcadeDBServer server) {
+    this.server = server;
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Server lifecycle
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * Stops this server (empty {@code serverName}) or asks HA to stop a named peer. The local branch
+   * schedules the stop a second out so the caller's own response can still be written before the
+   * JVM exits.
+   */
+  public void shutdownServer(final String serverName) throws IOException {
+
+    if (serverName.isEmpty()) {
+      // SHUTDOWN CURRENT SERVER
+      new Timer().schedule(new TimerTask() {
+        @Override
+        public void run() {
+          server.stop();
+          System.exit(0);
+        }
+      }, 1000);
+    } else {
+      requireHA().shutdownRemoteServer(serverName);
+    }
+  }
+
+  public JSONObject getServerEvents(final String fileName) {
+
+    final JSONArray events = fileName.isEmpty() ?
+        server.getEventLog().getCurrentEvents() :
+        server.getEventLog().getEvents(fileName);
+    final JSONArray files = server.getEventLog().getFiles();
+
+    return new JSONObject().put("events", events).put("files", files);
+  }
+
+  public void disconnectCluster() {
+
+    requireHA().disconnectCluster();
+  }
+
+  /**
+   * The {@code connect cluster} command of the HTTP control plane. Kept here with the rest so the
+   * command set is complete in one place; it has never been implemented by the current HA stack.
+   */
+  public void connectCluster(final String serverAddress) {
+
+    throw new CommandExecutionException(
+        "Connect cluster operation is not supported by the current HA implementation. Use the cluster configuration to join nodes.");
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Probes
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * Liveness. Reaching a request handler at all proves the process is live, so this deliberately
+   * does not consult server status: a node still warming up must not be killed.
+   */
+  public boolean isLive() {
+    return true;
+  }
+
+  /**
+   * Readiness, as {@code GET /ready} computes it: {@code null} when the node is ready to serve, and
+   * otherwise the reason it is not. Returning the reason rather than a boolean keeps the HTTP body
+   * and the gRPC status description identical.
+   */
+  public String notReadyReason() {
+    if (server.getStatus() != ArcadeDBServer.STATUS.ONLINE)
+      return "Server not started yet";
+
+    if (server.getConfiguration().getValueAsBoolean(GlobalConfiguration.SERVER_READINESS_REQUIRES_HA)
+        && server.getConfiguration().getValueAsBoolean(GlobalConfiguration.HA_ENABLED)) {
+      final HAServerPlugin ha = server.getHA();
+      if (ha == null || ha.getElectionStatus() != HAServerPlugin.ELECTION_STATUS.DONE)
+        return "Node has not yet joined the Raft group";
+
+      final long maxLag = Math.max(0L, server.getConfiguration().getValueAsLong(GlobalConfiguration.SERVER_READINESS_HA_MAX_LAG));
+      if (ha.getReadinessSignal(maxLag) == HAServerPlugin.READINESS_SIGNAL.NOT_READY)
+        return "Node is not yet in the Raft configuration or has not caught up";
+    }
+
+    return null;
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Discovery
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * The databases {@code user} is allowed to see, in the server's own order. A null user - a server
+   * with security disabled - sees all of them.
+   * <p>
+   * Listing is the one control-plane read that is not root-only on either transport, so the answer
+   * has to be narrowed to the caller instead: over HTTP, {@code list databases} and
+   * {@code GET /api/v1/databases} both filter here, and the gRPC {@code ListDatabases} does too
+   * since issue #7304. {@code ExistsDatabase} deliberately does not - it tests one name the caller
+   * already knows, and {@code GetExistsDatabaseHandler} says the same of its HTTP counterpart.
+   */
+  public static Set<String> filterAuthorizedDatabases(final ServerSecurityUser user, final Collection<String> databaseNames) {
+    final Set<String> authorized = new LinkedHashSet<>(databaseNames.size());
+    for (final String databaseName : databaseNames)
+      if (user == null || user.canAccessToDatabase(databaseName))
+        authorized.add(databaseName);
+    return authorized;
+  }
+
+  /**
+   * The databases {@code user} is allowed to see on this server.
+   */
+  public Set<String> listAuthorizedDatabases(final ServerSecurityUser user) {
+    return filterAuthorizedDatabases(user, server.getDatabaseNames());
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Database lifecycle
+  // ---------------------------------------------------------------------------------------------
+
+  public void openDatabase(final String databaseName) {
+    requireDatabaseName(databaseName);
+
+    server.getDatabase(databaseName);
+  }
+
+  public void closeDatabase(final String databaseName) {
+    requireDatabaseName(databaseName);
+
+    final ServerDatabase database = server.getDatabase(databaseName);
+    database.getEmbedded().close();
+
+
+    server.removeDatabase(database.getName());
+  }
+
+  public void alignDatabase(final String databaseName) {
+    requireDatabaseName(databaseName);
+
+    final Database database = server.getDatabase(databaseName);
+
+
+    try (final var rs = database.command("sql", "align database")) {
+      // align database is fire-and-forget here; close releases the ResultSet's plan state.
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Settings
+  // ---------------------------------------------------------------------------------------------
+
+  public void setDatabaseSetting(final String databaseName, final String key, final String value) throws IOException {
+    requireDatabaseName(databaseName);
+
+    final DatabaseInternal database = server.getDatabase(databaseName);
+    applySetting(database.getConfiguration(), key, value);
+    database.saveConfiguration();
+  }
+
+  public void setServerSetting(final String key, final String value) {
+    applySetting(server.getConfiguration(), key, value);
+  }
+
+  /**
+   * Stores one {@code <key> <value>} pair of a "set ... setting" command into {@code configuration}.
+   * <p>
+   * Issue #6875: both callers used to hand the raw tokens to {@link ContextConfiguration#setValue(String, Object)},
+   * which is a plain map put. Three things went wrong there and are fixed here:
+   * <ul>
+   * <li>the value kept the separating space that {@code substring(firstSpace)} left on it, so every value was
+   * stored with a leading blank;</li>
+   * <li>the tokens kept the backticks and quotes the documented command syntax uses
+   * ({@code SET SERVER SETTING `arcadedb.foo` 10}), so a quoted key was stored under a name nothing reads - a
+   * silent no-op answered with a 200;</li>
+   * <li>nothing checked the value against the setting's declared type, so an unparseable one was accepted here and
+   * threw later, inside whichever component read the setting next.</li>
+   * </ul>
+   * A key that names no declared setting is still stored verbatim, as it always has been: it carries no type to
+   * validate against, and rejecting it would change behaviour this endpoint has long allowed. The {@code
+   * set_server_setting} MCP tool is stricter on that point only - for a DECLARED setting the two now accept and
+   * refuse exactly the same values, both through {@link GlobalConfiguration#coerceFromAdminCommand(Object)}.
+   * <p>
+   * Issue #7124: that conversion is the STRICT one. A typo in a {@code Boolean} value used to reach
+   * {@code Boolean.parseBoolean} and read as {@code false}, so {@code ... requireAuthentication ture} was answered
+   * with a 200 and quietly published the metrics endpoint unauthenticated. Every other type already refused what it
+   * could not read; a boolean now does too, with the same 400.
+   * <p>
+   * The HTTP command is still tokenized on the first space(s) BEFORE the quotes are stripped, so quoting does not
+   * make a space part of a token: a database name or a setting key containing one would split wrong. That is
+   * unchanged here and harmless for what the grammar can address - every {@link GlobalConfiguration} key is a dotted
+   * identifier - and only the trailing {@code <value>}, which is whatever remains after the last split, can hold a
+   * quoted space. gRPC callers pass key and value as separate fields and are not subject to that tokenization at
+   * all, but they go through the same stripping and coercion so a declared setting accepts and refuses the same
+   * values on both transports.
+   */
+  public static void applySetting(final ContextConfiguration configuration, final String rawKey, final String rawValue) {
+    final String key = FileUtils.getStringContent(rawKey.trim());
+    final String value = FileUtils.getStringContent(rawValue.trim());
+
+    final GlobalConfiguration setting = GlobalConfiguration.findByKey(key);
+    if (setting == null) {
+      configuration.setValue(key, value);
+      return;
+    }
+
+    if (value.isEmpty() && setting.getType() != String.class)
+      throw new IllegalArgumentException(
+          "'value' must not be empty for setting '" + setting.getKey() + "' of type " + setting.getType().getSimpleName());
+
+    // setValue also runs the side effect of a declared SCOPE.SERVER setting, so one whose effect is not a value
+    // somebody later reads - arcadedb.server.logFormat swapping the console formatter - takes effect here too
+    // rather than being stored and ignored (issue #7121).
+    configuration.setValue(setting.getKey(), setting.coerceFromAdminCommand(value));
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Security
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * The users known to this server, without their password hashes - the projection
+   * {@code GET /api/v1/server/users} returns.
+   */
+  public JSONArray listUsers() {
+    final ServerSecurity security = server.getSecurity();
+    final JSONArray usersArray = new JSONArray();
+
+    for (final JSONObject userJson : security.usersToJSON()) {
+      final JSONObject userInfo = new JSONObject();
+      userInfo.put("name", userJson.getString("name"));
+      // Never expose password hashes
+      if (userJson.has("databases"))
+        userInfo.put("databases", userJson.getJSONObject("databases"));
+      else
+        userInfo.put("databases", new JSONObject());
+      usersArray.put(userInfo);
+    }
+
+    return usersArray;
+  }
+
+  /**
+   * Creates a user from the same JSON document the HTTP {@code create user} command takes:
+   * {@code name}, {@code password} and an optional {@code databases} map. The document is copied
+   * before the password is replaced by its hash, so a caller's object is not mutated.
+   */
+  public void createUser(final JSONObject user) {
+    if (!user.has("name"))
+      throw new IllegalArgumentException("User name is null");
+
+    final JSONObject json = new JSONObject(user.toString());
+
+    final String userPassword = json.getString("password");
+
+    // Enforce the single shared credentials policy (min length 8, correct message) used by the REST
+    // create-user path, instead of a divergent off-by-one length check.
+    server.getSecurity().getCredentialsValidator().validateCredentials(json.getString("name"), userPassword);
+
+    json.put("password", server.getSecurity().encodePassword(userPassword));
+
+
+    // The HA-vs-local decision, and the read-compute-submit serialisation it needs, live in ServerSecurity
+    // so the REST /api/v1/server/users handlers replicate through exactly the same path (issue #6808).
+    server.getSecurity().createUserClusterWide(json);
+  }
+
+  public void dropUser(final String userName) {
+    if (userName.isEmpty())
+      throw new IllegalArgumentException("User name was missing");
+
+
+    if (!server.getSecurity().dropUserClusterWide(userName))
+      throw new IllegalArgumentException("User '" + userName + "' not found on server");
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Backup
+  // ---------------------------------------------------------------------------------------------
+
+  public JSONObject getBackupConfig() {
+
+    final AutoBackupSchedulerPlugin plugin = getBackupPlugin();
+
+    final JSONObject response = new JSONObject();
+
+    if (plugin != null && plugin.isEnabled()) {
+      response.put("enabled", true);
+      final AutoBackupConfig config = plugin.getBackupConfig();
+      response.put("config", config != null ? config.toJSON() : JSONObject.NULL);
+    } else {
+      // Plugin not enabled at startup - try to read config from file directly
+      final Path configPath = Paths.get(server.getRootPath(), "config", AutoBackupConfig.CONFIG_FILE_NAME);
+      if (Files.exists(configPath)) {
+        try {
+          final String content = Files.readString(configPath);
+          final JSONObject configJson = new JSONObject(content);
+          response.put("enabled", false); // Plugin not running, but config exists
+          response.put("config", configJson);
+          response.put("message", "Configuration saved but requires server restart to take effect");
+        } catch (final IOException e) {
+          response.put("enabled", false);
+          response.put("config", JSONObject.NULL);
+        }
+      } else {
+        response.put("enabled", false);
+        response.put("config", JSONObject.NULL);
+      }
+    }
+
+    return response;
+  }
+
+  public JSONObject setBackupConfig(final JSONObject configJson) throws IOException {
+
+    // Validate backup directory - must be relative path without traversal
+    if (configJson.has("backupDirectory"))
+      validateBackupDirectory(configJson.getString("backupDirectory"));
+
+    // Save configuration to file
+    final Path configPath = Paths.get(server.getRootPath(), "config", AutoBackupConfig.CONFIG_FILE_NAME);
+
+    // Write configuration atomically so a crash mid-write leaves the previous valid file intact.
+    // atomicWriteFile also creates the parent config directory if needed.
+    FileUtils.atomicWriteFile(configPath.toFile(), configJson.toString(2));
+
+    // Reload configuration in the plugin
+    final AutoBackupSchedulerPlugin plugin = getBackupPlugin();
+    if (plugin != null && plugin.isEnabled())
+      plugin.reloadConfiguration();
+
+    return new JSONObject().put("result", "ok");
+  }
+
+  public JSONObject listBackups(final String databaseName) {
+    requireDatabaseName(databaseName);
+
+
+    final AutoBackupSchedulerPlugin plugin = getBackupPlugin();
+
+    final JSONArray backups = new JSONArray();
+
+    if (plugin != null && plugin.isEnabled()) {
+      final AutoBackupConfig config = plugin.getBackupConfig();
+      if (config != null) {
+        // Resolve backup directory
+        String backupDirectory = config.getBackupDirectory();
+        final Path backupPath = Paths.get(backupDirectory);
+        if (!backupPath.isAbsolute())
+          backupDirectory = Paths.get(server.getRootPath(), backupDirectory).toString();
+
+        final Path dbBackupDir = Paths.get(backupDirectory, databaseName);
+        if (Files.exists(dbBackupDir) && Files.isDirectory(dbBackupDir)) {
+          try (var stream = Files.list(dbBackupDir)) {
+            stream.filter(p -> p.toString().endsWith(".zip") && p.getFileName().toString().contains("-backup-"))
+                .sorted(Comparator.reverseOrder())
+                .forEach(p -> {
+                  final JSONObject backup = new JSONObject();
+                  backup.put("fileName", p.getFileName().toString());
+                  try {
+                    backup.put("size", Files.size(p));
+                    backup.put("lastModified", Files.getLastModifiedTime(p).toMillis());
+                  } catch (final IOException e) {
+                    backup.put("size", 0);
+                    backup.put("lastModified", 0);
+                  }
+
+                  // Parse timestamp from filename, through the same convention that wrote it (issue #6753)
+                  final LocalDateTime timestamp = BackupCoordinator.parseArchiveTimestamp(p.getFileName().toString());
+                  backup.put("timestamp", timestamp != null ? timestamp.toString() : JSONObject.NULL);
+
+                  backups.put(backup);
+                });
+          } catch (final IOException e) {
+            throw new RuntimeException("Error listing backups for database '" + databaseName + "'", e);
+          }
+        }
+      }
+    }
+
+    final JSONObject response = new JSONObject();
+    response.put("database", databaseName);
+    response.put("backups", backups);
+
+    // Get retention manager stats if available
+    if (plugin != null && plugin.getRetentionManager() != null) {
+      final BackupRetentionManager retentionManager = plugin.getRetentionManager();
+      response.put("totalSize", retentionManager.getBackupSizeBytes(databaseName));
+      response.put("totalCount", retentionManager.getBackupCount(databaseName));
+    }
+
+    return response;
+  }
+
+  /**
+   * Runs a full backup inline and returns {@code {"result":"ok","backupFile":...}}.
+   *
+   * @throws BackupInProgressException when another backup of the same database is already running.
+   *                                   This command runs the backup inline, so it is one of the entry points that can
+   *                                   have a database being backed up at the same time as the auto-backup schedule
+   *                                   does - down to resolving to the same archive name and writing into the same
+   *                                   file. Refusing outright is the honest answer to "back up a database that is
+   *                                   already being backed up": a second full backup of the same data produces
+   *                                   nothing the first one will not, and the caller gets told rather than silently
+   *                                   handed the other run's archive (issue #6753).
+   */
+  public JSONObject triggerBackup(final String databaseName) {
+    requireDatabaseName(databaseName);
+
+
+    final BackupCoordinator coordinator = server.getBackupCoordinator();
+    if (!coordinator.begin(databaseName))
+      throw new BackupInProgressException("A backup of database '" + databaseName + "' is already in progress");
+
+    try {
+      return executeImmediateBackup(databaseName);
+    } finally {
+      coordinator.end(databaseName);
+    }
+  }
+
+  public JSONObject deleteBackup(final String databaseName, final String fileName) {
+    if (databaseName.isEmpty() || fileName.isEmpty())
+      throw new IllegalArgumentException("Usage: delete backup <database> <fileName>");
+
+
+    final Path backupFile = resolveBackupFile(databaseName, fileName);
+
+    try {
+      Files.delete(backupFile);
+    } catch (final IOException e) {
+      throw new CommandExecutionException("Error deleting backup file '" + fileName + "'", e);
+    }
+
+    return new JSONObject().put("result", "ok");
+  }
+
+  public void validateBackupDirectory(final String backupDir) {
+    // Use consolidated validation from AutoBackupSchedulerPlugin
+    final Path serverRoot = Paths.get(server.getRootPath()).toAbsolutePath().normalize();
+    AutoBackupSchedulerPlugin.validateAndResolveBackupPath(backupDir, serverRoot);
+  }
+
+  /**
+   * Resolves a backup file name to an absolute path inside the configured auto-backup directory for
+   * the given database, rejecting any name that contains path separators or traversal sequences.
+   */
+  public Path resolveBackupFile(final String databaseName, final String fileName) {
+    requireDatabaseName(databaseName);
+
+    // Reject anything that is not a plain backup file name.
+    if (fileName.contains("/") || fileName.contains("\\") || fileName.contains("..") || fileName.isBlank()
+        || !fileName.endsWith(".zip") || !fileName.contains("-backup-"))
+      throw new IllegalArgumentException("Invalid backup file name: " + fileName);
+
+    final AutoBackupSchedulerPlugin plugin = getBackupPlugin();
+    if (plugin == null || !plugin.isEnabled() || plugin.getBackupConfig() == null)
+      throw new IllegalArgumentException("Auto-backup is not configured");
+
+    String backupDirectory = plugin.getBackupConfig().getBackupDirectory();
+    final Path backupPath = Paths.get(backupDirectory);
+    if (!backupPath.isAbsolute())
+      backupDirectory = Paths.get(server.getRootPath(), backupDirectory).toString();
+
+    final Path dbBackupDir = Paths.get(backupDirectory, databaseName).normalize();
+    final Path resolved = dbBackupDir.resolve(fileName).normalize();
+
+    // Defence in depth: the resolved file must still live inside the database backup directory.
+    if (!resolved.startsWith(dbBackupDir))
+      throw new IllegalArgumentException("Invalid backup file path");
+
+    if (!Files.exists(resolved) || !Files.isRegularFile(resolved))
+      throw new IllegalArgumentException("Backup file not found: " + fileName);
+
+    return resolved;
+  }
+
+  private JSONObject executeImmediateBackup(final String databaseName) {
+    final AutoBackupSchedulerPlugin plugin = getBackupPlugin();
+
+    // Try to get backup directory from config (plugin or file)
+    String backupDirectory = null;
+
+    if (plugin != null && plugin.isEnabled()) {
+      final AutoBackupConfig config = plugin.getBackupConfig();
+      backupDirectory = config != null ? config.getBackupDirectory() : null;
+    }
+
+    // If plugin not enabled, try to read from config file directly
+    if (backupDirectory == null) {
+      final Path configPath = Paths.get(server.getRootPath(), "config", AutoBackupConfig.CONFIG_FILE_NAME);
+      if (Files.exists(configPath)) {
+        try {
+          final String content = Files.readString(configPath);
+          final JSONObject configJson = new JSONObject(content);
+          if (configJson.has("backupDirectory"))
+            backupDirectory = configJson.getString("backupDirectory");
+        } catch (final IOException ignored) {
+        }
+      }
+    }
+
+    // Use config directory if available
+    if (backupDirectory != null) {
+      try {
+        // Validate the directory
+        validateBackupDirectory(backupDirectory);
+
+        // Resolve relative path
+        final Path backupPath = Paths.get(backupDirectory);
+        if (!backupPath.isAbsolute())
+          backupDirectory = Paths.get(server.getRootPath(), backupDirectory).toString();
+
+        // Perform backup using reflection (same as BackupTask)
+        final Database database = server.getDatabase(databaseName);
+        final Class<?> clazz = Class.forName("com.arcadedb.integration.backup.Backup");
+
+        final String backupFileName = server.getBackupCoordinator().newArchiveName(databaseName);
+
+        final Path dbBackupPath = Paths.get(backupDirectory, databaseName);
+        // Use Files.createDirectories to avoid TOCTOU race condition
+        Files.createDirectories(dbBackupPath);
+        final String dbBackupDir = dbBackupPath.toString();
+
+        final Object backup = clazz.getConstructor(Database.class, String.class)
+            .newInstance(database, backupFileName);
+        clazz.getMethod("setDirectory", String.class).invoke(backup, dbBackupDir);
+        clazz.getMethod("setVerboseLevel", Integer.TYPE).invoke(backup, 1);
+
+        final String backupFile = (String) clazz.getMethod("backupDatabase").invoke(backup);
+
+        final JSONObject response = new JSONObject();
+        response.put("result", "ok");
+        response.put("backupFile", backupFile);
+        return response;
+
+      } catch (final ClassNotFoundException e) {
+        throw new RuntimeException("Backup libs not found in classpath. Make sure arcadedb-integration module is included.", e);
+      } catch (final Exception e) {
+        final Throwable cause = e.getCause() != null ? e.getCause() : e;
+        throw new RuntimeException("Error triggering backup for database '" + databaseName + "': " + cause.getMessage(), cause);
+      }
+    }
+
+    // Fallback: use SQL command (uses GlobalConfiguration.SERVER_BACKUP_DIRECTORY). This one does not name the
+    // archive through the coordinator: with no target the SQL statement lets BackupSettings apply its own default,
+    // which is the same convention down to the milliseconds - the coordinator is where that convention was copied
+    // from in the first place.
+    try {
+      final Database database = server.getDatabase(databaseName);
+      try (final var result = database.command("sql", "backup database")) {
+
+        final JSONObject response = new JSONObject();
+        response.put("result", "ok");
+        // The SQL "backup database" command sets backupFile as a property on a Result row
+        // (see BackupDatabaseStatement). Read it via Result.getProperty rather than the
+        // pre-existing dead instanceof Map check, which never matched.
+        while (result.hasNext()) {
+          final var row = result.next();
+          final Object backupFile = row.getProperty("backupFile");
+          if (backupFile != null) {
+            response.put("backupFile", backupFile.toString());
+            break;
+          }
+        }
+        return response;
+      }
+    } catch (final Exception e) {
+      throw new RuntimeException("Error triggering backup for database '" + databaseName + "': " + e.getMessage(), e);
+    }
+  }
+
+  private AutoBackupSchedulerPlugin getBackupPlugin() {
+    for (final ServerPlugin plugin : server.getPlugins()) {
+      if (plugin instanceof AutoBackupSchedulerPlugin autoBackup)
+        return autoBackup;
+    }
+    return null;
+  }
+
+  /**
+   * Raised by {@link #triggerBackup(String)} when the database is already being backed up. HTTP
+   * answers it with a 409 and gRPC with {@code ABORTED}; both carry this message verbatim.
+   */
+  public static class BackupInProgressException extends RuntimeException {
+    public BackupInProgressException(final String message) {
+      super(message);
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Query profiler
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * Starts recording. A {@code timeoutSec} of zero or less starts an open-ended recording, which is
+   * what the HTTP {@code profiler start} command does when it carries no timeout.
+   */
+  public JSONObject profilerStart(final int timeoutSec) {
+    final ServerQueryProfiler profiler = server.getQueryProfiler();
+    if (timeoutSec > 0)
+      profiler.start(timeoutSec);
+    else
+      profiler.start();
+
+    return new JSONObject().put("result", "ok").put("recording", true);
+  }
+
+  public JSONObject profilerStop() {
+    final JSONObject results = server.getQueryProfiler().stop();
+    return results != null ? results : new JSONObject().put("result", "ok");
+  }
+
+  public JSONObject profilerReset() {
+    server.getQueryProfiler().reset();
+    return new JSONObject().put("result", "ok");
+  }
+
+  public JSONObject profilerResults() {
+    final JSONObject results = server.getQueryProfiler().getResults();
+    return results != null ? results : new JSONObject().put("result", "ok");
+  }
+
+  public JSONArray profilerList() {
+    return server.getQueryProfiler().listSavedRuns();
+  }
+
+  public JSONObject profilerLoad(final String fileName) {
+    return server.getQueryProfiler().loadSavedRun(fileName);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------------------------
+
+  private static void requireDatabaseName(final String databaseName) {
+    if (databaseName == null || databaseName.isEmpty())
+      throw new IllegalArgumentException("Database name empty");
+  }
+
+  private HAServerPlugin requireHA() {
+    final HAServerPlugin ha = server.getHA();
+    if (ha == null)
+      throw new CommandExecutionException(
+          "ArcadeDB is not running with High Availability module enabled. Please add this setting at startup: -Darcadedb.ha.enabled=true");
+    return ha;
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -126,7 +126,7 @@ public class ServerControlPlane {
    */
   public void connectCluster(final String serverAddress) {
 
-    throw new CommandExecutionException(
+    throw new OperationNotAvailableException(
         "Connect cluster operation is not supported by the current HA implementation. Use the cluster configuration to join nodes.");
   }
 
@@ -658,6 +658,24 @@ public class ServerControlPlane {
   }
 
   /**
+   * Raised when the operation cannot run in this server's current configuration at all - HA is not
+   * enabled, or the HA implementation does not support joining a node this way - as opposed to having
+   * been attempted and failed.
+   * <p>
+   * It extends {@link CommandExecutionException} so the HTTP protocol answers it exactly as it did
+   * before this type existed: a 500, through the {@code CommandExecutionException} arm of
+   * {@code AbstractServerHttpHandler}. gRPC needs a distinction the HTTP protocol does not draw -
+   * this is its {@code FAILED_PRECONDITION}, while every other {@code CommandExecutionException}
+   * raised here, such as a backup archive that could not be deleted, is a server-side fault and stays
+   * {@code INTERNAL}.
+   */
+  public static class OperationNotAvailableException extends CommandExecutionException {
+    public OperationNotAvailableException(final String message) {
+      super(message);
+    }
+  }
+
+  /**
    * Raised by {@link #triggerBackup(String)} when the database is already being backed up. HTTP
    * answers it with a 409 and gRPC with {@code ABORTED}; both carry this message verbatim.
    */
@@ -720,7 +738,7 @@ public class ServerControlPlane {
   private HAServerPlugin requireHA() {
     final HAServerPlugin ha = server.getHA();
     if (ha == null)
-      throw new CommandExecutionException(
+      throw new OperationNotAvailableException(
           "ArcadeDB is not running with High Availability module enabled. Please add this setting at startup: -Darcadedb.ha.enabled=true");
     return ha;
   }

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -39,6 +39,7 @@ import com.arcadedb.server.http.HttpSessionManager;
 import com.arcadedb.server.http.IdempotencyCache;
 import com.arcadedb.server.http.ResultSetTooLargeException;
 import com.arcadedb.server.security.ApiTokenConfiguration;
+import com.arcadedb.server.ServerControlPlane;
 import com.arcadedb.server.security.ServerSecurityException;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.micrometer.core.instrument.Metrics;
@@ -1234,11 +1235,9 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
    * @return a new set holding the accessible subset, in the iteration order of {@code databaseNames}
    */
   protected Set<String> filterAuthorizedDatabases(final ServerSecurityUser user, final Collection<String> databaseNames) {
-    final Set<String> authorized = new LinkedHashSet<>(databaseNames.size());
-    for (final String databaseName : databaseNames)
-      if (user == null || user.canAccessToDatabase(databaseName))
-        authorized.add(databaseName);
-    return authorized;
+    // The rule lives in ServerControlPlane so gRPC's ListDatabases narrows its answer the same way
+    // (issue #7304); this stays as the handlers' entry point into it.
+    return ServerControlPlane.filterAuthorizedDatabases(user, databaseNames);
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetHealthHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetHealthHandler.java
@@ -19,6 +19,7 @@
 package com.arcadedb.server.http.handler;
 
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ServerControlPlane;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.micrometer.core.instrument.Metrics;
@@ -31,8 +32,15 @@ import io.undertow.server.HttpServerExchange;
  * not be killed by the orchestrator.
  */
 public class GetHealthHandler extends AbstractServerHttpHandler {
+  /**
+   * Liveness as the control plane defines it, shared with gRPC's
+   * {@code ArcadeDbAdminService.Health} so the two probes cannot answer differently (issue #7304).
+   */
+  private final ServerControlPlane controlPlane;
+
   public GetHealthHandler(final HttpServer httpServer) {
     super(httpServer);
+    this.controlPlane = new ServerControlPlane(httpServer.getServer());
   }
 
   @Override
@@ -41,7 +49,7 @@ public class GetHealthHandler extends AbstractServerHttpHandler {
 
     // Liveness only: reaching this handler proves the HTTP layer is up, so the process is live.
     // It deliberately does not consult server status, so a node still warming up is not killed.
-    return new ExecutionResponse(204, "");
+    return controlPlane.isLive() ? new ExecutionResponse(204, "") : new ExecutionResponse(503, "");
   }
 
   @Override

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetReadyHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetReadyHandler.java
@@ -18,45 +18,32 @@
  */
 package com.arcadedb.server.http.handler;
 
-import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.serializer.json.JSONObject;
-import com.arcadedb.server.ArcadeDBServer;
-import com.arcadedb.server.HAServerPlugin;
+import com.arcadedb.server.ServerControlPlane;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.micrometer.core.instrument.Metrics;
 import io.undertow.server.HttpServerExchange;
 
 public class GetReadyHandler extends AbstractServerHttpHandler {
+  /**
+   * The readiness gates themselves, shared with gRPC's {@code ArcadeDbAdminService.Ready} so a node
+   * cannot be ready on one transport and not on the other (issue #7304).
+   */
+  private final ServerControlPlane controlPlane;
+
   public GetReadyHandler(final HttpServer httpServer) {
     super(httpServer);
+    this.controlPlane = new ServerControlPlane(httpServer.getServer());
   }
 
   @Override
   public ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user, final JSONObject payload) {
     Metrics.counter("http.ready").increment();
 
-    final ArcadeDBServer server = httpServer.getServer();
-    if (server.getStatus() != ArcadeDBServer.STATUS.ONLINE)
-      return new ExecutionResponse(503, "Server not started yet");
-
-    if (server.getConfiguration().getValueAsBoolean(GlobalConfiguration.SERVER_READINESS_REQUIRES_HA)
-        && server.getConfiguration().getValueAsBoolean(GlobalConfiguration.HA_ENABLED)) {
-      final HAServerPlugin ha = server.getHA();
-      // First gate: a leader must be known (election settled). Necessary but not sufficient - the deeper
-      // consensus gate below also requires committed-config membership and follower catch-up.
-      if (ha == null || ha.getElectionStatus() != HAServerPlugin.ELECTION_STATUS.DONE)
-        return new ExecutionResponse(503, "Node has not yet joined the Raft group");
-
-      // Deeper consensus gate: the node must be in the current Raft configuration and (for a follower) have
-      // replayed the committed log to within a small bound. Without it, a restarted follower with a
-      // wiped/lagging log would report Ready before catch-up and a rolling restart could drop the write
-      // quorum. A null signal means the HA implementation provides none: no extra gating. The lag bound is
-      // clamped to >= 0 so a misconfigured negative value cannot wedge a caught-up node out of readiness.
-      final long maxLag = Math.max(0L, server.getConfiguration().getValueAsLong(GlobalConfiguration.SERVER_READINESS_HA_MAX_LAG));
-      if (ha.getReadinessSignal(maxLag) == HAServerPlugin.READINESS_SIGNAL.NOT_READY)
-        return new ExecutionResponse(503, "Node is not yet in the Raft configuration or has not caught up");
-    }
+    final String notReadyReason = controlPlane.notReadyReason();
+    if (notReadyReason != null)
+      return new ExecutionResponse(503, notReadyReason);
 
     return new ExecutionResponse(204, "");
   }

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -146,37 +146,37 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     }
 
     if (command_lc.startsWith(SHUTDOWN))
-      count("http.server-shutdown").shutdownServer(extractTarget(command, SHUTDOWN));
+      shutdownServer(extractTarget(command, SHUTDOWN));
     else if (command_lc.startsWith(CREATE_DATABASE))
       createDatabase(extractTarget(command, CREATE_DATABASE));
     else if (command_lc.startsWith(DROP_DATABASE))
       dropDatabase(extractTarget(command, DROP_DATABASE));
     else if (command_lc.startsWith(CLOSE_DATABASE))
-      count("http.close-database").closeDatabase(extractTarget(command, CLOSE_DATABASE));
+      closeDatabase(extractTarget(command, CLOSE_DATABASE));
     else if (command_lc.startsWith(OPEN_DATABASE))
-      count("http.open-database").openDatabase(extractTarget(command, OPEN_DATABASE));
+      openDatabase(extractTarget(command, OPEN_DATABASE));
     else if (command_lc.startsWith(CREATE_USER))
-      count("http.create-user").createUser(new JSONObject(extractTarget(command, CREATE_USER)));
+      createUser(extractTarget(command, CREATE_USER));
     else if (command_lc.startsWith(DROP_USER))
-      count("http.drop-user").dropUser(extractTarget(command, DROP_USER));
+      dropUser(extractTarget(command, DROP_USER));
     else if (command_lc.startsWith(CONNECT_CLUSTER))
-      count("http.connect-cluster").connectCluster(extractTarget(command, CONNECT_CLUSTER));
+      connectCluster(extractTarget(command, CONNECT_CLUSTER));
     else if (DISCONNECT_CLUSTER.equals(command_lc))
-      count("http.server-disconnect").disconnectCluster();
+      disconnectCluster();
     else if (command_lc.startsWith(SET_DATABASE_SETTING))
       setDatabaseSetting(extractTarget(command, SET_DATABASE_SETTING));
     else if (command_lc.startsWith(SET_SERVER_SETTING))
       setServerSetting(extractTarget(command, SET_SERVER_SETTING));
     else if (command_lc.startsWith(GET_SERVER_EVENTS))
-      response.put("result", count("http.get-server-events").getServerEvents(extractTarget(command, GET_SERVER_EVENTS)));
+      response.put("result", getServerEvents(extractTarget(command, GET_SERVER_EVENTS)));
     else if (command_lc.startsWith(ALIGN_DATABASE))
-      count("http.align-database").alignDatabase(extractTarget(command, ALIGN_DATABASE));
+      alignDatabase(extractTarget(command, ALIGN_DATABASE));
     else if (GET_BACKUP_CONFIG.equals(command_lc))
-      return new ExecutionResponse(200, count("http.get-backup-config").getBackupConfig().toString());
+      return getBackupConfig();
     else if (SET_BACKUP_CONFIG.equals(command_lc))
       return setBackupConfig(payload);
     else if (command_lc.startsWith(LIST_BACKUPS))
-      return new ExecutionResponse(200, count("http.list-backups").listBackups(extractTarget(command, LIST_BACKUPS)).toString());
+      return listBackups(extractTarget(command, LIST_BACKUPS));
     else if (command_lc.startsWith(TRIGGER_BACKUP))
       return triggerBackup(extractTarget(command, TRIGGER_BACKUP));
     else if (command_lc.startsWith(RESTORE_BACKUP))
@@ -198,17 +198,80 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     return new ExecutionResponse(200, response.toString());
   }
 
-  /**
-   * Counts one HTTP server command and hands back the shared implementation to run it.
-   * <p>
-   * The {@code http.*} counters stay on this side of the split (issue #7304): they count HTTP
-   * requests, and {@link ServerControlPlane} now serves gRPC as well, so incrementing them there
-   * would silently fold gRPC admin traffic into the HTTP dashboards. gRPC's own admin calls are
-   * counted per method by {@code GrpcMetricsInterceptor}.
-   */
-  private ServerControlPlane count(final String metric) {
-    Metrics.counter(metric).increment();
-    return controlPlane;
+  // ---------------------------------------------------------------------------------------------
+  // The commands whose implementation moved to ServerControlPlane (issue #7304). Each wrapper runs
+  // the shared implementation and then increments this command's http.* counter.
+  //
+  // The counters stay on this side of the split because they count HTTP requests, and
+  // ServerControlPlane now serves gRPC as well: incrementing them there would fold gRPC admin
+  // traffic into the HTTP dashboards. gRPC counts its own admin calls per method in
+  // GrpcMetricsInterceptor.
+  //
+  // The increment comes AFTER the call, never before it. Every one of these counters used to be
+  // incremented inside the moved method, past that method's own validation, so a command rejected
+  // for an empty database name or a password the policy refuses was never counted. Chaining the
+  // increment onto the receiver would have counted attempts instead, because Java evaluates the
+  // receiver first.
+  // ---------------------------------------------------------------------------------------------
+
+  private void shutdownServer(final String serverName) throws IOException {
+    controlPlane.shutdownServer(serverName);
+    Metrics.counter("http.server-shutdown").increment();
+  }
+
+  private void closeDatabase(final String databaseName) {
+    controlPlane.closeDatabase(databaseName);
+    Metrics.counter("http.close-database").increment();
+  }
+
+  private void openDatabase(final String databaseName) {
+    controlPlane.openDatabase(databaseName);
+    Metrics.counter("http.open-database").increment();
+  }
+
+  private void createUser(final String payload) {
+    controlPlane.createUser(new JSONObject(payload));
+    Metrics.counter("http.create-user").increment();
+  }
+
+  private void dropUser(final String userName) {
+    controlPlane.dropUser(userName);
+    Metrics.counter("http.drop-user").increment();
+  }
+
+  private void connectCluster(final String serverAddress) {
+    // Always throws: the current HA implementation does not support it. Counted first, because there
+    // is no success to count after - which is what the moved implementation did too.
+    Metrics.counter("http.connect-cluster").increment();
+    controlPlane.connectCluster(serverAddress);
+  }
+
+  private void disconnectCluster() {
+    controlPlane.disconnectCluster();
+    Metrics.counter("http.server-disconnect").increment();
+  }
+
+  private void alignDatabase(final String databaseName) {
+    controlPlane.alignDatabase(databaseName);
+    Metrics.counter("http.align-database").increment();
+  }
+
+  private JSONObject getServerEvents(final String fileName) {
+    final JSONObject events = controlPlane.getServerEvents(fileName);
+    Metrics.counter("http.get-server-events").increment();
+    return events;
+  }
+
+  private ExecutionResponse getBackupConfig() {
+    final JSONObject config = controlPlane.getBackupConfig();
+    Metrics.counter("http.get-backup-config").increment();
+    return new ExecutionResponse(200, config.toString());
+  }
+
+  private ExecutionResponse listBackups(final String databaseName) {
+    final JSONObject backups = controlPlane.listBackups(databaseName);
+    Metrics.counter("http.list-backups").increment();
+    return new ExecutionResponse(200, backups.toString());
   }
 
   private String extractTarget(String command, String keyword) {
@@ -256,7 +319,9 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     if (!payload.has("config"))
       throw new IllegalArgumentException("Missing 'config' in payload");
 
-    return new ExecutionResponse(200, count("http.set-backup-config").setBackupConfig(payload.getJSONObject("config")).toString());
+    final JSONObject result = controlPlane.setBackupConfig(payload.getJSONObject("config"));
+    Metrics.counter("http.set-backup-config").increment();
+    return new ExecutionResponse(200, result.toString());
   }
 
   /**
@@ -265,7 +330,9 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
    */
   private ExecutionResponse triggerBackup(final String databaseName) {
     try {
-      return new ExecutionResponse(200, count("http.trigger-backup").triggerBackup(databaseName).toString());
+      final JSONObject result = controlPlane.triggerBackup(databaseName);
+      Metrics.counter("http.trigger-backup").increment();
+      return new ExecutionResponse(200, result.toString());
     } catch (final ServerControlPlane.BackupInProgressException e) {
       return new ExecutionResponse(409, new JSONObject().put("error", e.getMessage()).toString());
     }
@@ -282,7 +349,9 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     final String databaseName = args.substring(0, space).trim();
     final String fileName = args.substring(space + 1).trim();
 
-    return new ExecutionResponse(200, count("http.delete-backup").deleteBackup(databaseName, fileName).toString());
+    final JSONObject result = controlPlane.deleteBackup(databaseName, fileName);
+    Metrics.counter("http.delete-backup").increment();
+    return new ExecutionResponse(200, result.toString());
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -30,12 +30,7 @@ import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.ServerDatabase;
-import com.arcadedb.server.ServerPlugin;
-import com.arcadedb.server.monitor.ServerQueryProfiler;
-import com.arcadedb.server.backup.AutoBackupConfig;
-import com.arcadedb.server.backup.AutoBackupSchedulerPlugin;
-import com.arcadedb.server.backup.BackupCoordinator;
-import com.arcadedb.server.backup.BackupRetentionManager;
+import com.arcadedb.server.ServerControlPlane;
 import com.arcadedb.server.HAReplicatedDatabase;
 import com.arcadedb.server.HAServerPlugin;
 import com.arcadedb.server.LeaderForwardContext;
@@ -63,7 +58,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -105,8 +99,18 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
 
   private static final IPAddressBlocklist RESERVED_ADDRESSES = IPAddressBlocklist.defaultReservedRanges();
 
+  /**
+   * The transport-independent implementation of these commands, shared with gRPC's
+   * {@code ArcadeDbAdminService} so the two protocols cannot drift apart on what an administrative
+   * operation does (issue #7304). What stays in this handler is the command-string grammar, the
+   * leader forwarding, the mapping onto HTTP status codes, and the operations that stream progress
+   * over the exchange.
+   */
+  private final ServerControlPlane controlPlane;
+
   public PostServerCommandHandler(final HttpServer httpServer) {
     super(httpServer);
+    this.controlPlane = new ServerControlPlane(httpServer.getServer());
   }
 
   @Override
@@ -142,38 +146,37 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     }
 
     if (command_lc.startsWith(SHUTDOWN))
-      shutdownServer(extractTarget(command, SHUTDOWN));
+      count("http.server-shutdown").shutdownServer(extractTarget(command, SHUTDOWN));
     else if (command_lc.startsWith(CREATE_DATABASE))
       createDatabase(extractTarget(command, CREATE_DATABASE));
     else if (command_lc.startsWith(DROP_DATABASE))
       dropDatabase(extractTarget(command, DROP_DATABASE));
     else if (command_lc.startsWith(CLOSE_DATABASE))
-      closeDatabase(extractTarget(command, CLOSE_DATABASE));
+      count("http.close-database").closeDatabase(extractTarget(command, CLOSE_DATABASE));
     else if (command_lc.startsWith(OPEN_DATABASE))
-      openDatabase(extractTarget(command, OPEN_DATABASE));
+      count("http.open-database").openDatabase(extractTarget(command, OPEN_DATABASE));
     else if (command_lc.startsWith(CREATE_USER))
-      createUser(extractTarget(command, CREATE_USER));
+      count("http.create-user").createUser(new JSONObject(extractTarget(command, CREATE_USER)));
     else if (command_lc.startsWith(DROP_USER))
-      dropUser(extractTarget(command, DROP_USER));
-    else if (command_lc.startsWith(CONNECT_CLUSTER)) {
-      if (!connectCluster(extractTarget(command, CONNECT_CLUSTER), exchange))
-        return null;
-    } else if (DISCONNECT_CLUSTER.equals(command_lc))
-      disconnectCluster();
+      count("http.drop-user").dropUser(extractTarget(command, DROP_USER));
+    else if (command_lc.startsWith(CONNECT_CLUSTER))
+      count("http.connect-cluster").connectCluster(extractTarget(command, CONNECT_CLUSTER));
+    else if (DISCONNECT_CLUSTER.equals(command_lc))
+      count("http.server-disconnect").disconnectCluster();
     else if (command_lc.startsWith(SET_DATABASE_SETTING))
       setDatabaseSetting(extractTarget(command, SET_DATABASE_SETTING));
     else if (command_lc.startsWith(SET_SERVER_SETTING))
       setServerSetting(extractTarget(command, SET_SERVER_SETTING));
     else if (command_lc.startsWith(GET_SERVER_EVENTS))
-      response.put("result", getServerEvents(extractTarget(command, GET_SERVER_EVENTS)));
+      response.put("result", count("http.get-server-events").getServerEvents(extractTarget(command, GET_SERVER_EVENTS)));
     else if (command_lc.startsWith(ALIGN_DATABASE))
-      alignDatabase(extractTarget(command, ALIGN_DATABASE));
+      count("http.align-database").alignDatabase(extractTarget(command, ALIGN_DATABASE));
     else if (GET_BACKUP_CONFIG.equals(command_lc))
-      return getBackupConfig();
+      return new ExecutionResponse(200, count("http.get-backup-config").getBackupConfig().toString());
     else if (SET_BACKUP_CONFIG.equals(command_lc))
       return setBackupConfig(payload);
     else if (command_lc.startsWith(LIST_BACKUPS))
-      return listBackups(extractTarget(command, LIST_BACKUPS));
+      return new ExecutionResponse(200, count("http.list-backups").listBackups(extractTarget(command, LIST_BACKUPS)).toString());
     else if (command_lc.startsWith(TRIGGER_BACKUP))
       return triggerBackup(extractTarget(command, TRIGGER_BACKUP));
     else if (command_lc.startsWith(RESTORE_BACKUP))
@@ -195,12 +198,124 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     return new ExecutionResponse(200, response.toString());
   }
 
+  /**
+   * Counts one HTTP server command and hands back the shared implementation to run it.
+   * <p>
+   * The {@code http.*} counters stay on this side of the split (issue #7304): they count HTTP
+   * requests, and {@link ServerControlPlane} now serves gRPC as well, so incrementing them there
+   * would silently fold gRPC admin traffic into the HTTP dashboards. gRPC's own admin calls are
+   * counted per method by {@code GrpcMetricsInterceptor}.
+   */
+  private ServerControlPlane count(final String metric) {
+    Metrics.counter(metric).increment();
+    return controlPlane;
+  }
+
   private String extractTarget(String command, String keyword) {
     final int pos = command.toLowerCase().indexOf(keyword);
     if (pos == -1)
       return "";
 
     return command.substring(pos + keyword.length()).trim();
+  }
+
+  /**
+   * {@code set database setting <database> <key> <value>}. The command is tokenized on the first
+   * space(s) before {@link ServerControlPlane#applySetting} strips quotes, so quoting cannot make a
+   * space part of the database name or of the key.
+   */
+  private void setDatabaseSetting(final String triple) throws IOException {
+    final String tripleTrimmed = triple.trim();
+    final int firstSpace = tripleTrimmed.indexOf(" ");
+    if (firstSpace == -1)
+      throw new IllegalArgumentException("Expected <database> <key> <value>");
+
+    final String pairTrimmed = tripleTrimmed.substring(firstSpace).trim();
+    final int secondSpace = pairTrimmed.indexOf(" ");
+    if (secondSpace == -1)
+      throw new IllegalArgumentException("Expected <database> <key> <value>");
+
+    controlPlane.setDatabaseSetting(tripleTrimmed.substring(0, firstSpace), pairTrimmed.substring(0, secondSpace),
+        pairTrimmed.substring(secondSpace + 1));
+  }
+
+  /**
+   * {@code set server setting <key> <value>}.
+   */
+  private void setServerSetting(final String pair) {
+    final String pairTrimmed = pair.trim();
+
+    final int firstSpace = pairTrimmed.indexOf(" ");
+    if (firstSpace == -1)
+      throw new IllegalArgumentException("Expected <key> <value>");
+
+    controlPlane.setServerSetting(pairTrimmed.substring(0, firstSpace), pairTrimmed.substring(firstSpace + 1));
+  }
+
+  private ExecutionResponse setBackupConfig(final JSONObject payload) throws IOException {
+    if (!payload.has("config"))
+      throw new IllegalArgumentException("Missing 'config' in payload");
+
+    return new ExecutionResponse(200, count("http.set-backup-config").setBackupConfig(payload.getJSONObject("config")).toString());
+  }
+
+  /**
+   * {@code trigger backup <database>}. A backup already running for the same database is a 409 here
+   * and an {@code ABORTED} on gRPC; both carry the message the shared implementation raised.
+   */
+  private ExecutionResponse triggerBackup(final String databaseName) {
+    try {
+      return new ExecutionResponse(200, count("http.trigger-backup").triggerBackup(databaseName).toString());
+    } catch (final ServerControlPlane.BackupInProgressException e) {
+      return new ExecutionResponse(409, new JSONObject().put("error", e.getMessage()).toString());
+    }
+  }
+
+  /**
+   * {@code delete backup <database> <fileName>}.
+   */
+  private ExecutionResponse deleteBackup(final String args) {
+    final int space = args.indexOf(' ');
+    if (space <= 0)
+      throw new IllegalArgumentException("Usage: delete backup <database> <fileName>");
+
+    final String databaseName = args.substring(0, space).trim();
+    final String fileName = args.substring(space + 1).trim();
+
+    return new ExecutionResponse(200, count("http.delete-backup").deleteBackup(databaseName, fileName).toString());
+  }
+
+  /**
+   * {@code profiler <start [timeout] | stop | reset | results | list | load <file>>}. Only the
+   * sub-command grammar lives here; every branch runs the shared implementation.
+   */
+  private ExecutionResponse handleProfilerCommand(final String subCommand) {
+    final String sub = subCommand.toLowerCase(Locale.ENGLISH).trim();
+
+    if ("start".equals(sub) || sub.startsWith("start ")) {
+      final String timeoutStr = sub.substring(5).trim();
+      int timeoutSec = 0;
+      if (!timeoutStr.isEmpty()) {
+        try {
+          timeoutSec = Integer.parseInt(timeoutStr);
+        } catch (final NumberFormatException e) {
+          return new ExecutionResponse(400, "{ \"error\" : \"Invalid timeout value: " + timeoutStr + "\"}");
+        }
+      }
+      return new ExecutionResponse(200, controlPlane.profilerStart(timeoutSec).toString());
+
+    } else if ("stop".equals(sub))
+      return new ExecutionResponse(200, controlPlane.profilerStop().toString());
+    else if ("reset".equals(sub))
+      return new ExecutionResponse(200, controlPlane.profilerReset().toString());
+    else if ("results".equals(sub))
+      return new ExecutionResponse(200, controlPlane.profilerResults().toString());
+    else if ("list".equals(sub))
+      return new ExecutionResponse(200, new JSONObject().put("result", controlPlane.profilerList()).toString());
+    else if (sub.startsWith("load "))
+      return new ExecutionResponse(200, controlPlane.profilerLoad(sub.substring(5).trim()).toString());
+    else
+      return new ExecutionResponse(400, "{ \"error\" : \"Unknown profiler command: " + subCommand + "\"}");
   }
 
   private ExecutionResponse listDatabases(final ServerSecurityUser user) {
@@ -214,22 +329,6 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     return new ExecutionResponse(200, response.toString());
   }
 
-  private void shutdownServer(final String serverName) throws IOException {
-    Metrics.counter("http.server-shutdown").increment();
-
-    if (serverName.isEmpty()) {
-      // SHUTDOWN CURRENT SERVER
-      new Timer().schedule(new TimerTask() {
-        @Override
-        public void run() {
-          httpServer.getServer().stop();
-          System.exit(0);
-        }
-      }, 1000);
-    } else {
-      getHA().shutdownRemoteServer(serverName);
-    }
-  }
 
   private void createDatabase(final String databaseName) {
     if (databaseName.isEmpty())
@@ -311,7 +410,7 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     final ArcadeDBServer server = httpServer.getServer();
     Metrics.counter("http.restore-backup").increment();
 
-    final Path backupFile = resolveBackupFile(server, databaseName, fileName);
+    final Path backupFile = controlPlane.resolveBackupFile(databaseName, fileName);
 
     final String dbPath = server.getConfiguration().getValueAsString(GlobalConfiguration.SERVER_DATABASE_DIRECTORY)
         + File.separator + targetDatabase;
@@ -333,65 +432,6 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
    * validated and resolved server-side to prevent path traversal. Format:
    * {@code delete backup <database> <fileName>}.
    */
-  private ExecutionResponse deleteBackup(final String args) {
-    final int space = args.indexOf(' ');
-    if (space <= 0)
-      throw new IllegalArgumentException("Usage: delete backup <database> <fileName>");
-
-    final String databaseName = args.substring(0, space).trim();
-    final String fileName = args.substring(space + 1).trim();
-    if (databaseName.isEmpty() || fileName.isEmpty())
-      throw new IllegalArgumentException("Usage: delete backup <database> <fileName>");
-
-    Metrics.counter("http.delete-backup").increment();
-
-    final ArcadeDBServer server = httpServer.getServer();
-    final Path backupFile = resolveBackupFile(server, databaseName, fileName);
-
-    try {
-      Files.delete(backupFile);
-    } catch (final IOException e) {
-      throw new CommandExecutionException("Error deleting backup file '" + fileName + "'", e);
-    }
-
-    return new ExecutionResponse(200, new JSONObject().put("result", "ok").toString());
-  }
-
-  /**
-   * Resolves a backup file name to an absolute path inside the configured auto-backup directory for
-   * the given database, rejecting any name that contains path separators or traversal sequences.
-   */
-  private Path resolveBackupFile(final ArcadeDBServer server, final String databaseName, final String fileName) {
-    if (databaseName.isEmpty())
-      throw new IllegalArgumentException("Database name empty");
-
-    // Reject anything that is not a plain backup file name.
-    if (fileName.contains("/") || fileName.contains("\\") || fileName.contains("..") || fileName.isBlank()
-        || !fileName.endsWith(".zip") || !fileName.contains("-backup-"))
-      throw new IllegalArgumentException("Invalid backup file name: " + fileName);
-
-    final AutoBackupSchedulerPlugin plugin = getBackupPlugin(server);
-    if (plugin == null || !plugin.isEnabled() || plugin.getBackupConfig() == null)
-      throw new IllegalArgumentException("Auto-backup is not configured");
-
-    String backupDirectory = plugin.getBackupConfig().getBackupDirectory();
-    final Path backupPath = Paths.get(backupDirectory);
-    if (!backupPath.isAbsolute())
-      backupDirectory = Paths.get(server.getRootPath(), backupDirectory).toString();
-
-    final Path dbBackupDir = Paths.get(backupDirectory, databaseName).normalize();
-    final Path resolved = dbBackupDir.resolve(fileName).normalize();
-
-    // Defence in depth: the resolved file must still live inside the database backup directory.
-    if (!resolved.startsWith(dbBackupDir))
-      throw new IllegalArgumentException("Invalid backup file path");
-
-    if (!Files.exists(resolved) || !Files.isRegularFile(resolved))
-      throw new IllegalArgumentException("Backup file not found: " + fileName);
-
-    return resolved;
-  }
-
   /**
    * Shared restore execution used by {@code restore database} and {@code restore backup}. Performs
    * the actual restore from {@code url} into {@code dbPath}, streaming progress via SSE when
@@ -774,482 +814,7 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     }
   }
 
-  private void closeDatabase(final String databaseName) {
-    if (databaseName.isEmpty())
-      throw new IllegalArgumentException("Database name empty");
 
-    final ServerDatabase database = httpServer.getServer().getDatabase(databaseName);
-    database.getEmbedded().close();
-
-    Metrics.counter("http.close-database").increment();
-
-    httpServer.getServer().removeDatabase(database.getName());
-  }
-
-  private void openDatabase(final String databaseName) {
-    if (databaseName.isEmpty())
-      throw new IllegalArgumentException("Database name empty");
-
-    httpServer.getServer().getDatabase(databaseName);
-    Metrics.counter("http.open-database").increment();
-  }
-
-  private void createUser(final String payload) {
-    final JSONObject json = new JSONObject(payload);
-
-    if (!json.has("name"))
-      throw new IllegalArgumentException("User name is null");
-
-    final String userPassword = json.getString("password");
-
-    final ArcadeDBServer server = httpServer.getServer();
-    // Enforce the single shared credentials policy (min length 8, correct message) used by the REST
-    // create-user path, instead of a divergent off-by-one length check.
-    server.getSecurity().getCredentialsValidator().validateCredentials(json.getString("name"), userPassword);
-
-    json.put("password", server.getSecurity().encodePassword(userPassword));
-
-    Metrics.counter("http.create-user").increment();
-
-    // The HA-vs-local decision, and the read-compute-submit serialisation it needs, live in ServerSecurity
-    // so the REST /api/v1/server/users handlers replicate through exactly the same path (issue #6808).
-    server.getSecurity().createUserClusterWide(json);
-  }
-
-  private void dropUser(final String userName) {
-    if (userName.isEmpty())
-      throw new IllegalArgumentException("User name was missing");
-
-    Metrics.counter("http.drop-user").increment();
-
-    if (!httpServer.getServer().getSecurity().dropUserClusterWide(userName))
-      throw new IllegalArgumentException("User '" + userName + "' not found on server");
-  }
-
-  private boolean connectCluster(final String serverAddress, final HttpServerExchange exchange) {
-    Metrics.counter("http.connect-cluster").increment();
-
-    throw new CommandExecutionException(
-        "Connect cluster operation is not supported by the current HA implementation. Use the cluster configuration to join nodes.");
-  }
-
-  private void disconnectCluster() {
-    Metrics.counter("http.server-disconnect").increment();
-
-    getHA().disconnectCluster();
-  }
-
-  private void setDatabaseSetting(final String triple) throws IOException {
-
-    final String tripleTrimmed = triple.trim();
-    final int firstSpace = tripleTrimmed.indexOf(" ");
-    if (firstSpace == -1)
-      throw new IllegalArgumentException("Expected <database> <key> <value>");
-
-    final String pairTrimmed = tripleTrimmed.substring(firstSpace).trim();
-    final int secondSpace = pairTrimmed.indexOf(" ");
-    if (secondSpace == -1)
-      throw new IllegalArgumentException("Expected <database> <key> <value>");
-
-    final String db = tripleTrimmed.substring(0, firstSpace);
-
-    final DatabaseInternal database = httpServer.getServer().getDatabase(db);
-    applySetting(database.getConfiguration(), pairTrimmed.substring(0, secondSpace), pairTrimmed.substring(secondSpace + 1));
-    database.saveConfiguration();
-  }
-
-  private void setServerSetting(final String pair) {
-
-    final String pairTrimmed = pair.trim();
-
-    final int firstSpace = pairTrimmed.indexOf(" ");
-    if (firstSpace == -1)
-      throw new IllegalArgumentException("Expected <key> <value>");
-
-    applySetting(httpServer.getServer().getConfiguration(), pairTrimmed.substring(0, firstSpace),
-        pairTrimmed.substring(firstSpace + 1));
-  }
-
-  /**
-   * Stores one {@code <key> <value>} pair of a "set ... setting" command into {@code configuration}.
-   * <p>
-   * Issue #6875: both callers used to hand the raw tokens to {@link ContextConfiguration#setValue(String, Object)},
-   * which is a plain map put. Three things went wrong there and are fixed here:
-   * <ul>
-   * <li>the value kept the separating space that {@code substring(firstSpace)} left on it, so every value was
-   * stored with a leading blank;</li>
-   * <li>the tokens kept the backticks and quotes the documented command syntax uses
-   * ({@code SET SERVER SETTING `arcadedb.foo` 10}), so a quoted key was stored under a name nothing reads - a
-   * silent no-op answered with a 200;</li>
-   * <li>nothing checked the value against the setting's declared type, so an unparseable one was accepted here and
-   * threw later, inside whichever component read the setting next.</li>
-   * </ul>
-   * A key that names no declared setting is still stored verbatim, as it always has been: it carries no type to
-   * validate against, and rejecting it would change behaviour this endpoint has long allowed. The {@code
-   * set_server_setting} MCP tool is stricter on that point only - for a DECLARED setting the two now accept and
-   * refuse exactly the same values, both through {@link GlobalConfiguration#coerceFromAdminCommand(Object)}.
-   * <p>
-   * Issue #7124: that conversion is the STRICT one. A typo in a {@code Boolean} value used to reach
-   * {@code Boolean.parseBoolean} and read as {@code false}, so {@code ... requireAuthentication ture} was answered
-   * with a 200 and quietly published the metrics endpoint unauthenticated. Every other type already refused what it
-   * could not read; a boolean now does too, with the same 400.
-   * <p>
-   * The command is still tokenized on the first space(s) BEFORE the quotes are stripped, so quoting does not make a
-   * space part of a token: a database name or a setting key containing one would split wrong. That is unchanged
-   * here and harmless for what the grammar can address - every {@link GlobalConfiguration} key is a dotted
-   * identifier - and only the trailing {@code <value>}, which is whatever remains after the last split, can hold a
-   * quoted space.
-   */
-  private void applySetting(final ContextConfiguration configuration, final String rawKey, final String rawValue) {
-    final String key = FileUtils.getStringContent(rawKey.trim());
-    final String value = FileUtils.getStringContent(rawValue.trim());
-
-    final GlobalConfiguration setting = GlobalConfiguration.findByKey(key);
-    if (setting == null) {
-      configuration.setValue(key, value);
-      return;
-    }
-
-    if (value.isEmpty() && setting.getType() != String.class)
-      throw new IllegalArgumentException(
-          "'value' must not be empty for setting '" + setting.getKey() + "' of type " + setting.getType().getSimpleName());
-
-    // setValue also runs the side effect of a declared SCOPE.SERVER setting, so one whose effect is not a value
-    // somebody later reads - arcadedb.server.logFormat swapping the console formatter - takes effect here too
-    // rather than being stored and ignored (issue #7121).
-    configuration.setValue(setting.getKey(), setting.coerceFromAdminCommand(value));
-  }
-
-  private JSONObject getServerEvents(final String fileName) {
-    final ArcadeDBServer server = httpServer.getServer();
-    Metrics.counter("http.get-server-events").increment();
-
-    final JSONArray events = fileName.isEmpty() ?
-        server.getEventLog().getCurrentEvents() :
-        server.getEventLog().getEvents(fileName);
-    final JSONArray files = server.getEventLog().getFiles();
-
-    return new JSONObject().put("events", events).put("files", files);
-  }
-
-  private void alignDatabase(final String databaseName) {
-    if (databaseName.isEmpty())
-      throw new IllegalArgumentException("Database name empty");
-
-    final Database database = httpServer.getServer().getDatabase(databaseName);
-
-    Metrics.counter("http.align-database").increment();
-
-    try (final var rs = database.command("sql", "align database")) {
-      // align database is fire-and-forget here; close releases the ResultSet's plan state.
-    }
-  }
-
-  private ExecutionResponse getBackupConfig() {
-    Metrics.counter("http.get-backup-config").increment();
-
-    final ArcadeDBServer server = httpServer.getServer();
-    final AutoBackupSchedulerPlugin plugin = getBackupPlugin(server);
-
-    final JSONObject response = new JSONObject();
-
-    if (plugin != null && plugin.isEnabled()) {
-      response.put("enabled", true);
-      final AutoBackupConfig config = plugin.getBackupConfig();
-      response.put("config", config != null ? config.toJSON() : JSONObject.NULL);
-    } else {
-      // Plugin not enabled at startup - try to read config from file directly
-      final Path configPath = Paths.get(server.getRootPath(), "config", AutoBackupConfig.CONFIG_FILE_NAME);
-      if (Files.exists(configPath)) {
-        try {
-          final String content = Files.readString(configPath);
-          final JSONObject configJson = new JSONObject(content);
-          response.put("enabled", false); // Plugin not running, but config exists
-          response.put("config", configJson);
-          response.put("message", "Configuration saved but requires server restart to take effect");
-        } catch (final IOException e) {
-          response.put("enabled", false);
-          response.put("config", JSONObject.NULL);
-        }
-      } else {
-        response.put("enabled", false);
-        response.put("config", JSONObject.NULL);
-      }
-    }
-
-    return new ExecutionResponse(200, response.toString());
-  }
-
-  private ExecutionResponse setBackupConfig(final JSONObject payload) throws IOException {
-    Metrics.counter("http.set-backup-config").increment();
-
-    if (!payload.has("config"))
-      throw new IllegalArgumentException("Missing 'config' in payload");
-
-    final JSONObject configJson = payload.getJSONObject("config");
-
-    // Validate backup directory - must be relative path without traversal
-    if (configJson.has("backupDirectory")) {
-      final String backupDir = configJson.getString("backupDirectory");
-      validateBackupDirectory(backupDir);
-    }
-
-    final ArcadeDBServer server = httpServer.getServer();
-
-    // Save configuration to file
-    final Path configPath = Paths.get(server.getRootPath(), "config", AutoBackupConfig.CONFIG_FILE_NAME);
-
-    // Write configuration atomically so a crash mid-write leaves the previous valid file intact.
-    // atomicWriteFile also creates the parent config directory if needed.
-    FileUtils.atomicWriteFile(configPath.toFile(), configJson.toString(2));
-
-    // Reload configuration in the plugin
-    final AutoBackupSchedulerPlugin plugin = getBackupPlugin(server);
-    if (plugin != null && plugin.isEnabled())
-      plugin.reloadConfiguration();
-
-    final JSONObject response = new JSONObject().put("result", "ok");
-    return new ExecutionResponse(200, response.toString());
-  }
-
-  private void validateBackupDirectory(final String backupDir) {
-    // Use consolidated validation from AutoBackupSchedulerPlugin
-    final Path serverRoot = Paths.get(httpServer.getServer().getRootPath()).toAbsolutePath().normalize();
-    AutoBackupSchedulerPlugin.validateAndResolveBackupPath(backupDir, serverRoot);
-  }
-
-  private ExecutionResponse listBackups(final String databaseName) {
-    if (databaseName.isEmpty())
-      throw new IllegalArgumentException("Database name empty");
-
-    Metrics.counter("http.list-backups").increment();
-
-    final ArcadeDBServer server = httpServer.getServer();
-    final AutoBackupSchedulerPlugin plugin = getBackupPlugin(server);
-
-    final JSONArray backups = new JSONArray();
-
-    if (plugin != null && plugin.isEnabled()) {
-      final AutoBackupConfig config = plugin.getBackupConfig();
-      if (config != null) {
-        // Resolve backup directory
-        String backupDirectory = config.getBackupDirectory();
-        final Path backupPath = Paths.get(backupDirectory);
-        if (!backupPath.isAbsolute())
-          backupDirectory = Paths.get(server.getRootPath(), backupDirectory).toString();
-
-        final Path dbBackupDir = Paths.get(backupDirectory, databaseName);
-        if (Files.exists(dbBackupDir) && Files.isDirectory(dbBackupDir)) {
-          try (var stream = Files.list(dbBackupDir)) {
-            stream.filter(p -> p.toString().endsWith(".zip") && p.getFileName().toString().contains("-backup-"))
-                .sorted(Comparator.reverseOrder())
-                .forEach(p -> {
-                  final JSONObject backup = new JSONObject();
-                  backup.put("fileName", p.getFileName().toString());
-                  try {
-                    backup.put("size", Files.size(p));
-                    backup.put("lastModified", Files.getLastModifiedTime(p).toMillis());
-                  } catch (final IOException e) {
-                    backup.put("size", 0);
-                    backup.put("lastModified", 0);
-                  }
-
-                  // Parse timestamp from filename, through the same convention that wrote it (issue #6753)
-                  final LocalDateTime timestamp = BackupCoordinator.parseArchiveTimestamp(p.getFileName().toString());
-                  backup.put("timestamp", timestamp != null ? timestamp.toString() : JSONObject.NULL);
-
-                  backups.put(backup);
-                });
-          } catch (final IOException e) {
-            throw new RuntimeException("Error listing backups for database '" + databaseName + "'", e);
-          }
-        }
-      }
-    }
-
-    final JSONObject response = new JSONObject();
-    response.put("database", databaseName);
-    response.put("backups", backups);
-
-    // Get retention manager stats if available
-    if (plugin != null && plugin.getRetentionManager() != null) {
-      final BackupRetentionManager retentionManager = plugin.getRetentionManager();
-      response.put("totalSize", retentionManager.getBackupSizeBytes(databaseName));
-      response.put("totalCount", retentionManager.getBackupCount(databaseName));
-    }
-
-    return new ExecutionResponse(200, response.toString());
-  }
-
-  private ExecutionResponse triggerBackup(final String databaseName) {
-    if (databaseName.isEmpty())
-      throw new IllegalArgumentException("Database name empty");
-
-    Metrics.counter("http.trigger-backup").increment();
-
-    final ArcadeDBServer server = httpServer.getServer();
-
-    // This command runs the backup inline, so it is one of the entry points that can have a database being backed up
-    // at the same time as the auto-backup schedule does - down to resolving to the same archive name and writing into
-    // the same file. Refusing outright is the honest answer to "back up a database that is already being backed up":
-    // a second full backup of the same data produces nothing the first one will not, and the caller gets told rather
-    // than silently handed the other run's archive (issue #6753).
-    final BackupCoordinator coordinator = server.getBackupCoordinator();
-    if (!coordinator.begin(databaseName))
-      return new ExecutionResponse(409, new JSONObject().put("error",
-          "A backup of database '" + databaseName + "' is already in progress").toString());
-
-    try {
-      return executeImmediateBackup(server, databaseName);
-    } finally {
-      coordinator.end(databaseName);
-    }
-  }
-
-  private ExecutionResponse executeImmediateBackup(final ArcadeDBServer server, final String databaseName) {
-    final AutoBackupSchedulerPlugin plugin = getBackupPlugin(server);
-
-    // Try to get backup directory from config (plugin or file)
-    String backupDirectory = null;
-
-    if (plugin != null && plugin.isEnabled()) {
-      final AutoBackupConfig config = plugin.getBackupConfig();
-      backupDirectory = config != null ? config.getBackupDirectory() : null;
-    }
-
-    // If plugin not enabled, try to read from config file directly
-    if (backupDirectory == null) {
-      final Path configPath = Paths.get(server.getRootPath(), "config", AutoBackupConfig.CONFIG_FILE_NAME);
-      if (Files.exists(configPath)) {
-        try {
-          final String content = Files.readString(configPath);
-          final JSONObject configJson = new JSONObject(content);
-          if (configJson.has("backupDirectory"))
-            backupDirectory = configJson.getString("backupDirectory");
-        } catch (final IOException ignored) {
-        }
-      }
-    }
-
-    // Use config directory if available
-    if (backupDirectory != null) {
-      try {
-        // Validate the directory
-        validateBackupDirectory(backupDirectory);
-
-        // Resolve relative path
-        final Path backupPath = Paths.get(backupDirectory);
-        if (!backupPath.isAbsolute())
-          backupDirectory = Paths.get(server.getRootPath(), backupDirectory).toString();
-
-        // Perform backup using reflection (same as BackupTask)
-        final Database database = server.getDatabase(databaseName);
-        final Class<?> clazz = Class.forName("com.arcadedb.integration.backup.Backup");
-
-        final String backupFileName = server.getBackupCoordinator().newArchiveName(databaseName);
-
-        final Path dbBackupPath = Paths.get(backupDirectory, databaseName);
-        // Use Files.createDirectories to avoid TOCTOU race condition
-        Files.createDirectories(dbBackupPath);
-        final String dbBackupDir = dbBackupPath.toString();
-
-        final Object backup = clazz.getConstructor(Database.class, String.class)
-            .newInstance(database, backupFileName);
-        clazz.getMethod("setDirectory", String.class).invoke(backup, dbBackupDir);
-        clazz.getMethod("setVerboseLevel", Integer.TYPE).invoke(backup, 1);
-
-        final String backupFile = (String) clazz.getMethod("backupDatabase").invoke(backup);
-
-        final JSONObject response = new JSONObject();
-        response.put("result", "ok");
-        response.put("backupFile", backupFile);
-        return new ExecutionResponse(200, response.toString());
-
-      } catch (final ClassNotFoundException e) {
-        throw new RuntimeException("Backup libs not found in classpath. Make sure arcadedb-integration module is included.", e);
-      } catch (final Exception e) {
-        final Throwable cause = e.getCause() != null ? e.getCause() : e;
-        throw new RuntimeException("Error triggering backup for database '" + databaseName + "': " + cause.getMessage(), cause);
-      }
-    }
-
-    // Fallback: use SQL command (uses GlobalConfiguration.SERVER_BACKUP_DIRECTORY). This one does not name the
-    // archive through the coordinator: with no target the SQL statement lets BackupSettings apply its own default,
-    // which is the same convention down to the milliseconds - the coordinator is where that convention was copied
-    // from in the first place.
-    try {
-      final Database database = server.getDatabase(databaseName);
-      try (final var result = database.command("sql", "backup database")) {
-
-        final JSONObject response = new JSONObject();
-        response.put("result", "ok");
-        // The SQL "backup database" command sets backupFile as a property on a Result row
-        // (see BackupDatabaseStatement). Read it via Result.getProperty rather than the
-        // pre-existing dead instanceof Map check, which never matched.
-        while (result.hasNext()) {
-          final var row = result.next();
-          final Object backupFile = row.getProperty("backupFile");
-          if (backupFile != null) {
-            response.put("backupFile", backupFile.toString());
-            break;
-          }
-        }
-        return new ExecutionResponse(200, response.toString());
-      }
-    } catch (final Exception e) {
-      throw new RuntimeException("Error triggering backup for database '" + databaseName + "': " + e.getMessage(), e);
-    }
-  }
-
-  private ExecutionResponse handleProfilerCommand(final String subCommand) {
-    final ServerQueryProfiler profiler = httpServer.getServer().getQueryProfiler();
-    final String sub = subCommand.toLowerCase(Locale.ENGLISH).trim();
-
-    if ("start".equals(sub) || sub.startsWith("start ")) {
-      final String timeoutStr = sub.substring(5).trim();
-      if (!timeoutStr.isEmpty()) {
-        try {
-          profiler.start(Integer.parseInt(timeoutStr));
-        } catch (final NumberFormatException e) {
-          return new ExecutionResponse(400, "{ \"error\" : \"Invalid timeout value: " + timeoutStr + "\"}");
-        }
-      } else
-        profiler.start();
-      return new ExecutionResponse(200, new JSONObject().put("result", "ok").put("recording", true).toString());
-
-    } else if ("stop".equals(sub)) {
-      final JSONObject results = profiler.stop();
-      return new ExecutionResponse(200, results != null ? results.toString() : new JSONObject().put("result", "ok").toString());
-
-    } else if ("reset".equals(sub)) {
-      profiler.reset();
-      return new ExecutionResponse(200, new JSONObject().put("result", "ok").toString());
-
-    } else if ("results".equals(sub)) {
-      final JSONObject results = profiler.getResults();
-      return new ExecutionResponse(200, results != null ? results.toString() : new JSONObject().put("result", "ok").toString());
-
-    } else if ("list".equals(sub)) {
-      final JSONArray files = profiler.listSavedRuns();
-      return new ExecutionResponse(200, new JSONObject().put("result", files).toString());
-
-    } else if (sub.startsWith("load ")) {
-      final String fileName = sub.substring(5).trim();
-      final JSONObject run = profiler.loadSavedRun(fileName);
-      return new ExecutionResponse(200, run.toString());
-
-    } else {
-      return new ExecutionResponse(400, "{ \"error\" : \"Unknown profiler command: " + subCommand + "\"}");
-    }
-  }
-
-  private AutoBackupSchedulerPlugin getBackupPlugin(final ArcadeDBServer server) {
-    for (final ServerPlugin plugin : server.getPlugins()) {
-      if (plugin instanceof AutoBackupSchedulerPlugin)
-        return (AutoBackupSchedulerPlugin) plugin;
-    }
-    return null;
-  }
 
   /**
    * If this node is an HA replica, forwards the server command to the leader and returns its response.


### PR DESCRIPTION
Closes #7304

## Summary

`ArcadeDbAdminService` had 9 RPCs and, of those, `CreateUser`/`DeleteUser` answered `UNIMPLEMENTED` at runtime, so a gRPC-only deployment still needed the HTTP port open purely for administration - it could not take a backup, manage a user, change a setting, read the profiler, or answer a container probe. This adds 22 RPCs covering the rest of the exchange-free control plane and, rather than reimplementing what the HTTP handlers do, moves those semantics into a new `com.arcadedb.server.ServerControlPlane` that both protocols run. `PostServerCommandHandler` keeps what is genuinely HTTP - the command-string grammar, leader forwarding, the mapping onto status codes, and the three operations that stream progress over the `HttpServerExchange` - and delegates the rest; `GetReadyHandler` and `GetHealthHandler` delegate their gates too, so a node cannot be ready on one transport and not the other.

Security is the substance of the change as much as the RPCs are. Every new RPC carries the root-user gate that mirrors `checkRootUser`, asserted as a table so an RPC added without its gate is the visible omission. The four operations HTTP forwards to the leader (create/drop database, create/drop user) are refused on a follower with `FAILED_PRECONDITION` and the leader's address on the `LeaderRedirectProtocol` trailers - gRPC has no request proxy, so the caller redirects itself, which is the pattern `graphBatchLoad` already established here. `Health` and `Ready` are exempted from the admin authentication choke point, matching `isRequireAuthentication() == false` on their HTTP counterparts, because a probe that needs credentials is not one an orchestrator can use. And three pre-existing RPCs disclosed more over gRPC than over HTTP - `ListDatabases` returned every database name on the server to any authenticated caller, `GetDatabaseInfo` reported any database's schema shape and record counts, `GetServerInfo.databases_count` counted them all - which now narrow to the caller through the same `filterAuthorizedDatabases` the HTTP routes use.

## Test plan

- [ ] `mvn -o -pl grpcw verify -DskipITs=false -Dit.test='Issue7304GrpcControlPlaneIT'` - one test per control-plane group, driven through its own RPC: database lifecycle, settings (including that the strict #7124 coercion is on this transport), users with per-database grants, backup config/listing/validation, profiler round trip, server events, cluster, and the two probes.
- [ ] `mvn -o -pl grpcw verify -DskipITs=false -Dit.test='Issue7304GrpcControlPlaneAuthorizationIT'` - every control-plane RPC as a table, each asserted to deny an authenticated non-root caller with `PERMISSION_DENIED` and an invalid password with `UNAUTHENTICATED`, plus a check that the denied calls changed nothing and that only the probes answer without credentials.
- [ ] `mvn -o -pl grpcw verify -DskipITs=false -Dit.test='Issue7304GrpcAdminLeaderRoutingIT'` - a real 3-node Raft cluster: `CreateUser` and `CreateDatabase` refused on a follower with the leader named on the trailers and nothing written on any node, plus the two controls that make those refusals mean something - the same call succeeding on the leader, and a read-only RPC still answering on a follower.
- [ ] `mvn -o -pl grpc-client verify -DskipITs=false -Dit.test='Issue7304RemoteGrpcServerControlPlaneIT'` - each new `RemoteGrpcServer` method against a live server, so proto, service and client are proved to agree rather than only to compile.
- [ ] Regression net for the refactor: `mvn -o -pl server verify -DskipITs=false -DskipTests=true -Dit.test='PostServerCommandHandlerIT,Issue6875SetServerSettingHttpIT,Issue7124BooleanSettingHttpIT,BackupApiCommandsIT,BackupRestoreDeleteApiIT,Issue6753ConcurrentBackupIT,RestoreImportSecurityDurabilityIT,HealthProbesIT,UngatedHandlerCrossDatabaseIT,HTTPGraphIT,OpenApiSpecGenerationIT'` plus the full `server` and `grpcw` unit suites.

One caveat worth naming rather than leaving to be discovered: `Issue7304GrpcAdminLeaderRoutingIT` inherits `BaseRaftHATest`'s teardown, which compares every node's copy of the database after each test method. That comparison failed once, as `Types: DB1 7 <> DB2 8`, on a machine running several builds at once - a follower one schema entry behind at the moment it looked, after `waitForReplicationIsCompleted` had spent its 30 s budget. It is not an assertion this test makes, and no method here writes a type; in isolation the class passed 3 of 3 runs, and the pre-existing `Issue6183FollowerCommandRoutingIT` on the same fixture passed 3 of 3 alongside it. The class was reduced from four methods to two afterwards, which halves the number of cluster restarts (51 s to 28 s) and so the exposure, without dropping an assertion.

Note for anyone re-running the `server` HTTP tests locally: they bind port 2480, and several of them build their URLs as `localhost:2480`. On a machine where anything else is listening on `*:2480`, `localhost` resolves to `::1` and reaches that process while the test server binds `127.0.0.1:2480` beside it, so the assertions read as values that were never stored - or, in `Issue6753ConcurrentBackupIT`, as `expected 409 but was 200`, because the coordinator asked is a different process's. Pristine `main` fails the same suites the same way under that condition. Check with `lsof -nP -iTCP:2480 -sTCP:LISTEN` and `curl -o /dev/null -w '%{remote_ip}' http://localhost:2480/api/v1/server` before believing a red run.

## Coverage

Every exchange-free operation of the HTTP control plane now has a gRPC equivalent:

| Area | RPCs |
|---|---|
| Database lifecycle | `OpenDatabase`, `CloseDatabase`, `AlignDatabase` (`Create`/`Drop`/`List`/`Exists` already existed) |
| Settings | `SetServerSetting`, `SetDatabaseSetting` |
| Backup | `GetBackupConfig`, `SetBackupConfig`, `ListBackups`, `TriggerBackup`, `DeleteBackup` |
| Security | `ListUsers`, and `CreateUser`/`DeleteUser` implemented rather than `UNIMPLEMENTED` - `CreateUser` now carries per-database groups |
| Profiler | `ProfilerStart`, `ProfilerStop`, `ProfilerReset`, `ProfilerResults`, `ProfilerList`, `ProfilerLoad` |
| Server and cluster | `GetServerEvents`, `Shutdown`, `DisconnectCluster` |
| Probes | `Health`, `Ready` - unauthenticated, as their HTTP counterparts are |

**Known gaps**

| Left out | Why | Tracked by |
|---|---|---|
| `restore backup`, `restore database`, `import database` | the only control-plane operations that need the `HttpServerExchange` itself: they stream progress as SSE, so the gRPC equivalent is a server-streaming RPC with the progress reporting extracted behind a callback, which is a design of its own rather than an adapter | #7308 |
| `PUT /server/users`, `GET/POST/DELETE /server/groups`, `GET/POST/DELETE /server/api-tokens` | groups and user-update are plain adapters; API tokens are the one control-plane operation that returns secret material in a response body, and putting that on a second transport - past `GrpcLoggingInterceptor` and `GrpcMetricsInterceptor`, and with nothing today refusing to receive a minted token over a plaintext channel - is a security review of its own | #7309 |
| `GET /progress/{database}`, `GET /sessions` | progress polling has no gRPC equivalent at all; `/sessions` is a read-only view of HTTP session state that an operator driving the server over gRPC cannot see. `POST /login` and `POST /logout` are not gaps: gRPC authenticates every admin RPC from the request body and has no session to create or destroy | #7310 |
| `connect cluster` | not a gap. The HTTP implementation is a single unconditional `throw new CommandExecutionException("Connect cluster operation is not supported by the current HA implementation...")`; an RPC for it would reproduce an error, not an operation | - |

OpenAPI is unchanged on purpose: no new HTTP route is introduced, and the routes these RPCs mirror are already described. `OpenApiSpecGenerationIT` is run to prove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExK43vNXCF5WGoHu6CtDiy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded gRPC administration with database lifecycle, settings, user management, backups, profiling, server events, shutdown, and cluster operations.
  - Added gRPC health and readiness probes.
  - Added per-database user groups and access-filtered database information.
- **Security**
  - Applied consistent root-user authorization across administrative operations.
  - Health and readiness probes can be accessed without credentials.
- **Bug Fixes**
  - Improved error reporting for invalid requests, unavailable operations, backup conflicts, and leader-only actions.
  - Health and readiness responses now accurately reflect server status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->