### PR TITLE
fix(#7316): the Raft gRPC listener closes a connection that has fallen idle

### DIFF
--- a/docs/7316-reap-revoked-raft-grpc-connection.md
+++ b/docs/7316-reap-revoked-raft-grpc-connection.md
@@ -94,9 +94,14 @@ grpcw/src/test/java/com/arcadedb/server/grpc/Issue5050GrpcPluginLifecycleTest.ja
 ```
 
 `GrpcServerPlugin` is the only other gRPC listener, and it is not the same shape: it has no allowlist and no
-revocation, so it has no "refused every RPC but still connected" state, and it already sets
-`keepAliveTime`/`keepAliveTimeout`/`permitKeepAlive*` (lines 181-184), so its connections are not unbounded either.
-Argued, not fixed here.
+revocation, so it never reaches the "refused every RPC but still connected" state this issue is about. Argued, not
+fixed here.
+
+It is worth being precise about what it does have, because the first draft of this paragraph overstated it: the
+`keepAliveTime`/`keepAliveTimeout`/`permitKeepAlive*` it sets at lines 181-184 make it detect a peer that has
+stopped answering pings. That is not the same bound as `maxConnectionIdle`, which closes a connection that is alive
+and simply carrying nothing. So a connection there that is idle but healthy is still unbounded; if that listener
+ever wants the same treatment it needs an idle window of its own rather than its existing keepalive settings.
 
 ### Coverage table
 
@@ -222,3 +227,25 @@ agent - which is the weaker form of the check, and is recorded here as such. Wha
 | "A negative or absurdly large window could throw or overflow" | Not real. Values `<= 0` never reach gRPC (the `> 0` guard), and `TimeUnit.MILLISECONDS.toNanos` saturates rather than wrapping, so a huge value lands above gRPC's `AS_LARGE_AS_INFINITE` and is read as "disabled" - the same as 0, by a different road |
 | "The idle window could cut a long-running Raft RPC" | Not real. `NettyServerHandler` drives the idle manager from `connection.numActiveStreams()` reaching 0, so the timer is only ever running while nothing is in flight |
 | "`GrpcServerPlugin` has the same defect" | Not real. It is a different listener with no allowlist and no revocation, and it already sets `keepAliveTime`/`keepAliveTimeout` (lines 181-184) |
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/7349
+
+## Review cycles
+
+### Cycle 1 - `8717356`
+
+`claude` reviewed on the PR as an issue comment: no blocking findings, two doc nits, both real and both fixed in
+cycle 2:
+
+1. `RaftGrpcServicesCustomizer`'s pre-existing class javadoc said "Ratis 3.2.2" while `ha-raft/pom.xml` pins
+   `3.3.0`. Rewritten, and made accurate about *why* one customizer covers every inbound RPC: it is not that all
+   three service types share a listener (they do not when `raft.grpc.admin.port`/`raft.grpc.client.port` name their
+   own), it is that `GrpcServicesImpl.buildServer` runs the customizer on each builder it constructs -
+   `GrpcServicesImpl.java:250, 335, 345`.
+2. This doc claimed `GrpcServerPlugin`'s connections are "not unbounded either" because it sets keepalive. That is
+   overstated: keepalive detects a peer that stopped answering pings, it does not close an idle-but-healthy
+   connection. Paragraph corrected, and the correction left visible rather than quietly reworded.
+
+Nothing was deferred and nothing was skipped.

--- a/docs/7316-reap-revoked-raft-grpc-connection.md
+++ b/docs/7316-reap-revoked-raft-grpc-connection.md
@@ -249,3 +249,33 @@ cycle 2:
    connection. Paragraph corrected, and the correction left visible rather than quietly reworded.
 
 Nothing was deferred and nothing was skipped.
+
+### Cycle 2 - `6c01e6d`
+
+`claude` reviewed again after the two doc fixes: no blocking findings, and it independently re-derived the two
+claims this change rests on - that `GrpcLogAppender.appendLogRequestObserver` is created once and reset only on
+error/completion, and that `MaxConnectionIdleManager`'s timer is only armed once `numActiveStreams()` reaches zero.
+It also noticed a side effect worth naming: `allowlistFilter`/`allowlistInterceptor` are now assigned on every
+`buildParameters` call rather than only when the allowlist branch is taken, so a rebuild with the allowlist turned
+off can no longer leave the previous call's references in place.
+
+Four non-blocking notes, none of which is a code change, with the reason for each:
+
+1. *The "window disabled" check exists in both `installGrpcServerCustomizations` and `customize`.* Left as is, and
+   the reviewer reached the same conclusion in the same comment: the two guards answer different questions - one
+   decides whether a customizer is installed at all, the other whether the builder method is called - and
+   collapsing them would mean the customizer could no longer be constructed with a disabled window by a caller that
+   wants only the allowlist.
+2. *Whether the release-notes process picks up a default-on behaviour change.* Checked: this repo has no
+   `CHANGELOG.md` and no release-notes file - `ls *.md` is ATTRIBUTIONS, CLAUDE, CONTRIBUTING, GOVERNANCE, PLUGINS,
+   README, SECURITY - so there is no file to add an entry to. The change is declared in the PR body, the setting's
+   own javadoc and this doc.
+3. *The test plan's "on a real cluster" checkbox is unchecked.* It is, deliberately: it is a multi-node manual step
+   this branch cannot run, it was written into the PR body as an unchecked box from the first push rather than
+   quietly omitted, and it is called out again at handoff.
+4. *#7339 is filed rather than silently left out.* Acknowledged, no action.
+
+## Final state
+
+`clean-approval` after 2 review cycles. Nothing deferred; every review point is either applied (cycle 1's two doc
+nits) or answered above with its evidence.

--- a/docs/7316-reap-revoked-raft-grpc-connection.md
+++ b/docs/7316-reap-revoked-raft-grpc-connection.md
@@ -1,0 +1,224 @@
+# #7316 - a revoked Raft gRPC peer keeps its TCP/HTTP-2 connection open
+
+Follow-up to #7250 (chain: #7132 -> #7225 -> #7250 -> #7316).
+
+## The gap
+
+#7250 made a peer that stops being admitted by `PeerAddressAllowlistFilter` lose its *reach* on a connection it
+had already established: the in-flight Raft RPCs are closed with `PERMISSION_DENIED` and every later RPC on that
+transport is refused by `PeerAllowlistCallInterceptor`. It does not close the connection - gRPC's public API hands
+out no handle on one established server transport - so the socket and its HTTP/2 framing state survive until the
+peer, the kernel, or a network event drops it.
+
+## Root cause
+
+`ServerTransportFilter` has two methods and neither carries a transport handle:
+
+```
+$ grep -n "public" org/apache/ratis/thirdparty/io/grpc/ServerTransportFilter.java
+public abstract class ServerTransportFilter {
+  public Attributes transportReady(Attributes transportAttrs)
+  public void transportTerminated(Attributes transportAttrs)
+}
+```
+
+Every connection-lifetime knob is on the builder instead, and Ratis sets none of them
+(`GrpcServicesImpl.newNettyServerBuilder` sets only `SO_REUSEADDR`, `maxInboundMessageSize`, `flowControlWindow`,
+the channel type / event loop groups and the SSL context):
+
+```
+$ grep -n "maxConnectionIdle\|maxConnectionAge\|keepAlive\|permitKeepAlive" \
+    org/apache/ratis/grpc/server/GrpcServicesImpl.java
+(no output)
+```
+
+so a Raft gRPC connection on ArcadeDB has, before this change, no server-side lifetime bound at all.
+
+## The invariant
+
+> An inbound Raft gRPC connection that carries no active HTTP/2 stream for the configured window is closed by the
+> server, instead of living until the peer drops it - which is what a revoked transport becomes, because
+> `PeerAllowlistCallInterceptor` refuses every RPC on it.
+
+## Completeness
+
+### Writers of the customizer
+
+```
+$ grep -rn "setServicesCustomizer" .
+./ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java:4241
+```
+
+One writer. It lives in `installPeerAllowlist`, which returns early when
+`arcadedb.ha.peerAllowlist.enabled` is false - so before this change a customizer existed only when the allowlist
+did. That is why the idle window is installed from a method that no longer returns early on the allowlist flag:
+otherwise `arcadedb.ha.grpcMaxConnectionIdleMs` would be a setting that silently does nothing on exactly the
+clusters that set `peerAllowlist.enabled=false`.
+
+### Readers / callers
+
+```
+$ grep -rn "buildParameters(" .
+ha-raft/.../RaftHAServer.java:998            # startRatis
+ha-raft/.../RaftHAServer.java:1531           # restartRatis (recovery)
+ha-raft/.../RaftHAServer.java:4175           # the method
++ 11 call sites in ha-raft tests
+```
+
+Both production callers run the whole method, so both get the customizer.
+
+### Stale claims that the fix invalidates
+
+Every place that documented "the connection stays open" had to move with the code, or it becomes the next bug
+report:
+
+```
+$ grep -rn "stays open\|stays connected\|no way to close one established" ha-raft/src \
+    engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+PeerAddressAllowlistFilter.java:108     # class javadoc
+PeerAddressAllowlistFilter.java:607     # the revocation log message an operator reads
+PeerTransportSession.java:41,43         # class javadoc
+GlobalConfiguration.java:2140           # HA_PEER_ALLOWLIST_ENABLED description
+Issue7250RevokesEstablishedTransportTest.java:59   # test class javadoc
+```
+
+All five are updated by this change.
+
+### Same-shape siblings
+
+```
+$ grep -rln "NettyServerBuilder" --exclude-dir=target .
+ha-raft/.../PeerTransportSession.java, ha-raft/.../RaftGrpcServicesCustomizer.java   # this fix
+grpcw/src/main/java/com/arcadedb/server/grpc/GrpcServerPlugin.java
+grpcw/src/test/java/com/arcadedb/server/grpc/Issue5050GrpcPluginLifecycleTest.java
+```
+
+`GrpcServerPlugin` is the only other gRPC listener, and it is not the same shape: it has no allowlist and no
+revocation, so it has no "refused every RPC but still connected" state, and it already sets
+`keepAliveTime`/`keepAliveTimeout`/`permitKeepAlive*` (lines 181-184), so its connections are not unbounded either.
+Argued, not fixed here.
+
+### Coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| `buildParameters` -> allowlist ON + idle window -> customizer sets `maxConnectionIdle` | yes | yes - `anIdleConnectionIsReapedWhenTheAllowlistIsOn` |
+| `buildParameters` -> allowlist OFF + idle window -> customizer still installed | yes | yes - `anIdleConnectionIsReapedWithTheAllowlistDisabled` |
+| `buildParameters` -> idle window 0 -> no lifetime bound, connection lingers (documented) | n/a - deliberate | yes - `aZeroIdleWindowLeavesTheConnectionOpen` |
+| `buildParameters` -> allowlist OFF + idle window 0 -> no customizer at all | n/a - deliberate | yes - `noCustomizerIsInstalledWhenNothingNeedsOne` |
+| `RaftGrpcServicesCustomizer.customize` applies filters + interceptors as before | yes - unchanged | yes - `theAllowlistFilterAndInterceptorAreStillInstalled` |
+| A revoked peer that keeps starting RPCs never lets the connection go idle | **no** | no - filed as a follow-up |
+
+## Residual risk
+
+`maxConnectionIdle` measures idleness from the most recent moment the transport's active-stream count reached
+zero, not from the connection's age:
+
+```
+$ sed -n '/public void onTransportIdle/,/^  }/p' \
+    org/apache/ratis/thirdparty/io/grpc/internal/MaxConnectionIdleManager.java
+  public void onTransportIdle() {
+    isActive = false;
+    ...
+      nextIdleMonitorTime = ticker.nanoTime() + maxConnectionIdleInNanos;
+```
+
+So a revoked peer that keeps *starting* RPCs - each of which the interceptor refuses immediately - pushes the
+deadline forward every time and its connection is never reaped. That covers a peer whose Ratis division has not
+learned it was removed and is still campaigning, and it covers a deliberate squatter. `maxConnectionAge`, which is
+unconditional, is the knob that would close it; it also recycles every healthy Raft connection on the same period,
+which is why it is not being turned on in the same change as the fix. Filed as a follow-up (see below).
+
+What the fix does cover: a revoked transport that has gone quiet - the normal removal case, where the removed peer
+stops driving Raft RPCs at us - and, more generally, any abandoned or half-dead inbound Raft connection, none of
+which had a server-side lifetime bound before.
+
+The replication path is not affected by the default window. `appendEntries` is a bidirectional stream, and Ratis's
+log appender opens one per follower and keeps it:
+
+```
+$ grep -n "appendEntries" org/apache/ratis/grpc/server/GrpcServerProtocolService.java
+242:  public StreamObserver<AppendEntriesRequestProto> appendEntries(
+
+$ grep -n "appendLogRequestObserver" org/apache/ratis/grpc/server/GrpcLogAppender.java
+162:  private volatile StreamObservers appendLogRequestObserver;
+405:      if (appendLogRequestObserver == null) {
+406:        appendLogRequestObserver = new StreamObservers(     # created once, reset only on ERROR/COMPLETE
+```
+
+so the follower's inbound connection carries an active stream continuously and never reaches an active-stream count
+of zero. What the window can reach are the quiet direction-of-travel connections (a follower's channel to a peer it
+only dials to campaign, an idle Ratis admin/client channel); those are closed with a graceful GOAWAY, which a gRPC
+`ManagedChannel` answers by reconnecting on the next RPC.
+
+## Test results
+
+Red, before the one-line application of the window in `RaftGrpcServicesCustomizer.customize`, with everything else
+already in place - so the two failures are the fix, not the plumbing:
+
+```
+[ERROR] Tests run: 5, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 124.1 s
+[ERROR] ...Issue7316ReapsIdleRaftConnectionTest.anIdleConnectionIsReapedWhenTheAllowlistIsOn -- 61.06 s <<< FAILURE!
+[ERROR] ...Issue7316ReapsIdleRaftConnectionTest.anIdleConnectionIsReapedWithTheAllowlistDisabled -- 60.01 s <<< FAILURE!
+```
+
+Green, after:
+
+```
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.838 s
+```
+
+The 124 s -> 5.8 s drop is the same evidence read a second way: before the change both connections sat there until
+the test's own read timeout expired.
+
+Regression set:
+
+| Run | Result |
+|---|---|
+| `-pl engine -Dtest='Issue7124BooleanSettingStrictCoercionTest,Issue7163DatabaseScopeCallbackTest'` (the two that enumerate every setting) | `Tests run: 19, Failures: 0, Errors: 0` |
+| `-pl ha-raft -Dtest='Issue7250*,Issue7225*,Issue7132*,Issue3890RaftParametersPublicationTest,PeerAddressAllowlistFilterTest,HAConfigDefaultsTest,Issue7316*'` | `Tests run: 90, Failures: 0, Errors: 0` |
+| `-pl ha-raft -DexcludedGroups=benchmark,slow,vector` (the module's whole unit lane) | `Tests run: 1045, Failures: 0, Errors: 0` |
+
+The full-lane run still exited 1: surefire could not *start* a fork for `WaitForApplyTest` ("The forked VM
+terminated without properly saying goodbye... Error occurred in starting fork"), on a machine that had a dozen
+other surefire forks live at the time. Re-running that class on its own is green - `Tests run: 4, Failures: 0,
+Errors: 0` in 62 s - so the exit code is the machine, not the change.
+
+## Summary of changes
+
+| File | Change |
+|---|---|
+| `engine/.../GlobalConfiguration.java` | new `HA_GRPC_MAX_CONNECTION_IDLE_MS` (`arcadedb.ha.grpcMaxConnectionIdleMs`, `Long`, `SCOPE.SERVER`, default `300_000`); `HA_PEER_ALLOWLIST_ENABLED`'s description no longer claims the connection stays open until the peer drops it |
+| `ha-raft/.../RaftGrpcServicesCustomizer.java` | takes the window and applies `NettyServerBuilder.maxConnectionIdle` when it is positive |
+| `ha-raft/.../RaftHAServer.java` | `installPeerAllowlist` split into `buildPeerAllowlistFilter` (returns the filter or null) and `installGrpcServerCustomizations`, which installs the customizer when *either* half is configured |
+| `ha-raft/.../PeerAddressAllowlistFilter.java` | class javadoc and the revocation log message now say what actually happens to the socket |
+| `ha-raft/.../PeerTransportSession.java` | same, for the class that documents what a revocation revokes |
+| `ha-raft/.../Issue7250RevokesEstablishedTransportTest.java` | class javadoc only - it asserted, in prose, that the socket is never closed. No test code touched |
+| `ha-raft/.../Issue7316ReapsIdleRaftConnectionTest.java` | new: five tests, one per row of the coverage table |
+
+## Finding ledger
+
+- [x] 1. A revoked Raft gRPC peer keeps its TCP/HTTP-2 connection open - fixed for a connection that goes quiet;
+      the still-retrying case is filed as #7339
+
+## Impact
+
+Default-on, and the default is the behaviour change: a cluster that upgrades gets a five-minute idle bound on its
+Raft listener where it had none. The replication path cannot reach that bound (see the `appendEntries` evidence
+above); the connections that can are closed with a graceful GOAWAY, and `maxConnectionIdle` only ever fires when
+the transport's active-stream count is zero, so no in-flight RPC can be interrupted by it. Set
+`arcadedb.ha.grpcMaxConnectionIdleMs=0` to restore the previous unbounded behaviour.
+
+## Adversarial pass
+
+The orchestrator's Phase 1.5 asks for a subagent that has not been persuaded by the author's reasoning. **No
+`Task` tool is available in this environment**, so the pass was run inline against the diff rather than by a fresh
+agent - which is the weaker form of the check, and is recorded here as such. What it turned up:
+
+| Finding | Disposition |
+|---|---|
+| "The fix does not close the connection in the case the title describes, if the peer keeps retrying" | Real, out of scope - filed as **#7339**, named in the PR body and in the coverage table |
+| "`Issue7250RevokesEstablishedTransportTest`'s class javadoc still states the socket is never closed" | Real, in scope - javadoc corrected in this branch; no test code changed |
+| "A negative or absurdly large window could throw or overflow" | Not real. Values `<= 0` never reach gRPC (the `> 0` guard), and `TimeUnit.MILLISECONDS.toNanos` saturates rather than wrapping, so a huge value lands above gRPC's `AS_LARGE_AS_INFINITE` and is read as "disabled" - the same as 0, by a different road |
+| "The idle window could cut a long-running Raft RPC" | Not real. `NettyServerHandler` drives the idle manager from `connection.numActiveStreams()` reaching 0, so the timer is only ever running while nothing is in flight |
+| "`GrpcServerPlugin` has the same defect" | Not real. It is a different listener with no allowlist and no revocation, and it already sets `keepAliveTime`/`keepAliveTimeout` (lines 181-184) |

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2137,8 +2137,10 @@ public enum GlobalConfiguration {
       service behind arcadedb.ha.k8sSuffix is resolved too, so a StatefulSet scale-up pod can complete its \
       auto-join. Loopback is always allowed. A host that stops being admitted also loses the reach an \
       already-established connection still gave it: the Raft RPCs running on that connection are closed with \
-      a permission error and later ones are refused, though the connection itself stays open until the peer \
-      drops it. Does not provide peer identity or encryption: use mTLS on untrusted networks.""",
+      a permission error and later ones are refused. gRPC exposes no way to close one established transport on \
+      demand, so the connection itself goes when it falls idle, after arcadedb.ha.grpcMaxConnectionIdleMs - or \
+      never, if that window is set to 0. Does not provide peer identity or encryption: use mTLS on untrusted \
+      networks.""",
       Boolean.class, true),
 
   HA_GRPC_ALLOWLIST_REFRESH_MS("arcadedb.ha.grpcAllowlistRefreshMs", SCOPE.SERVER,
@@ -2164,6 +2166,21 @@ public enum GlobalConfiguration {
       when a later DNS re-resolution of that host fails. Bridges transient DNS outages and pod-IP churn so a peer that \
       resolved moments ago is not evicted from the allowlist by a momentary lookup failure. Set to 0 to disable \
       stickiness (drop a host from the allowlist as soon as it stops resolving).""",
+      Long.class, 300_000L),
+
+  HA_GRPC_MAX_CONNECTION_IDLE_MS("arcadedb.ha.grpcMaxConnectionIdleMs", SCOPE.SERVER,
+      """
+      How long in milliseconds an inbound Raft gRPC connection may carry no RPC before the server closes it with a \
+      graceful GOAWAY. Ratis leaves the Raft listener with no server-side lifetime bound at all, so a connection \
+      survives until the peer, the kernel or a network event drops it; that is what leaves the socket of a peer \
+      removed from the allowlist connected after its reach has been revoked (issue #7316). The window is measured \
+      from the moment the connection's last RPC finished, so it cannot reap the replication path: a leader's \
+      AppendEntries to a follower is one long-lived stream, which keeps that follower's inbound connection busy \
+      for as long as replication runs. What it does close are the quiet \
+      connections - a revoked peer that has stopped talking, a follower's channel to a peer it only dials to \
+      campaign, an idle Ratis admin/client channel - and a gRPC client answers the GOAWAY by reconnecting on its \
+      next call. Values below one second are raised to one second by gRPC. Set to 0 to leave connections unbounded, \
+      which is the behaviour before 26.10.1.""",
       Long.class, 300_000L),
 
   HA_TLS_ENABLED("arcadedb.ha.tls.enabled", SCOPE.SERVER,

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java
@@ -105,9 +105,11 @@ import java.util.logging.Level;
  * admission gate and gRPC hands it no handle on the transport it admitted, so every transport this filter admits
  * gets a {@link PeerTransportSession} stashed in its {@code Attributes}; a resolution that stops admitting the
  * session's address revokes it, {@link PeerAllowlistCallInterceptor} then refuses every further RPC on it, and the
- * RPCs already running on it are closed. The socket itself is not closed - gRPC's public API exposes no way to close
- * one established transport - so the accurate operator-facing claim is that removing a peer revokes its reach, not
- * that it drops its connection.
+ * RPCs already running on it are closed. The socket is not closed on the spot - gRPC's public API exposes no way to
+ * close one established transport on demand - but it is no longer left to the peer either: since issue #7316 the
+ * Raft listener carries {@code arcadedb.ha.grpcMaxConnectionIdleMs}, so a connection that stops carrying RPCs, which
+ * a revoked one does as soon as it stops retrying, is closed with a graceful GOAWAY. The accurate operator-facing
+ * claim is that removing a peer revokes its reach immediately and its connection once that connection falls idle.
  * <p>
  * This is NOT a substitute for mTLS: it does not authenticate peer identity and does not
  * encrypt the traffic. See GitHub issue #3890. The bounded startup fail-open is an acceptable
@@ -603,8 +605,9 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
         continue; // swept while transportReady was still deciding: it is being rejected, and that is logged there
       LogManager.instance().log(this, Level.INFO,
           "Revoked the established Raft gRPC transport of %s: the address is no longer in the peer allowlist. "
-              + "%d in-flight RPC(s) closed; every further RPC on that transport is refused. The connection itself "
-              + "stays open until the peer drops it - gRPC exposes no way to close one established transport.",
+              + "%d in-flight RPC(s) closed; every further RPC on that transport is refused. gRPC exposes no way to "
+              + "close one established transport on demand, so the connection is closed once it has been idle for "
+              + "arcadedb.ha.grpcMaxConnectionIdleMs - a peer that keeps retrying keeps it open until it stops.",
           session.getRemoteIp(), closed);
     }
   }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerTransportSession.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerTransportSession.java
@@ -39,10 +39,12 @@ import java.util.concurrent.ConcurrentHashMap;
  * neither the session nor a call outlives its transport, which is the part the issue asked to design carefully.
  * <p>
  * <b>What a revocation actually revokes.</b> gRPC's public API hands out no way to close one established transport
- * (checked across {@code ServerTransportFilter} and every public method of {@code NettyServerBuilder}), so the socket
- * stays connected until one side drops it. What is revoked is everything the socket can carry: in-flight calls are
- * closed with {@link #REVOKED} and every subsequent call on the transport is refused by the interceptor, which sits
- * in the server-wide interceptor chain that every RPC passes.
+ * on demand (checked across {@code ServerTransportFilter} and every public method of {@code NettyServerBuilder}), so
+ * revoking is not the same act as disconnecting. What is revoked is everything the socket can carry: in-flight calls
+ * are closed with {@link #REVOKED} and every subsequent call on the transport is refused by the interceptor, which
+ * sits in the server-wide interceptor chain that every RPC passes. The socket then goes when it falls idle: the one
+ * connection-lifetime knob {@code NettyServerBuilder} does expose is builder-wide, and
+ * {@link RaftGrpcServicesCustomizer} sets it from {@code arcadedb.ha.grpcMaxConnectionIdleMs} (issue #7316).
  */
 final class PeerTransportSession {
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGrpcServicesCustomizer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGrpcServicesCustomizer.java
@@ -24,6 +24,7 @@ import org.apache.ratis.thirdparty.io.grpc.ServerTransportFilter;
 import org.apache.ratis.thirdparty.io.grpc.netty.NettyServerBuilder;
 
 import java.util.EnumSet;
+import java.util.concurrent.TimeUnit;
 
 /**
  * {@link GrpcServices.Customizer} that installs the configured server-side transport filters and call interceptors
@@ -35,6 +36,13 @@ import java.util.EnumSet;
  * established before its address stopped being admitted. Interceptors registered on the builder are server-wide -
  * {@code ServerImpl} applies them to every call whatever order the services were added in - so the two are installed
  * together here rather than per service.
+ * <p>
+ * It also carries the connection-lifetime bound the Raft listener otherwise has none of (issue #7316). Neither of the
+ * two surfaces above can close a connection: {@code ServerTransportFilter} is handed no reference to the transport it
+ * admits, and a {@code ServerCall} reaches only its own HTTP/2 stream. So a peer whose reach a revocation took away
+ * kept its socket until something else dropped it. The only knobs gRPC exposes for that are builder-wide, and
+ * {@code GrpcServicesImpl.newNettyServerBuilder} sets none of them, which is why this customizer is where the window
+ * is applied.
  */
 final class RaftGrpcServicesCustomizer implements GrpcServices.Customizer {
 
@@ -43,10 +51,17 @@ final class RaftGrpcServicesCustomizer implements GrpcServices.Customizer {
 
   private final ServerTransportFilter[] filters;
   private final ServerInterceptor[]     interceptors;
+  private final long                    maxConnectionIdleMs;
 
-  RaftGrpcServicesCustomizer(final ServerTransportFilter[] filters, final ServerInterceptor[] interceptors) {
+  /**
+   * @param maxConnectionIdleMs how long a connection may carry no RPC before the server closes it, or {@code 0} or
+   *                            less to leave connections unbounded, which is what Ratis does on its own
+   */
+  RaftGrpcServicesCustomizer(final ServerTransportFilter[] filters, final ServerInterceptor[] interceptors,
+      final long maxConnectionIdleMs) {
     this.filters = filters == null ? NO_FILTERS : filters;
     this.interceptors = interceptors == null ? NO_INTERCEPTORS : interceptors;
+    this.maxConnectionIdleMs = maxConnectionIdleMs;
   }
 
   @Override
@@ -56,6 +71,11 @@ final class RaftGrpcServicesCustomizer implements GrpcServices.Customizer {
       result = result.addTransportFilter(f);
     for (final ServerInterceptor i : interceptors)
       result = result.intercept(i);
+    // Not gated on the allowlist: this is a connection-lifetime bound, and Ratis leaves the Raft listener without
+    // one whether or not the allowlist is installed. gRPC clamps anything under a second up to a second and treats
+    // anything from 1000 days up as "disabled", so the only value handled here is the one that means off.
+    if (maxConnectionIdleMs > 0)
+      result = result.maxConnectionIdle(maxConnectionIdleMs, TimeUnit.MILLISECONDS);
     return result;
   }
 }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGrpcServicesCustomizer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGrpcServicesCustomizer.java
@@ -28,8 +28,10 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * {@link GrpcServices.Customizer} that installs the configured server-side transport filters and call interceptors
- * on the Ratis Netty gRPC server builder. Ratis 3.2.2 routes all service types (ADMIN, CLIENT,
- * SERVER) through the same listener, so one customizer covers every inbound RPC.
+ * on the Ratis Netty gRPC server builder. Ratis (3.3.0, the version {@code ha-raft/pom.xml} pins) routes ADMIN,
+ * CLIENT and SERVER through one listener unless {@code raft.grpc.admin.port} or {@code raft.grpc.client.port} names
+ * a different port; either way this customizer covers every inbound RPC, because {@code GrpcServicesImpl.buildServer}
+ * runs it on each builder it constructs rather than only on the SERVER one.
  * <p>
  * A transport filter gates a connection once, when it is established; an interceptor is consulted on every RPC. The
  * peer allowlist needs both (issue #7250): the filter to refuse a connection, the interceptor to revoke one that was

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -4185,7 +4185,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
       LogManager.instance().log(this, Level.INFO,
           "Raft gRPC transport secured with TLS (mutual authentication: %s)", tlsConfig.getMtlsEnabled());
 
-    installPeerAllowlist(configuration, parameters);
+    installGrpcServerCustomizations(configuration, parameters);
 
     // Last line on every path: see the field's comment. Nothing above may publish a partially-configured
     // Parameters, and nothing below may add to it.
@@ -4193,9 +4193,40 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     return parameters;
   }
 
-  private void installPeerAllowlist(final ContextConfiguration configuration, final Parameters parameters) {
-    if (!configuration.getValueAsBoolean(GlobalConfiguration.HA_PEER_ALLOWLIST_ENABLED))
+  /**
+   * Installs the one {@code GrpcServices.Customizer} the Raft listener gets: the peer allowlist's transport filter
+   * and call interceptor (issues #7132, #7225, #7250) and the connection-idle window (issue #7316).
+   * <p>
+   * The two are configured independently, so this method is not gated on either of them: gating it on
+   * {@code arcadedb.ha.peerAllowlist.enabled}, which is where the allowlist install used to live, would have made
+   * {@code arcadedb.ha.grpcMaxConnectionIdleMs} a setting that silently does nothing on exactly the clusters that
+   * turned the allowlist off. When neither is configured no customizer is installed at all, which leaves Ratis's
+   * builder exactly as it was.
+   */
+  private void installGrpcServerCustomizations(final ContextConfiguration configuration, final Parameters parameters) {
+    final PeerAddressAllowlistFilter filter = buildPeerAllowlistFilter(configuration);
+    final PeerAllowlistCallInterceptor interceptor = filter == null ? null : new PeerAllowlistCallInterceptor();
+    // The filter gates a connection once, when it is established. The interceptor enforces the same decision on
+    // every RPC, which is what revokes a transport already open when its address stopped being admitted (#7250):
+    // it reads the session the filter attached to the transport and refuses the call when that session is revoked.
+    this.allowlistFilter = filter;
+    this.allowlistInterceptor = interceptor;
+
+    // Neither surface can close the connection itself, so the socket of a revoked peer outlived its reach (#7316).
+    final long maxConnectionIdleMs = configuration.getValueAsLong(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_IDLE_MS);
+    if (filter == null && maxConnectionIdleMs <= 0)
       return;
+
+    GrpcConfigKeys.Server.setServicesCustomizer(parameters, new RaftGrpcServicesCustomizer(
+        filter == null ? new ServerTransportFilter[0] : new ServerTransportFilter[] { filter },
+        interceptor == null ? new ServerInterceptor[0] : new ServerInterceptor[] { interceptor },
+        maxConnectionIdleMs));
+  }
+
+  /** The inbound peer allowlist filter, or {@code null} when it is disabled or has no host to admit. */
+  private PeerAddressAllowlistFilter buildPeerAllowlistFilter(final ContextConfiguration configuration) {
+    if (!configuration.getValueAsBoolean(GlobalConfiguration.HA_PEER_ALLOWLIST_ENABLED))
+      return null;
 
     final String serverList = configuration.getValueAsString(GlobalConfiguration.HA_SERVER_LIST);
     final long refreshMs = configuration.getValueAsLong(GlobalConfiguration.HA_GRPC_ALLOWLIST_REFRESH_MS);
@@ -4214,7 +4245,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     if (peerHosts.isEmpty()) {
       LogManager.instance().log(this, Level.WARNING,
           "arcadedb.ha.peerAllowlist.enabled=true but arcadedb.ha.serverList is empty; allowlist not installed");
-      return;
+      return null;
     }
     final PeerAddressAllowlistFilter filter = new PeerAddressAllowlistFilter(peerHosts, refreshMs, startupGraceMs,
         stickyTtlMs);
@@ -4232,14 +4263,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     if (serviceDomain != null)
       filter.learnPeerHosts(List.of(serviceDomain));
 
-    // The filter gates a connection once, when it is established. The interceptor enforces the same decision on
-    // every RPC, which is what revokes a transport already open when its address stopped being admitted (#7250):
-    // it reads the session the filter attached to the transport and refuses the call when that session is revoked.
-    final PeerAllowlistCallInterceptor interceptor = new PeerAllowlistCallInterceptor();
-    this.allowlistFilter = filter;
-    this.allowlistInterceptor = interceptor;
-    GrpcConfigKeys.Server.setServicesCustomizer(parameters, new RaftGrpcServicesCustomizer(
-        new ServerTransportFilter[] { filter }, new ServerInterceptor[] { interceptor }));
+    return filter;
   }
 
   /**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7250RevokesEstablishedTransportTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7250RevokesEstablishedTransportTest.java
@@ -55,9 +55,11 @@ import static org.mockito.Mockito.when;
  * <p>
  * The filter now attaches a {@link PeerTransportSession} to every transport it admits, revokes the sessions whose
  * address a resolution stopped admitting, and {@link PeerAllowlistCallInterceptor} enforces that per RPC: in-flight
- * calls are closed with {@code PERMISSION_DENIED} and later ones are refused. What is NOT closed is the socket -
- * gRPC's public API offers no way to close one established transport - which is the residual risk the tracking doc
- * records.
+ * calls are closed with {@code PERMISSION_DENIED} and later ones are refused. What is NOT closed on the spot is the
+ * socket - gRPC's public API offers no way to close one established transport on demand - which was the residual
+ * risk the tracking doc records, and which issue #7316 then bounded with a connection-idle window on the listener
+ * ({@code Issue7316ReapsIdleRaftConnectionTest}). Nothing below asserts on the socket either way: these tests are
+ * about reach.
  *
  * @author Roberto Franchini (r.franchini@arcadedata.com)
  */

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7316ReapsIdleRaftConnectionTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7316ReapsIdleRaftConnectionTest.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+import org.apache.ratis.conf.Parameters;
+import org.apache.ratis.grpc.GrpcConfigKeys;
+import org.apache.ratis.grpc.server.GrpcServices;
+import org.apache.ratis.thirdparty.io.grpc.Server;
+import org.apache.ratis.thirdparty.io.grpc.netty.NettyServerBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.util.EnumSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for issue #7316, a follow-up to #7250.
+ * <p>
+ * #7250 made a peer that stops being admitted lose its <i>reach</i> on a connection it had already established: the
+ * in-flight Raft RPCs are closed with {@code PERMISSION_DENIED} and every later one is refused. It could not close
+ * the connection - {@code ServerTransportFilter} is handed no reference to the transport it admits, and a
+ * {@code ServerCall} reaches only its own HTTP/2 stream - so the socket lived until the peer, the kernel or a
+ * network event dropped it. Ratis sets none of gRPC's builder-wide connection-lifetime knobs, so the Raft listener
+ * had no server-side bound at all.
+ * <p>
+ * These tests drive the real production path: {@code RaftHAServer.buildParameters} publishes a
+ * {@code GrpcServices.Customizer}, the test applies that customizer to a {@link NettyServerBuilder} exactly as
+ * {@code GrpcServicesImpl.buildServer} does, starts the server, and then watches a real HTTP/2 connection from the
+ * outside. Asserting on the builder would have proved only that a setter was called.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue7316ReapsIdleRaftConnectionTest {
+
+  private static final String SERVER_LIST = "localhost:2434:2480,localhost:2435:2481";
+
+  /**
+   * gRPC clamps any window below one second up to one second ({@code MIN_MAX_CONNECTION_IDLE_NANO}), so this is the
+   * shortest window the server will actually honour.
+   */
+  private static final long   MIN_IDLE_MS  = 1_000L;
+
+  // ---------------------------------------------------------------------------
+  // Row 1: the reported case - the allowlist is on, so a revocation can happen
+  // ---------------------------------------------------------------------------
+
+  @Test
+  @Timeout(120)
+  void anIdleConnectionIsReapedWhenTheAllowlistIsOn() throws IOException {
+    final ContextConfiguration config = allowlistConfiguration();
+    config.setValue(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_IDLE_MS, MIN_IDLE_MS);
+
+    try (final RaftGrpcServer server = start(config); final Http2Peer peer = server.connect()) {
+      assertThat(peer.awaitClose(60_000))
+          .as("a connection carrying no RPC must be closed by the server, not left to the peer to drop")
+          .isTrue();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Row 2: the window is a connection-lifetime setting, not an allowlist setting
+  // ---------------------------------------------------------------------------
+
+  @Test
+  @Timeout(120)
+  void anIdleConnectionIsReapedWithTheAllowlistDisabled() throws IOException {
+    final ContextConfiguration config = allowlistConfiguration();
+    config.setValue(GlobalConfiguration.HA_PEER_ALLOWLIST_ENABLED, false);
+    config.setValue(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_IDLE_MS, MIN_IDLE_MS);
+
+    final RaftHAServer haServer = detachedServer();
+    final Parameters parameters = haServer.buildParameters(config);
+    assertThat(haServer.allowlistFilterForTest())
+        .as("the allowlist is off, so no filter is built")
+        .isNull();
+    assertThat(GrpcConfigKeys.Server.servicesCustomizer(parameters))
+        .as("the idle window must still reach the builder, or it is a setting that silently does nothing")
+        .isNotNull();
+
+    try (final RaftGrpcServer server = start(parameters); final Http2Peer peer = server.connect()) {
+      assertThat(peer.awaitClose(60_000)).isTrue();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Row 3: zero means unbounded, which is the behaviour every release before this
+  // ---------------------------------------------------------------------------
+
+  @Test
+  @Timeout(120)
+  void aZeroIdleWindowLeavesTheConnectionOpen() throws IOException {
+    final ContextConfiguration config = allowlistConfiguration();
+    config.setValue(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_IDLE_MS, 0L);
+
+    try (final RaftGrpcServer server = start(config); final Http2Peer peer = server.connect()) {
+      // A short wait that is EXPECTED to time out: a stall can only make it more true.
+      assertThat(peer.awaitClose(3_000))
+          .as("with the window disabled nothing may close the connection")
+          .isFalse();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Row 4: neither half configured - Ratis's builder is left exactly as it was
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void noCustomizerIsInstalledWhenNothingNeedsOne() {
+    final ContextConfiguration config = allowlistConfiguration();
+    config.setValue(GlobalConfiguration.HA_PEER_ALLOWLIST_ENABLED, false);
+    config.setValue(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_IDLE_MS, 0L);
+
+    final Parameters parameters = detachedServer().buildParameters(config);
+
+    assertThat(GrpcConfigKeys.Server.servicesCustomizer(parameters))
+        .as("nothing to customize means nothing installed")
+        .isNull();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Row 5: the #7250 halves still reach the builder alongside the new window
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void theAllowlistFilterAndInterceptorAreStillInstalled() {
+    final ContextConfiguration config = allowlistConfiguration();
+    config.setValue(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_IDLE_MS, MIN_IDLE_MS);
+
+    final RaftHAServer haServer = detachedServer();
+    final Parameters parameters = haServer.buildParameters(config);
+
+    assertThat(haServer.allowlistFilterForTest()).isNotNull();
+    assertThat(haServer.allowlistInterceptorForTest()).isNotNull();
+    assertThat(GrpcConfigKeys.Server.servicesCustomizer(parameters)).isNotNull();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Harness
+  // ---------------------------------------------------------------------------
+
+  private static ContextConfiguration allowlistConfiguration() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_SERVER_LIST, SERVER_LIST);
+    return config;
+  }
+
+  private static RaftHAServer detachedServer() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_SERVER_LIST, SERVER_LIST);
+
+    final ArcadeDBServer arcadeServer = mock(ArcadeDBServer.class);
+    when(arcadeServer.getServerName()).thenReturn("ArcadeDB_0");
+
+    return new RaftHAServer(arcadeServer, config);
+  }
+
+  private static RaftGrpcServer start(final ContextConfiguration config) throws IOException {
+    return start(detachedServer().buildParameters(config));
+  }
+
+  /**
+   * Applies the published customizer to a fresh {@link NettyServerBuilder} the same way
+   * {@code GrpcServicesImpl.buildServer} does, and starts the result on an ephemeral port.
+   */
+  private static RaftGrpcServer start(final Parameters parameters) throws IOException {
+    final GrpcServices.Customizer customizer = GrpcConfigKeys.Server.servicesCustomizer(parameters);
+    assertThat(customizer).as("no customizer was published, so there is nothing to start").isNotNull();
+
+    final NettyServerBuilder builder = NettyServerBuilder.forPort(0);
+    final Server server = customizer.customize(builder, EnumSet.allOf(GrpcServices.Type.class)).build().start();
+    return new RaftGrpcServer(server);
+  }
+
+  /** A started gRPC server plus the connections a test opened to it, all closed together. */
+  private record RaftGrpcServer(Server server) implements AutoCloseable {
+
+    Http2Peer connect() throws IOException {
+      final Socket socket = new Socket();
+      socket.connect(new InetSocketAddress("localhost", server.getPort()), 10_000);
+      return new Http2Peer(socket);
+    }
+
+    @Override
+    public void close() {
+      server.shutdownNow();
+    }
+  }
+
+  /**
+   * The smallest thing that counts as an HTTP/2 client to gRPC: it sends the connection preface and an empty
+   * SETTINGS frame, then reads frames and acknowledges SETTINGS and PING.
+   * <p>
+   * The PING acknowledgement is what makes this fast rather than correct-but-slow. gRPC's graceful shutdown sends
+   * the first GOAWAY, then a PING, and only closes the socket once that PING is acknowledged or its own ten-second
+   * timeout expires; a client that never answers turns a one-second idle window into an eleven-second test.
+   */
+  private static final class Http2Peer implements AutoCloseable {
+
+    private static final byte[] PREFACE  = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
+    private static final int    SETTINGS = 0x4;
+    private static final int    PING     = 0x6;
+    private static final int    ACK      = 0x1;
+
+    private final Socket       socket;
+    private final InputStream  in;
+    private final OutputStream out;
+
+    Http2Peer(final Socket socket) throws IOException {
+      this.socket = socket;
+      this.in = socket.getInputStream();
+      this.out = socket.getOutputStream();
+      out.write(PREFACE);
+      writeFrame(SETTINGS, 0, new byte[0]);
+    }
+
+    /**
+     * Reads and answers frames until the server closes the connection or until {@code timeoutMs} elapses with the
+     * connection silent. The handshake frames the server sends straight away are consumed by the same loop, which
+     * is why this cannot be "read one frame and see what it is".
+     * <p>
+     * The timeout is per read, and it is a hang detector rather than a latency bound on either side of the
+     * assertion: where the expected answer is true it is sized far above the window under test, and where it is
+     * false the wait is one that is SUPPOSED to expire, which a stalled JVM can only make more true.
+     *
+     * @return true when the server closed the connection, false when it went quiet instead
+     */
+    boolean awaitClose(final int timeoutMs) throws IOException {
+      socket.setSoTimeout(timeoutMs);
+      while (true) {
+        try {
+          readOneFrame();
+        } catch (final EOFException closedByServer) {
+          return true;
+        } catch (final SocketTimeoutException stillOpen) {
+          return false;
+        }
+      }
+    }
+
+    private void readOneFrame() throws IOException {
+      final byte[] header = readFully(9);
+      final int length = ((header[0] & 0xff) << 16) | ((header[1] & 0xff) << 8) | (header[2] & 0xff);
+      final int type = header[3] & 0xff;
+      final int flags = header[4] & 0xff;
+      final byte[] payload = readFully(length);
+
+      if (type == SETTINGS && (flags & ACK) == 0)
+        writeFrame(SETTINGS, ACK, new byte[0]);
+      else if (type == PING && (flags & ACK) == 0)
+        writeFrame(PING, ACK, payload);
+    }
+
+    private byte[] readFully(final int length) throws IOException {
+      final byte[] buffer = new byte[length];
+      int read = 0;
+      while (read < length) {
+        final int n = in.read(buffer, read, length - read);
+        if (n < 0)
+          throw new EOFException("the server closed the connection");
+        read += n;
+      }
+      return buffer;
+    }
+
+    private void writeFrame(final int type, final int flags, final byte[] payload) throws IOException {
+      final byte[] frame = new byte[9 + payload.length];
+      frame[0] = (byte) (payload.length >>> 16);
+      frame[1] = (byte) (payload.length >>> 8);
+      frame[2] = (byte) payload.length;
+      frame[3] = (byte) type;
+      frame[4] = (byte) flags;
+      System.arraycopy(payload, 0, frame, 9, payload.length);
+      out.write(frame);
+      out.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+      socket.close();
+    }
+  }
+}


### PR DESCRIPTION
Closes #7316

## Summary

#7250 made a peer that stops being admitted by `PeerAddressAllowlistFilter` lose its *reach* on a connection it had
already established, but not the connection: gRPC's public API hands out no handle on one established server
transport, so the socket lived until the peer, the kernel or a network event dropped it. Ratis sets none of the
builder-wide connection-lifetime knobs either, so the Raft listener had no server-side bound at all. This adds one -
`arcadedb.ha.grpcMaxConnectionIdleMs`, applied as `NettyServerBuilder.maxConnectionIdle` from
`RaftGrpcServicesCustomizer` - so a connection that stops carrying RPCs, which is what a revoked transport becomes
once it stops retrying, is closed with a graceful GOAWAY instead of being left to the peer. The window is installed
whether or not the allowlist is on, which is why `installPeerAllowlist` is split into a filter builder and an
installer: gating a connection-lifetime setting on `peerAllowlist.enabled` would have made it a setting that
silently does nothing on exactly the clusters that turned the allowlist off.

Default is 300000 ms and it is on by default, so this is a behaviour change on upgrade. It cannot reach the
replication path: `appendEntries` is a bidirectional stream that Ratis's log appender opens once per follower and
resets only on error, so a follower's inbound connection never reaches an active-stream count of zero - and gRPC
only ever runs the idle timer while that count *is* zero, so no in-flight RPC can be cut by it. What it does close
are the quiet connections (a revoked peer that has stopped talking, a follower's channel to a peer it only dials to
campaign, an idle Ratis admin/client channel), and a gRPC `ManagedChannel` answers a GOAWAY by reconnecting on its
next call. Set it to 0 to restore the previous unbounded behaviour.

Three doc sites that stated, in prose, that the socket stays open until the peer drops it are corrected in the same
change - `PeerAddressAllowlistFilter`'s class javadoc and its operator-facing revocation log message,
`PeerTransportSession`'s javadoc, the `HA_PEER_ALLOWLIST_ENABLED` setting description, and the class javadoc of
`Issue7250RevokesEstablishedTransportTest` (javadoc only; no test code touched).

## Test plan

- [ ] `mvn -o -pl ha-raft test -Dtest='Issue7316ReapsIdleRaftConnectionTest'` - 5 tests. Each one applies the
      customizer `RaftHAServer.buildParameters` actually published to a real `NettyServerBuilder`, exactly as
      `GrpcServicesImpl.buildServer` does, starts the server on an ephemeral port and then speaks HTTP/2 to it from
      a raw socket, so the assertion is about a real connection rather than about a setter having been called
- [ ] Confirm the red: revert the two lines in `RaftGrpcServicesCustomizer.customize` that apply the window and the
      same class reports `Tests run: 5, Failures: 2` in 124 s (both reaping tests sit until their read timeout);
      with them, `Tests run: 5, Failures: 0` in 5.8 s
- [ ] `mvn -o -pl ha-raft test -Dtest='Issue7250*,Issue7225*,Issue7132*,Issue3890RaftParametersPublicationTest,PeerAddressAllowlistFilterTest,HAConfigDefaultsTest,Issue7316*'` - 90 tests, the allowlist family that shares
      `buildParameters` with the refactor
- [ ] `mvn -o -pl engine test -Dtest='Issue7124BooleanSettingStrictCoercionTest,Issue7163DatabaseScopeCallbackTest'` -
      19 tests, the two that enumerate every `GlobalConfiguration` entry
- [ ] `mvn -o -pl ha-raft test -DexcludedGroups=benchmark,slow,vector` - the module's full unit lane
- [ ] On a real cluster: remove a peer, confirm its RPCs are refused immediately (#7250's behaviour, unchanged) and
      that its connection is gone within the window once it stops retrying

## Coverage

Entry points this fix covers, from the tracking doc's completeness table:

| Entry point | Fixed | Test |
|---|---|---|
| `buildParameters` -> allowlist ON + window -> customizer sets `maxConnectionIdle` | yes | `anIdleConnectionIsReapedWhenTheAllowlistIsOn` |
| `buildParameters` -> allowlist OFF + window -> customizer still installed | yes | `anIdleConnectionIsReapedWithTheAllowlistDisabled` |
| `buildParameters` -> window 0 -> unbounded, as before | deliberate | `aZeroIdleWindowLeavesTheConnectionOpen` |
| `buildParameters` -> allowlist OFF + window 0 -> no customizer at all | deliberate | `noCustomizerIsInstalledWhenNothingNeedsOne` |
| `RaftGrpcServicesCustomizer.customize` still installs filter + interceptor | yes (unchanged) | `theAllowlistFilterAndInterceptorAreStillInstalled` |

**Known gaps**

- **#7339** - a revoked peer that keeps *starting* RPCs never lets the connection go idle. gRPC measures idleness
  from the most recent moment the active-stream count reached zero, so every refused RPC pushes the deadline
  forward by the whole window. That covers a removed peer whose Ratis division has not learned it was removed and
  is still campaigning, and a deliberate squatter. `maxConnectionAge` is unconditional and would close it, but it
  also recycles every healthy Raft connection on the same period, so turning it on needs a measurement rather than
  a judgement call - which is what #7339 is for. The blast radius is unchanged from #7316's own: a revoked
  transport can carry nothing, so what remains is a socket, not reach.

Filed before this PR opened, as the completeness gate requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvLjzQpwWHt6h7GAeSXh5a
