### PR TITLE
fix(#7290,#7297,#7299): pattern-order named paths, declared-key configuration storage, and the last copy-on-write schema members

### DIFF
--- a/engine/src/main/java/com/arcadedb/ContextConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/ContextConfiguration.java
@@ -44,7 +44,7 @@ public class ContextConfiguration implements Serializable {
   private transient final SystemVariableResolver customResolver = new SystemVariableResolver() {
     @Override
     public String resolve(final String variable) {
-      Object result = config.get(variable);
+      Object result = config.get(normalizeKey(variable));
       if (result == null)
         result = super.resolve(variable);
       return result != null ? result.toString() : null;
@@ -63,7 +63,8 @@ public class ContextConfiguration implements Serializable {
    * @param iConfig Map of parameters of type {@literal Map<String, Object>}.
    */
   public ContextConfiguration(final Map<String, Object> iConfig) {
-    this.config.putAll(iConfig);
+    for (final Map.Entry<String, Object> entry : iConfig.entrySet())
+      this.config.put(normalizeKey(entry.getKey()), entry.getValue());
   }
 
   public ContextConfiguration(final ContextConfiguration iParent) {
@@ -114,9 +115,19 @@ public class ContextConfiguration implements Serializable {
         //
         // What the callback makes of it is what gets stored, so a callback that NORMALISES its argument
         // normalises it here too rather than only on the enum's own path.
-        config.put(GlobalConfiguration.PREFIX + k,
-            GlobalConfiguration.externalizeValue(cfgEntry.applyContextValue(coerced)));
-      }
+        //
+        // Under the DECLARED key, not the file's spelling. findByKey is case-INSENSITIVE while this map is not,
+        // so "ha.tls.mutualauth" used to resolve to the right setting, pass the coercion, the allow-list and the
+        // callback, and then land under a name no reader looks up - every reader asks for iConfig.getKey(). The
+        // setting silently kept its default while the operator had positive evidence it had been understood: no
+        // error, and for a setting with a callback, visible side effects at startup (issue #7297).
+        config.put(cfgEntry.getKey(), GlobalConfiguration.externalizeValue(cfgEntry.applyContextValue(coerced)));
+      } else
+        // A key that resolves to no setting is dropped, and used to be dropped in silence, which makes a typo in
+        // the key name the same silent no-op the case variant above was. Say so once: the file is operator-authored
+        // and the line is wrong however it got there (issue #7297).
+        LogManager.instance().log(this, Level.WARNING,
+            "Unknown setting '%s' in the server configuration file: ignored", GlobalConfiguration.PREFIX + k);
     }
   }
 
@@ -142,11 +153,19 @@ public class ContextConfiguration implements Serializable {
     return config.put(iConfig.getKey(), iConfig.applyContextValue(iValue));
   }
 
+  /**
+   * Issue #7297: the key stored is the resolved setting's DECLARED key, not the caller's spelling. Resolution is
+   * case-insensitive and this map is not, so a case variant used to be applied - callback included - and then
+   * stored where no reader looks. Only a name that resolves to no setting keeps the caller's spelling, because
+   * there is no declared one to use.
+   */
   public Object setValue(final String iName, final Object iValue) {
     final GlobalConfiguration cfg = GlobalConfiguration.findByKey(iName);
+    if (cfg != null)
+      return setValue(cfg, iValue);
     if (iValue == null)
-      return removeValue(cfg, iName);
-    return config.put(iName, cfg != null ? cfg.applyContextValue(iValue) : iValue);
+      return removeValue(null, iName);
+    return config.put(iName, iValue);
   }
 
   /**
@@ -209,13 +228,16 @@ public class ContextConfiguration implements Serializable {
   }
 
   public boolean hasValue(final String iName) {
-    return config.containsKey(iName);
+    return config.containsKey(normalizeKey(iName));
   }
 
   @SuppressWarnings("unchecked")
   public <T> T getValue(final String iName, final T defaultValue) {
-    if (config.containsKey(iName))
-      return (T) config.get(iName);
+    // Normalized for the same reason the writers are: the string-keyed accessors have to agree with the
+    // GlobalConfiguration-keyed ones about which entry a case variant names (issue #7297).
+    final String key = normalizeKey(iName);
+    if (config.containsKey(key))
+      return (T) config.get(key);
 
     final String sysProperty = System.getProperty(iName);
     if (sysProperty != null)
@@ -348,6 +370,27 @@ public class ContextConfiguration implements Serializable {
 
   public void reset() {
     config.clear();
+  }
+
+  /**
+   * Maps a caller-supplied key onto the declared key of the setting it names, when it names one.
+   * <p>
+   * {@link GlobalConfiguration#findByKey(String)} is case-INSENSITIVE by design - its javadoc says so - while this
+   * overlay is a plain map keyed by the declared spelling, which is what every {@code GlobalConfiguration}-keyed
+   * accessor looks up. Without this, a key written in another case resolved to the right setting on the way in,
+   * passed the type coercion, the allow-list and the callback, and was then stored under a name nothing reads:
+   * the setting silently kept its default, with no error and, for a setting with a callback, visible side effects
+   * that made it look applied. That is the shape {@code PostServerCommandHandler.applySetting} was fixed into in
+   * issue #6875; this is the same fix for the two string-keyed writers and their matching readers (issue #7297).
+   * <p>
+   * A key that resolves to no setting is returned unchanged: an overlay also carries plugin-defined entries that
+   * this enum knows nothing about, and those keep the spelling their owner uses.
+   */
+  private static String normalizeKey(final String key) {
+    if (key == null)
+      return null;
+    final GlobalConfiguration cfg = GlobalConfiguration.findByKey(key);
+    return cfg != null ? cfg.getKey() : key;
   }
 
   private String getVariable(final String name, final String defValue) {

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2688,10 +2688,14 @@ public enum GlobalConfiguration {
   }
 
   public static GlobalConfiguration findByKey(final String iKey) {
-    String key = iKey;
+    // Lowercased BEFORE the prefix test, not after: the lookup is case-insensitive, so the test for the prefix
+    // that makes a key already-qualified has to be too. Otherwise "ARCADEDB.HA.TLS.MUTUALAUTH" was read as an
+    // unqualified name and looked up as "arcadedb.arcadedb.ha.tls.mutualauth", which resolves to nothing while
+    // every other spelling of the same key resolves (issue #7297).
+    String key = iKey.toLowerCase(Locale.ENGLISH);
     if (!key.startsWith(PREFIX))
-      key = PREFIX + iKey;
-    return BY_KEY.get(key.toLowerCase(Locale.ENGLISH));
+      key = PREFIX + key;
+    return BY_KEY.get(key);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/database/bucketselectionstrategy/PartitionedBucketSelectionStrategy.java
+++ b/engine/src/main/java/com/arcadedb/database/bucketselectionstrategy/PartitionedBucketSelectionStrategy.java
@@ -74,7 +74,11 @@ public class PartitionedBucketSelectionStrategy extends RoundRobinBucketSelectio
    */
   private static final Object UNKNOWN_STORED_FORM = new Object();
 
-  private       LocalDocumentType type;
+  // Dereferenced on the lock-free read paths (getBucketIdByRecord, getBucketIdByKeys) while setType rebinds it on
+  // every bucket add and every index add. Volatile because the publication edge cannot be borrowed from the
+  // volatile 'total' write in super.setType(): that write happens BEFORE this one, so it orders nothing here
+  // (issue #7299).
+  private volatile LocalDocumentType type;
   private final List<String>      propertyNames;
 
   public PartitionedBucketSelectionStrategy(final List<String> propertyNames) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -2427,15 +2427,17 @@ public class CypherExecutionPlan {
                 currentStep = scanStep;
               }
               // Swap source/target and reverse direction: go OUT from scanned target to bound source
+              // reversePathOrder: this hop is walked from the pattern's right-hand node back to its left-hand
+              // one, so a named path has to be assembled the other way round (#7290).
               nextStep = new MatchRelationshipStep(effectiveTargetVar, relVar, effectiveSourceVar, relPattern,
                   pathVariable, sourceNode, boundWithSource, matchVariables, clauseRelVariables, Direction.OUT,
-                  context);
+                  true, context);
             } else {
               // Normal case: pass target node pattern for label filtering and bound variables for identity
               // checking. The relationship-uniqueness scope is published once the clause is complete.
               nextStep = new MatchRelationshipStep(effectiveSourceVar, relVar, effectiveTargetVar, relPattern,
                   pathVariable, effectiveTargetNode, targetIdentityVars, matchVariables, clauseRelVariables,
-                  directionOverride, context);
+                  directionOverride, reversed, context);
             }
           }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchRelationshipStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchRelationshipStep.java
@@ -95,6 +95,18 @@ public class MatchRelationshipStep extends AbstractExecutionStep {
    */
   private final Set<String> clauseRelationshipVariables;
   private final Direction directionOverride; // When non-null, overrides pattern.getDirection()
+  /**
+   * True when this hop is traversed against the direction it was WRITTEN in, which the plan builder does
+   * whenever starting from the other end is cheaper: the bound-target reversal, and the restructuring of an IN
+   * hop on a unidirectional edge type, which has no incoming links to follow.
+   * <p>
+   * Both of those swap {@code sourceVariable} and {@code targetVariable} relative to the pattern, and that swap
+   * is invisible to everything except the named path: {@code nodes(p)} is defined to answer in the order the
+   * nodes appear ALONG THE PATTERN, from its start to its end, so it must not follow the order the executor
+   * happened to walk them in. Without this the same query returned {@code [129, 128]} or {@code [128, 129]}
+   * depending only on whether a preceding {@code WITH} had bound the pattern's right-hand node (issue #7290).
+   */
+  private final boolean reversePathOrder;
 
   // GAV provider for CSR-accelerated fast path (null = not checked yet, resolved lazily)
   private volatile GraphTraversalProvider gavProvider;
@@ -127,7 +139,7 @@ public class MatchRelationshipStep extends AbstractExecutionStep {
       final Set<String> boundVariableNames, final Set<String> clauseVariables,
       final Set<String> clauseRelationshipVariables, final CommandContext context) {
     this(sourceVariable, relationshipVariable, targetVariable, pattern, pathVariable, targetNodePattern,
-        boundVariableNames, clauseVariables, clauseRelationshipVariables, null, context);
+        boundVariableNames, clauseVariables, clauseRelationshipVariables, null, false, context);
   }
 
   /**
@@ -140,6 +152,21 @@ public class MatchRelationshipStep extends AbstractExecutionStep {
       final Set<String> boundVariableNames, final Set<String> clauseVariables,
       final Set<String> clauseRelationshipVariables, final Direction directionOverride,
       final CommandContext context) {
+    this(sourceVariable, relationshipVariable, targetVariable, pattern, pathVariable, targetNodePattern,
+        boundVariableNames, clauseVariables, clauseRelationshipVariables, directionOverride, false, context);
+  }
+
+  /**
+   * Creates a match relationship step that is traversed against the direction the pattern was written in.
+   *
+   * @param reversePathOrder true when {@code sourceVariable}/{@code targetVariable} are the pattern's RIGHT and
+   *                         LEFT ends respectively, so a named path has to be assembled the other way round
+   */
+  public MatchRelationshipStep(final String sourceVariable, final String relationshipVariable, final String targetVariable,
+      final RelationshipPattern pattern, final String pathVariable, final NodePattern targetNodePattern,
+      final Set<String> boundVariableNames, final Set<String> clauseVariables,
+      final Set<String> clauseRelationshipVariables, final Direction directionOverride,
+      final boolean reversePathOrder, final CommandContext context) {
     super(context);
     this.sourceVariable = sourceVariable;
     this.relationshipVariable = relationshipVariable;
@@ -151,6 +178,7 @@ public class MatchRelationshipStep extends AbstractExecutionStep {
     this.clauseVariables = clauseVariables;
     this.clauseRelationshipVariables = clauseRelationshipVariables;
     this.directionOverride = directionOverride;
+    this.reversePathOrder = reversePathOrder;
   }
 
   /**
@@ -557,16 +585,23 @@ public class MatchRelationshipStep extends AbstractExecutionStep {
 
             // Add path binding if path variable is specified (e.g., p = (a)-[r]->(b))
             if (pathVariable != null && !pathVariable.isEmpty()) {
+              // A named path is assembled in PATTERN order, which is the traversal order only when this hop is
+              // walked the way it was written. On a reversed hop the two ends swap: the vertex this hop reached
+              // is the pattern's LEFT end and the one it started from is the pattern's RIGHT end, so the path
+              // still grows left to right and nodes(p) still answers from the start of the pattern (#7290).
+              final Vertex patternLeftEnd = reversePathOrder ? targetVertex : (Vertex) lastResult.getProperty(sourceVariable);
+              final Vertex patternRightEnd = reversePathOrder ? (Vertex) lastResult.getProperty(sourceVariable) : targetVertex;
+
               // Check if there's an existing path from a previous hop to extend
               final Object existingPath = lastResult.getProperty(pathVariable);
               final TraversalPath path;
               if (existingPath instanceof TraversalPath)
                 // Extend existing path (multi-hop pattern)
-                path = new TraversalPath((TraversalPath) existingPath, edge, targetVertex);
+                path = new TraversalPath((TraversalPath) existingPath, edge, patternRightEnd);
               else {
-                // Create new path starting from source vertex
-                path = new TraversalPath((Vertex) lastResult.getProperty(sourceVariable));
-                path.addStep(edge, targetVertex);
+                // Create new path starting from the pattern's left-hand node
+                path = new TraversalPath(patternLeftEnd);
+                path.addStep(edge, patternRightEnd);
               }
               result.setProperty(pathVariable, path);
             }

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -56,11 +56,21 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 
 public class LocalDocumentType implements DocumentType {
-  protected       String                            name;
+  // Reassigned by rename() under the schema write lock (with a rollback assignment on failure) and read lock-free by
+  // getName() and by instanceOf(String), which openCypher's Labels calls during query planning while holding no
+  // database lock. Volatile for the same reason as the copy-on-write members below: without it a planning thread has
+  // no happens-before edge against a concurrent ALTER TYPE ... NAME and can match on either spelling indefinitely
+  // (issues #6678, #7033, #7119, #7299).
+  protected volatile String                         name;
   protected final LocalSchema                       schema;
   protected final List<LocalDocumentType>           superTypes                   = new ArrayList<>();
   protected final List<LocalDocumentType>           subTypes                     = new ArrayList<>();
-  private         Set<String>                       aliases                      = Collections.emptySet();
+  // Sixth member of the copy-on-write family: reassigned by setAliases under the schema mutation lock and read
+  // lock-free by instanceOf(String) from openCypher label resolution during query planning. Volatile for the
+  // publication edge, and always assigned an unmodifiable COPY: setAliases used to store the caller's set by
+  // reference, so a caller that kept its set and mutated it afterwards was editing live schema state that a
+  // lock-free reader is walking (issue #7299).
+  private volatile Set<String>                      aliases                      = Set.of();
   // Mutated by CREATE/DROP PROPERTY under the schema write lock. Record creation reads it under the read lock and is
   // therefore excluded, but two readers are not: query planning, and toJSON() - which LocalSchema.recordFileChanges
   // calls to save schema.json AFTER the write lock is released, so a save running alongside another thread's DDL threw
@@ -435,7 +445,9 @@ public class LocalDocumentType implements DocumentType {
     for (String alias : aliases)
       schema.types.put(alias, this);
 
-    this.aliases = aliases;
+    // A copy, and an unmodifiable one: the parameter belongs to the caller. Published last so a lock-free
+    // instanceOf() either sees the whole previous set or the whole new one.
+    this.aliases = Set.copyOf(aliases);
     schema.saveConfiguration();
     return this;
   }

--- a/engine/src/test/java/com/arcadedb/Issue7297ConfigurationKeyCaseTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue7297ConfigurationKeyCaseTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7297: {@link GlobalConfiguration#findByKey(String)} is case-INSENSITIVE and the
+ * {@link ContextConfiguration} overlay is not, so a configuration key written in another case resolved to the
+ * right setting, passed the type coercion, the allow-list and the callback, and was then stored under the
+ * caller's spelling - where no reader looks, because every reader asks for the setting's declared key.
+ * <p>
+ * The setting silently kept its default. That is worse than a rejected key: the operator has positive evidence
+ * the line was understood - no error, and for a setting with a callback, visible side effects at startup.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue7297ConfigurationKeyCaseTest {
+
+  private static final GlobalConfiguration MUTUAL_AUTH = GlobalConfiguration.HA_TLS_MUTUAL_AUTH;
+
+  @Test
+  public void theDeclaredKeyIsNotAlreadyLowercase() {
+    // Guards the premise of the whole issue: without a camelCase key in the enum there is nothing to get wrong.
+    assertThat(MUTUAL_AUTH.getKey()).isNotEqualTo(MUTUAL_AUTH.getKey().toLowerCase(Locale.ENGLISH));
+  }
+
+  @Test
+  public void aLowercasedKeyInTheConfigurationFileTakesEffect() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.fromJSON("{\"configuration\":{\"" + shortKey(MUTUAL_AUTH).toLowerCase(Locale.ENGLISH) + "\":false}}");
+
+    // The read every component actually performs, through the enum constant.
+    assertThat(cfg.getValueAsBoolean(MUTUAL_AUTH)).isFalse();
+    assertThat(cfg.<Object>getValue(MUTUAL_AUTH)).isEqualTo(Boolean.FALSE);
+    // And it is in the map under the DECLARED key, so toJSON round-trips it as one entry rather than two.
+    assertThat(cfg.getContextKeys()).containsExactly(MUTUAL_AUTH.getKey());
+  }
+
+  @Test
+  public void anUppercasedKeyInTheConfigurationFileTakesEffectToo() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.fromJSON("{\"configuration\":{\"" + shortKey(MUTUAL_AUTH).toUpperCase(Locale.ENGLISH) + "\":false}}");
+
+    assertThat(cfg.getValueAsBoolean(MUTUAL_AUTH)).isFalse();
+  }
+
+  @Test
+  public void theStringKeyedWriterNormalisesToo() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.setValue(MUTUAL_AUTH.getKey().toLowerCase(Locale.ENGLISH), false);
+
+    assertThat(cfg.getValueAsBoolean(MUTUAL_AUTH)).isFalse();
+    assertThat(cfg.getContextKeys()).containsExactly(MUTUAL_AUTH.getKey());
+  }
+
+  @Test
+  public void theMapConstructorNormalisesToo() {
+    final ContextConfiguration cfg = new ContextConfiguration(
+        Map.of(MUTUAL_AUTH.getKey().toLowerCase(Locale.ENGLISH), Boolean.FALSE));
+
+    assertThat(cfg.getValueAsBoolean(MUTUAL_AUTH)).isFalse();
+  }
+
+  @Test
+  public void theStringKeyedReadersAgreeWithTheWriters() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.setValue(MUTUAL_AUTH, false);
+
+    // Same setting, three spellings, one answer - including the short form without the "arcadedb." prefix,
+    // which findByKey adds and which the readers therefore have to accept as well.
+    assertThat(cfg.hasValue(MUTUAL_AUTH.getKey().toLowerCase(Locale.ENGLISH))).isTrue();
+    assertThat(cfg.hasValue(shortKey(MUTUAL_AUTH))).isTrue();
+    assertThat(cfg.<Object>getValue(MUTUAL_AUTH.getKey().toUpperCase(Locale.ENGLISH), Boolean.TRUE)).isEqualTo(
+        Boolean.FALSE);
+  }
+
+  @Test
+  public void aCaseVariantRemovalRemovesTheDeclaredEntry() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.setValue(MUTUAL_AUTH, false);
+
+    cfg.setValue(MUTUAL_AUTH.getKey().toLowerCase(Locale.ENGLISH), null);
+
+    assertThat(cfg.getContextKeys()).isEmpty();
+    assertThat(cfg.getValueAsBoolean(MUTUAL_AUTH)).isEqualTo(MUTUAL_AUTH.getValueAsBoolean());
+  }
+
+  @Test
+  public void aKeyThatNamesNoSettingKeepsItsOwnSpelling() {
+    // A plugin-defined entry: this enum knows nothing about it, so there is no declared key to normalise onto.
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.setValue("arcadedb.myPlugin.someSetting", "x");
+
+    assertThat(cfg.getContextKeys()).containsExactly("arcadedb.myPlugin.someSetting");
+    assertThat(cfg.<Object>getValue("arcadedb.myPlugin.someSetting", null)).isEqualTo("x");
+  }
+
+  private static String shortKey(final GlobalConfiguration cfg) {
+    return cfg.getKey().substring(GlobalConfiguration.PREFIX.length());
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPathDirectionAfterWithIssue7290Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherPathDirectionAfterWithIssue7290Test.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7290: a semantically neutral {@code WITH} between the CREATE and the MATCH reversed the node order
+ * reported by {@code nodes(p)}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class OpenCypherPathDirectionAfterWithIssue7290Test {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    database = new DatabaseFactory("./target/databases/testopencypher-7290-path-direction").create();
+  }
+
+  @AfterEach
+  void cleanup() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void pathNodeOrderWithoutWith() {
+    assertPathOrder("""
+        CREATE (n0 {id: 128, k3: false}) <-[:rt7 {id: 420}]- (:V {id: 129, k2: 'k', k3: true})
+        MATCH p0 = (s0 {k3: true, k2: 'k'}) -[r0:rt7 {id: 420}]-> (n0)
+        RETURN s0.id AS sourceId, n0.id AS targetId, r0.id AS relationshipId,
+               [x IN nodes(p0) | x.id] AS pathNodeIds,
+               [x IN relationships(p0) | x.id] AS pathRelationshipIds""");
+  }
+
+  @Test
+  void pathNodeOrderWithNeutralWith() {
+    assertPathOrder("""
+        CREATE (n0 {id: 128, k3: false}) <-[:rt7 {id: 420}]- (:V {id: 129, k2: 'k', k3: true})
+        WITH n0
+        MATCH p0 = (s0 {k3: true, k2: 'k'}) -[r0:rt7 {id: 420}]-> (n0)
+        RETURN s0.id AS sourceId, n0.id AS targetId, r0.id AS relationshipId,
+               [x IN nodes(p0) | x.id] AS pathNodeIds,
+               [x IN relationships(p0) | x.id] AS pathRelationshipIds""");
+  }
+
+  /**
+   * The same shape reached from the other side: the bound variable is the pattern's LEFT end rather than its
+   * right one, so a rule that simply starts from whatever the previous clause bound would get this one right and
+   * the two above wrong.
+   */
+  @Test
+  void pathNodeOrderWithBoundStartNode() {
+    database.command("opencypher",
+        "CREATE (n0 {id: 128, k3: false}) <-[:rt7 {id: 420}]- (:V {id: 129, k2: 'k', k3: true})");
+
+    final ResultSet rs = database.query("opencypher", """
+        MATCH (s0 {id: 129})
+        WITH s0
+        MATCH p0 = (s0) -[r0:rt7]-> (n0)
+        RETURN [x IN nodes(p0) | x.id] AS pathNodeIds""");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat((List<Object>) rs.next().getProperty("pathNodeIds")).containsExactly(129, 128);
+  }
+
+  /**
+   * The other route into a reversed traversal: an IN hop on a UNIDIRECTIONAL edge type, which stores no
+   * incoming links, so the plan scans the written source type and walks OUT to the bound node instead. Same
+   * swap of the two ends, so the same path-order rule has to hold, over two hops as well as one.
+   */
+  @Test
+  void pathNodeOrderOnReversedUnidirectionalHops() {
+    database.command("sql", "CREATE VERTEX TYPE N");
+    database.command("sql", "CREATE EDGE TYPE U UNIDIRECTIONAL");
+    database.command("opencypher", "CREATE (:N {id: 1}) <-[:U]- (:N {id: 2})");
+
+    final ResultSet single = database.query("opencypher", """
+        MATCH (a:N {id: 1})
+        WITH a
+        MATCH p = (a) <-[:U]- (b)
+        RETURN [x IN nodes(p) | x.id] AS pathNodeIds""");
+    assertThat(single.hasNext()).isTrue();
+    assertThat(single.next().<List<Object>>getProperty("pathNodeIds")).containsExactly(1, 2);
+
+    database.command("opencypher", "MATCH (b:N {id: 2}) CREATE (b) <-[:U]- (:N {id: 3})");
+
+    final ResultSet twoHops = database.query("opencypher", """
+        MATCH (a:N {id: 1})
+        WITH a
+        MATCH p = (a) <-[:U]- (b) <-[:U]- (c)
+        RETURN [x IN nodes(p) | x.id] AS pathNodeIds""");
+    assertThat(twoHops.hasNext()).isTrue();
+    assertThat(twoHops.next().<List<Object>>getProperty("pathNodeIds")).containsExactly(1, 2, 3);
+  }
+
+  private void assertPathOrder(final String query) {
+    final ResultSet rs = database.command("opencypher", query);
+
+    assertThat(rs.hasNext()).isTrue();
+    final Result row = rs.next();
+
+    assertThat(((Number) row.getProperty("sourceId")).intValue()).isEqualTo(129);
+    assertThat(((Number) row.getProperty("targetId")).intValue()).isEqualTo(128);
+    assertThat(((Number) row.getProperty("relationshipId")).intValue()).isEqualTo(420);
+    // Cypher requires nodes(p) in traversal order, from the start of the pattern to its end. The pattern is
+    // directed s0 -> n0, so 129 comes first however the executor chose to reach it.
+    assertThat((List<Object>) row.<List<Object>>getProperty("pathNodeIds")).containsExactly(129, 128);
+    assertThat((List<Object>) row.<List<Object>>getProperty("pathRelationshipIds")).containsExactly(420);
+    assertThat(rs.hasNext()).isFalse();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/Issue7299SchemaCopyOnWritePublicationTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue7299SchemaCopyOnWritePublicationTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.bucketselectionstrategy.PartitionedBucketSelectionStrategy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7299, and the end of a series: #6678 made two members of {@link LocalDocumentType} volatile, #7033 added
+ * two more, #7119 a fifth, and each pass fixed only the member its own issue happened to name.
+ * <p>
+ * The members of this class are reassigned under the schema mutation lock and read LOCK-FREE by query planning -
+ * {@code instanceOf} is called by openCypher label resolution with no database lock held - so every one of them
+ * needs the publication edge a volatile write provides. The reflective test below is what closes the series: a
+ * seventh field added without it fails here rather than in a sixth issue.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue7299SchemaCopyOnWritePublicationTest {
+  private Database database;
+
+  @BeforeEach
+  public void setUp() {
+    database = new DatabaseFactory("./target/databases/test-issue-7299").create();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  /**
+   * The sweep, run by the machine rather than by the next reader of the class.
+   */
+  @Test
+  public void everyMutableReferenceMemberIsPublishedSafely() {
+    final List<String> offenders = new ArrayList<>();
+
+    for (final Field field : LocalDocumentType.class.getDeclaredFields()) {
+      final int modifiers = field.getModifiers();
+      if (Modifier.isStatic(modifiers) || Modifier.isFinal(modifiers) || Modifier.isVolatile(modifiers))
+        continue;
+      offenders.add(field.getType().getSimpleName() + " " + field.getName());
+    }
+
+    assertThat(offenders).as(
+            "Members of LocalDocumentType that a schema mutation reassigns while a lock-free reader walks them must "
+                + "be final (immutable or a concurrent collection) or volatile, so the reader gets a happens-before "
+                + "edge against the write. Add the keyword rather than relaxing this assertion (issue #7299).")
+        .isEmpty();
+  }
+
+  /**
+   * The half of the issue that needs no concurrency at all.
+   */
+  @Test
+  public void setAliasesDoesNotPublishTheCallersSet() {
+    database.getSchema().createDocumentType("Invoice");
+    final LocalDocumentType invoice = (LocalDocumentType) database.getSchema().getType("Invoice");
+
+    final Set<String> callerOwned = new HashSet<>(Set.of("Bill"));
+    invoice.setAliases(callerOwned);
+
+    // The caller keeps its set and goes on using it. That must not reach live schema state.
+    callerOwned.add("Smuggled");
+
+    assertThat(invoice.getAliases()).containsExactly("Bill");
+    assertThat(invoice.instanceOf("Smuggled")).isFalse();
+    assertThat(invoice.instanceOf("Bill")).isTrue();
+
+    // And what getAliases() hands out is not a back door into it either.
+    assertThatThrownBy(() -> invoice.getAliases().add("Smuggled")).isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  public void aliasesStillBehaveAsBefore() {
+    database.getSchema().createDocumentType("Order");
+    final DocumentType order = database.getSchema().getType("Order");
+
+    order.setAliases(Set.of("PurchaseOrder", "PO"));
+    assertThat(order.getAliases()).containsExactlyInAnyOrder("PurchaseOrder", "PO");
+    assertThat(database.getSchema().getType("PO")).isSameAs(order);
+
+    // Replacing the set deregisters the previous aliases, and the type stops answering to them.
+    order.setAliases(Set.of("PO"));
+    assertThat(order.getAliases()).containsExactly("PO");
+    assertThat(order.instanceOf("PurchaseOrder")).isFalse();
+    assertThat(database.getSchema().existsType("PurchaseOrder")).isFalse();
+
+    order.setAliases(Set.of());
+    assertThat(order.getAliases()).isEmpty();
+    assertThat(database.getSchema().existsType("PO")).isFalse();
+  }
+
+  /**
+   * The field #7119's closing argument rests on: the volatile write in {@code super.setType} happens BEFORE this
+   * one, so it orders nothing here and cannot be borrowed as the publication edge.
+   */
+  @Test
+  public void thePartitionStrategyTypeReferenceIsPublishedSafely() throws NoSuchFieldException {
+    final Field type = PartitionedBucketSelectionStrategy.class.getDeclaredField("type");
+    assertThat(Modifier.isVolatile(type.getModifiers())).isTrue();
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6070GraphBatchLoadLeaderGuardIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6070GraphBatchLoadLeaderGuardIT.java
@@ -64,7 +64,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class Issue6070GraphBatchLoadLeaderGuardIT extends BaseRaftHATest {
 
-  private static final int    BASE_GRPC_PORT = 51091;
+  // 20 apart from every other gRPC IT's base, because each of these starts three servers on BASE..BASE+2.
+  // This class used to share 51091 with TimeSeriesGrpcForwardedInsertTypeIT, so whenever the two ran close
+  // enough together the second one's GrpcServerPlugin failed to bind and took the whole class down with
+  // "Failed to bind to address 0.0.0.0:51092" - reported as a plugin startup error rather than as a port clash.
+  private static final int    BASE_GRPC_PORT = 51161;
   private static final String VERTEX_TYPE    = "Issue6070LeaderGuardNode";
 
   private static final Metadata.Key<String> USER_HEADER     = Metadata.Key.of("x-arcade-user",


### PR DESCRIPTION
Fixes #7290, fixes #7297, fixes #7299.

## #7290 - path direction reversed after a semantically neutral `WITH`

**Root cause.** The plan builder reverses a single-hop traversal whenever the pattern's right-hand node is already bound: instead of scanning every candidate source and checking whether it connects to the bound target, it starts from the bound target and follows the edge backwards. `WITH n0` is exactly what makes `n0` bound, which is why the same `MATCH` answered differently with and without it.

The reversal swaps `sourceVariable` and `targetVariable` relative to the written pattern, and that swap is invisible to everything except the named path: `MatchRelationshipStep` built the `TraversalPath` starting from the vertex it *started at* and appending the vertex it *reached*. Cypher defines `nodes(p)` as the nodes in the order they appear along the pattern, from its start to its end, so the executor's choice of starting end must not be observable.

The step now knows which of its two ends is the pattern's left-hand one and grows the path left to right regardless.

**A second site with the same defect.** There is a second route into a reversed hop: an `IN` hop on a `UNIDIRECTIONAL` edge type, which stores no incoming links, so the plan scans the written source type and walks `OUT` to the bound node. That branch had the identical single-hop ordering bug *and* corrupted multi-hop named paths outright - it appended the step's target (the vertex already in the path) instead of the pattern's next node, producing `[a, e, b, e2, b]`. Both are fixed by the same rule, and both are covered.

The `ExpandPathStep` (variable-length) branch already had this right via `reverseResultPath`; this brings the fixed-length hop in line with it.

## #7297 - a case-variant configuration key is stored where no reader looks

`GlobalConfiguration.findByKey` is case-insensitive by design; the `ContextConfiguration` overlay is a plain map keyed by the declared spelling, which is what every `GlobalConfiguration`-keyed accessor looks up. So `"ha.tls.mutualauth": true` in a server configuration file resolved to the right setting, passed the strict Boolean parse, the allow-list and the callback, and then landed under `arcadedb.ha.tls.mutualauth` - invisible to a read of `arcadedb.ha.tls.mutualAuth`. Mutual TLS stayed off, and the operator had positive evidence it had been understood: no error, and visible callback side effects at startup.

Fixed at the boundary rather than only where the issue pointed:

- `fromJSON` and `setValue(String, Object)` store under the resolved setting's **declared** key - the convention `PostServerCommandHandler.applySetting` was fixed into in #6875, and the one `setValue(GlobalConfiguration, Object)` already followed.
- The `Map` constructor normalises the same way, so an overlay built from a raw map cannot start out inconsistent.
- The matching string-keyed **readers** - `hasValue`, `getValue(String, T)`, and the `${...}` resolver - normalise too, so the two families of accessor cannot disagree about which entry a spelling names. This also makes the unqualified short form (`ha.tls.mutualAuth`) work, which `findByKey` has always accepted.
- `findByKey` lowercases *before* testing for the `arcadedb.` prefix. The test was case-sensitive, so a fully uppercased key was treated as unqualified and looked up as `arcadedb.arcadedb....`, resolving to nothing while every other spelling of the same key resolved.
- A key that resolves to no setting keeps its own spelling - plugin-defined entries own theirs - but is now reported at WARNING rather than dropped in silence, which is the second half of the operator-facing problem the issue raised.

## #7299 - the end of the copy-on-write series

`name` and `aliases` are reassigned under the schema mutation lock and read **lock-free** by `instanceOf(String)`, which openCypher label resolution calls during query planning holding no database lock - the same argument #6678, #7033 and #7119 were each accepted on. Both are now `volatile`.

**A better fix than the one proposed.** The issue suggests `setAliases` should assign `newAliases` rather than the parameter. That would be wrong: `newAliases` is the *delta* (the aliases not already held), computed for the duplicate-name check, so assigning it would silently drop every alias the type already answered to. The actual defect is publishing the caller's set by reference, and the fix for that is an immutable defensive copy - `Set.copyOf(aliases)`. It closes the same hole (a caller that keeps its set and mutates it later is editing live schema state), and as a bonus `getAliases()` now hands out something a caller cannot write through either.

`PartitionedBucketSelectionStrategy.type` is volatile as well: `setType` does the volatile write in `super.setType` *first* and the plain write second, so the volatile write orders nothing for it.

**And the sweep, run by the machine.** Six fields have now been found one at a time across four issues. `everyMutableReferenceMemberIsPublishedSafely` reflects over `LocalDocumentType`'s declared fields and fails on any non-static, non-final, non-volatile member, so a seventh is caught in CI rather than in a fifth issue.

## Tests

- `OpenCypherPathDirectionAfterWithIssue7290Test` - 4 cases: the issue's control query and its `WITH` query, a bound *left* end (which a naive "start from what's bound" rule would get right while getting the other two wrong), and the unidirectional route over one and two hops. Verified non-vacuous: 2 of the 4 fail on the unfixed step.
- `Issue7297ConfigurationKeyCaseTest` - 8 cases covering both writers, the map constructor, the readers, removal by case variant, and the plugin-key escape hatch, plus a guard that the setting under test is not already lowercase (without which the whole issue is unreproducible).
- `Issue7299SchemaCopyOnWritePublicationTest` - the reflective sweep, the defensive-copy behaviour, an alias regression test, and the strategy field.

Full `engine` suite: **14672 tests, 0 failures, 0 errors**. `RemoteDocumentTypeTest`, `Issue7032JsonlRoundTripIT` and the server configuration tests green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Configuration keys are now handled consistently regardless of capitalization, including fully qualified settings, while unknown plugin settings retain their original spelling.
  - Corrected OpenCypher path ordering so `nodes(p)` reports nodes in pattern order, including reversed traversals and queries using `WITH`.
  - Improved consistency when reading and updating configuration settings.

- **Reliability**
  - Improved safe publication of schema aliases and partitioning state during concurrent operations.
  - Resolved a gRPC integration test port conflict.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->