### PR TITLE
fix(#7280): a full backup archives the sealed TimeSeries segments, paired with the page image

### DIFF
--- a/docs/7280-backup-omits-sealed-timeseries.md
+++ b/docs/7280-backup-omits-sealed-timeseries.md
@@ -1,0 +1,210 @@
+# #7280 — a full backup silently omits every sealed TimeSeries segment
+
+## Problem
+
+`FullBackupFormat` archives the two configuration files plus every **page** file, taken either from
+`PageSnapshot.getFiles()` (`backupFromSnapshot`) or from `FileManager.getFiles()` (`backupFromFrozenFiles`).
+`TimeSeriesSealedStore` opens `<base>.ts.sealed` with plain `RandomAccessFile`/`FileChannel` I/O and never
+registers it as a `ComponentFile`, so it appears in neither enumeration. Every compacted historical sample is
+absent from the archive, the restore reports success, and the loss is visible only to a later range query.
+
+The same gap was found and fixed on the HA snapshot-ship path under #4382 (`SnapshotHttpHandler`); the backup
+format never got the equivalent treatment.
+
+## Root cause
+
+Two independent defects, not one:
+
+1. **Presence.** Neither backup path enumerates `.ts.sealed`.
+2. **Consistency.** A `.ts.sealed` file is replaced as a whole file, outside the page snapshot's point-in-time
+   window and outside the flush suspension. Simply adding a directory listing (the `SnapshotHttpHandler`
+   copy-paste) pairs a sealed image read at time `T` with a page image fixed at `t0 <= T`, which can duplicate
+   samples. See the interleaving analysis below.
+
+## Interleaving analysis — why a directory listing alone is not enough
+
+Compaction (`TimeSeriesShard.compactInternal`) is crash-safe in three committed steps:
+
+- **Phase 0** (under `compactionLock.writeLock`): commits `compactionInProgress = true` and
+  `compactionWatermark = <sealed block count before compaction>`.
+- **Phases 1-3**: lock-free, writes `.ts.sealed.tmp`.
+- **Phase 4c** (under `compactionLock.writeLock`): `Files.move(tmp -> .ts.sealed, ATOMIC_MOVE)`, then
+  `mutableBucket.clearDataPages()` and `compactionInProgress = false`, **committed in one transaction**.
+
+Recovery on open (`TimeSeriesShard` constructor, lines 193-203) truncates the sealed store back to the
+watermark whenever `compactionInProgress` is still true.
+
+Let `P` be the page image the backup captures (t0 for the snapshot path, the freeze point for the frozen path)
+and `Z` the `.ts.sealed` image, read at `T >= P`.
+
+| Compaction position | Page image `P` | Sealed image `Z` | Restored result |
+|---|---|---|---|
+| No compaction in `[P, T]` | consistent | consistent | correct |
+| Phase 0 committed **before** `P`, Phase 4c in `(P, T]` | flag `true`, watermark set, samples still in the mutable bucket | post-swap, extra blocks | **correct** — open-time recovery truncates `Z` back to the watermark |
+| Phase 0 **and** Phase 4c both inside `(P, T]` | flag `false`, samples still in the mutable bucket | post-swap, extra blocks | **duplicated samples** — nothing tells recovery to truncate |
+
+The third row is the one a plain directory listing ships. Compaction runs on the maintenance scheduler every
+60s per type; a backup of a real database is longer than that.
+
+The mirror-image ordering (read `Z` before establishing `P`) is strictly worse: it turns duplication into
+**loss**, because a Phase 4c landing in between clears the mutable pages the archived sealed image does not yet
+carry.
+
+## The invariant
+
+> A full backup archive carries, for every TimeSeries shard, a `.ts.sealed` image that pairs with the page
+> image in the same archive either identically or as a torn compaction the restored database's own open-time
+> recovery repairs — so the restore reproduces the complete sample set with neither loss nor duplication.
+
+The second clause is what makes the fix cheap: the pause only has to exclude a **whole** compaction from the
+window, not every compaction, because a compaction that started before `P` is already covered by the
+`compactionInProgress` watermark recovery.
+
+## Fix
+
+1. `TimeSeriesSealedStore.FILE_EXTENSION` + `TimeSeriesSealedStore.listSealedFiles(File)` — one definition of
+   "which files in a database directory are sealed stores", replacing the two hand-rolled listings in
+   `SnapshotHttpHandler`. `endsWith(".ts.sealed")` deliberately excludes `.ts.sealed.tmp` (compaction scratch)
+   and `.ts.sealed.incoming` (HA install staging).
+2. `TimeSeriesCompactionPause` (new, in `com.arcadedb.engine.timeseries` because `getCompactionLock()` is
+   package-private) — holds every shard's `compactionLock.readLock()` of every TimeSeries type in the database.
+   Blocks Phase 0 / 4a / 4c, all of which need the write lock; leaves appends running (they take the read lock).
+3. `FullBackupFormat` archives the sealed stores on both paths, with the pause held across
+   `[page image established, sealed images fully read]`.
+   - The pause is acquired at the top of each backup attempt, **outside `executeInReadLock` and outside the
+     flush suspension**, for two independent reasons documented on `pauseCompaction()`:
+     - **Outside the database read lock**, because compaction's own order is compaction-write-lock first,
+       database read lock second (`LocalDatabase.commit()` runs under the read lock). Taking them the other way
+       round closes a cycle with any waiting DDL: the database lock is a `ReentrantReadWriteLock`, a queued
+       writer stops new readers from barging, so the compaction could not commit, the backup could not take the
+       compaction lock, and the DDL could not take the write lock the backup's read lock holds.
+     - **Outside the flush suspension**, because a compaction in Phase 4c holds the compaction write lock while
+       it commits, and a commit throttled by a suspension this thread already took would never release it.
+   - Snapshot path: released **immediately after** the sealed files are archived — the page bytes are streamed
+     afterwards from the already-fixed t0 window, so compaction is held for the sealed-store copy only and not
+     for the whole backup. This preserves what #6075 bought. Safe because `ParallelZipArchiveWriter.addFile`
+     and `addEntry` read their input to the end before returning (the worker threads only compress), so no
+     sealed file is still being read at that point.
+   - Frozen path: held for the whole callback; that path already freezes everything for its duration.
+
+## Completeness
+
+### Invariant
+
+Stated above.
+
+### Enumeration (commands run)
+
+`grep -rn "getFileManager().getFiles()" --include='*.java' . | grep -v /test/`
+
+```
+ha-raft/.../SnapshotHttpHandler.java:537          ha-raft/.../SnapshotHttpHandler.java:648
+ha-raft/.../RaftReplicatedDatabase.java:3112      ha-raft/.../PostVerifyDatabaseHandler.java:178
+integration/.../FullBackupFormat.java:211         server/.../ServerSecurityDatabaseUser.java:280
+engine/.../LocalSchema.java:283,428               engine/.../SortedIndexBuildRecoveryMarker.java:70,102,155
+engine/.../PaginatedSparseVectorEngine.java:1621,1826,1913,1974
+engine/.../LSMVectorIndex.java:1365,1447          engine/.../PageManager.java:825
+engine/.../UnreferencedFiles.java:234
+```
+
+`grep -rn "snapshot.getFiles()" --include='*.java' . | grep -v /test/`
+
+```
+ha-raft/.../SnapshotHttpHandler.java:534,645      ha-raft/.../SnapshotManager.java:182
+ha-raft/.../PostVerifyDatabaseHandler.java:155    integration/.../FullBackupFormat.java:190
+```
+
+`grep -rn '\.ts\.sealed' --include='*.java' . | grep /main/java/ | grep -v engine/timeseries/`
+
+```
+ha-raft/.../SnapshotHttpHandler.java:543,548,652   ha-raft/.../ArcadeStateMachine.java:2501,2703
+ha-raft/.../RaftReplicatedDatabase.java:2323       ha-raft/.../SnapshotManager.java:152
+engine/.../LocalTimeSeriesType.java:141            engine/.../LocalSchema.java:2121
+engine/.../DatabaseChecker.java:237,668
+```
+
+### Coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| `FullBackupFormat.backupFromSnapshot` (`PAGE_SNAPSHOT_ENABLED=true`) | yes | yes — `sealedSegmentsSurviveABackupRoundTrip[1]`, `theArchiveCarriesOneEntryPerSealedStoreAndNoScratchFile[1]` |
+| `FullBackupFormat.backupFromFrozenFiles` (`PAGE_SNAPSHOT_ENABLED=false`) | yes | yes — the same two, `[2]` |
+| Compaction committing **inside** the backup window (both paths) | yes | yes — `aCompactionRacingTheBackupNeitherLosesNorDuplicatesSamples[1,2]`, plus `Issue7280CompactionPauseTest.aHeldPauseBlocksCompactionUntilItIsReleased` for the pause itself |
+| `FullRestoreFormat` extraction of a `.ts.sealed` entry | no change needed — extracts every entry by name into the database directory, and `FileUtils.checkValidName` accepts `<type>_shard_<n>.ts.sealed` (rejects only empty / separators / `.` / `..`) | yes — the round-trip tests are the evidence |
+| `SnapshotHttpHandler.serveSnapshotZip` (HA snapshot ship) | presence already fixed under #4382; **consistency not fixed** — filed as #7337 | pre-existing HA coverage |
+| `SnapshotHttpHandler.estimateUncompressedBytes` | already counts sealed files (line 652); switched to the shared helper | pre-existing |
+| `SnapshotManager.computeFileChecksums` (`/checksums`) | already covers sealed — reads every non-transient file in the directory | pre-existing |
+| `PostVerifyDatabaseHandler` checksums | **not covered** — it iterates the file list, so `.ts.sealed` is never CRC'd on either of its paths. Pre-existing HA-verify gap, unrelated to backup — filed as #7338 | no |
+| `Exporter` (logical export) | argued: reads samples through the query engine, which merges sealed + mutable, so it never sees the physical file layer | n/a |
+| Retention / downsampling rewriting a sealed store inside the window | argued: they rewrite the sealed store only and never touch the mutable bucket, so the archived pair `pages(P) + sealed(post-retention)` is exactly the state the live database is in a moment later — a valid state, not a torn one. Reads are safe against the rewrite because it is `tmp`-then-`ATOMIC_MOVE`, so an opened stream keeps a complete old inode | no |
+
+### Reachability
+
+`FullBackupFormat` is constructed by `Backup.backupDatabase()` (`integration/.../backup/Backup.java`), which is
+what `BACKUP DATABASE`, the server's backup HTTP handler and the console all reach. Both paths are selected at
+runtime by `PAGE_SNAPSHOT_ENABLED`, and the tests drive both. `TimeSeriesCompactionPause.acquire` walks
+`database.getSchema().getTypes()`, so on a database with no TimeSeries type it acquires nothing and costs one
+type-list iteration.
+
+### Adversarial pass
+
+The isolated `general-purpose` subagent this step calls for is not available in this environment (no `Task`
+tool), so the pass was run by hand against the two claims the patch most depends on. Both found something:
+
+1. **"The pause is safe to release after the sealed copy."** Only true if the archive writer has finished
+   reading by then. Verified: `ParallelZipArchiveWriter.addFile` opens the file and drives `addEntry`, which
+   reads the stream to exhaustion on the CALLING thread before returning - the pool threads only deflate chunks
+   handed to them ("THE SINGLE THREAD THAT CALLS addFile ... DO NOT START TOUCHING THEM FROM A WORKER").
+   `ZipStreamArchiveWriter` is single-threaded outright. Claim holds; the reasoning is now in the code comment
+   rather than left implicit.
+2. **"Acquiring the pause inside the database read lock is fine."** It was NOT. Compaction takes the
+   compaction write lock and then commits, and `LocalDatabase.commit()` runs under the database READ lock, so
+   compaction's order is compaction-then-database. The first draft took them database-then-compaction, which
+   closes a three-way cycle with a waiting DDL writer (a `ReentrantReadWriteLock` queued writer blocks new
+   readers from barging). The 60s budget would have turned it into a failed backup rather than a hang, but a
+   backup that fails whenever a `CREATE TYPE` overlaps it is its own bug report. **Fixed in this branch**: the
+   pause is now acquired at the top of the attempt, outside `executeInReadLock`, so the backup and compaction
+   take the two locks in the same order and there is no cycle.
+
+### Residual risk
+
+- A backup taken **on an HA follower** can still tear: the follower installs a leader's sealed blob through
+  `TimeSeriesSealedStore.installSealedFile`, which takes the store's own `directoryLock`, not the shard's
+  `compactionLock`, so the pause does not exclude it. Filed as **#7337**.
+- `PostVerifyDatabaseHandler` never checksums `.ts.sealed`, so a sealed-store divergence between HA peers is
+  invisible to `/verify`. Pre-existing, filed as **#7338**.
+- The pause is bounded at 60s. If a shard's compaction write lock cannot be taken inside that budget the backup
+  **fails loudly** rather than writing an archive that may restore with duplicated samples.
+
+## Verification
+
+| Command | Result |
+|---|---|
+| `mvn -o -pl engine test -Dtest='com.arcadedb.engine.timeseries.*Test'` | 415 tests, 0 failures |
+| `mvn -o -pl integration test` | 318 tests, 0 failures, 9 skipped |
+| `mvn -o -pl integration -Pintegration verify -Dit.test='*Backup*IT'` | 39 tests, 0 failures |
+| `mvn -o -pl ha-raft test -Dtest='*Snapshot*Test'` | 185 tests, 0 failures |
+
+### Proof the new tests can fail
+
+Both halves of the fix were reverted in turn and the suite re-run, so neither test is passing for a reason
+other than the one it names:
+
+- **Sealed archiving removed, pause kept** — all 6 `Issue7280SealedTimeSeriesBackupIT` cases fail, with the
+  message each is for: "every sample, sealed and mutable alike, must come back" (round trip, both paths), the
+  missing `Reading_shard_*.ts.sealed` archive entries, and "the archive must be a point in time between the two
+  samplings" (the race test, failing as loss).
+- **Pause removed, sealed archiving kept** — `aCompactionRacingTheBackupNeitherLosesNorDuplicatesSamples` fails
+  on "a repeated timestamp means a post-compaction sealed image was paired with a pre-compaction page image",
+  listing ~4,000 duplicated timestamps. Three consecutive runs: 2, 1 and 2 of the two parameterisations red.
+  This is the third row of the interleaving table, reproduced.
+
+## Impact
+
+- A full backup of a database with TimeSeries types now restores the compacted history instead of silently
+  dropping it. Archives taken before this fix are still incomplete and cannot be repaired after the fact.
+- The archive gains one entry per shard. On the snapshot path TimeSeries compaction is held only for the time it
+  takes to read the sealed stores, not for the whole backup; on the frozen path it is held for the window that
+  path already freezes.
+- `SnapshotHttpHandler`'s two hand-rolled `.ts.sealed` listings are now the one shared helper, so the suffix has
+  a single definition.

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesCompactionPause.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesCompactionPause.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.LocalTimeSeriesType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+
+/**
+ * A held pause of TimeSeries compaction across every shard of every TimeSeries type of one database. While it is
+ * open, no compaction can COMPLETE: it holds each shard's compaction read lock, which is the lock
+ * {@code TimeSeriesShard.compactInternal} needs the write half of in its Phase 0, Phase 4a and Phase 4c.
+ * Appends are unaffected - they take the read lock too.
+ *
+ * <h2>Why a copy of a database needs this (issue #7280)</h2>
+ *
+ * A sealed store is replaced as a whole file, atomically, entirely outside the point-in-time window a
+ * {@code PageSnapshot} gives the page files and outside the flush suspension the fallback path gives them. So a
+ * caller that fixes a page image at {@code t0} and then reads {@code .ts.sealed} at {@code T >= t0} can pair a
+ * post-swap sealed image with a page image whose mutable bucket has not been cleared yet: the same samples
+ * twice, restored.
+ * <p>
+ * The pause does not have to exclude every compaction, only a WHOLE one. A compaction that had already
+ * committed its Phase 0 when the pause was taken has left {@code compactionInProgress} and its block-count
+ * watermark in the page image, and the restored database's own open-time recovery
+ * ({@code TimeSeriesShard}'s constructor) truncates the sealed store back to that watermark - so that
+ * interleaving repairs itself. What has to be excluded is a compaction that both starts and finishes inside the
+ * window, because nothing in the page image records that it happened.
+ *
+ * <h2>Lock ordering</h2>
+ *
+ * Take it BEFORE any flush suspension or point-in-time window, never inside one: a compaction sitting in Phase
+ * 4c holds the write lock while it commits, and a commit that cannot proceed because the caller has already
+ * suspended flushing would never release it. Taken first, it waits for that compaction to finish and only then
+ * closes the door.
+ * <p>
+ * The read locks are released by the thread that took them, so acquire and {@link #close()} on the same thread.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class TimeSeriesCompactionPause implements AutoCloseable {
+  private final List<Lock> held;
+  private       boolean    released;
+
+  private TimeSeriesCompactionPause(final List<Lock> held) {
+    this.held = held;
+  }
+
+  /**
+   * Pauses compaction on every shard of every TimeSeries type registered in {@code database}. Returns
+   * immediately, holding nothing, on a database with no TimeSeries type.
+   *
+   * @param database  the database whose schema is walked for TimeSeries types
+   * @param timeoutMs total budget for acquiring every shard's lock, not a per-shard one
+   *
+   * @return the held pause, to be closed by the caller
+   *
+   * @throws TimeoutException if the budget runs out, with every lock already taken released first. The caller
+   *                          must treat this as a failure rather than proceeding unpaused: an archive written
+   *                          without the pause can restore with duplicated samples and report success.
+   */
+  public static TimeSeriesCompactionPause acquire(final Database database, final long timeoutMs) {
+    final List<Lock> acquired = new ArrayList<>();
+    final long deadline = System.currentTimeMillis() + timeoutMs;
+    try {
+      for (final DocumentType type : database.getSchema().getTypes()) {
+        if (!(type instanceof final LocalTimeSeriesType tsType))
+          continue;
+
+        // The unchecked accessor on purpose: this is engine-internal housekeeping on behalf of a caller that has
+        // already been authorized for the whole database, and a type whose engine never started (issue #6356)
+        // has no shard to pause.
+        final TimeSeriesEngine engine = tsType.getEngine();
+        if (engine == null)
+          continue;
+
+        for (int i = 0; i < engine.getShardCount(); i++) {
+          final Lock lock = engine.getShard(i).getCompactionLock().readLock();
+          final long remaining = deadline - System.currentTimeMillis();
+          if (remaining <= 0 || !lock.tryLock(remaining, TimeUnit.MILLISECONDS))
+            throw new TimeoutException(
+                "Timeout of %dms expired while pausing the compaction of TimeSeries type '%s' shard %d".formatted(
+                    timeoutMs, tsType.getName(), i));
+          acquired.add(lock);
+        }
+      }
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      release(acquired);
+      throw new TimeoutException("Interrupted while pausing TimeSeries compaction", e);
+    } catch (final RuntimeException | Error e) {
+      release(acquired);
+      throw e;
+    }
+    return new TimeSeriesCompactionPause(acquired);
+  }
+
+  /** How many shards this pause is holding. Zero when the database has no TimeSeries type. */
+  public int getPausedShards() {
+    return held.size();
+  }
+
+  /**
+   * Releases every shard. Idempotent, so a caller that releases the pause early - as a backup does, the moment
+   * the sealed stores have been read - can still close it from a try-with-resources.
+   */
+  @Override
+  public void close() {
+    if (released)
+      return;
+    released = true;
+    release(held);
+  }
+
+  private static void release(final List<Lock> locks) {
+    for (int i = locks.size() - 1; i >= 0; i--)
+      locks.get(i).unlock();
+    locks.clear();
+  }
+}

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
@@ -105,6 +105,15 @@ public class TimeSeriesSealedStore implements AutoCloseable {
    */
   private static final double SUM_RELATIVE_TOLERANCE = 1e-9;
 
+  /**
+   * The filename suffix of a sealed store, as built by {@link #sealedFileNameFor(String, int)}. Public because
+   * every layer that copies a database whole - backup, HA snapshot ship - has to be able to recognise a file the
+   * paginated layer knows nothing about.
+   */
+  public static final String FILE_EXTENSION = ".ts.sealed";
+
+  private static final File[] EMPTY_FILES = new File[0];
+
   private final String               basePath;
   private final List<ColumnDefinition> columns;
   private       RandomAccessFile     indexFile;
@@ -2313,6 +2322,27 @@ public class TimeSeriesSealedStore implements AutoCloseable {
    */
   public static String sealedFileNameFor(final String typeName, final int shardIndex) {
     return typeName + "_shard_" + shardIndex + ".ts.sealed";
+  }
+
+  /**
+   * Every sealed store in a database directory, as files. This is the only way to find them: a sealed store is
+   * opened with raw {@link RandomAccessFile}/{@link FileChannel} I/O and is never registered as a
+   * {@code ComponentFile}, so it appears in neither {@code FileManager.getFiles()} nor a {@code PageSnapshot} -
+   * which is what made a full backup omit every compacted sample (issue #7280) and, before it, an HA snapshot
+   * ship (issue #4382).
+   * <p>
+   * The suffix match is exact and therefore excludes the two neighbours that share its prefix and must never be
+   * copied anywhere: {@code .ts.sealed.tmp}, the half-written file of a compaction in flight, and
+   * {@code .ts.sealed.incoming}, the staging file of an HA install. It is also narrow enough not to pick up an
+   * unrelated file that happens to live in the database directory - a backup archive written there, say.
+   *
+   * @param databaseDirectory the database directory to list
+   *
+   * @return the sealed-store files, never {@code null} and empty when the directory holds none or cannot be read
+   */
+  public static File[] listSealedFiles(final File databaseDirectory) {
+    final File[] files = databaseDirectory.listFiles((dir, name) -> name.endsWith(FILE_EXTENSION));
+    return files != null ? files : EMPTY_FILES;
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue7280CompactionPauseTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue7280CompactionPauseTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseContext;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7280 - the two engine-side primitives a consistent backup of a TimeSeries database needs.
+ * <p>
+ * {@link TimeSeriesSealedStore#listSealedFiles(File)} is the enumeration the page-file layer cannot provide,
+ * because a sealed store is raw {@code FileChannel} I/O and is never registered with the {@code FileManager}.
+ * {@link TimeSeriesCompactionPause} is what stops the enumeration from being a trap: without it a sealed image
+ * read after the page image can carry samples the page image still holds in the mutable bucket, which restores
+ * as duplicates.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7280CompactionPauseTest extends TestHelper {
+  private static final int  SAMPLES = 30_000;
+  private static final long BASE_TS = 1_700_000_000_000L;
+
+  /**
+   * A wait that is EXPECTED to expire: it is the assertion that compaction did not get through the pause. Kept
+   * short because a stall can only make it more true, never less.
+   */
+  private static final long BLOCKED_PROBE_MS = 2_000L;
+
+  @Override
+  protected void beginTest() {
+    database.command("sql", "CREATE TIMESERIES TYPE Reading TIMESTAMP ts TAGS (host STRING) FIELDS (value DOUBLE) SHARDS 2");
+  }
+
+  @Test
+  void listSealedFilesReturnsTheSealedStoresAndNothingElse() throws Exception {
+    ingest(SAMPLES);
+    engine().compactAll();
+
+    final File dir = new File(database.getDatabasePath());
+
+    // Scratch and staging files sit in the same directory and must never reach an archive: the first is a
+    // half-written compaction, the second a half-received HA install.
+    assertThat(new File(dir, "Reading_shard_0.ts.sealed.tmp").createNewFile()).isTrue();
+    assertThat(new File(dir, "Reading_shard_1.ts.sealed.incoming").createNewFile()).isTrue();
+
+    final List<String> names = Arrays.stream(TimeSeriesSealedStore.listSealedFiles(dir)).map(File::getName).sorted()
+        .toList();
+
+    assertThat(names).containsExactly("Reading_shard_0.ts.sealed", "Reading_shard_1.ts.sealed");
+    for (final String name : names)
+      assertThat(new File(dir, name)).exists().isFile();
+  }
+
+  @Test
+  void listSealedFilesOnADirectoryWithoutTimeSeriesIsEmptyRatherThanNull() {
+    assertThat(TimeSeriesSealedStore.listSealedFiles(new File(database.getDatabasePath(), "does-not-exist"))).isEmpty();
+  }
+
+  /**
+   * The property the backup relies on: while the pause is held no compaction can COMPLETE, so a sealed image
+   * read inside it still pairs with the mutable bucket the page image carries.
+   */
+  @Test
+  void aHeldPauseBlocksCompactionUntilItIsReleased() throws Exception {
+    ingest(SAMPLES);
+
+    final long blocksBefore = totalSealedBlocks();
+    assertThat(blocksBefore).as("the test must start with nothing sealed, or it proves nothing").isZero();
+
+    final CountDownLatch compacted = new CountDownLatch(1);
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+
+    try (final TimeSeriesCompactionPause pause = TimeSeriesCompactionPause.acquire(database, 30_000L)) {
+      final Thread compactor = new Thread(() -> {
+        DatabaseContext.INSTANCE.init((DatabaseInternal) database);
+        try {
+          engine().compactAll();
+        } catch (final Throwable e) {
+          failure.set(e);
+        } finally {
+          DatabaseContext.INSTANCE.removeContext(database.getDatabasePath());
+          compacted.countDown();
+        }
+      }, "issue7280-compactor");
+      compactor.setDaemon(true);
+      compactor.start();
+
+      assertThat(compacted.await(BLOCKED_PROBE_MS, TimeUnit.MILLISECONDS))
+          .as("compaction must not complete while the pause is held").isFalse();
+      assertThat(totalSealedBlocks()).as("no sealed block may appear while the pause is held").isZero();
+
+      pause.close();
+
+      assertThat(compacted.await(60, TimeUnit.SECONDS)).as("compaction must complete once the pause is released")
+          .isTrue();
+      assertThat(failure.get()).isNull();
+      compactor.join(60_000);
+    }
+
+    assertThat(totalSealedBlocks()).as("the released compaction must actually have sealed something")
+        .isGreaterThan(blocksBefore);
+  }
+
+  /** Closing twice is a no-op: the backup releases the pause early and the try-with-resources closes it again. */
+  @Test
+  void closingThePauseTwiceIsANoOp() throws Exception {
+    ingest(1_000);
+
+    final TimeSeriesCompactionPause pause = TimeSeriesCompactionPause.acquire(database, 30_000L);
+    pause.close();
+    pause.close();
+
+    // A double release would have thrown above on an unheld lock; compaction still works afterwards.
+    engine().compactAll();
+    assertThat(totalSealedBlocks()).isGreaterThan(0);
+  }
+
+  /**
+   * The pause covers every shard of every TimeSeries type and nothing else, so a database with no TimeSeries
+   * type pays nothing for it and one with several is covered whole.
+   */
+  @Test
+  void thePauseCoversEveryShardOfEveryTimeSeriesTypeAndNothingElse() {
+    database.command("sql", "CREATE DOCUMENT TYPE Plain");
+    try (final TimeSeriesCompactionPause pause = TimeSeriesCompactionPause.acquire(database, 30_000L)) {
+      assertThat(pause.getPausedShards()).isEqualTo(engine().getShardCount());
+    }
+
+    database.command("sql", "CREATE TIMESERIES TYPE Second TIMESTAMP ts TAGS (host STRING) FIELDS (v DOUBLE) SHARDS 3");
+    try (final TimeSeriesCompactionPause pause = TimeSeriesCompactionPause.acquire(database, 30_000L)) {
+      assertThat(pause.getPausedShards()).isEqualTo(engine().getShardCount() + 3);
+    }
+  }
+
+  private TimeSeriesEngine engine() {
+    return ((LocalTimeSeriesType) database.getSchema().getType("Reading")).getEngine();
+  }
+
+  private long totalSealedBlocks() {
+    long total = 0;
+    for (int i = 0; i < engine().getShardCount(); i++)
+      total += engine().getShard(i).getSealedStore().getBlockCount();
+    return total;
+  }
+
+  private void ingest(final int samples) throws Exception {
+    final long[] timestamps = new long[samples];
+    final Object[] hosts = new Object[samples];
+    final Object[] values = new Object[samples];
+    for (int i = 0; i < samples; i++) {
+      timestamps[i] = BASE_TS + i * 1_000L;
+      hosts[i] = "host_" + (i % 4);
+      values[i] = (double) i;
+    }
+    engine().appendBatch(timestamps, new Object[][] { hosts, values });
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
@@ -25,6 +25,7 @@ import com.arcadedb.database.LocalDatabase;
 import com.arcadedb.engine.TransactionManager;
 import com.arcadedb.engine.ComponentFile;
 import com.arcadedb.engine.PageSnapshot;
+import com.arcadedb.engine.timeseries.TimeSeriesSealedStore;
 import com.arcadedb.exception.PageSnapshotException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.utility.CodeUtils;
@@ -544,11 +545,8 @@ public class SnapshotHttpHandler implements HttpHandler {
       // the FileManager, so they are absent from getFiles(). Add them explicitly so a snapshot-syncing
       // follower also receives the compacted time-series data instead of only the mutable buckets
       // (issue #4382).
-      final File dbDir = new File(db.getDatabasePath());
-      final File[] sealedFiles = dbDir.listFiles((d, name) -> name.endsWith(".ts.sealed"));
-      if (sealedFiles != null)
-        for (final File sealedFile : sealedFiles)
-          addFileToZip(zipOut, sealedFile, manifest);
+      for (final File sealedFile : TimeSeriesSealedStore.listSealedFiles(new File(db.getDatabasePath())))
+        addFileToZip(zipOut, sealedFile, manifest);
 
       // Ship the recency marker (issue #5277). last-tx-id.bin is written on a clean close and on WAL
       // rotation, but a follower that receives this database via snapshot and is later force-killed
@@ -649,10 +647,8 @@ public class SnapshotHttpHandler implements HttpHandler {
         if (file != null)
           total += file.getOSFile().length();
 
-    final File[] sealedFiles = new File(db.getDatabasePath()).listFiles((d, name) -> name.endsWith(".ts.sealed"));
-    if (sealedFiles != null)
-      for (final File sealedFile : sealedFiles)
-        total += sealedFile.length();
+    for (final File sealedFile : TimeSeriesSealedStore.listSealedFiles(new File(db.getDatabasePath())))
+      total += sealedFile.length();
 
     return total + Long.BYTES; // the last-tx-id marker
   }

--- a/integration/src/main/java/com/arcadedb/integration/backup/format/FullBackupFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/backup/format/FullBackupFormat.java
@@ -184,13 +184,17 @@ public class FullBackupFormat extends AbstractBackupFormat {
   }
 
   /**
-   * Archives the two configuration files plus every PAGE file as it stood at the snapshot's t0 (issue #6075).
+   * Archives the two configuration files and the TimeSeries sealed stores, plus every PAGE file as it stood at the
+   * snapshot's t0 (issue #6075).
    * <p>
    * The configuration files are still read straight off the filesystem: they are not page files, so the snapshot
    * does not cover them, and the database read lock this runs under is what keeps them consistent with the page
    * files - it excludes the DDL that rewrites them. Files created after t0 are absent from the snapshot by
    * construction, which is correct: they did not exist at the point in time being archived. Files DROPPED after t0
    * are still readable, because their physical deletion is deferred until the window closes.
+   * <p>
+   * The sealed stores are read straight off the filesystem for the same reason and are NOT covered by the read
+   * lock, which is why the caller's compaction pause is held until they have been read (issue #7280).
    */
   private long backupFromSnapshot(final BackupArchiveWriter archive, final TimeSeriesCompactionPause pause)
       throws Exception {

--- a/integration/src/main/java/com/arcadedb/integration/backup/format/FullBackupFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/backup/format/FullBackupFormat.java
@@ -23,6 +23,8 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.LocalDatabase;
 import com.arcadedb.engine.ComponentFile;
 import com.arcadedb.engine.PageSnapshot;
+import com.arcadedb.engine.timeseries.TimeSeriesCompactionPause;
+import com.arcadedb.engine.timeseries.TimeSeriesSealedStore;
 import com.arcadedb.exception.PageSnapshotException;
 import com.arcadedb.integration.backup.BackupException;
 import com.arcadedb.integration.backup.BackupSettings;
@@ -40,6 +42,7 @@ import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -54,6 +57,14 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class FullBackupFormat extends AbstractBackupFormat {
+  /**
+   * How long the backup waits to pause TimeSeries compaction before giving up. A tripwire, not a latency bound:
+   * the compaction write lock is only ever held across one brief transaction, so a budget this size expiring
+   * means something is wrong rather than merely slow. Expiring FAILS the backup - proceeding unpaused would risk
+   * the one outcome worth failing over, an archive that restores with duplicated samples and reports success.
+   */
+  private static final long COMPACTION_PAUSE_TIMEOUT_MS = 60_000L;
+
   private interface BackupCallback {
     void backup(BackupArchiveWriter archive) throws Exception;
   }
@@ -119,12 +130,12 @@ public class FullBackupFormat extends AbstractBackupFormat {
       final AtomicReference<Exception> failure = new AtomicReference<>();
       final boolean snapshotAttempt = useSnapshot;
 
-      try {
+      try (final TimeSeriesCompactionPause pause = pauseCompaction()) {
         writeArchive(backupFile, compressionLevel, compressionThreads, maxMBPerSecond, failure, archive ->
           // ACQUIRE A READ LOCK. TRANSACTION CAN STILL RUN, BUT CREATION OF NEW FILES (BUCKETS, TYPES, INDEXES) WILL BE PUT ON PAUSE UNTIL THIS LOCK IS RELEASED
           database.executeInReadLock(() -> {
             if (snapshotAttempt)
-              databaseOrigSize.set(backupFromSnapshot(archive));
+              databaseOrigSize.set(backupFromSnapshot(archive, pause));
             else
               // FORCE FLUSHING BEFORE THE BACKUP AND AVOID FLUSHING OF DATA PAGES TO DISK
               database.getPageManager().suspendFlushAndExecute(database, () -> {
@@ -181,11 +192,20 @@ public class FullBackupFormat extends AbstractBackupFormat {
    * construction, which is correct: they did not exist at the point in time being archived. Files DROPPED after t0
    * are still readable, because their physical deletion is deferred until the window closes.
    */
-  private long backupFromSnapshot(final BackupArchiveWriter archive) throws Exception {
+  private long backupFromSnapshot(final BackupArchiveWriter archive, final TimeSeriesCompactionPause pause)
+      throws Exception {
     long origSize = 0L;
     try (final PageSnapshot snapshot = database.getPageManager().openSnapshot(database)) {
       origSize += compressFile(archive, ((LocalDatabase) database.getEmbedded()).getConfigurationFile());
       origSize += compressFile(archive, ((LocalSchema) database.getSchema()).getConfigurationFile());
+      origSize += compressSealedStores(archive);
+      // RELEASED HERE AND NOT AT THE END: THE SPAN THAT HAS TO EXCLUDE A COMPACTION ENDS WITH THE LAST SEALED
+      // BYTE READ, BECAUSE THE PAGE IMAGE IS ALREADY FIXED AT THE WINDOW'S t0 NO MATTER WHEN ITS BYTES ARE
+      // STREAMED. HOLDING IT FOR THE WHOLE BACKUP WOULD POSTPONE TIMESERIES COMPACTION FOR THE WHOLE BACKUP,
+      // WHICH IS EXACTLY THE COST #6075 REMOVED FOR EVERY OTHER BACKGROUND JOB. addFile/addEntry READ THEIR
+      // INPUT TO THE END BEFORE RETURNING - THE WORKER THREADS ONLY COMPRESS - SO NOTHING IS STILL READING A
+      // SEALED FILE AT THIS POINT
+      pause.close();
 
       for (final PageSnapshot.SnapshotFile file : snapshot.getFiles())
         origSize += compressEntry(archive, file.fileName(), file.lastModified(), snapshot.newInputStream(file.fileId()));
@@ -207,6 +227,10 @@ public class FullBackupFormat extends AbstractBackupFormat {
     long origSize = 0L;
     origSize += compressFile(archive, ((LocalDatabase) database.getEmbedded()).getConfigurationFile());
     origSize += compressFile(archive, ((LocalSchema) database.getSchema()).getConfigurationFile());
+    // THE CALLER'S PAUSE IS NOT RELEASED EARLY ON THIS PATH, UNLIKE THE SNAPSHOT ONE: HERE THE PAGE IMAGE IS THE
+    // ON-DISK ONE THE FLUSH SUSPENSION IS FREEZING, SO IT IS ONLY FIXED FOR AS LONG AS THE SUSPENSION LASTS AND
+    // THE PAUSE HAS TO SPAN THE WHOLE CALLBACK - WHICH THIS PATH ALREADY THROTTLES WRITERS FOR ANYWAY
+    origSize += compressSealedStores(archive);
 
     final Collection<ComponentFile> files = database.getFileManager().getFiles();
 
@@ -215,6 +239,54 @@ public class FullBackupFormat extends AbstractBackupFormat {
         origSize += compressFile(archive, file.getOSFile());
 
     return origSize;
+  }
+
+  /**
+   * Archives the TimeSeries sealed stores, which neither backup path can reach through its own file
+   * enumeration: {@code TimeSeriesSealedStore} opens {@code <base>.ts.sealed} with raw {@code FileChannel} I/O
+   * and never registers it as a {@code ComponentFile}, so it is absent from {@code FileManager.getFiles()} and
+   * from the page snapshot alike. Without this a restored backup returns the schema, the graph, the tag
+   * dictionary and whatever samples had not been compacted yet, and reports success (issue #7280).
+   * <p>
+   * The restore side needs no counterpart: {@code FullRestoreFormat} extracts every archive entry by name into
+   * the database directory, so a {@code .ts.sealed} entry lands where the reopened database looks for it.
+   */
+  private long compressSealedStores(final BackupArchiveWriter archive) throws IOException {
+    long origSize = 0L;
+    for (final File sealedFile : TimeSeriesSealedStore.listSealedFiles(new File(database.getDatabasePath())))
+      try {
+        origSize += compressFile(archive, sealedFile);
+      } catch (final FileNotFoundException e) {
+        // THE LISTING AND THE READ ARE NOT ONE OPERATION. A COMPACTION CANNOT REPLACE THE FILE HERE - THE PAUSE
+        // IS HELD - BUT RETENTION AND DOWNSAMPLING REWRITE A SEALED STORE WITHOUT THE COMPACTION LOCK, AND THEY
+        // DO IT BY ATOMIC RENAME, SO THE PATH ALWAYS RESOLVES TO A COMPLETE FILE. WHAT IS LEFT IS A STORE THAT
+        // WENT AWAY ENTIRELY BETWEEN THE TWO, WHICH IS NOT WORTH FAILING A BACKUP OVER
+        logger.logLine(2, "- File '%s' disappeared while being archived, skipped", sealedFile.getName());
+      }
+    return origSize;
+  }
+
+  /**
+   * Holds TimeSeries compaction back while the sealed stores are paired with the page image. See
+   * {@link TimeSeriesCompactionPause} for why a whole compaction landing inside that span - and only a whole one
+   * - would restore as duplicated samples.
+   * <p>
+   * Called OUTSIDE {@code executeInReadLock} and outside the flush suspension, and both matter.
+   * <p>
+   * Outside the read lock, because compaction's own order is compaction-write-lock first and database read lock
+   * second (Phase 0/4a/4c take the write lock and then commit, and {@code LocalDatabase.commit()} runs under the
+   * database READ lock). Taking them the other way round here would close a cycle with any waiting DDL: the
+   * database lock is a {@code ReentrantReadWriteLock}, so a queued writer stops new readers from barging, which
+   * would leave the compaction unable to commit, this backup unable to take the compaction lock it is waiting
+   * for, and the DDL unable to take the write lock this backup's read lock is holding. Acquiring the pause first
+   * puts both this backup and compaction in the same order and there is no cycle to close.
+   * <p>
+   * Outside the flush suspension, because a compaction already in its Phase 4c holds the compaction write lock
+   * while it commits, and a commit throttled by a suspension this thread has already taken would never release
+   * it. Taken first, this waits for that compaction and only then closes the door.
+   */
+  private TimeSeriesCompactionPause pauseCompaction() {
+    return TimeSeriesCompactionPause.acquire(database, COMPACTION_PAUSE_TIMEOUT_MS);
   }
 
   private long compressEntry(final BackupArchiveWriter archive, final String name, final long lastModified,

--- a/integration/src/test/java/com/arcadedb/integration/backup/Issue7280SealedTimeSeriesBackupIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/backup/Issue7280SealedTimeSeriesBackupIT.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.backup;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseContext;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.timeseries.TimeSeriesEngine;
+import com.arcadedb.integration.TestHelper;
+import com.arcadedb.integration.restore.Restore;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7280 - a full backup archives the compacted TimeSeries segments, and restores them consistently.
+ * <p>
+ * A {@code .ts.sealed} sealed store is raw {@code FileChannel} I/O and is registered with neither the
+ * {@code FileManager} nor the page snapshot, so both backup paths used to walk straight past it: the archive
+ * completed, the restore completed, and every compacted sample was gone. Two properties are defended here, on
+ * both paths ({@code PAGE_SNAPSHOT_ENABLED} true and false):
+ * <ol>
+ *   <li>the sealed segments are in the archive and come back out of a restore, sample for sample;</li>
+ *   <li>a compaction running DURING the backup window neither loses nor duplicates samples - the sealed image
+ *       and the page image in one archive are a pair, not two unrelated instants.</li>
+ * </ol>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7280SealedTimeSeriesBackupIT {
+  private static final String DATABASE_PATH = "target/databases/backup-sealed-ts";
+  private static final String RESTORED_PATH = "target/databases/backup-sealed-ts-restored";
+  private static final String BACKUP_FILE   = "target/backup-sealed-ts.zip";
+  private static final String TYPE          = "Reading";
+  private static final int    SHARDS        = 2;
+  private static final int    SAMPLES       = 60_000;
+  private static final long   BASE_TS       = 1_700_000_000_000L;
+  private static final long   STEP_MS       = 1_000L;
+  /** Throttled so the racing compaction has a window to land inside. */
+  private static final int    MAX_MB_PER_SECOND = 1;
+  /** Small enough that a full ingest+compact cycle fits several times inside the throttled backup window. */
+  private static final int    RACE_CHUNK        = 2_000;
+  private static final String DOC_TYPE          = "Sensor";
+  /** Bulk that makes the throttled backup last seconds, so compactions are certain to land inside its window. */
+  private static final int    DOCUMENTS         = 8_000;
+  private static final String PAYLOAD           = "x".repeat(500);
+
+  @BeforeEach
+  @AfterEach
+  void clean() {
+    GlobalConfiguration.PAGE_SNAPSHOT_ENABLED.reset();
+    FileUtils.deleteRecursively(new File(DATABASE_PATH));
+    FileUtils.deleteRecursively(new File(RESTORED_PATH));
+    new File(BACKUP_FILE).delete();
+  }
+
+  /**
+   * The reported defect: everything that had been compacted into a sealed segment was missing from the restore,
+   * and only the mutable {@code .tstb} tail came back.
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = { true, false })
+  void sealedSegmentsSurviveABackupRoundTrip(final boolean snapshot) throws Exception {
+    GlobalConfiguration.PAGE_SNAPSHOT_ENABLED.setValue(snapshot);
+
+    final List<Object[]> expected;
+    try (final Database database = createDatabase()) {
+      populateDocuments(database, 100);
+
+      final TimeSeriesEngine engine = engineOf(database);
+      ingest(engine, 0, SAMPLES);
+      engine.compactAll();
+
+      // The test is only about sealed data if there IS sealed data: without this the fix could be a no-op and
+      // the assertions below would still pass on the mutable tail alone.
+      assertThat(sealedBlocks(engine)).as("the fixture must have sealed at least one segment").isPositive();
+      assertThat(sealedFiles()).as("the sealed stores must exist on disk before the backup").hasSize(SHARDS);
+
+      // Samples written after the compaction stay in the mutable bucket, so the restore has to reassemble both
+      // halves rather than either one alone.
+      ingest(engine, SAMPLES, SAMPLES / 10);
+
+      expected = readAll(engine);
+      assertThat(expected).hasSize(SAMPLES + SAMPLES / 10);
+
+      new Backup(database, BACKUP_FILE).setVerboseLevel(0).backupDatabase();
+    }
+
+    new Restore(BACKUP_FILE, RESTORED_PATH).setVerboseLevel(0).restoreDatabase();
+
+    try (final Database restored = new DatabaseFactory(RESTORED_PATH).open()) {
+      assertThat(restored.command("sql", "check database").nextIfAvailable().<Long>getProperty("totalErrors")).isZero();
+      assertThat(restored.countType(DOC_TYPE, false)).as("the graph half must be unaffected").isEqualTo(100);
+
+      final List<Object[]> actual = readAll(engineOf(restored));
+      assertThat(actual).as("every sample, sealed and mutable alike, must come back").hasSameSizeAs(expected);
+      for (int i = 0; i < expected.size(); i++)
+        assertThat(actual.get(i)).as("sample %d", i).containsExactly(expected.get(i));
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  /**
+   * Guards the entry NAMES: a sealed store written under a path-qualified or otherwise wrong name would extract
+   * somewhere the reopened database never looks, and the round-trip above would fail with no clue why. The
+   * compaction scratch file must NOT be in there.
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = { true, false })
+  void theArchiveCarriesOneEntryPerSealedStoreAndNoScratchFile(final boolean snapshot) throws Exception {
+    GlobalConfiguration.PAGE_SNAPSHOT_ENABLED.setValue(snapshot);
+
+    try (final Database database = createDatabase()) {
+      final TimeSeriesEngine engine = engineOf(database);
+      ingest(engine, 0, SAMPLES);
+      engine.compactAll();
+      assertThat(sealedBlocks(engine)).isPositive();
+
+      // A leftover scratch file from an interrupted compaction: it is not a sealed store and must be skipped.
+      assertThat(new File(DATABASE_PATH, TYPE + "_shard_0.ts.sealed.tmp").createNewFile()).isTrue();
+
+      new Backup(database, BACKUP_FILE).setVerboseLevel(0).backupDatabase();
+    }
+
+    final List<String> entries = new ArrayList<>();
+    try (final ZipFile zip = new ZipFile(BACKUP_FILE)) {
+      final Enumeration<? extends ZipEntry> it = zip.entries();
+      while (it.hasMoreElements())
+        entries.add(it.nextElement().getName());
+    }
+
+    assertThat(entries).contains(TYPE + "_shard_0.ts.sealed", TYPE + "_shard_1.ts.sealed");
+    assertThat(entries).doesNotContain(TYPE + "_shard_0.ts.sealed.tmp");
+    TestHelper.checkActiveDatabases();
+  }
+
+  /**
+   * The consistency half. A {@code .ts.sealed} is swapped as a whole file, outside the page snapshot's window
+   * and outside the flush suspension, so a compaction that both STARTS and FINISHES inside the backup window
+   * would otherwise pair a post-swap sealed image with a pre-clear page image - the same samples twice.
+   * <p>
+   * Compactions are driven in a loop for the duration of a throttled backup, rather than left to the 60-second
+   * maintenance scheduler, so at least one of them is certainly contained in the window. Two things are then
+   * asserted about the restore, and each fails for its own reason: the sample count must sit inside the
+   * [before, after] band the backup's point in time can legitimately fall in (a smaller count is loss), and no
+   * timestamp may appear twice (a repeat is a torn sealed/page pair). Timestamps are unique by construction,
+   * so both are decidable.
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = { true, false })
+  void aCompactionRacingTheBackupNeitherLosesNorDuplicatesSamples(final boolean snapshot) throws Exception {
+    GlobalConfiguration.PAGE_SNAPSHOT_ENABLED.setValue(snapshot);
+
+    final long countBefore;
+    final long countAfter;
+    try (final Database database = createDatabase()) {
+      // The bulk lives in the document type: it is what makes the throttled backup last long enough for a
+      // compaction to both start and finish inside its window, which is the interleaving under test.
+      populateDocuments(database, DOCUMENTS);
+
+      final TimeSeriesEngine engine = engineOf(database);
+      ingest(engine, 0, SAMPLES);
+      engine.compactAll();
+      assertThat(sealedBlocks(engine)).as("the fixture must start with a sealed segment").isPositive();
+
+      final AtomicReference<Throwable> failure = new AtomicReference<>();
+      final AtomicBoolean running = new AtomicBoolean(true);
+      final AtomicInteger written = new AtomicInteger(SAMPLES);
+      final AtomicInteger compactions = new AtomicInteger();
+      final CountDownLatch warmedUp = new CountDownLatch(1);
+      final int compactionsAtStart = compactions.get();
+
+      final Thread compactor = new Thread(() -> {
+        DatabaseContext.INSTANCE.init((DatabaseInternal) database);
+        try {
+          while (running.get()) {
+            ingest(engine, written.get(), RACE_CHUNK);
+            written.addAndGet(RACE_CHUNK);
+            engine.compactAll();
+            compactions.incrementAndGet();
+            warmedUp.countDown();
+          }
+        } catch (final Throwable e) {
+          failure.set(e);
+          warmedUp.countDown();
+        } finally {
+          DatabaseContext.INSTANCE.removeContext(database.getDatabasePath());
+        }
+      }, "issue7280-racing-compactor");
+      compactor.setDaemon(true);
+      compactor.start();
+
+      try {
+        assertThat(warmedUp.await(120, TimeUnit.SECONDS)).isTrue();
+        assertThat(failure.get()).isNull();
+
+        final int compactionsBefore = compactions.get();
+        // Every one of these samples is fully committed before the backup starts, so the archive owes all of
+        // them whatever point in time it settles on.
+        countBefore = written.get();
+        new Backup(database, BACKUP_FILE).setVerboseLevel(0).setMaxMBPerSecond(MAX_MB_PER_SECOND).backupDatabase();
+        final int compactionsInsideWindow = compactions.get() - compactionsBefore;
+
+        // The two paths hold the pause for different spans, so what "raced the backup" means differs, and the
+        // assertion says which one it is rather than papering over the difference:
+        //
+        // - the snapshot path releases the pause as soon as the sealed stores have been read, so compactions
+        //   run freely for the whole (long, throttled) page-streaming phase. A compaction completing there IS
+        //   the interleaving under test, and the restore below has to survive it;
+        // - the frozen path holds the pause for its whole callback, so a compaction is expected to be BLOCKED
+        //   rather than to complete. Asserting zero would be racy - a compaction already in its lock-free phase
+        //   when the pause was taken can still finish - so what is asserted for that path is only that the
+        //   blocked compaction is released and completes, below.
+        if (snapshot)
+          assertThat(compactionsInsideWindow)
+              .as("with the pause released after the sealed copy, a compaction must have completed inside the "
+                  + "page-streaming phase").isPositive();
+      } finally {
+        running.set(false);
+        compactor.join(120_000);
+      }
+      assertThat(failure.get()).isNull();
+      assertThat(compactions.get()).as("compaction must survive the pause, not be deadlocked by it")
+          .isGreaterThan(compactionsAtStart);
+      // Sampled only once the writer has stopped, so no chunk is half-committed behind the counter and the
+      // upper bound is a real ceiling rather than a racing read.
+      countAfter = written.get();
+    }
+
+    new Restore(BACKUP_FILE, RESTORED_PATH).setVerboseLevel(0).restoreDatabase();
+
+    try (final Database restored = new DatabaseFactory(RESTORED_PATH).open()) {
+      final List<Long> timestamps = readTimestamps(engineOf(restored));
+
+      assertThat(timestamps.size()).as("the archive must be a point in time between the two samplings")
+          .isBetween((int) countBefore, (int) countAfter);
+      assertThat(timestamps).as("a repeated timestamp means a post-compaction sealed image was paired with a "
+          + "pre-compaction page image").doesNotHaveDuplicates();
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  /**
+   * A TimeSeries type alongside a plain document type. The document type is not decoration: the user who
+   * reported this saw "the backups appear to only be capturing the graph", so the test has to show the graph
+   * half still restoring, and {@code CHECK DATABASE} reports {@code totalErrors} from record buckets, of which a
+   * TimeSeries type owns none.
+   */
+  private Database createDatabase() {
+    final Database database = new DatabaseFactory(DATABASE_PATH).create();
+    database.command("sql",
+        "CREATE TIMESERIES TYPE " + TYPE + " TIMESTAMP ts TAGS (host STRING) FIELDS (value DOUBLE) SHARDS " + SHARDS);
+    database.command("sql", "CREATE DOCUMENT TYPE " + DOC_TYPE);
+    return database;
+  }
+
+  private static void populateDocuments(final Database database, final int count) {
+    database.transaction(() -> {
+      for (int i = 0; i < count; i++)
+        database.newDocument(DOC_TYPE).set("id", i).set("payload", PAYLOAD).save();
+    });
+  }
+
+  private static TimeSeriesEngine engineOf(final Database database) {
+    return ((LocalTimeSeriesType) database.getSchema().getType(TYPE)).getEngine();
+  }
+
+  private static int sealedBlocks(final TimeSeriesEngine engine) {
+    int total = 0;
+    for (int i = 0; i < engine.getShardCount(); i++)
+      total += engine.getShard(i).getSealedStore().getBlockCount();
+    return total;
+  }
+
+  private static File[] sealedFiles() {
+    final File[] files = new File(DATABASE_PATH).listFiles((d, name) -> name.endsWith(".ts.sealed"));
+    return files != null ? files : new File[0];
+  }
+
+  private static void ingest(final TimeSeriesEngine engine, final int from, final int count) throws Exception {
+    final long[] timestamps = new long[count];
+    final Object[] hosts = new Object[count];
+    final Object[] values = new Object[count];
+    for (int i = 0; i < count; i++) {
+      timestamps[i] = BASE_TS + (long) (from + i) * STEP_MS;
+      hosts[i] = "host_" + ((from + i) % 4);
+      values[i] = (double) (from + i);
+    }
+    engine.appendBatch(timestamps, new Object[][] { hosts, values });
+  }
+
+  /** Every sample in timestamp order, as one row per sample, so the assertions can compare element-wise. */
+  private static List<Object[]> readAll(final TimeSeriesEngine engine) throws Exception {
+    final List<Object[]> rows = new ArrayList<>();
+    final Iterator<Object[]> it = engine.iterateQuery(Long.MIN_VALUE, Long.MAX_VALUE, null, null);
+    while (it.hasNext())
+      rows.add(it.next());
+    return rows;
+  }
+
+  /** The timestamp column alone, in order. */
+  private static List<Long> readTimestamps(final TimeSeriesEngine engine) throws Exception {
+    final List<Long> timestamps = new ArrayList<>();
+    for (final Object[] row : readAll(engine))
+      timestamps.add((Long) row[0]);
+    return timestamps;
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/backup/Issue7280SealedTimeSeriesBackupIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/backup/Issue7280SealedTimeSeriesBackupIT.java
@@ -187,8 +187,8 @@ class Issue7280SealedTimeSeriesBackupIT {
   void aCompactionRacingTheBackupNeitherLosesNorDuplicatesSamples(final boolean snapshot) throws Exception {
     GlobalConfiguration.PAGE_SNAPSHOT_ENABLED.setValue(snapshot);
 
-    final long countBefore;
-    final long countAfter;
+    final int countBefore;
+    final int countAfter;
     try (final Database database = createDatabase()) {
       // The bulk lives in the document type: it is what makes the throttled backup last long enough for a
       // compaction to both start and finish inside its window, which is the interleaving under test.
@@ -204,7 +204,6 @@ class Issue7280SealedTimeSeriesBackupIT {
       final AtomicInteger written = new AtomicInteger(SAMPLES);
       final AtomicInteger compactions = new AtomicInteger();
       final CountDownLatch warmedUp = new CountDownLatch(1);
-      final int compactionsAtStart = compactions.get();
 
       final Thread compactor = new Thread(() -> {
         DatabaseContext.INSTANCE.init((DatabaseInternal) database);
@@ -256,8 +255,8 @@ class Issue7280SealedTimeSeriesBackupIT {
         compactor.join(120_000);
       }
       assertThat(failure.get()).isNull();
-      assertThat(compactions.get()).as("compaction must survive the pause, not be deadlocked by it")
-          .isGreaterThan(compactionsAtStart);
+      assertThat(compactor.isAlive())
+          .as("the compactor must have finished, not still be blocked on a pause that was never released").isFalse();
       // Sampled only once the writer has stopped, so no chunk is half-committed behind the counter and the
       // upper bound is a real ceiling rather than a racing read.
       countAfter = written.get();
@@ -269,7 +268,7 @@ class Issue7280SealedTimeSeriesBackupIT {
       final List<Long> timestamps = readTimestamps(engineOf(restored));
 
       assertThat(timestamps.size()).as("the archive must be a point in time between the two samplings")
-          .isBetween((int) countBefore, (int) countAfter);
+          .isBetween(countBefore, countAfter);
       assertThat(timestamps).as("a repeated timestamp means a post-compaction sealed image was paired with a "
           + "pre-compaction page image").doesNotHaveDuplicates();
     }


### PR DESCRIPTION
Closes #7280

## Summary

A `.ts.sealed` sealed store is opened with raw `RandomAccessFile`/`FileChannel` I/O and never registered as a `ComponentFile`, so it appears in neither `FileManager.getFiles()` nor a `PageSnapshot`. Both `FullBackupFormat` paths walked straight past it: the archive completed, the restore completed, and every compacted historical sample was gone with nothing reporting an error. This adds the sealed stores to both paths - and, because a directory listing alone would trade the loss for duplication, holds TimeSeries compaction back for the span in which the sealed image is paired with the page image.

## Why a directory listing alone is not enough

A sealed store is swapped as a whole file, atomically, outside the snapshot's point-in-time window and outside the flush suspension. Let `P` be the page image the backup captures and `Z` the sealed image, read at `T >= P`:

| Compaction position | Page image `P` | Sealed image `Z` | Restored result |
|---|---|---|---|
| No compaction in `[P, T]` | consistent | consistent | correct |
| Phase 0 committed **before** `P`, Phase 4c in `(P, T]` | flag `true`, watermark set, samples still in the mutable bucket | post-swap, extra blocks | **correct** - open-time recovery truncates `Z` back to the watermark |
| Phase 0 **and** Phase 4c both inside `(P, T]` | flag `false`, samples still in the mutable bucket | post-swap, extra blocks | **duplicated samples** |

The third row is what the `SnapshotHttpHandler` copy-paste would have shipped; the maintenance scheduler compacts every 60s per type, and a backup of a real database is longer than that. Reading `Z` before establishing `P` is strictly worse - it turns duplication into loss.

So the pause only has to exclude a **whole** compaction, not every compaction: one that started before the window already leaves `compactionInProgress` plus its block-count watermark in the page image, and `TimeSeriesShard`'s constructor repairs that on open.

## Changes

- **`TimeSeriesSealedStore.FILE_EXTENSION` + `listSealedFiles(File)`** - one definition of which files in a database directory are sealed stores, replacing the two hand-rolled listings in `SnapshotHttpHandler`. The exact suffix match excludes `.ts.sealed.tmp` (compaction scratch) and `.ts.sealed.incoming` (HA install staging).
- **`TimeSeriesCompactionPause`** (new; lives in `com.arcadedb.engine.timeseries` because `getCompactionLock()` is package-private) - holds every shard's compaction read lock, which is the half compaction needs the write of in Phase 0, 4a and 4c. Appends take the read lock too, so they keep running.
- **`FullBackupFormat`** archives the sealed stores on both paths. The pause is acquired at the top of each attempt, **outside `executeInReadLock` and outside the flush suspension**:
  - outside the database read lock, because compaction's own order is compaction-write-lock first and database read lock second (`LocalDatabase.commit()` runs under the read lock). The reverse order closes a three-way cycle with a waiting DDL writer, since a queued writer on a `ReentrantReadWriteLock` stops new readers from barging;
  - outside the flush suspension, because a compaction in Phase 4c holds the write lock while it commits, and a commit throttled by a suspension this thread already took would never release it.
  - The snapshot path releases the pause the moment the sealed stores are read - the page image is already fixed at t0, so compaction is held for the sealed copy only and not for the whole backup, preserving what #6075 bought. Safe because `addFile`/`addEntry` read their input to the end before returning; the pool threads only deflate.

The restore side needs no change: `FullRestoreFormat` extracts every entry by name into the database directory, and `FileUtils.checkValidName` accepts `<type>_shard_<n>.ts.sealed`.

## Test plan

- [ ] `mvn -o -pl engine test -Dtest='com.arcadedb.engine.timeseries.*Test'` - 417 tests, 0 failures (includes the new `Issue7280CompactionPauseTest`: the listing excludes scratch/staging files, a held pause blocks compaction until released, double close is a no-op, coverage is every shard of every TimeSeries type)
- [ ] `mvn -o -pl integration test` - 319 tests, 0 failures
- [ ] `mvn -o -pl integration -Pintegration verify -Dit.test='*Backup*IT'` - 39 tests, 0 failures (includes the new `Issue7280SealedTimeSeriesBackupIT`, parameterised over `PAGE_SNAPSHOT_ENABLED` true/false: sealed segments survive a round trip sample-for-sample, the archive carries one entry per sealed store and no scratch file, and a compaction racing the backup neither loses nor duplicates samples)
- [ ] `mvn -o -pl ha-raft test -Dtest='*Snapshot*Test'` - 185 tests, 0 failures

### Proof the new tests can fail

Each half of the fix was reverted in turn:

- **sealed archiving removed, pause kept** - all 6 IT cases fail, each with the message it is for: "every sample, sealed and mutable alike, must come back", the missing `Reading_shard_*.ts.sealed` entries, and "the archive must be a point in time between the two samplings" (failing as loss).
- **pause removed, sealed archiving kept** - `aCompactionRacingTheBackupNeitherLosesNorDuplicatesSamples` fails on "a repeated timestamp means a post-compaction sealed image was paired with a pre-compaction page image", listing ~4,000 duplicated timestamps. Three consecutive runs: 2, 1 and 2 of the two parameterisations red. That is the third row of the table above, reproduced.

## Coverage

Covered by this PR, each with a test through that entry point:

| Entry point | Test |
|---|---|
| `backupFromSnapshot` (`PAGE_SNAPSHOT_ENABLED=true`) | `sealedSegmentsSurviveABackupRoundTrip[1]`, `theArchiveCarriesOneEntryPerSealedStoreAndNoScratchFile[1]` |
| `backupFromFrozenFiles` (`PAGE_SNAPSHOT_ENABLED=false`) | the same two, `[2]` |
| a compaction committing inside the backup window, both paths | `aCompactionRacingTheBackupNeitherLosesNorDuplicatesSamples[1,2]`, plus `Issue7280CompactionPauseTest.aHeldPauseBlocksCompactionUntilItIsReleased` for the pause itself |
| `FullRestoreFormat` extraction of a `.ts.sealed` entry | no change needed; the round-trip tests are the evidence |

Argued rather than fixed, with the evidence in `docs/7280-backup-omits-sealed-timeseries.md`:

- **`Exporter`** reads samples through the query engine, which merges sealed and mutable, so it never sees the physical file layer.
- **Retention and downsampling rewriting a sealed store inside the window** rewrite the sealed store only and never touch the mutable bucket, so `pages(P) + sealed(post-retention)` is exactly the state the live database is in a moment later - a valid state, not a torn one. Their rewrite is tmp-then-`ATOMIC_MOVE`, so an opened stream keeps a complete old inode.
- **`SnapshotManager.computeFileChecksums`** (the `/checksums` endpoint) already covers sealed stores: it reads every non-transient file in the directory.

### Known gaps

- **#7337** - a backup or snapshot taken on an **HA follower** can still tear. The follower's sealed store is replaced by the leader's blob through `TimeSeriesSealedStore.installSealedFile`, which takes the store's own `directoryLock`, not the shard's `compactionLock`, so this pause does not exclude it - and `compactionInProgress` is never set for a shipped blob, so open-time recovery has nothing to key on either.
- **#7338** - `PostVerifyDatabaseHandler` never checksums `.ts.sealed` on either of its paths, so a sealed-store divergence between HA peers is invisible to `/verify`. Pre-existing and unrelated to backup.

Archives taken before this fix are still incomplete and cannot be repaired after the fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvLjzQpwWHt6h7GAeSXh5a