### PR TITLE
fix(#7325): both HTTP time-series endpoints refuse an unknown aggregation type by name

### DIFF
--- a/docs/7325-http-ts-aggregation-type-guard.md
+++ b/docs/7325-http-ts-aggregation-type-guard.md
@@ -249,6 +249,29 @@ The reviewer also asked that CI be confirmed green before merge, since the two e
 That is the developer's check at merge time, and it is the reason the "not run locally" note is in the PR
 body rather than buried here.
 
+### Cycle 2 - `a542bd0`
+
+The `claude` review again traced the claims against the source and confirmed them, this time including the
+one the first review had not checked - that every *other* refusal in `PostGrafanaQueryHandler`'s target loop
+already routes through `buildErrorFrame(...)` and `continue`s, so the unguarded `valueOf` really was the only
+call in that loop that could fail the whole request. Two non-blocking notes, neither actionable:
+
+1. Confirm #7340 was actually filed before merge. Verified:
+   `gh issue view 7340` reports it OPEN - "The other required members of an HTTP time-series aggregation
+   request are refused through a JSONException production mode conceals".
+2. The `type` property description now says "Required" in prose, but neither request-body schema lists it in
+   a `required` array. The reviewer checked and reported this as a pre-existing, codebase-wide gap in how
+   request-body schemas express required fields, and called it a non-blocker. **No change**: making the
+   aggregation-request schema the one place that declares it would be inconsistent with every sibling schema,
+   and `field` - which would have to be declared required alongside `type` - is the subject of #7340.
+
+Codacy passes on this head, which confirms the diagnosis of the previous cycle: the locale-less
+`toLowerCase()` in the new test was the one issue it had added.
+
 ## Final state
 
-`clean-approval` - one review cycle, no actionable review items, no deferred items.
+`clean-approval` - two review cycles, no actionable review items in either, no deferred items. The one
+commit made in response to the loop came from a CI static-analysis finding, not from the reviewer.
+
+The two endpoint ITs still have not run anywhere but CI (see "The two endpoint ITs were not executed
+locally" above); confirming that CI is green is the check to make at merge time.

--- a/docs/7325-http-ts-aggregation-type-guard.md
+++ b/docs/7325-http-ts-aggregation-type-guard.md
@@ -211,3 +211,44 @@ What it produced:
 4. **Echoing the caller's value into an error body.** Both renderings build the body with `JSONObject`, so
    the value is escaped, and the echo is truncated to 64 characters. Not a finding, but the truncation is
    pinned by a test so it stays that way.
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/7343
+
+## Review cycles
+
+### Cycle 1 - `0360f11`
+
+The `claude` review traced the PR's claims against the code and confirmed each one (the mapper's
+`IllegalArgumentException` arm and the production concealment of `detail`, the declaration order of
+`AggregationType`, `opt` vs `getString` for the absent key, the tightly-scoped `try` blocks, the escaping of
+the echoed value). It raised three observations and marked all three explicitly non-blocking:
+
+1. `req.getString("field")` still throws unguarded, ahead of the new resolver call - the reviewer noted this
+   is scoped out and filed as #7340, and called that a reasonable boundary. **No change**: it is #7340.
+2. "is required and must be one of ..." reads oddly when a value was supplied - the reviewer wrote "not
+   asking for a change". **No change**: the wording mirrors the gRPC message the issue quotes, and the
+   `: received '<value>'` clause separates the two cases.
+3. `unknownAggregationType` passes a `null` cause when the field is absent - "harmless ... not worth a
+   change". **No change**: `IllegalArgumentException(message, null)` is equivalent to the single-argument
+   constructor, and one call site keeps the real cause.
+
+Nothing in the review was actionable, so no code changed in response to it. What did change in the follow-up
+commit came from CI rather than from the review:
+
+- **Codacy Static Code Analysis** reported `Issues Added 1` on this head. Scanning the added lines for the
+  patterns Codacy's Java rule set flags found exactly one candidate,
+  `expected.name().toLowerCase()` in the new unit test - a locale-less case conversion
+  (`UseLocaleWithCaseConversions`). Fixed to `toLowerCase(Locale.ENGLISH)`, matching the
+  `toUpperCase(Locale.ENGLISH)` the resolver itself already used.
+- `MAX_ECHOED_VALUE_LENGTH` was declared between the private constructor and the first method; moved to the
+  top of the class, where a field declaration belongs.
+
+The reviewer also asked that CI be confirmed green before merge, since the two endpoint ITs run only there.
+That is the developer's check at merge time, and it is the reason the "not run locally" note is in the PR
+body rather than buried here.
+
+## Final state
+
+`clean-approval` - one review cycle, no actionable review items, no deferred items.

--- a/docs/7325-http-ts-aggregation-type-guard.md
+++ b/docs/7325-http-ts-aggregation-type-guard.md
@@ -1,0 +1,213 @@
+# Issue #7325 - HTTP time-series aggregation rejects an unknown `type` with an unguarded `IllegalArgumentException`
+
+## Problem
+
+Both HTTP aggregation paths read the aggregation function straight off the request payload:
+
+```java
+// server/.../PostTimeSeriesQueryHandler.java:199
+final AggregationType aggType = AggregationType.valueOf(req.getString("type"));
+
+// server/.../PostGrafanaQueryHandler.java:199
+final AggregationType aggType = AggregationType.valueOf(reqJson.getString("type"));
+```
+
+`AggregationType.valueOf` accepts only the exact enum spellings `SUM`, `AVG`, `MIN`, `MAX`, `COUNT`.
+Anything else - a lower-cased `avg`, a typo, a Grafana panel built by hand - throws, and the throw
+leaves the handler for the generic error mapper in `AbstractServerHttpHandler`.
+
+Two consequences, both verified by reading the mapper:
+
+1. **The message is useless outside development.** The `IllegalArgumentException` arm
+   (`AbstractServerHttpHandler:824-828`) answers `400 "Cannot execute command"` and puts the JVM's own
+   `No enum constant com.arcadedb.engine.timeseries.AggregationType.avg` into the `detail` field. But
+   `buildErrorBody` conceals `detail` whenever the server is in production mode, so a production caller
+   receives `{"error":"Cannot execute command","exception":"java.lang.IllegalArgumentException"}` - the
+   field that was wrong is not named and the accepted values are not listed. Every other refusal in the
+   same handler (`Type 'x' does not exist`, `Field 'x' not found in type`) is an explicit
+   `ExecutionResponse(400, ...)` whose text survives production mode.
+2. **On the Grafana endpoint it fails the whole request, not the target.** `PostGrafanaQueryHandler`
+   answers per-target problems with an error *frame* keyed by `refId`, and keeps serving the other
+   targets. The unguarded `valueOf` is the one refusal in that loop that escapes it, so one mistyped
+   aggregation in panel B also blanks panels A and C.
+
+The gRPC twin proposed in #7305 (PR #7323, still open at the time of writing - the class does not exist
+on `main`) answers this cleanly with `INVALID_ARGUMENT` and a message that lists the accepted values.
+
+## Invariant the fix establishes
+
+An aggregation `type` that no `AggregationType` matches is refused with a message that names the field
+and lists the accepted values, rendered on the surface that endpoint answers errors on - a `400` body
+for `/ts/{db}/query`, a per-target error frame for `/ts/{db}/grafana/query` - and the message survives
+production mode.
+
+## Completeness
+
+### Entry points reached by grep, not by memory
+
+Every value of `AggregationType` that comes from a request payload:
+
+```
+$ grep -rn "AggregationType\.valueOf" --include="*.java" .
+./server/src/main/java/com/arcadedb/server/http/handler/PostGrafanaQueryHandler.java:199
+./server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java:199
+```
+
+Same-shape sibling sweep - an `Enum.valueOf` applied to a value taken off the request payload, anywhere
+in the HTTP handler package:
+
+```
+$ grep -rn "\.valueOf(.*getString\|\.valueOf(.*get(" --include="*.java" \
+    server/src/main/java/com/arcadedb/server/http/handler/
+server/src/main/java/com/arcadedb/server/http/handler/PostGrafanaQueryHandler.java:199
+server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java:199
+```
+
+Two hits, both the ones this issue names.
+
+Every reader of `AggregationType` in main source, to find a path that could resolve one another way:
+
+```
+$ grep -rln "AggregationType" --include="*.java" . | grep "/src/main/"
+server/src/main/java/com/arcadedb/server/http/handler/PostGrafanaQueryHandler.java
+server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
+server/src/main/java/com/arcadedb/server/http/handler/GetGrafanaMetadataHandler.java
+engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+engine/src/main/java/com/arcadedb/engine/timeseries/{AggregationType,AggregationResult,
+  MultiColumnAggregationRequest,MultiColumnAggregationResult,TimeSeriesEngine,TimeSeriesSealedStore}.java
+```
+
+Every reader of the `aggregation` payload object:
+
+```
+$ grep -rn '"aggregation"' --include="*.java" server/src/main/java
+PostGrafanaQueryHandler.java:119, 183
+PostTimeSeriesQueryHandler.java:108, 189
+(+ the two OpenAPI spec builders, which describe the field rather than read it)
+```
+
+### Coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| `POST /api/v1/ts/{db}/query`, `aggregation.requests[].type` -> `PostTimeSeriesQueryHandler:199` | yes | yes - `aggregationRejectsUnknownTypeWithANamedError`, `aggregationTypeIsCaseInsensitive`, `aggregationTypeIsRequired` |
+| `POST /api/v1/ts/{db}/grafana/query`, `targets[].aggregation.requests[].type` -> `PostGrafanaQueryHandler:199` | yes | yes - `grafanaAggregationRejectsUnknownTypeAsAnErrorFrame`, `grafanaAggregationTypeIsCaseInsensitive` |
+| SQL push-down, `SelectExecutionPlanner:3087` | no - argued | n/a |
+| `GET /api/v1/ts/{db}/grafana/metadata` -> `GetGrafanaMetadataHandler:95` | no - argued | n/a |
+| gRPC `TimeSeriesAggregationRequest.type` | no - argued | n/a |
+
+**Argued rows, with the evidence:**
+
+- **SQL push-down.** `SelectExecutionPlanner:3087-3096` is a `switch` over the lower-cased SQL function
+  name with `default -> null`, and `if (aggType == null) return false;` on the next line - an unknown
+  function simply declines the push-down and the query runs through the normal execution path. No
+  exception, nothing to guard.
+- **Grafana metadata endpoint.** `GetGrafanaMetadataHandler:95` iterates `AggregationType.values()` to
+  *publish* the accepted names. It reads nothing off the request, so it cannot carry a bad one.
+- **gRPC.** `grep -rn "TS_AGG_UNSPECIFIED" --include="*.java" .` returns nothing and
+  `find . -name "GrpcTimeSeriesSupport.java"` finds no file: the class the issue quotes lives on PR
+  #7323, which `gh pr view 7323` reports as `OPEN`. There is no gRPC time-series aggregation path on
+  `main` to fix, and the fix here does not touch `grpcw`.
+
+### Residual risk
+
+Neither handler validates the *other* required members of an aggregation request - `bucketInterval`,
+`requests`, `field` - beyond what `JSONObject` itself throws, so a payload missing `field` still leaves
+through `JSONException` and answers `400 "Invalid JSON payload"` with the specifics concealed in
+production. That is a different defect (missing-required-property reporting, shared by every endpoint
+that reads a payload) rather than the same one at another entry point, and it is deliberately not
+widened into here. The two `Enum.valueOf`-on-payload sites the sweep found are both fixed.
+
+## Decision: the resolver accepts a case-insensitive name
+
+The issue names a lower-cased `avg` as "what a hand-written client is most likely to send". Answering it
+with a better-worded refusal still refuses it, so the resolver upper-cases and trims before matching.
+This is a strict superset of what was accepted before, so no request that worked stops working, and it
+matches the SQL push-down path, which has always matched the same five functions case-insensitively
+(`funcName.toLowerCase()` at `SelectExecutionPlanner:3086`). The OpenAPI description and the
+`grafana/metadata` endpoint keep advertising the canonical upper-case spellings.
+
+## Changes
+
+- `TimeSeriesHandlerUtils.resolveAggregationType(JSONObject, int)` - new shared resolver. Trims and
+  upper-cases before matching, and throws an `IllegalArgumentException` whose message names
+  `aggregation.requests[<i>].type`, lists the accepted values built from `AggregationType.values()`, and
+  echoes the received value truncated to 64 characters. It signals with an exception rather than choosing
+  a rendering, because the two endpoints render errors differently.
+- `PostTimeSeriesQueryHandler` - catches it and answers `new ExecutionResponse(400, {"error": ...})`, the
+  same shape as the `Type '...' does not exist` and `Field '...' not found in type` refusals beside it, so
+  the text survives production mode.
+- `PostGrafanaQueryHandler` - catches it and answers `buildErrorFrame(...)` for that target, so the other
+  targets in the request are still served.
+- `TimeSeriesApiSpec` / `GrafanaApiSpec` - the `type` property description now states that the field is
+  required, lists the five values, and says the match is case-insensitive; the Grafana one also states
+  that a bad value is reported as an error frame on that target.
+
+## Reachability
+
+```
+$ grep -rn "PostTimeSeriesQueryHandler\|PostGrafanaQueryHandler" --include="*.java" server/src/main/java
+server/src/main/java/com/arcadedb/server/http/HttpServer.java:254  .post("/ts/{database}/query", new PostTimeSeriesQueryHandler(this))
+server/src/main/java/com/arcadedb/server/http/HttpServer.java:258  .post("/ts/{database}/grafana/query", new PostGrafanaQueryHandler(this))
+```
+
+Both handlers are constructed unconditionally and bound to live routes; no flag gates either one.
+
+## Test results
+
+`mvn -o -pl server test -Dtest='Issue7325AggregationTypeResolverTest,TimeSeriesApiSpecTest,GrafanaApiSpecTest,OpenApiSpecGeneratorTest'`
+
+```
+Tests run: 27, Failures: 0, Errors: 0, Skipped: 0
+BUILD SUCCESS
+```
+
+The new tests were proved able to fail: with the resolver mutated to drop the upper-casing and to drop the
+field name from the message, the same run reported `Tests run: 6, Failures: 2, Errors: 1` - the
+case-insensitivity test errored with `bad type: SUM, AVG, MIN, MAX, COUNT: received 'sum'` and the two
+message tests failed. The mutation was reverted and the suite is green again.
+
+### The two endpoint ITs were not executed locally
+
+`TimeSeriesQueryHandlerIT` and `GrafanaTimeSeriesHandlerIT` extend `BaseGraphServerTest`, whose HTTP
+requests are addressed to a hard-coded `127.0.0.1:248<serverIndex>`. On this machine ports 2480 and 2481
+were already held:
+
+```
+$ lsof -nP -iTCP:2480 -sTCP:LISTEN
+java  93797  ... TCP *:2480 (LISTEN)   # com.arcadedb.server.ArcadeDBServer, homebrew 26.9.1, up 5 days
+$ lsof -nP -iTCP:2481 -sTCP:LISTEN
+java  45616  ... TCP *:2481 (LISTEN)
+```
+
+`SERVER_HTTP_INCOMING_PORT` defaults to the range `2480-2489`, so a test server started here binds 2482
+while the test still addresses 2480 - the requests would reach the long-running server instead, fail
+authentication, and count against its brute-force lockout. The ITs were therefore compiled but not run
+locally (`mvn -o -pl server test` compiles the full test tree, which is what proved they compile); they
+run in CI, where the ports are free. The resolver unit test covers the shared logic without a server.
+
+## Adversarial pass
+
+The orchestrator's Phase 1.5 spawns a subagent that has not seen this document. No `Task` tool was
+available in this session, so the pass was run against the diff directly rather than by a second agent -
+which is weaker, because the reader had already been convinced. Recorded here rather than skipped.
+
+What it produced:
+
+1. **The residual-risk paragraph deserves an issue, not just a paragraph.** `bucketInterval`, `requests`
+   and `field` are read with bare `JSONObject` getters, whose `JSONException` the mapper answers as
+   `400 "Invalid JSON payload"` with the specifics in the concealed `detail` field - and on the Grafana
+   endpoint that throw escapes the per-target loop, which is exactly the second half of what this PR fixes
+   for `type`. Verified by reading `JSONObject.getNotNullElement:728` and the mapper's `JSONException` arm
+   at `AbstractServerHttpHandler:818-823`. **Filed as #7340**, out of scope here.
+2. **The Grafana endpoint's status for a bad aggregation type changes from 400 to 200-with-an-error-frame.**
+   Real, intended, and what the issue asked for ("its half needs to route through that instead of a plain
+   400"). Checked that no existing test pins the old status: the only `postGrafanaQueryRaw(...) == 400`
+   assertion in `GrafanaTimeSeriesHandlerIT` is `missingTargets`, which this does not touch, and
+   `grep -rn "Cannot execute command" server/src/test/.../{TimeSeries,Grafana}*IT.java` returns nothing.
+3. **"is required and must be one of ..." reads oddly when a value WAS supplied.** Not real enough to
+   change: the wording deliberately mirrors the gRPC message the issue quotes, and the trailing
+   `: received '<value>'` clause disambiguates the two cases.
+4. **Echoing the caller's value into an error body.** Both renderings build the body with `JSONObject`, so
+   the value is escaped, and the echo is truncated to 64 characters. Not a finding, but the truncation is
+   pinned by a test so it stays that way.

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostGrafanaQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostGrafanaQueryHandler.java
@@ -196,7 +196,15 @@ public class PostGrafanaQueryHandler extends AbstractServerHttpHandler {
     for (int i = 0; i < requestsJson.length(); i++) {
       final JSONObject req = requestsJson.getJSONObject(i);
       final String fieldName = req.getString("field");
-      final AggregationType aggType = AggregationType.valueOf(req.getString("type"));
+      final AggregationType aggType;
+      try {
+        aggType = TimeSeriesHandlerUtils.resolveAggregationType(req, i);
+      } catch (final IllegalArgumentException e) {
+        // An error frame, like every other per-target refusal here: this used to be the one that escaped the
+        // target loop, so a mistyped aggregation on one panel failed the whole request and blanked the panels
+        // that were fine (issue #7325).
+        return buildErrorFrame(e.getMessage());
+      }
       final String alias = req.getString("alias", fieldName + "_" + aggType.name().toLowerCase());
 
       final int colIndex = TimeSeriesHandlerUtils.findColumnIndex(fieldName, columns);

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
@@ -196,7 +196,16 @@ public class PostTimeSeriesQueryHandler extends AbstractServerHttpHandler {
     for (int i = 0; i < requestsJson.length(); i++) {
       final JSONObject req = requestsJson.getJSONObject(i);
       final String fieldName = req.getString("field");
-      final AggregationType aggType = AggregationType.valueOf(req.getString("type"));
+      final AggregationType aggType;
+      try {
+        aggType = TimeSeriesHandlerUtils.resolveAggregationType(req, i);
+      } catch (final IllegalArgumentException e) {
+        // An explicit 400 rather than the throw the generic mapper would turn into "Cannot execute command":
+        // that mapper puts the specifics in the 'detail' field, which buildErrorBody conceals in production
+        // mode, so the caller would be told nothing about which field was wrong (issue #7325). This is the same
+        // shape as the "Field '...' not found in type" refusal below.
+        return new ExecutionResponse(400, new JSONObject().put("error", e.getMessage()).toString());
+      }
       final String alias = req.getString("alias", fieldName + "_" + aggType.name().toLowerCase());
 
       // Find column index by name

--- a/server/src/main/java/com/arcadedb/server/http/handler/TimeSeriesHandlerUtils.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/TimeSeriesHandlerUtils.java
@@ -34,14 +34,14 @@ import java.util.StringJoiner;
  */
 final class TimeSeriesHandlerUtils {
 
-  private TimeSeriesHandlerUtils() {
-  }
-
   /**
    * Longest caller-supplied value echoed back in the refusal below. The payload is already bounded by the HTTP
    * body-size limit, so this only keeps a long-but-legal string out of an error body that exists to be read.
    */
   private static final int MAX_ECHOED_VALUE_LENGTH = 64;
+
+  private TimeSeriesHandlerUtils() {
+  }
 
   /**
    * Resolves the aggregation function named by one {@code aggregation.requests[]} entry, matching the

--- a/server/src/main/java/com/arcadedb/server/http/handler/TimeSeriesHandlerUtils.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/TimeSeriesHandlerUtils.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.http.handler;
 
+import com.arcadedb.engine.timeseries.AggregationType;
 import com.arcadedb.engine.timeseries.ColumnDefinition;
 import com.arcadedb.engine.timeseries.TagFilter;
 import com.arcadedb.serializer.json.JSONArray;
@@ -25,6 +26,8 @@ import com.arcadedb.serializer.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.StringJoiner;
 
 /**
  * Shared utilities for TimeSeries HTTP handlers.
@@ -32,6 +35,68 @@ import java.util.List;
 final class TimeSeriesHandlerUtils {
 
   private TimeSeriesHandlerUtils() {
+  }
+
+  /**
+   * Longest caller-supplied value echoed back in the refusal below. The payload is already bounded by the HTTP
+   * body-size limit, so this only keeps a long-but-legal string out of an error body that exists to be read.
+   */
+  private static final int MAX_ECHOED_VALUE_LENGTH = 64;
+
+  /**
+   * Resolves the aggregation function named by one {@code aggregation.requests[]} entry, matching the
+   * {@link AggregationType} names case-insensitively after trimming.
+   * <p>
+   * Both time-series HTTP endpoints route through this so the same bad request gets the same answer on either.
+   * It exists because {@code AggregationType.valueOf} is exact: a lower-cased {@code avg} - the spelling a
+   * hand-written client is most likely to send - used to throw an {@link IllegalArgumentException} the generic
+   * handler mapper renders as "Cannot execute command", with the JVM's own "No enum constant ..." text in the
+   * {@code detail} field that {@code buildErrorBody} conceals in production mode. Accepting the lower-cased
+   * spelling only widens what is accepted, so no request that used to work stops working, and it matches the SQL
+   * push-down planner, which has always matched the same five functions on a lower-cased function name.
+   * <p>
+   * The message is built from {@link AggregationType#values()} rather than a literal list so a new constant cannot
+   * leave it stale. The caller renders it on whatever surface that endpoint answers errors on - a 400 body or a
+   * Grafana error frame - which is why this signals with an exception rather than choosing one itself.
+   *
+   * @param request the aggregation request object, expected to carry a {@code type} member
+   * @param index   position of this entry in {@code aggregation.requests}, used to name the field in the message
+   *
+   * @throws IllegalArgumentException if {@code type} is absent, null, not a string, or matches no aggregation type
+   */
+  static AggregationType resolveAggregationType(final JSONObject request, final int index) {
+    final Object rawType = request.opt("type");
+    if (rawType instanceof String name) {
+      final String trimmed = name.trim();
+      if (!trimmed.isEmpty()) {
+        try {
+          return AggregationType.valueOf(trimmed.toUpperCase(Locale.ENGLISH));
+        } catch (final IllegalArgumentException e) {
+          throw unknownAggregationType(index, rawType, e);
+        }
+      }
+    }
+    throw unknownAggregationType(index, rawType, null);
+  }
+
+  /**
+   * Refusal of an aggregation function name, worded identically on both time-series HTTP endpoints so the two
+   * surfaces report the same thing. Names the field, lists every accepted value, and echoes what arrived.
+   */
+  private static IllegalArgumentException unknownAggregationType(final int index, final Object rawType,
+      final Throwable cause) {
+    final StringJoiner accepted = new StringJoiner(", ");
+    for (final AggregationType type : AggregationType.values())
+      accepted.add(type.name());
+
+    return new IllegalArgumentException(
+        "'aggregation.requests[" + index + "].type' is required and must be one of " + accepted
+            + (rawType == null ? "" : ": received '" + truncate(String.valueOf(rawType)) + "'"), cause);
+  }
+
+  private static String truncate(final String value) {
+    return value.length() <= MAX_ECHOED_VALUE_LENGTH ? value
+        : value.substring(0, MAX_ECHOED_VALUE_LENGTH) + "...";
   }
 
   static TagFilter buildTagFilter(final JSONObject tagsJson, final List<ColumnDefinition> columns) {

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/GrafanaApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/GrafanaApiSpec.java
@@ -124,7 +124,10 @@ public class GrafanaApiSpec implements OpenApiContributor {
   private Schema<?> createQueryRequestSchema() {
     final Schema<Object> aggregationRequest = SpecBuilders.object("One aggregation to compute");
     aggregationRequest.addProperty("field", SpecBuilders.string("Field name to aggregate"));
-    aggregationRequest.addProperty("type", SpecBuilders.string("Aggregation function"));
+    aggregationRequest.addProperty("type", SpecBuilders.string(
+        "Aggregation function. Required, one of SUM, AVG, MIN, MAX, COUNT, matched case-insensitively. "
+            + "A value that matches none is reported as an error frame on this target, leaving the other "
+            + "targets served."));
     aggregationRequest.addProperty("alias", SpecBuilders.string(
         "Output field name. Defaults to the field name suffixed with the lower-cased aggregation type."));
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/TimeSeriesApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/TimeSeriesApiSpec.java
@@ -149,7 +149,7 @@ public class TimeSeriesApiSpec implements OpenApiContributor {
     final Schema<Object> request = SpecBuilders.object("One aggregation to compute over a bucket");
     request.addProperty("field", SpecBuilders.string("Field name to aggregate"));
     request.addProperty("type", SpecBuilders.string(
-        "Aggregation function, for example AVG, SUM, MIN, MAX, COUNT"));
+        "Aggregation function. Required, one of SUM, AVG, MIN, MAX, COUNT, matched case-insensitively."));
     request.addProperty("alias", SpecBuilders.string(
         "Output name. Defaults to the field name suffixed with the lower-cased aggregation type."));
 

--- a/server/src/test/java/com/arcadedb/server/GrafanaTimeSeriesHandlerIT.java
+++ b/server/src/test/java/com/arcadedb/server/GrafanaTimeSeriesHandlerIT.java
@@ -292,6 +292,91 @@ class GrafanaTimeSeriesHandlerIT extends BaseGraphServerTest {
     });
   }
 
+  /**
+   * Issue #7325: this endpoint answers a per-target problem with an error frame keyed by refId and keeps serving
+   * the other targets. The unguarded {@code AggregationType.valueOf} was the one refusal in that loop that escaped
+   * it: a mistyped aggregation on one panel failed the whole request, blanking the panels that were fine.
+   */
+  @Test
+  void grafanaAggregationRejectsUnknownTypeAsAnErrorFrame() throws Exception {
+    testEachServer(serverIndex -> {
+      createTypeAndIngestData(serverIndex);
+
+      final JSONArray targets = new JSONArray();
+      targets.put(aggregationTarget("A", "MEDIAN"));
+      targets.put(aggregationTarget("B", "AVG"));
+
+      final JSONObject request = new JSONObject();
+      request.put("from", 1000L);
+      request.put("to", 3000L);
+      request.put("targets", targets);
+
+      final JSONObject results = postGrafanaQuery(serverIndex, request).getJSONObject("results");
+
+      final JSONObject refA = results.getJSONObject("A");
+      assertThat(refA.getString("error"))
+          .as("must name the field that was wrong and every value it accepts")
+          .contains("aggregation.requests[0].type")
+          .contains("SUM", "AVG", "MIN", "MAX", "COUNT")
+          .contains("MEDIAN");
+      assertThat(refA.getJSONArray("frames").length()).isEqualTo(0);
+
+      assertThat(results.getJSONObject("B").getJSONArray("frames").length())
+          .as("a bad aggregation on one target must not blank the targets that were fine")
+          .isEqualTo(1);
+    });
+  }
+
+  /**
+   * Issue #7325: the lower-cased spelling a hand-written Grafana panel is most likely to send now resolves.
+   */
+  @Test
+  void grafanaAggregationTypeIsCaseInsensitive() throws Exception {
+    testEachServer(serverIndex -> {
+      createTypeAndIngestData(serverIndex);
+
+      final JSONArray targets = new JSONArray();
+      targets.put(aggregationTarget("A", "avg"));
+
+      final JSONObject request = new JSONObject();
+      request.put("from", 1000L);
+      request.put("to", 3000L);
+      request.put("targets", targets);
+
+      final JSONObject refA = postGrafanaQuery(serverIndex, request).getJSONObject("results").getJSONObject("A");
+      assertThat(refA.has("error")).isFalse();
+
+      final JSONArray fields = refA.getJSONArray("frames").getJSONObject(0).getJSONObject("schema")
+          .getJSONArray("fields");
+      assertThat(fields.length()).isEqualTo(2);
+      assertThat(fields.getJSONObject(1).getString("name"))
+          .as("alias defaults to the field name plus the canonical lower-cased function name")
+          .isEqualTo("temperature_avg");
+    });
+  }
+
+  /**
+   * Builds a target that aggregates the ingested "weather" type with the given function name.
+   */
+  private static JSONObject aggregationTarget(final String refId, final String aggregationType) {
+    final JSONObject aggRequest = new JSONObject();
+    aggRequest.put("field", "temperature");
+    aggRequest.put("type", aggregationType);
+
+    final JSONArray requests = new JSONArray();
+    requests.put(aggRequest);
+
+    final JSONObject aggregation = new JSONObject();
+    aggregation.put("bucketInterval", 5000L);
+    aggregation.put("requests", requests);
+
+    final JSONObject target = new JSONObject();
+    target.put("refId", refId);
+    target.put("type", "weather");
+    target.put("aggregation", aggregation);
+    return target;
+  }
+
   // --- helper methods ---
 
   private void createTypeAndIngestData(final int serverIndex) throws Exception {

--- a/server/src/test/java/com/arcadedb/server/TimeSeriesQueryHandlerIT.java
+++ b/server/src/test/java/com/arcadedb/server/TimeSeriesQueryHandlerIT.java
@@ -138,6 +138,88 @@ class TimeSeriesQueryHandlerIT extends BaseGraphServerTest {
     });
   }
 
+  /**
+   * Issue #7325: an aggregation function the server does not know must be refused with a message that names the
+   * field and lists the accepted values. It used to reach {@code AggregationType.valueOf} unguarded, whose
+   * {@code IllegalArgumentException} the generic mapper answers as "Cannot execute command" with the specifics in
+   * the {@code detail} field - and {@code detail} is concealed whenever the server runs in production mode, so the
+   * caller was left with no way to tell which field was wrong.
+   */
+  @Test
+  void aggregationRejectsUnknownTypeWithANamedError() throws Exception {
+    testEachServer(serverIndex -> {
+      createTypeAndIngestData(serverIndex);
+
+      final JSONObject error = postTsQueryError(serverIndex, aggregationRequest("MEDIAN"));
+
+      assertThat(error.getString("error"))
+          .as("must name the field that was wrong and every value it accepts")
+          .contains("aggregation.requests[0].type")
+          .contains("SUM", "AVG", "MIN", "MAX", "COUNT")
+          .contains("MEDIAN");
+    });
+  }
+
+  /**
+   * Issue #7325: a missing aggregation function is the same client error as an unknown one and gets the same
+   * answer, instead of the JSONException the raw {@code getString} used to throw.
+   */
+  @Test
+  void aggregationTypeIsRequired() throws Exception {
+    testEachServer(serverIndex -> {
+      createTypeAndIngestData(serverIndex);
+
+      final JSONObject error = postTsQueryError(serverIndex, aggregationRequest(null));
+
+      assertThat(error.getString("error"))
+          .contains("aggregation.requests[0].type")
+          .contains("SUM", "AVG", "MIN", "MAX", "COUNT");
+    });
+  }
+
+  /**
+   * Issue #7325: the lower-cased spelling a hand-written client is most likely to send now resolves instead of
+   * being refused, and the default alias is unchanged by which spelling arrived.
+   */
+  @Test
+  void aggregationTypeIsCaseInsensitive() throws Exception {
+    testEachServer(serverIndex -> {
+      createTypeAndIngestData(serverIndex);
+
+      for (final String spelling : new String[] { "avg", " Avg ", "AVG" }) {
+        final JSONObject result = postTsQuery(serverIndex, aggregationRequest(spelling));
+
+        assertThat(result.getJSONArray("aggregations").getString(0))
+            .as("alias defaults to the field name plus the canonical lower-cased function name")
+            .isEqualTo("temperature_avg");
+        assertThat(result.getJSONArray("buckets").length()).isGreaterThan(0);
+      }
+    });
+  }
+
+  /**
+   * Builds a bucketed aggregation over the ingested "weather" type whose single request carries the given
+   * function name, or no "type" member at all when it is null.
+   */
+  private static JSONObject aggregationRequest(final String aggregationType) {
+    final JSONObject aggRequest = new JSONObject();
+    aggRequest.put("field", "temperature");
+    if (aggregationType != null)
+      aggRequest.put("type", aggregationType);
+
+    final JSONArray requests = new JSONArray();
+    requests.put(aggRequest);
+
+    final JSONObject aggregation = new JSONObject();
+    aggregation.put("bucketInterval", 5000L);
+    aggregation.put("requests", requests);
+
+    final JSONObject request = new JSONObject();
+    request.put("type", "weather");
+    request.put("aggregation", aggregation);
+    return request;
+  }
+
   @Test
   void queryWithTagFilter() throws Exception {
     testEachServer(serverIndex -> {

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue7325AggregationTypeResolverTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue7325AggregationTypeResolverTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.engine.timeseries.AggregationType;
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7325: the aggregation function both time-series HTTP endpoints read off the request used to reach
+ * {@code AggregationType.valueOf} unguarded. This pins the shared resolver that replaced it - the resolver is what
+ * makes the two endpoints answer the same bad request the same way, so its behaviour is tested once here and the
+ * endpoint-specific rendering (a 400 body, a Grafana error frame) in the two handler ITs.
+ */
+class Issue7325AggregationTypeResolverTest {
+
+  @Test
+  void resolvesEveryDeclaredAggregationTypeByItsCanonicalName() {
+    for (final AggregationType expected : AggregationType.values())
+      assertThat(TimeSeriesHandlerUtils.resolveAggregationType(request(expected.name()), 0)).isEqualTo(expected);
+  }
+
+  @Test
+  void resolvesTheLowerCasedAndPaddedSpellingsAHandWrittenClientSends() {
+    for (final AggregationType expected : AggregationType.values()) {
+      assertThat(TimeSeriesHandlerUtils.resolveAggregationType(request(expected.name().toLowerCase()), 0))
+          .isEqualTo(expected);
+      assertThat(TimeSeriesHandlerUtils.resolveAggregationType(request("  " + expected.name() + "  "), 0))
+          .isEqualTo(expected);
+    }
+  }
+
+  @Test
+  void refusesAnUnknownNameNamingTheFieldAndEveryAcceptedValue() {
+    assertThatThrownBy(() -> TimeSeriesHandlerUtils.resolveAggregationType(request("MEDIAN"), 2))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("aggregation.requests[2].type")
+        .hasMessageContaining("SUM, AVG, MIN, MAX, COUNT")
+        .hasMessageContaining("MEDIAN");
+  }
+
+  /**
+   * The accepted values are listed from {@link AggregationType#values()} so a constant added later cannot leave the
+   * message advertising a stale set.
+   */
+  @Test
+  void listsEveryDeclaredAggregationTypeInTheRefusal() {
+    assertThatThrownBy(() -> TimeSeriesHandlerUtils.resolveAggregationType(request("nope"), 0))
+        .satisfies(e -> {
+          for (final AggregationType type : AggregationType.values())
+            assertThat(e).hasMessageContaining(type.name());
+        });
+  }
+
+  @Test
+  void refusesAnAbsentNullBlankOrNonStringTypeTheSameWay() {
+    final JSONObject absent = new JSONObject();
+    absent.put("field", "temperature");
+
+    final JSONObject blank = request("   ");
+
+    final JSONObject nonString = new JSONObject();
+    nonString.put("field", "temperature");
+    nonString.put("type", 7);
+
+    for (final JSONObject request : new JSONObject[] { absent, blank, nonString })
+      assertThatThrownBy(() -> TimeSeriesHandlerUtils.resolveAggregationType(request, 0))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("aggregation.requests[0].type")
+          .hasMessageContaining("is required");
+  }
+
+  /**
+   * The refusal echoes what arrived so the caller can see which of its requests was wrong, but a legal-yet-long
+   * value must not turn the error body into a copy of the request.
+   */
+  @Test
+  void truncatesAnOverlongEchoedValue() {
+    final String overlong = "X".repeat(500);
+
+    assertThatThrownBy(() -> TimeSeriesHandlerUtils.resolveAggregationType(request(overlong), 0))
+        .satisfies(e -> {
+          assertThat(e.getMessage()).contains("...");
+          assertThat(e.getMessage().length()).isLessThan(200);
+        });
+  }
+
+  private static JSONObject request(final String type) {
+    final JSONObject request = new JSONObject();
+    request.put("field", "temperature");
+    request.put("type", type);
+    return request;
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue7325AggregationTypeResolverTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue7325AggregationTypeResolverTest.java
@@ -22,6 +22,8 @@ import com.arcadedb.engine.timeseries.AggregationType;
 import com.arcadedb.serializer.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -42,7 +44,7 @@ class Issue7325AggregationTypeResolverTest {
   @Test
   void resolvesTheLowerCasedAndPaddedSpellingsAHandWrittenClientSends() {
     for (final AggregationType expected : AggregationType.values()) {
-      assertThat(TimeSeriesHandlerUtils.resolveAggregationType(request(expected.name().toLowerCase()), 0))
+      assertThat(TimeSeriesHandlerUtils.resolveAggregationType(request(expected.name().toLowerCase(Locale.ENGLISH)), 0))
           .isEqualTo(expected);
       assertThat(TimeSeriesHandlerUtils.resolveAggregationType(request("  " + expected.name() + "  "), 0))
           .isEqualTo(expected);


### PR DESCRIPTION
Closes #7325

Both HTTP time-series aggregation paths read the aggregation function straight off the request with `AggregationType.valueOf`, which accepts only the exact enum spellings. Anything else - a lower-cased `avg` above all, which is what a hand-written client sends - threw, and the throw left the handler for the generic mapper in `AbstractServerHttpHandler`: its `IllegalArgumentException` arm answers `400 "Cannot execute command"` and puts the JVM's own `No enum constant com.arcadedb.engine.timeseries.AggregationType.avg` into the `detail` field, which `buildErrorBody` conceals whenever the server runs in production mode - so a production caller was told neither which field was wrong nor what the endpoint accepts. On the Grafana endpoint there was a second half to it: that handler answers a per-target problem with an error frame keyed by `refId` and keeps serving the other targets, and the unguarded `valueOf` was the one refusal in that loop that escaped it, so a mistyped aggregation on one panel failed the whole request. A new shared `TimeSeriesHandlerUtils.resolveAggregationType` now matches the `AggregationType` names case-insensitively after trimming, and signals a value that matches none with a message naming `aggregation.requests[<i>].type`, listing the accepted values built from `AggregationType.values()` so a constant added later cannot leave it stale, and echoing what arrived truncated to 64 characters; it throws rather than choosing a rendering, because the query endpoint answers an explicit 400 body (the same shape as the `Type '...' does not exist` refusal beside it, which survives production mode) while the Grafana endpoint answers an error frame on that target. Accepting the lower-cased spelling only widens what is accepted, so no request that used to work stops working, and it matches the SQL push-down planner, which has always matched the same five functions on a lower-cased function name.

## Test plan

- [ ] `mvn -o -pl server -am test -Dtest='Issue7325AggregationTypeResolverTest,TimeSeriesApiSpecTest,GrafanaApiSpecTest,OpenApiSpecGeneratorTest'` - 27 tests, green locally.
- [ ] `mvn -o -pl server -am verify -Dit.test='TimeSeriesQueryHandlerIT,GrafanaTimeSeriesHandlerIT'` - **not run locally**: these extend `BaseGraphServerTest` and address a hard-coded `127.0.0.1:248<serverIndex>`, and on the development machine ports 2480 and 2481 were held by a long-running `ArcadeDBServer`. Since `SERVER_HTTP_INCOMING_PORT` defaults to the range `2480-2489`, a test server started there binds 2482 while the test still addresses 2480, so the requests would have reached the running server and failed authentication against it. They compile (the full test tree compiles in the run above) and run in CI, where the ports are free.
- [ ] By hand: `POST /api/v1/ts/{db}/query` with `aggregation.requests[0].type = "MEDIAN"` answers `400` whose `error` names `aggregation.requests[0].type` and lists `SUM, AVG, MIN, MAX, COUNT` - and keeps doing so with `arcadedb.server.mode=production`, where it used to say only "Cannot execute command".
- [ ] By hand: the same value on `POST /api/v1/ts/{db}/grafana/query` answers `200` with an error frame on that `refId` while a second, valid target still returns its frame.
- [ ] By hand: `"avg"`, `" Avg "` and `"AVG"` all resolve, and the default alias is `temperature_avg` for each.

The new tests were proved able to fail: with the resolver mutated to drop the upper-casing and to drop the field name from the message, the unit test run reported `Tests run: 6, Failures: 2, Errors: 1` (the case-insensitivity test erroring with `bad type: SUM, AVG, MIN, MAX, COUNT: received 'sum'`). The mutation was reverted.

## Coverage

| Entry point | Covered | Test |
|---|---|---|
| `POST /api/v1/ts/{db}/query`, `aggregation.requests[].type` (`PostTimeSeriesQueryHandler:199`) | fixed here | `TimeSeriesQueryHandlerIT.aggregationRejectsUnknownTypeWithANamedError`, `.aggregationTypeIsRequired`, `.aggregationTypeIsCaseInsensitive` |
| `POST /api/v1/ts/{db}/grafana/query`, `targets[].aggregation.requests[].type` (`PostGrafanaQueryHandler:199`) | fixed here | `GrafanaTimeSeriesHandlerIT.grafanaAggregationRejectsUnknownTypeAsAnErrorFrame`, `.grafanaAggregationTypeIsCaseInsensitive` |
| The shared resolver itself | fixed here | `Issue7325AggregationTypeResolverTest` (6 tests, incl. every declared constant and the truncation bound) |
| SQL push-down (`SelectExecutionPlanner:3087`) | argued - cannot reach the bug | n/a |
| `GET /api/v1/ts/{db}/grafana/metadata` (`GetGrafanaMetadataHandler:95`) | argued - cannot reach the bug | n/a |
| gRPC `TimeSeriesAggregationRequest.type` | argued - not on `main` | n/a |

`grep -rn "AggregationType\.valueOf" --include="*.java" .` returns exactly the two handler sites, both fixed. A sibling sweep for any `Enum.valueOf` applied to a request-payload value across the whole HTTP handler package returns the same two hits and nothing else.

**Argued rows.** `SelectExecutionPlanner:3087-3096` is a `switch` with `default -> null` followed by `if (aggType == null) return false;` - an unknown function declines the push-down rather than throwing. `GetGrafanaMetadataHandler:95` iterates `AggregationType.values()` to *publish* the accepted names and reads nothing off the request. The gRPC class the issue quotes lives on PR #7323, which is still open: `find . -name "GrpcTimeSeriesSupport.java"` and `grep -rn "TS_AGG_UNSPECIFIED"` both return nothing on `main`, so there is no gRPC aggregation path here to fix and `grpcw` is untouched.

### Known gaps

- **#7340** - the other required members of the same aggregation request (`bucketInterval`, `requests`, `field`) are still read with bare `JSONObject` getters, so an absent one is answered through a `JSONException` as `400 "Invalid JSON payload"` with the specifics in the same concealed `detail` field, and on the Grafana endpoint that throw still escapes the per-target loop. Filed rather than folded in: it is missing-property reporting, a different mechanism from the `Enum.valueOf` this issue names, and the fix shape it needs is the one this PR just established.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvLjzQpwWHt6h7GAeSXh5a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Time-series aggregation types now accept case-insensitive values with surrounding whitespace.
  - Invalid or missing types return clear validation errors listing supported values.
  - Grafana queries isolate invalid targets while continuing to serve valid targets.

- **Documentation**
  - Updated API documentation to describe supported aggregation types and error behavior.

- **Tests**
  - Added coverage for invalid, missing, lowercase, whitespace-padded, and mixed-validity aggregation requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->