### PR TITLE
fix(#7315): the RDF branch of SourceDiscovery hands the delimiter it detected to the format

### DIFF
--- a/docs/7315-rdf-source-discovery-drops-detected-delimiter.md
+++ b/docs/7315-rdf-source-discovery-drops-detected-delimiter.md
@@ -1,0 +1,190 @@
+# #7315 - the RDF branch of `SourceDiscovery` drops the delimiter it just detected
+
+## Problem
+
+A canonical, space-delimited N-Triples file cannot be imported at all:
+
+```
+com.arcadedb.integration.importer.ImportException: Error on parsing source 'file:///tmp/t.nt'
+Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
+	at com.arcadedb.integration.importer.format.RDFImporterFormat.load(RDFImporterFormat.java:88)
+```
+
+`row` carries one element because the parser split the line on `,` while the file is space-delimited.
+
+## Root cause
+
+`SourceDiscovery.analyzeChar()` identifies a source as RDF by collecting every character that falls outside
+`<...>` on the first line and checking they are all the same. That character *is* the delimiter. The CSV
+branches of the same class hand the resolved delimiter to the format they build
+(`new CSVImporterFormat(userDelimiter)`, `SourceDiscovery.java:286` and `:408`); the RDF branch built
+`new RDFImporterFormat()` and threw the character away.
+
+`RDFImporterFormat extends CSVImporterFormat` and inherits both readers of that field -
+`createCSVParser(settings)` (used by `load()`) and `analyze()` - each of which resolves through
+`CSVImporterFormat.delimiterFor(settings)`:
+
+```java
+private String delimiterFor(final ImporterSettings settings) {
+  return delimiter != null ? delimiter : settings.getValue("delimiter", ",");
+}
+```
+
+The no-arg constructor leaves the field null, so the lookup fell through the generic `delimiter` option to a
+comma. The stale comment on the branch claimed "the RDF importer never reads it", which is not the case: it
+reads it twice over, and #6946 removed the only thing that populated either.
+
+## Invariant the fix establishes
+
+> When content sniffing resolves a source to `RDFImporterFormat`, the delimiter that format parses with is the
+> user's own when they set one and the detected character otherwise - never the inherited comma fallback - and
+> that delimiter is carried on the format, never written into the import-wide `settings.options`.
+
+## Completeness
+
+### Commands run
+
+```
+$ grep -rn "analyzeChar" integration/src/main/java
+SourceDiscovery.java:323:    FormatImporter format = analyzeChar(parser, settings);
+SourceDiscovery.java:344:      format = analyzeChar(parser, settings);
+SourceDiscovery.java:355:      format = analyzeChar(parser, settings);
+SourceDiscovery.java:446:  private FormatImporter analyzeChar(final Parser parser, final ImporterSettings settings)
+
+$ grep -rn "extends CSVImporterFormat" --include='*.java' .
+gremlin/.../GraphSONImporterFormat.java:59
+gremlin/.../GraphMLImporterFormat.java:36
+integration/.../RDFImporterFormat.java:36
+
+$ grep -rn "createCSVParser" --include='*.java' .
+CSVImporterFormat.java:110, :357, :517, :911 (the declaration)
+RDFImporterFormat.java:42
+
+$ grep -rn 'delimiterFor|getValue("delimiter"' --include='*.java' .
+SourceDiscovery.java:282
+CSVImporterFormat.java:85 (the declaration), :86, :780 (analyze), :912 (createCSVParser)
+
+$ grep -rn 'new RDFImporterFormat|new CSVImporterFormat' --include='*.java' .
+SourceDiscovery.java:286, :408, :485          <- the three production construction sites
+integration/src/test/... 14 direct instantiations in RDFImporterFormatCommitCadenceTest,
+                            RDFImporterFormatTransactionLeakTest, CSVImporterFormatLoadEdgesTransactionLeakTest
+
+$ grep -n "delimiter|createCSVParser|super\(" gremlin/.../GraphMLImporterFormat.java gremlin/.../GraphSONImporterFormat.java
+(no matches)
+
+$ grep -rn "SourceDiscovery|RDFImporterFormat|CSVImporterFormat" --include='*.java' engine server
+5 hits, all inside comments or a test's allow-list string - no call sites
+```
+
+### Coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| `Importer -url <space-delimited .nt>` -> `analyzeChar` site 1 -> `RDFImporterFormat.load()` | yes | yes - `aSpaceDelimitedNTriplesFileImportsThroughTheUrlRoute` |
+| `Importer -edges <space-delimited .nt>` -> same branch, different `loadFromSource()` call | yes | yes - `aSpaceDelimitedNTriplesFileImportsThroughTheEdgesRoute` |
+| tab-delimited source -> `createCSVParser`'s `TsvParser` branch (a second parser shape) | yes | yes - `aTabDelimitedTriplesFileImportsThroughTheUrlRoute` |
+| `CSVImporterFormat.analyze()` - the schema-inference reader of the same field, called by `SourceDiscovery.getSchema()` before `load()` | yes (same constructor argument feeds both readers) | yes - implicitly by all three above: with a comma the header row is one column and `fieldNames.get(1)` would throw before `load()` ever ran |
+| user's explicit `-delimiter` / `-edgesDelimiter` must still beat the detected one (#6946) | yes - via the existing `resolveDelimiter()` | yes - `anExplicitDelimiterStillOverridesTheDetectedOne` (a guard: it passed before the fix too) |
+| the detected RDF delimiter must not reach the next entity of the same import (#6946) | yes - carried on the format, nothing written to `settings.options` | yes - `theDetectedRdfDelimiterDoesNotLeakIntoTheNextEntityOfTheSameImport` |
+| `analyzeChar` sites 2 and 3 (the `#` and `//` comment-skip loops inside `analyzeText`) | yes - the parameter is threaded to all three sites | argued, see below |
+| `GraphMLImporterFormat` / `GraphSONImporterFormat` - the other two subclasses of `CSVImporterFormat`, also built with the no-arg constructor | n/a | argued, see below |
+
+### Rows argued with evidence
+
+- **`analyzeChar` sites 2 and 3 are unreachable for the RDF branch today.** Both are called immediately after
+  `skipLine(parser)`, which is `while (parser.isAvailable() && parser.nextChar() != '\n');` - it exits with
+  `currentChar == '\n'`, and `Parser.getCurrentChar()` returns exactly that field. `analyzeChar` dispatches on
+  `'<'` and `'{'`, so neither branch can be entered from those two call sites. They still receive the
+  delimiter, so the two are correct rather than merely unreached, but no test can drive the RDF branch through
+  them without first changing `skipLine`, which is out of scope here.
+- **`GraphMLImporterFormat` and `GraphSONImporterFormat` cannot reach this defect.** The grep above finds no
+  occurrence of `delimiter`, `createCSVParser` or a `super(` call in either file - they override `load` and
+  `analyze` with TinkerPop's own XML/JSON readers and never consult the inherited field. They are also selected
+  by file extension at `SourceDiscovery.java:290`/`:299`, before `analyzeChar` runs at all.
+
+### Reachability
+
+The changed line is `SourceDiscovery.java:485`, inside the production content-sniffing path that
+`Importer.loadFromSource()` drives on every source with no recognised extension. All five new tests go through
+`new Importer(args).load()` end to end rather than instantiating the format directly, so the assertion is that
+the live CLI path works, not merely that the constructor accepts an argument. No feature flag gates it.
+
+## Fix
+
+- `RDFImporterFormat` gains an explicit no-arg constructor and a delimiter-carrying one delegating to
+  `super(delimiter)` - the same pair `CSVImporterFormat` already has.
+- The RDF branch of `SourceDiscovery.analyzeChar()` returns
+  `new RDFImporterFormat(resolveDelimiter(userDelimiter, delimiter))`, reusing the existing
+  `resolveDelimiter()` that the `analyzeText` CSV branch uses, so an explicit user delimiter still wins and a
+  discarded guess is still logged.
+- `analyzeChar` takes `userDelimiter` as a parameter, threaded from all three of its call sites.
+- The stale comment claiming "the RDF importer never reads it" is replaced with what the code does hold.
+
+Nothing is written into `settings.options`, so #6946's leak stays fixed.
+
+## Test results
+
+`mvn -pl integration test -Dtest=RDFImporterFormatDelimiterDetectionTest`
+
+- Before the fix: `Tests run: 5, Failures: 0, Errors: 4` - all four with
+  `java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1`, the reported stack.
+  `anExplicitDelimiterStillOverridesTheDetectedOne` passed, as a #6946 guard should.
+- After the fix: `Tests run: 5, Failures: 0, Errors: 0`.
+
+`mvn -pl integration test -DexcludedGroups=benchmark,vector,slow`: `Tests run: 323, Failures: 0, Errors: 0,
+Skipped: 9` - BUILD SUCCESS.
+
+`mvn -pl gremlin-it verify -DskipITs=false`: `Tests run: 395, Failures: 0, Errors: 7`. All seven are
+`AbstractGremlinServerIT` port-bind and database-delete failures - "Unable to listen to a HTTP port in the
+configured port range 2480 - 2489". `lsof -nP -iTCP:2480 -sTCP:LISTEN` showed two other JVMs already holding
+the port (parallel agents on this machine), which is the conflict `CLAUDE.md` documents. The diff touches no
+server code. `Issue6751GraphSONMultiPropertyTest` - the one gremlin test that exercises an importer format -
+passed.
+
+## Impact
+
+A space- or tab-delimited N-Triples file now imports without `-delimiter`. Nothing else changes shape: the
+comma-delimited RDF sources the existing tests use still resolve to a comma (detected, not inherited), and
+every direct `new RDFImporterFormat()` in the test sources keeps the previous fallback behaviour through the
+no-arg constructor.
+
+## Adversarial pass
+
+No isolated subagent could be spawned - this session has no `Task` tool - so the pass was run by hand against
+the tree instead, by probing the N-Triples shapes adjacent to the one the issue reported. Every result below
+was produced by running `new Importer(...).load()` on the patched tree, not by reading:
+
+```
+                                             result
+LF,   <s> <p> <o> .                          {parsedRecords=3, createdEdges=2}     <- the shape the fix covers
+LF,   <s> <p> <o>       (no trailing dot)    {parsedRecords=3, createdEdges=2}     <- the issue's own repro
+CRLF, <s> <p> <o> .                          THREW NumberFormatException: "<http://a/rel>"
+LF,   <s> <p> "literal" .                    THREW NumberFormatException: "<http://a/rel>"
+LF,   # comment, then triples                THREW NumberFormatException: "generated"
+```
+
+| Finding | Disposition |
+|---|---|
+| CRLF line endings defeat RDF detection: the `size() - 1` bound in `allDelimitersAreTheSame` tolerates exactly one trailing character, and `\r` is a second one after the `.` | real, out of scope - the branch is never taken, so the delimiter never gets a chance to be dropped. Filed as **#7346** |
+| A literal object (`"hello world"`) is not inside `<...>`, so its characters join the delimiter set and the uniformity test fails at index 1 | real, out of scope - same reason. Filed as **#7346** |
+| A leading `#` or `//` comment is sniffed as the first data line: `skipLine()` leaves `currentChar` on `'\n'`, so both comment loops exit after one pass and `parser.reset()` rewinds past what they consumed | real, out of scope - a general sniffing defect, not RDF-specific. Filed as **#7347**. It is also why `analyzeChar`'s other two call sites are dead, which is the row argued above |
+| The first triple of every N-Triples file is dropped as a header row | real, out of scope. Filed as **#7345** |
+| An exotic detected delimiter (`"`, which is also univocity's quote character) would now be handed to the parser where a comma was used before | not real as a regression: such a source produced one column and the same `ArrayIndexOutOfBoundsException` before the fix. It fails either way, and no valid RDF line has that shape |
+| The new tests could pass against a fix that only covers `load()` and not `analyze()` | not real: `SourceDiscovery.getSchema()` calls `analyze()` before `load()` ever runs, and with a comma the header row is one column while the data rows are three or four, so `fieldNames.get(1)` throws first. Both readers take the delimiter from the same constructor argument |
+
+All three filed issues are named in the PR body under **Known gaps**.
+
+## Residual risk
+
+Two behaviours the reporter may hit next; neither is this defect and both predate it:
+
+- RDF sources still skip their first line as a header by default (`RDFImporterFormat.load()` sets
+  `skipEntries = 1` when `-edgesSkipEntries` is unset). N-Triples has no header row, so the first triple of a
+  file is silently dropped unless `-edgesSkipEntries 0` is passed. Filed as **#7345**; it is why the new
+  tests assert N-1 edges for an N-triple file.
+- `SourceDiscovery.analyzeChar()` reads the delimiter from the first line only; a file whose first line uses a
+  different separator from the rest still misparses. That is the same one-line-sample limitation the CSV
+  branch has always had.
+- Three shapes of canonical N-Triples still do not reach this branch at all, so the fix does not rescue them:
+  CRLF line endings and literal objects (**#7346**), and files with a leading comment block (**#7347**). The
+  patch is correct for every source the RDF branch is taken on; it does not widen which sources those are.

--- a/docs/7315-rdf-source-discovery-drops-detected-delimiter.md
+++ b/docs/7315-rdf-source-discovery-drops-detected-delimiter.md
@@ -188,3 +188,25 @@ Two behaviours the reporter may hit next; neither is this defect and both predat
 - Three shapes of canonical N-Triples still do not reach this branch at all, so the fix does not rescue them:
   CRLF line endings and literal objects (**#7346**), and files with a leading comment block (**#7347**). The
   patch is correct for every source the RDF branch is taken on; it does not widen which sources those are.
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/7348
+
+## Review cycles
+
+| Cycle | Head SHA | Changes in this cycle | Bot outcome |
+|---|---|---|---|
+| 1 | `20bb21b` | the fix, the five regression tests and this document - the initial push | `claude` reviewed and found no correctness, security or performance issue. It independently re-ran the two greps this document relies on (the three `analyzeChar` call sites, and the no-arg `RDFImporterFormat` constructor's remaining callers) and checked the tests' edge-count arithmetic against `load()`'s default header skip. Two non-blocking observations, neither asking for a change: that the production comments are dense (it notes this matches the file's existing style) and that the test's cleanup swallows a delete failure ("fine for test hygiene, no concern"). No formal review and no inline review comments were posted on this SHA; CodeRabbit had not finished when the loop exited |
+
+Nothing was applied in cycle 1, no deferred-items notes file was produced, and the bot review carried no
+actionable item - the three conditions for a clean approval - so the loop exited after one cycle.
+
+## Deferred items
+
+None.
+
+## Final state
+
+`clean-approval`. Three follow-up issues were opened before the PR: **#7345**, **#7346**, **#7347**, all named
+in the PR body under **Known gaps**. The merge belongs to the developer.

--- a/integration/src/main/java/com/arcadedb/integration/importer/SourceDiscovery.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/SourceDiscovery.java
@@ -320,7 +320,7 @@ public class SourceDiscovery {
 
     parser.nextChar();
 
-    FormatImporter format = analyzeChar(parser, settings);
+    FormatImporter format = analyzeChar(parser, settings, userDelimiter);
     if (format != null)
       return format;
 
@@ -341,7 +341,7 @@ public class SourceDiscovery {
     // SKIP COMMENTS '#' IF ANY
     while (parser.isAvailable() && parser.getCurrentChar() == '#') {
       skipLine(parser);
-      format = analyzeChar(parser, settings);
+      format = analyzeChar(parser, settings, userDelimiter);
       if (format != null)
         return format;
     }
@@ -352,7 +352,7 @@ public class SourceDiscovery {
     try {
       while (parser.getCurrentChar() == '/' && parser.nextChar() == '/') {
         skipLine(parser);
-        format = analyzeChar(parser, settings);
+        format = analyzeChar(parser, settings, userDelimiter);
         if (format != null)
           return format;
       }
@@ -443,7 +443,14 @@ public class SourceDiscovery {
       ;
   }
 
-  private FormatImporter analyzeChar(final Parser parser, final ImporterSettings settings) throws IOException {
+  /**
+   * The first-character dispatch: {@code <} opens either an RDF triple line or XML, <code>{</code> opens JSON.
+   *
+   * @param userDelimiter the delimiter the user supplied for this entity, or null - a detected one yields to it, the
+   *                      same way {@link #analyzeText} treats its own guess
+   */
+  private FormatImporter analyzeChar(final Parser parser, final ImporterSettings settings, final String userDelimiter)
+      throws IOException {
     char currentChar = parser.getCurrentChar();
     if (currentChar == '<') {
       // READ THE FIRST LINE
@@ -479,10 +486,13 @@ public class SourceDiscovery {
         }
 
         if (allDelimitersAreTheSame) {
-          // RDF. THE DELIMITER FOUND HERE USED TO BE WRITTEN INTO settings.options ALTHOUGH THE RDF IMPORTER NEVER READS IT,
-          // WHERE IT LEAKED INTO THE NEXT CSV ENTITY OF THE SAME IMPORT (ISSUE #6946)
+          // RDF. THE CHARACTER WHOSE REPETITION IDENTIFIED THE SOURCE IS ALSO ITS DELIMITER, SO IT IS HANDED TO THE FORMAT
+          // THE SAME WAY THE CSV BRANCHES ABOVE HAND THEIRS OVER: RDFImporterFormat INHERITS CSVImporterFormat'S PARSER
+          // CONSTRUCTION, WHOSE FALLBACK IS A COMMA, SO DROPPING IT READ A SPACE-DELIMITED N-TRIPLES FILE AS ONE COLUMN
+          // (ISSUE #7315). PER-FORMAT AND NOT THROUGH settings.options, WHICH ONE IMPORT SHARES ACROSS ITS DOCUMENTS,
+          // VERTICES AND EDGES FILES - WRITING IT THERE IS WHAT LEAKED IT INTO THE NEXT CSV ENTITY (ISSUE #6946)
           settings.typeIdProperty = "id";
-          return new RDFImporterFormat();
+          return new RDFImporterFormat(resolveDelimiter(userDelimiter, delimiter));
         }
       }
 

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java
@@ -36,6 +36,28 @@ import java.util.logging.Level;
 public class RDFImporterFormat extends CSVImporterFormat {
   private static final char[] STRING_CONTENT_SKIP = new char[] { '\'', '\'', '"', '"', '<', '>' };
 
+  /**
+   * The delimiter fallback the inherited {@code createCSVParser}/{@code analyze} resolve to: the generic
+   * {@code delimiter} option, then a comma. Only the direct instantiations in the test sources take this form -
+   * {@link com.arcadedb.integration.importer.SourceDiscovery} builds the format through
+   * {@link #RDFImporterFormat(String)} with the delimiter it detected.
+   */
+  public RDFImporterFormat() {
+    super();
+  }
+
+  /**
+   * @param delimiter the delimiter this source is parsed with - the user's own when they set one, else the character
+   *                  content sniffing found repeating between the {@code <...>} terms, which is the very thing that
+   *                  identified the source as RDF. It is carried on the format rather than written into
+   *                  {@code settings.options}, which one import shares across its entities (issue #6946), and dropping
+   *                  it made the canonical space-delimited N-Triples form unimportable: the inherited fallback is a
+   *                  comma, so the whole line arrived as a single column (issue #7315).
+   */
+  public RDFImporterFormat(final String delimiter) {
+    super(delimiter);
+  }
+
   @Override
   public void load(final SourceSchema sourceSchema, final AnalyzedEntity.EntityType entityType, final Parser parser, final DatabaseInternal database,
       final ImporterContext context, final ImporterSettings settings) throws ImportException {

--- a/integration/src/test/java/com/arcadedb/integration/importer/format/RDFImporterFormatDelimiterDetectionTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/format/RDFImporterFormatDelimiterDetectionTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer.format;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.integration.importer.ImportException;
+import com.arcadedb.integration.importer.Importer;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7315: the RDF branch of {@code SourceDiscovery.analyzeChar()} sniffs the delimiter out of the first
+ * line - it is the very character whose repetition identifies the source as RDF - and then threw it away,
+ * returning {@code new RDFImporterFormat()} with no delimiter at all. {@code RDFImporterFormat} inherits
+ * {@code CSVImporterFormat}'s parser construction, whose delimiter falls back to a comma, so the canonical
+ * space-delimited N-Triples form was read as a single column and the import died on {@code row[1]} with an
+ * {@link ArrayIndexOutOfBoundsException}. The CSV branch of the same method has handed the resolved
+ * delimiter to the format it builds since #6946; this is the same hand-off on the branch that was missed.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class RDFImporterFormatDelimiterDetectionTest {
+
+  private static final String DB_PATH = "target/databases/rdf-importer-delimiter-detection-test";
+
+  private final List<Path> sourceFiles = new ArrayList<>();
+
+  @BeforeEach
+  void setup() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    try (final Database database = new DatabaseFactory(DB_PATH).create()) {
+      database.transaction(() -> {
+        database.getSchema().createVertexType("Node").createProperty("id", Type.STRING);
+        database.getSchema().getType("Node").getOrCreateTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, new String[] { "id" });
+        database.getSchema().createEdgeType("Related");
+      });
+    }
+  }
+
+  @AfterEach
+  void cleanup() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    for (final Path file : sourceFiles) {
+      try {
+        Files.deleteIfExists(file);
+      } catch (final Exception ignored) {
+        // A leftover source file under target/ is not worth failing a green run over.
+      }
+    }
+    sourceFiles.clear();
+  }
+
+  private Path sourceFile(final String name, final String content) throws Exception {
+    final Path file = Path.of("target", name).toAbsolutePath();
+    Files.createDirectories(file.getParent());
+    Files.writeString(file, content, StandardCharsets.UTF_8);
+    sourceFiles.add(file);
+    return file;
+  }
+
+  private long countOf(final String typeName) {
+    try (final Database database = new DatabaseFactory(DB_PATH).open()) {
+      return database.query("sql", "select count(*) as c from " + typeName).next().<Long>getProperty("c");
+    }
+  }
+
+  /**
+   * The reported case: canonical N-Triples, space-delimited, trailing {@code .} on every line, imported with
+   * no {@code -delimiter} at all. Before the fix this threw
+   * {@code ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1} out of
+   * {@code RDFImporterFormat.load()}, because the whole line arrived as one column.
+   */
+  @Test
+  void aSpaceDelimitedNTriplesFileImportsThroughTheUrlRoute() throws Exception {
+    final Path rdf = sourceFile("rdf-delimiter-space-url.nt", """
+        <http://a/s1> <http://a/rel> <http://a/o1> .
+        <http://a/s2> <http://a/rel> <http://a/o2> .
+        <http://a/s3> <http://a/rel> <http://a/o3> .
+        <http://a/s4> <http://a/rel> <http://a/o4> .
+        """);
+
+    final Map<String, Object> report = new Importer(
+        ("-url file://" + rdf + " -database " + DB_PATH + " -edgeType Related").split(" ")).load();
+
+    assertThat(report.get("createdEdges"))
+        .as("the detected space delimiter must reach the parser: three of the four triples become edges, the first "
+            + "being skipped as the header row RDF sources default to")
+        .isEqualTo(3L);
+    assertThat(countOf("Related"))
+        .as("and the edges are durable, not merely counted")
+        .isEqualTo(3L);
+  }
+
+  /**
+   * The other of the two {@code Importer.load()} call sites that can dispatch an RDF source to this format.
+   * Same defect, different entry point - the {@code -url} test above does not drive it.
+   */
+  @Test
+  void aSpaceDelimitedNTriplesFileImportsThroughTheEdgesRoute() throws Exception {
+    final Path rdf = sourceFile("rdf-delimiter-space-edges.nt", """
+        <http://a/s1> <http://a/rel> <http://a/o1> .
+        <http://a/s2> <http://a/rel> <http://a/o2> .
+        <http://a/s3> <http://a/rel> <http://a/o3> .
+        """);
+
+    final Map<String, Object> report = new Importer(
+        ("-edges file://" + rdf + " -database " + DB_PATH + " -vertexType Node -edgeType Related").split(" ")).load();
+
+    assertThat(report.get("createdEdges"))
+        .as("the -edges route resolves the delimiter through the same branch")
+        .isEqualTo(2L);
+  }
+
+  /**
+   * The second parser shape: {@code createCSVParser()} switches from {@code CsvParser} to {@code TsvParser}
+   * for a tab, so a tab-delimited source exercises a code path the space case never reaches.
+   */
+  @Test
+  void aTabDelimitedTriplesFileImportsThroughTheUrlRoute() throws Exception {
+    final Path rdf = sourceFile("rdf-delimiter-tab-url.nt",
+        "<http://a/s1>\t<http://a/rel>\t<http://a/o1>\n"
+            + "<http://a/s2>\t<http://a/rel>\t<http://a/o2>\n"
+            + "<http://a/s3>\t<http://a/rel>\t<http://a/o3>\n");
+
+    final Map<String, Object> report = new Importer(
+        ("-url file://" + rdf + " -database " + DB_PATH + " -edgeType Related").split(" ")).load();
+
+    assertThat(report.get("createdEdges"))
+        .as("a tab detected on an RDF source has to reach the TsvParser branch of createCSVParser()")
+        .isEqualTo(2L);
+  }
+
+  /**
+   * #6946's invariant, which the fix must not undo: a sniffed delimiter is a guess and never overrides the
+   * delimiter the user set explicitly. Asserted in its negative form because the two can only differ on a
+   * source one of them fails to split - a comma forced onto a space-delimited N-Triples file leaves one
+   * column, and {@code row[1]} is out of bounds. The guess does not silently rescue it.
+   */
+  @Test
+  void anExplicitDelimiterStillOverridesTheDetectedOne() throws Exception {
+    final Path rdf = sourceFile("rdf-delimiter-explicit-override.nt", """
+        <http://a/s1> <http://a/rel> <http://a/o1> .
+        <http://a/s2> <http://a/rel> <http://a/o2> .
+        <http://a/s3> <http://a/rel> <http://a/o3> .
+        """);
+
+    assertThatThrownBy(() -> new Importer(
+        ("-url file://" + rdf + " -database " + DB_PATH + " -edgeType Related -delimiter ,").split(" ")).load())
+        .isInstanceOf(ImportException.class)
+        .hasRootCauseInstanceOf(ArrayIndexOutOfBoundsException.class);
+
+    assertThat(countOf("Related"))
+        .as("nothing was imported: the user's comma was honoured, not the detected space")
+        .isZero();
+  }
+
+  /**
+   * The other half of #6946: the delimiter this branch resolves is handed to the format, not written into
+   * {@code settings.options}, which one import shares across its url, documents, vertices and edges sources.
+   * The RDF source here is space-delimited and is processed first; the comma-delimited CSV that follows it
+   * in the same import must still be split on commas.
+   */
+  @Test
+  void theDetectedRdfDelimiterDoesNotLeakIntoTheNextEntityOfTheSameImport() throws Exception {
+    final Path rdf = sourceFile("rdf-delimiter-no-leak.nt", """
+        <http://a/s1> <http://a/rel> <http://a/o1> .
+        <http://a/s2> <http://a/rel> <http://a/o2> .
+        <http://a/s3> <http://a/rel> <http://a/o3> .
+        """);
+    final Path csv = sourceFile("rdf-delimiter-no-leak-documents.csv", """
+        id,name
+        1,alpha
+        2,beta
+        """);
+
+    final Map<String, Object> report = new Importer(("-url file://" + rdf
+        + " -documents file://" + csv
+        + " -database " + DB_PATH
+        + " -edgeType Related -documentType Doc").split(" ")).load();
+
+    assertThat(report.get("createdEdges"))
+        .as("the RDF source still imports on its own detected space")
+        .isEqualTo(2L);
+
+    try (final Database database = new DatabaseFactory(DB_PATH).open()) {
+      final List<String> names = database.query("sql", "select from Doc order by id").stream()
+          .map(doc -> doc.<String>getProperty("name"))
+          .toList();
+
+      assertThat(names)
+          .as("the CSV entity that follows keeps its own comma: a leaked space would have made each line one column, "
+              + "so there would be no 'name' property at all")
+          .containsExactly("alpha", "beta");
+    }
+  }
+}


### PR DESCRIPTION
Closes #7315

## Summary

`SourceDiscovery.analyzeChar()` identifies a source as RDF by collecting every character outside the `<...>`
terms of the first line and checking they are all the same - that character IS the source's delimiter. The
branch then discarded it and returned `new RDFImporterFormat()`, while the two CSV branches of the same class
have handed the resolved delimiter to the format they build since #6946. `RDFImporterFormat extends
CSVImporterFormat` and inherits both readers of that field (`createCSVParser()`, used by `load()`, and
`analyze()`), each resolving through `delimiterFor()`, whose fallback is the generic `delimiter` option and
then a comma - so the canonical space-delimited N-Triples form was read as a single column and every import
died on `row[1]` with `ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1`. The comment on the
branch asserted the RDF importer never reads the delimiter; it reads it twice over, and #6946 removed the only
thing that populated either. The fix gives `RDFImporterFormat` the delimiter-carrying constructor
`CSVImporterFormat` already has and passes `resolveDelimiter(userDelimiter, delimiter)` - the same helper the
`analyzeText` CSV branch uses, so an explicit `-delimiter` still beats the guess and a discarded guess is still
logged. `analyzeChar()` takes `userDelimiter` as a parameter, threaded from all three call sites. Nothing is
written into `settings.options`, so #6946's leak into the next entity of the same import stays fixed.

## Test plan

- [ ] `mvn -pl integration test -Dtest=RDFImporterFormatDelimiterDetectionTest` - 5 tests. Reverting either
      production hunk turns 4 of them red with the exact stack from the issue; the fifth is a #6946 guard that
      passes on both sides on purpose.
- [ ] `mvn -pl integration test -DexcludedGroups=benchmark,vector,slow` - `Tests run: 323, Failures: 0,
      Errors: 0, Skipped: 9`.
- [ ] Manual: `printf "<http://a/s1> <http://a/rel> <http://a/o1> .\n<http://a/s2> <http://a/rel> <http://a/o2> .\n" > /tmp/t.nt`
      then `Importer("-url file:///tmp/t.nt -database /tmp/db -edgeType Related")` imports instead of throwing.
      (One edge, not two - the first line is skipped as a header row, which is #7345.)

## Coverage

| Entry point | Fixed | Test |
|---|---|---|
| `Importer -url <space-delimited .nt>` -> `analyzeChar` -> `RDFImporterFormat.load()` | yes | `aSpaceDelimitedNTriplesFileImportsThroughTheUrlRoute` |
| `Importer -edges <space-delimited .nt>` - the other `loadFromSource()` call that dispatches here | yes | `aSpaceDelimitedNTriplesFileImportsThroughTheEdgesRoute` |
| tab-delimited source -> `createCSVParser()`'s `TsvParser` branch, a second parser shape | yes | `aTabDelimitedTriplesFileImportsThroughTheUrlRoute` |
| `CSVImporterFormat.analyze()`, the schema-inference reader of the same field, run before `load()` | yes | implicitly by all three above - with a comma it throws first |
| explicit `-delimiter` must still beat the detected one (#6946) | yes, via `resolveDelimiter()` | `anExplicitDelimiterStillOverridesTheDetectedOne` |
| the detected delimiter must not reach the next entity of the same import (#6946) | yes, carried on the format | `theDetectedRdfDelimiterDoesNotLeakIntoTheNextEntityOfTheSameImport` |
| `analyzeChar`'s other two call sites (the `#` / `//` comment loops) | yes, parameter threaded | argued: unreachable today - `skipLine()` exits with `currentChar == '\n'`, and `analyzeChar` dispatches only on `<` and `{`. That defect is #7347 |
| `GraphMLImporterFormat` / `GraphSONImporterFormat`, the other two `CSVImporterFormat` subclasses | n/a | argued: `grep -n "delimiter\|createCSVParser\|super("` finds nothing in either file, and both are selected by extension before `analyzeChar` runs |

### Known gaps

Three shapes of N-Triples still fail, all because the RDF branch is never taken rather than because the
delimiter is dropped. All three were reproduced against this branch, not inferred:

- **#7345** - the first triple of every N-Triples file is dropped as a header row. It is why the tests here
  assert N-1 edges for an N-triple file.
- **#7346** - CRLF line endings and literal objects (`<s> <p> "hello world" .`) both defeat the
  `allDelimitersAreTheSame` test, so the file is imported as CSV and fails with a `NumberFormatException`
  about an IRI.
- **#7347** - a leading `#` or `//` comment block is never skipped: the comment line itself is sniffed as the
  first data line. General to content sniffing, not RDF-specific, and it is what makes the two extra
  `analyzeChar` call sites dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvLjzQpwWHt6h7GAeSXh5a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed RDF imports for space- and tab-delimited sources detected automatically during source analysis.
  * Explicitly provided delimiters now take precedence over detected delimiters.
  * Prevented detected RDF delimiters from affecting subsequent CSV imports in the same operation.

* **Documentation**
  * Added documentation covering the RDF delimiter-detection issue, its resolution, test coverage, known limitations, and follow-up considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->