### PR TITLE
fix(#7328,#7329,#7330): importer transaction ownership, profiler self-costs, and Cypher profiling without an eager drain

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -150,6 +150,7 @@ import com.arcadedb.schema.VertexType;
 import com.arcadedb.query.sql.executor.AbstractExecutionStep;
 import com.arcadedb.query.sql.executor.BasicCommandContext;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.ExecutionPlan;
 import com.arcadedb.query.sql.executor.ExecutionStep;
 import com.arcadedb.query.sql.executor.InternalResultSet;
 import com.arcadedb.query.sql.executor.IteratorResultSet;
@@ -169,6 +170,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.logging.Level;
@@ -287,14 +289,52 @@ public class CypherExecutionPlan {
    * @return result set
    */
   public ResultSet execute(final CommandContext outerContext) {
+    return execute(outerContext, false);
+  }
+
+  /**
+   * Executes the query plan with per-step timing turned on, and <b>without changing what it executes</b>: the same
+   * streaming chain {@link #execute(CommandContext)} builds, pulled by the caller at the caller's own pace.
+   * <p>
+   * This is what the server profiler and Studio's {@code profileExecution: "detailed"} use, and it is the whole
+   * point of the overload. They used to be routed onto {@link #profile()}, which drains the plan into heap before
+   * returning: the number they then reported was the cost of a materialising execution the statement never performs
+   * otherwise, and switching the diagnostic on turned every Cypher read on the server into a full in-heap
+   * materialisation for the length of the recording window (issue #7330). The step timers accumulate during
+   * {@code syncPull}, so no drain is needed to collect them - {@code profile()}'s drain exists to produce a result
+   * <i>shape</i>, not to time anything.
+   * <p>
+   * The returned set carries an {@link ExecutionPlan} built on demand from the live step chain, so a consumer that
+   * asks for it after streaming (which is what {@code ProfilingResultSet} and the HTTP handler both do) sees the
+   * costs the run actually accumulated. Asking earlier is legal and reports what has been measured so far.
+   *
+   * @param outerContext the enclosing statement's context, or {@code null} for a top-level statement
+   * @param profiling    whether to time each step and attach the plan; {@code false} is the plain streaming path
+   *
+   * @return result set
+   */
+  public ResultSet execute(final CommandContext outerContext, final boolean profiling) {
+    if (!profiling)
+      return executeStreaming(outerContext, null);
+
+    final StreamingProfile profile = new StreamingProfile();
+    return profile.attach(executeStreaming(outerContext, profile));
+  }
+
+  /**
+   * @param profile when not null, per-step timing is on and this collector is handed the root step the run built,
+   *                so the plan can be reconstructed from it once the caller has finished streaming
+   */
+  private ResultSet executeStreaming(final CommandContext outerContext, final StreamingProfile profile) {
     // Handle UNION queries specially
     if (unionSubqueryPlans != null && !unionSubqueryPlans.isEmpty())
-      return executeUnion(outerContext);
+      return executeUnion(outerContext, profile);
 
     // Build execution context
     final BasicCommandContext context = new BasicCommandContext();
     context.setDatabase(database);
     context.setInputParameters(parameters);
+    context.setProfiling(profile != null);
     setupFunctionResolver(context);
     CypherFunctionHelper.inheritStatementTime(context, outerContext);
 
@@ -304,6 +344,9 @@ public class CypherExecutionPlan {
     // Must be checked BEFORE the optimizer dispatch, because the optimizer produces
     // GAVExpandAll operators that still materialize individual rows (O(paths) memory).
     rootStep = tryCountPushDown(context, false);
+
+    if (profile != null)
+      profile.countPushedDown = rootStep != null;
 
     if (rootStep == null) {
       // Phase 4: Use optimized physical plan if available
@@ -318,6 +361,11 @@ public class CypherExecutionPlan {
         // This path correctly handles clause ordering (UNWIND before MATCH), VLP patterns, etc.
         rootStep = buildExecutionSteps(context);
       }
+    }
+
+    if (profile != null) {
+      profile.rootStep = rootStep;
+      profile.context = context;
     }
 
     if (rootStep == null) {
@@ -710,14 +758,17 @@ public class CypherExecutionPlan {
    * Executes a UNION query by combining results from all subqueries.
    *
    * @param outerContext the enclosing statement's context, or {@code null} for a top-level statement
+   * @param profile      when not null, per-step timing is on and this collector is handed the UnionStep as the
+   *                     plan's root, so the profiled plan describes the same streaming run (issue #7330)
    *
    * @return combined result set
    */
-  private ResultSet executeUnion(final CommandContext outerContext) {
+  private ResultSet executeUnion(final CommandContext outerContext, final StreamingProfile profile) {
     // Use UnionStep to combine results from all subqueries
     final BasicCommandContext context = new BasicCommandContext();
     context.setDatabase(database);
     context.setInputParameters(parameters);
+    context.setProfiling(profile != null);
     setupFunctionResolver(context);
     // Every branch runs on a context of its own, so the statement clock has to travel from here into each of
     // them - and into here from an enclosing statement when this UNION is a CALL body (issue #7052).
@@ -725,6 +776,11 @@ public class CypherExecutionPlan {
 
     final UnionStep unionStep =
         new UnionStep(unionSubqueryPlans, unionRemoveDuplicates, context);
+
+    if (profile != null) {
+      profile.rootStep = unionStep;
+      profile.context = context;
+    }
 
     // Read UNION: stay lazy/streaming, no statistics to surface.
     if (statement.isReadOnly())
@@ -974,13 +1030,17 @@ public class CypherExecutionPlan {
   }
 
   /**
-   * Executes the query with profiling enabled.
-   * The query is executed to collect real metrics, but only the profiling
-   * information is returned (actual query results are discarded).
-   * Returns an {@link ExplainResultSet} so the server handler populates the
-   * dedicated {@code explain} field in the JSON response.
+   * Executes the query with profiling enabled and <b>eagerly</b>: every row is pulled into heap before this method
+   * returns, and the rows are returned alongside the profile via {@code getExecutionPlan()}. The javadoc here used
+   * to claim the results were discarded and that the return was an {@code ExplainResultSet}; neither has been true
+   * of this implementation, and the drain is precisely what a caller has to know about (issue #7330).
+   * <p>
+   * This is the {@code PROFILE <statement>} path - a user asking, in the statement itself, for the whole execution
+   * to be run and summarised, which is what Neo4j's PROFILE does too. It is deliberately NOT the path taken by the
+   * server profiler or by Studio's {@code profileExecution: "detailed"}: those must not change how the statement
+   * executes, and use {@link #execute(CommandContext, boolean)} instead, which times the ordinary streaming run.
    *
-   * @return result set containing profiling metrics via {@code getExecutionPlan()}
+   * @return result set carrying the rows and, via {@code getExecutionPlan()}, the profiling metrics
    */
   public ResultSet profile() {
     final long startTime = System.nanoTime();
@@ -1026,15 +1086,36 @@ public class CypherExecutionPlan {
     }
 
     final long endTime = System.nanoTime();
-    final double executionTimeMs = (endTime - startTime) / 1_000_000.0;
     final long rowCount = results.countEntries();
 
+    results.setPlan(buildProfilePlan(context, rootStep, countPushedDown, endTime - startTime, rowCount, errorMessage));
+    // Surface the CRUD-count accumulator built up by the mutation steps during the profiled run,
+    // mirroring execute()'s write path so a profiled write still reports its counters. Read-only
+    // statements never attach a statistics accumulator, matching execute()'s read path.
+    if (!statement.isReadOnly())
+      results.setStatistics(context.getStatistics());
+    return results;
+  }
+
+  /**
+   * The profile of a run that has just finished: the human-readable report plus the live step chain that carries
+   * the per-step costs. Shared by the eager {@link #profile()} and the streaming
+   * {@link #execute(CommandContext, boolean)} so the two describe the same run the same way, and one of them cannot
+   * quietly grow a section the other lacks.
+   *
+   * @param elapsedNanos wall clock of the run being described
+   * @param rowCount     rows the run produced - for the streaming path, rows the caller actually pulled
+   * @param errorMessage the failure that ended the run, or {@code null}
+   */
+  private OpenCypherExplainExecutionPlan buildProfilePlan(final CommandContext context,
+      final AbstractExecutionStep rootStep, final boolean countPushedDown, final long elapsedNanos, final long rowCount,
+      final String errorMessage) {
     final StringBuilder profileOutput = new StringBuilder();
     profileOutput.append("OpenCypher Query Profile\n");
     profileOutput.append("========================\n\n");
     if (Boolean.TRUE.equals(context.getVariable(CommandContext.CSR_ACCELERATED_VAR)))
       profileOutput.append("CSR-accelerated via Graph Analytical View\n");
-    profileOutput.append(String.format("Execution Time: %.3f ms\n", executionTimeMs));
+    profileOutput.append(String.format("Execution Time: %.3f ms\n", elapsedNanos / 1_000_000.0));
     profileOutput.append(String.format("Rows Returned: %d\n", rowCount));
 
     if (errorMessage != null)
@@ -1067,13 +1148,79 @@ public class CypherExecutionPlan {
         profileOutput.append("No execution steps generated\n");
     }
 
-    results.setPlan(new OpenCypherExplainExecutionPlan(profileOutput.toString(), executionSteps, endTime - startTime));
-    // Surface the CRUD-count accumulator built up by the mutation steps during the profiled run,
-    // mirroring execute()'s write path so a profiled write still reports its counters. Read-only
-    // statements never attach a statistics accumulator, matching execute()'s read path.
-    if (!statement.isReadOnly())
-      results.setStatistics(context.getStatistics());
-    return results;
+    return new OpenCypherExplainExecutionPlan(profileOutput.toString(), executionSteps, elapsedNanos);
+  }
+
+  /**
+   * Times a streaming execution without altering it: the caller pulls the rows it wants, at its own pace, and the
+   * plan is reconstructed from the live step chain whenever it is asked for.
+   * <p>
+   * The alternative - the one this replaces - was to reroute the statement onto {@link #profile()}, whose drain
+   * changes the execution mode: what got reported was then the cost of materialising every row, which is not what
+   * the statement costs when nobody is watching, and every Cypher read on the server was materialised in heap for
+   * as long as the recording window lasted (issue #7330).
+   * <p>
+   * The clock stops at the first of: the delegate reporting exhaustion, {@code close()}, or the plan being asked
+   * for. Consumers ask for the plan after streaming - {@code ProfilingResultSet} at close,
+   * {@code PostCommandHandler} after draining - so the elapsed they see covers the whole run.
+   */
+  private final class StreamingProfile implements ResultSet {
+    private final long                  startNanos = System.nanoTime();
+    private       ResultSet             delegate;
+    private       CommandContext        context;
+    private       AbstractExecutionStep rootStep;
+    private       boolean               countPushedDown;
+    private       long                  rowCount;
+    private       long                  elapsedNanos = -1;
+
+    private ResultSet attach(final ResultSet delegate) {
+      this.delegate = delegate;
+      return this;
+    }
+
+    @Override
+    public boolean hasNext() {
+      final boolean hasNext = delegate.hasNext();
+      if (!hasNext)
+        stopClock();
+      return hasNext;
+    }
+
+    @Override
+    public Result next() {
+      final Result row = delegate.next();
+      ++rowCount;
+      return row;
+    }
+
+    @Override
+    public void close() {
+      stopClock();
+      delegate.close();
+    }
+
+    @Override
+    public void reset() {
+      delegate.reset();
+    }
+
+    @Override
+    public Optional<QueryStatistics> getStatistics() {
+      return delegate.getStatistics();
+    }
+
+    @Override
+    public Optional<ExecutionPlan> getExecutionPlan() {
+      stopClock();
+      // Built here rather than at construction: the step timers accumulate while the caller streams, so a plan
+      // snapshotted before the first row would report a chain that had not run yet.
+      return Optional.of(buildProfilePlan(context, rootStep, countPushedDown, elapsedNanos, rowCount, null));
+    }
+
+    private void stopClock() {
+      if (elapsedNanos < 0)
+        elapsedNanos = System.nanoTime() - startNanos;
+    }
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -1160,9 +1160,10 @@ public class CypherExecutionPlan {
    * the statement costs when nobody is watching, and every Cypher read on the server was materialised in heap for
    * as long as the recording window lasted (issue #7330).
    * <p>
-   * The clock stops at the first of: the delegate reporting exhaustion, {@code close()}, or the plan being asked
-   * for. Consumers ask for the plan after streaming - {@code ProfilingResultSet} at close,
-   * {@code PostCommandHandler} after draining - so the elapsed they see covers the whole run.
+   * The clock stops at the first of the delegate reporting exhaustion and {@code close()} - never at the plan
+   * being asked for, so inspecting the plan mid-stream does not freeze the number a later ask reports. Consumers
+   * ask for it after streaming ({@code ProfilingResultSet} at close, {@code PostCommandHandler} after draining),
+   * so the elapsed they see covers the whole run.
    */
   private final class StreamingProfile implements ResultSet {
     private final long                  startNanos = System.nanoTime();
@@ -1211,12 +1212,20 @@ public class CypherExecutionPlan {
 
     @Override
     public Optional<ExecutionPlan> getExecutionPlan() {
-      stopClock();
       // Built here rather than at construction: the step timers accumulate while the caller streams, so a plan
       // snapshotted before the first row would report a chain that had not run yet.
-      return Optional.of(buildProfilePlan(context, rootStep, countPushedDown, elapsedNanos, rowCount, null));
+      //
+      // Reading the clock rather than stopping it: a caller that inspects progress mid-stream and asks again at
+      // the end must get the elapsed of the whole run the second time, not the reading frozen by the first ask.
+      return Optional.of(buildProfilePlan(context, rootStep, countPushedDown, elapsedSoFar(), rowCount, null));
     }
 
+    /** The run's elapsed: final once the run has ended, and how long it has been going otherwise. */
+    private long elapsedSoFar() {
+      return elapsedNanos < 0 ? System.nanoTime() - startNanos : elapsedNanos;
+    }
+
+    /** Ends the run's clock, at the first of the delegate reporting exhaustion and {@code close()}. */
     private void stopClock() {
       if (elapsedNanos < 0)
         elapsedNanos = System.nanoTime() - startNanos;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
@@ -181,9 +181,15 @@ public class OpenCypherQueryEngine implements QueryEngine {
         actualQuery = actualQuery.substring(8).trim();
       }
 
-      // Also check for $profileExecution parameter (set by HTTP handler when Studio sends profileExecution: "detailed")
-      if (!profile && parameters != null && Boolean.TRUE.equals(parameters.get("$profileExecution")))
-        profile = true;
+      // The $profileExecution parameter - injected by the HTTP handler for Studio's profileExecution: "detailed",
+      // and by ServerDatabase for every statement while the server profiler is recording - asks for the statement
+      // to be TIMED, not for it to be run differently. It therefore turns on per-step timing over the ordinary
+      // streaming execution and is deliberately NOT folded into `profile` here: doing that rerouted every Cypher
+      // statement on a recording server onto CypherExecutionPlan.profile(), which drains the plan into heap, so
+      // the reported cost described a materialising execution the statement never otherwise performs and the
+      // diagnostic itself changed what it was diagnosing (issue #7330).
+      final boolean timeExecution =
+          parameters != null && Boolean.TRUE.equals(parameters.get("$profileExecution"));
 
       // Use statement cache to avoid re-parsing. Carries the parameter names the query references, so the
       // check below costs no extra lookup.
@@ -210,7 +216,7 @@ public class OpenCypherQueryEngine implements QueryEngine {
       if (!explain && !profile && !statement.isReadOnly())
         throw new QueryNotIdempotentException("Query '" + query + "' is not idempotent");
 
-      return execute(actualQuery, statement, configuration, effectiveParameters, explain, profile);
+      return execute(actualQuery, statement, configuration, effectiveParameters, explain, profile, timeExecution);
     } catch (final QueryNotIdempotentException | CommandExecutionException | CommandParsingException | SecurityException e) {
       throw e;
     } catch (final Exception e) {
@@ -240,9 +246,15 @@ public class OpenCypherQueryEngine implements QueryEngine {
         actualQuery = actualQuery.substring(8).trim();
       }
 
-      // Also check for $profileExecution parameter (set by HTTP handler when Studio sends profileExecution: "detailed")
-      if (!profile && parameters != null && Boolean.TRUE.equals(parameters.get("$profileExecution")))
-        profile = true;
+      // The $profileExecution parameter - injected by the HTTP handler for Studio's profileExecution: "detailed",
+      // and by ServerDatabase for every statement while the server profiler is recording - asks for the statement
+      // to be TIMED, not for it to be run differently. It therefore turns on per-step timing over the ordinary
+      // streaming execution and is deliberately NOT folded into `profile` here: doing that rerouted every Cypher
+      // statement on a recording server onto CypherExecutionPlan.profile(), which drains the plan into heap, so
+      // the reported cost described a materialising execution the statement never otherwise performs and the
+      // diagnostic itself changed what it was diagnosing (issue #7330).
+      final boolean timeExecution =
+          parameters != null && Boolean.TRUE.equals(parameters.get("$profileExecution"));
 
       // Use statement cache to avoid re-parsing. Carries the parameter names the query references, so the
       // check below costs no extra lookup.
@@ -280,7 +292,7 @@ public class OpenCypherQueryEngine implements QueryEngine {
       if (statement instanceof CypherSessionStatement)
         return executeSession((CypherSessionStatement) statement, session, effectiveParameters);
 
-      return execute(actualQuery, statement, configuration, effectiveParameters, explain, profile);
+      return execute(actualQuery, statement, configuration, effectiveParameters, explain, profile, timeExecution);
     } catch (final CommandExecutionException | CommandParsingException | SecurityException e) {
       throw e;
     } catch (final Exception e) {
@@ -334,11 +346,15 @@ public class OpenCypherQueryEngine implements QueryEngine {
    * @param configuration context configuration
    * @param parameters    query parameters
    * @param explain       if true, return EXPLAIN output instead of executing
-   * @param profile       if true, execute with profiling and return metrics
+   * @param profile       if true, take the eager PROFILE path: drain the whole plan and return the metrics with it
+   * @param timeExecution if true, time each step of the ordinary streaming execution and attach the resulting plan.
+   *                      Unlike {@code profile} this changes nothing about what runs - see
+   *                      {@link CypherExecutionPlan#execute(com.arcadedb.query.sql.executor.CommandContext, boolean)}
+   *                      (issue #7330)
    * @return result set
    */
   private ResultSet execute(final String queryString, final CypherStatement statement, final ContextConfiguration configuration,
-      final Map<String, Object> parameters, final boolean explain, final boolean profile) {
+      final Map<String, Object> parameters, final boolean explain, final boolean profile, final boolean timeExecution) {
     // Try to get cached physical plan first (saves optimization time: 200-500ms)
     final CypherExecutionPlan plan;
     final DatabaseInternal execDb = executionDatabase(statement);
@@ -374,7 +390,7 @@ public class OpenCypherQueryEngine implements QueryEngine {
       return plan.explain();
     if (profile)
       return plan.profile();
-    return plan.execute();
+    return plan.execute(null, timeExecution);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
@@ -181,15 +181,7 @@ public class OpenCypherQueryEngine implements QueryEngine {
         actualQuery = actualQuery.substring(8).trim();
       }
 
-      // The $profileExecution parameter - injected by the HTTP handler for Studio's profileExecution: "detailed",
-      // and by ServerDatabase for every statement while the server profiler is recording - asks for the statement
-      // to be TIMED, not for it to be run differently. It therefore turns on per-step timing over the ordinary
-      // streaming execution and is deliberately NOT folded into `profile` here: doing that rerouted every Cypher
-      // statement on a recording server onto CypherExecutionPlan.profile(), which drains the plan into heap, so
-      // the reported cost described a materialising execution the statement never otherwise performs and the
-      // diagnostic itself changed what it was diagnosing (issue #7330).
-      final boolean timeExecution =
-          parameters != null && Boolean.TRUE.equals(parameters.get("$profileExecution"));
+      final boolean timeExecution = asksForTimedExecution(parameters);
 
       // Use statement cache to avoid re-parsing. Carries the parameter names the query references, so the
       // check below costs no extra lookup.
@@ -246,15 +238,7 @@ public class OpenCypherQueryEngine implements QueryEngine {
         actualQuery = actualQuery.substring(8).trim();
       }
 
-      // The $profileExecution parameter - injected by the HTTP handler for Studio's profileExecution: "detailed",
-      // and by ServerDatabase for every statement while the server profiler is recording - asks for the statement
-      // to be TIMED, not for it to be run differently. It therefore turns on per-step timing over the ordinary
-      // streaming execution and is deliberately NOT folded into `profile` here: doing that rerouted every Cypher
-      // statement on a recording server onto CypherExecutionPlan.profile(), which drains the plan into heap, so
-      // the reported cost described a materialising execution the statement never otherwise performs and the
-      // diagnostic itself changed what it was diagnosing (issue #7330).
-      final boolean timeExecution =
-          parameters != null && Boolean.TRUE.equals(parameters.get("$profileExecution"));
+      final boolean timeExecution = asksForTimedExecution(parameters);
 
       // Use statement cache to avoid re-parsing. Carries the parameter names the query references, so the
       // check below costs no extra lookup.
@@ -303,6 +287,24 @@ public class OpenCypherQueryEngine implements QueryEngine {
   @Override
   public ResultSet command(final String query, final ContextConfiguration configuration, final Object... parameters) {
     return command(query, configuration, convertPositionalParameters(parameters));
+  }
+
+  /**
+   * Whether the caller asked for the statement to be TIMED - not for it to be run differently.
+   * <p>
+   * {@code $profileExecution} is injected by the HTTP handler for Studio's {@code profileExecution: "detailed"},
+   * and by {@code ServerDatabase} for every statement while the server profiler is recording. It turns on per-step
+   * timing over the ordinary streaming execution, and is deliberately NOT folded into the {@code PROFILE} keyword's
+   * own flag: doing that rerouted every Cypher statement on a recording server onto
+   * {@link CypherExecutionPlan#profile()}, which drains the plan into heap, so the reported cost described a
+   * materialising execution the statement never otherwise performs - the diagnostic changed what it was diagnosing
+   * (issue #7330).
+   * <p>
+   * One method rather than a copy in {@link #query} and another in {@link #command}, so the two cannot drift apart
+   * the way the folding they replace did.
+   */
+  private static boolean asksForTimedExecution(final Map<String, Object> parameters) {
+    return parameters != null && Boolean.TRUE.equals(parameters.get("$profileExecution"));
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/AbstractExecutionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/AbstractExecutionStep.java
@@ -76,8 +76,19 @@ public abstract class AbstractExecutionStep implements ExecutionStepInternal {
   }
 
   protected String getCostFormatted() {
-    final long computedCost = getCost();
-    return computedCost > -1 ? new DecimalFormat().format(computedCost / 1000) + "μs" : "";
+    return formatCost(getCost());
+  }
+
+  /**
+   * The subtree roll-up, formatted. What a container step - one whose whole job is to dispatch to its sub-steps,
+   * so it has no self cost to show - prints in an EXPLAIN tree (issue #7329).
+   */
+  protected String getTotalCostFormatted() {
+    return formatCost(getTotalCost());
+  }
+
+  private static String formatCost(final long cost) {
+    return cost > -1 ? new DecimalFormat().format(cost / 1000) + "μs" : "";
   }
 
   public long getRowCount() {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/BasicCommandContext.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/BasicCommandContext.java
@@ -539,10 +539,20 @@ public class BasicCommandContext implements CommandContext {
   }
 
   public void setInputParameters(final Map<String, Object> inputParameters) {
-    this.inputParameters = inputParameters;
-    this.profiling = inputParameters != null && inputParameters.containsKey("$profileExecution") ?
-        (Boolean) inputParameters.remove("$profileExecution") :
-        false;
+    if (inputParameters != null && inputParameters.containsKey("$profileExecution")) {
+      this.profiling = Boolean.TRUE.equals(inputParameters.get("$profileExecution"));
+      // The flag is stripped so it cannot be mistaken for a query parameter, but out of a COPY. Removing it in
+      // place threw UnsupportedOperationException when the caller passed an immutable map (a plain Map.of(...)),
+      // and silently mutated the caller's own map otherwise - including the parameter map a cached execution plan
+      // holds on to, so a second run of the same plan no longer saw the flag. Copied only on the rare path that
+      // carries it, so the ordinary one still hands the map straight through (issue #7330).
+      final Map<String, Object> stripped = new HashMap<>(inputParameters);
+      stripped.remove("$profileExecution");
+      this.inputParameters = stripped;
+    } else {
+      this.inputParameters = inputParameters;
+      this.profiling = false;
+    }
   }
 
   public void setInputParameters(final Object[] args) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ExecutionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ExecutionStep.java
@@ -39,12 +39,63 @@ public interface ExecutionStep {
   List<ExecutionStep> getSubSteps();
 
   /**
-   * returns the absolute cost (in nanoseconds) of the execution of this step
+   * The <b>self</b> cost (in nanoseconds) of this step: the time spent inside this step's own work, with the time
+   * its sub-steps spent inside theirs excluded. Every step in a plan reports its own, so the self costs of a plan
+   * partition its total rather than overlapping - which is what lets a consumer sum them, and what identifies the
+   * one step worth optimising.
+   * <p>
+   * A container step that only dispatches to its sub-steps has no work of its own to time and reports -1 here, the
+   * same sentinel as a step that ran with profiling off. {@link #getTotalCost()} is the subtree roll-up, and the
+   * number to display for such a container. Returning the roll-up from this method instead is what made the
+   * profiler count a plain type scan twice, once on the container and once on the bucket step that actually timed
+   * it (issue #7329).
    *
-   * @return the absolute cost (in nanoseconds) of the execution of this step, -1 if not calculated
+   * @return the self cost (in nanoseconds) of the execution of this step, -1 if not calculated
    */
   default long getCost() {
     return -1L;
+  }
+
+  /**
+   * The total cost (in nanoseconds) of the subtree rooted at this step: this step's self cost plus, recursively,
+   * that of every sub-step and of every step of every sub-execution-plan hanging off it. -1 when nothing in the
+   * subtree was timed.
+   * <p>
+   * Never sum this across the steps of a plan - a parent's total already contains its children's. It is the number
+   * to <i>display</i> for one node; {@link #getCost()} is the number to <i>aggregate</i>.
+   */
+  default long getTotalCost() {
+    long total = getCost();
+
+    final List<ExecutionStep> subSteps = getSubSteps();
+    if (subSteps != null)
+      for (final ExecutionStep step : subSteps)
+        total = addCost(total, step.getTotalCost());
+
+    if (this instanceof final ExecutionStepInternal stepInternal) {
+      final List<ExecutionPlan> subPlans = stepInternal.getSubExecutionPlans();
+      if (subPlans != null)
+        for (final ExecutionPlan plan : subPlans) {
+          final List<ExecutionStep> planSteps = plan.getSteps();
+          if (planSteps != null)
+            for (final ExecutionStep step : planSteps)
+              total = addCost(total, step.getTotalCost());
+        }
+    }
+
+    return total;
+  }
+
+  /**
+   * Adds two costs treating -1 ("not calculated") as absent rather than as a duration, so a subtree where only some
+   * steps were timed reports the sum of the timed ones instead of a value pulled below zero by the sentinel.
+   */
+  private static long addCost(final long a, final long b) {
+    if (a < 0)
+      return b;
+    if (b < 0)
+      return a;
+    return a + b;
   }
 
   default Result toResult() {
@@ -53,7 +104,11 @@ public interface ExecutionStep {
     result.setProperty("type", getType());
     result.setProperty("targetNode", getType());
     result.setProperty(InternalExecutionPlan.JAVA_TYPE, getClass().getName());
+    // Self cost and subtree roll-up under distinct names: an aggregator sums "cost" across the whole tree, a
+    // display picks "totalCost" for the node it is drawing. Emitting the roll-up as "cost" while also emitting
+    // each sub-step with its own "cost" in the same node double-counted every container (issue #7329).
     result.setProperty("cost", getCost());
+    result.setProperty("totalCost", getTotalCost());
 
     // Collect direct sub-steps
     final List<Result> subStepResults = getSubSteps() == null ? null

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ExecutionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ExecutionStep.java
@@ -63,6 +63,9 @@ public interface ExecutionStep {
    * <p>
    * Never sum this across the steps of a plan - a parent's total already contains its children's. It is the number
    * to <i>display</i> for one node; {@link #getCost()} is the number to <i>aggregate</i>.
+   * <p>
+   * Re-walks the subtree on every call, so it is for the one node a caller is about to draw. A traversal that
+   * already visits every node folds the totals up instead of calling this per node - see {@link #toResult()}.
    */
   default long getTotalCost() {
     long total = getCost();
@@ -107,11 +110,11 @@ public interface ExecutionStep {
     // Self cost and subtree roll-up under distinct names: an aggregator sums "cost" across the whole tree, a
     // display picks "totalCost" for the node it is drawing. Emitting the roll-up as "cost" while also emitting
     // each sub-step with its own "cost" in the same node double-counted every container (issue #7329).
-    result.setProperty("cost", getCost());
-    result.setProperty("totalCost", getTotalCost());
+    final long selfCost = getCost();
+    result.setProperty("cost", selfCost);
 
     // Collect direct sub-steps
-    final List<Result> subStepResults = getSubSteps() == null ? null
+    List<Result> subStepResults = getSubSteps() == null ? null
         : getSubSteps().stream().map(ExecutionStep::toResult).collect(Collectors.toList());
 
     // Also include steps from sub-execution plans (e.g. SubQueryStep, GlobalLetQueryStep)
@@ -125,13 +128,23 @@ public interface ExecutionStep {
             for (final ExecutionStep s : planSteps)
               allSubSteps.add(s.toResult());
         }
-        result.setProperty("subSteps", allSubSteps);
-      } else {
-        result.setProperty("subSteps", subStepResults);
+        subStepResults = allSubSteps;
       }
-    } else {
-      result.setProperty("subSteps", subStepResults);
     }
+    result.setProperty("subSteps", subStepResults);
+
+    // The roll-up is folded up from the children's ALREADY-computed totals rather than read from
+    // getTotalCost(), which re-walks the whole subtree on every call: one such call per node, inside a
+    // traversal that already visits every node, makes serializing a plan quadratic in step count. Bottom-up
+    // here it is linear, and every node still reports the same number getTotalCost() would.
+    long totalCost = selfCost;
+    if (subStepResults != null)
+      for (final Result subStep : subStepResults) {
+        final Long subTotal = subStep.getProperty("totalCost");
+        // A step that overrides toResult() and omits the field contributes nothing rather than a wrong number.
+        totalCost = addCost(totalCost, subTotal != null ? subTotal : -1L);
+      }
+    result.setProperty("totalCost", totalCost);
 
     result.setProperty("description", getDescription());
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromClustersExecutionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromClustersExecutionStep.java
@@ -163,7 +163,9 @@ public class FetchFromClustersExecutionStep extends AbstractExecutionStep {
     builder.append(ind);
     builder.append("+ FETCH FROM BUCKETS");
     if( context.isProfiling() ) {
-      builder.append(" (").append(getCostFormatted()).append(")");
+      // The subtree roll-up rather than a self cost this pure-dispatch step does not have - see
+      // FetchFromTypeExecutionStep.prettyPrint() (issue #7329).
+      builder.append(" (").append(getTotalCostFormatted()).append(")");
     }
     builder.append("\n");
     for (int i = 0; i < subSteps.size(); i++) {
@@ -179,11 +181,6 @@ public class FetchFromClustersExecutionStep extends AbstractExecutionStep {
   @Override
   public List<ExecutionStep> getSubSteps() {
     return subSteps;
-  }
-
-  @Override
-  public long getCost() {
-    return subSteps.stream().map(ExecutionStep::getCost).reduce((a, b) -> a > 0 && b > 0 ? a + b : a > 0 ? a : b > 0 ? b : -1L).orElse(-1L);
   }
 
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromTypeExecutionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromTypeExecutionStep.java
@@ -552,7 +552,10 @@ public class FetchFromTypeExecutionStep extends AbstractExecutionStep {
     if (parallelScan)
       builder.append(" (parallel)");
     if (context.isProfiling()) {
-      builder.append(" (").append(getCostFormatted()).append(")");
+      // The subtree roll-up, because this step is pure dispatch: the bucket sub-steps below own every nanosecond
+      // it would otherwise claim, and claiming them here as if they were its own is what made a plain type scan
+      // appear twice in the server profiler's aggregated table (issue #7329).
+      builder.append(" (").append(getTotalCostFormatted()).append(")");
     }
     builder.append("\n");
     for (int i = 0; i < getSubSteps().size(); i++) {
@@ -563,12 +566,6 @@ public class FetchFromTypeExecutionStep extends AbstractExecutionStep {
       }
     }
     return builder.toString();
-  }
-
-  @Override
-  public long getCost() {
-    return subSteps.stream().map(ExecutionStep::getCost).reduce((a, b) -> a > 0 && b > 0 ? a + b : a > 0 ? a : b > 0 ? b : -1L)
-        .orElse(-1L);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromTypeWithFilterStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromTypeWithFilterStep.java
@@ -178,7 +178,9 @@ public class FetchFromTypeWithFilterStep extends AbstractExecutionStep {
     builder.append(ind);
     builder.append("+ FETCH FROM TYPE ").append(typeName).append(" WITH FILTER");
     if (context.isProfiling())
-      builder.append(" (").append(getCostFormatted()).append(")");
+      // The subtree roll-up rather than a self cost this pure-dispatch step does not have - see
+      // FetchFromTypeExecutionStep.prettyPrint() (issue #7329).
+      builder.append(" (").append(getTotalCostFormatted()).append(")");
     builder.append("\n");
     for (int i = 0; i < subSteps.size(); i++) {
       final ExecutionStepInternal step = (ExecutionStepInternal) subSteps.get(i);
@@ -187,12 +189,6 @@ public class FetchFromTypeWithFilterStep extends AbstractExecutionStep {
         builder.append("\n");
     }
     return builder.toString();
-  }
-
-  @Override
-  public long getCost() {
-    return subSteps.stream().map(ExecutionStep::getCost).reduce((a, b) -> a > 0 && b > 0 ? a + b : a > 0 ? a : b > 0 ? b : -1L)
-        .orElse(-1L);
   }
 
   @Override

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherProfiledExecutionIsStreamingIssue7330Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherProfiledExecutionIsStreamingIssue7330Test.java
@@ -125,6 +125,40 @@ class CypherProfiledExecutionIsStreamingIssue7330Test {
   }
 
   /**
+   * The plan is a reading, not a snapshot: a caller free to inspect progress mid-stream must still get the whole
+   * run when it asks again at the end. Asking cannot be what ends the run's clock.
+   * <p>
+   * Asserted as a monotonic relation between the two readings rather than against a wall-clock bound, which a
+   * shared-JVM suite could never hold to.
+   */
+  @Test
+  void inspectingThePlanMidStreamDoesNotFreezeWhatALaterAskReports() {
+    try (final ResultSet rs = database.query("opencypher", "MATCH (i:Item) RETURN i.idx AS idx",
+        Map.of("$profileExecution", true))) {
+
+      assertThat(rs.hasNext()).isTrue();
+      rs.next();
+      final long midStreamElapsed = rs.getExecutionPlan().orElseThrow().toResult().getProperty("cost");
+
+      long consumed = 1;
+      while (rs.hasNext()) {
+        rs.next();
+        ++consumed;
+      }
+      assertThat(consumed).isEqualTo(ROWS);
+
+      final ExecutionPlan finalPlan = rs.getExecutionPlan().orElseThrow();
+      assertThat(finalPlan.prettyPrint(0, 2))
+          .as("the second ask must describe the whole run, not the one row the first ask saw")
+          .contains("Rows Returned: " + ROWS);
+      final long finalElapsed = finalPlan.toResult().getProperty("cost");
+      assertThat(finalElapsed)
+          .as("the run kept going after the first ask, so its elapsed cannot have gone backwards")
+          .isGreaterThanOrEqualTo(midStreamElapsed);
+    }
+  }
+
+  /**
    * The explicit {@code PROFILE <statement>} keyword is a different request - the user asking, in the statement
    * itself, for the whole execution to be run and summarised - and keeps the eager path. Neo4j's PROFILE executes
    * fully too, so this is also the parity behaviour.

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherProfiledExecutionIsStreamingIssue7330Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherProfiledExecutionIsStreamingIssue7330Test.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ExecutionPlan;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The {@code $profileExecution} flag - injected by the HTTP handler for Studio's {@code profileExecution: "detailed"},
+ * and by {@code ServerDatabase} for every statement while the server profiler is recording - asks for a statement to
+ * be TIMED, not for it to be run differently.
+ * <p>
+ * It used to reroute every OpenCypher statement onto {@code CypherExecutionPlan.profile()}, which drains the whole
+ * plan into heap before returning. The number the profiler then reported was the cost of a materialising execution
+ * the statement never performs otherwise, and turning the diagnostic on made every Cypher read on the server
+ * materialise in heap for the length of the recording window (issue #7330).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherProfiledExecutionIsStreamingIssue7330Test {
+  private static final int    ROWS         = 500;
+  private static final String DATABASE_DIR = "./target/databases/testcypher-profiled-streaming-7330";
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    database = new DatabaseFactory(DATABASE_DIR).create();
+    database.getSchema().createVertexType("Item");
+    database.transaction(() -> {
+      for (int i = 0; i < ROWS; i++)
+        database.newVertex("Item").set("idx", i).save();
+    });
+  }
+
+  @AfterEach
+  void cleanup() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  /**
+   * The point of the issue: with the flag on, the statement must still stream. Pulling a single row out of
+   * {@link #ROWS} and then reading the plan must report one row returned, because that is all the caller asked for -
+   * the eager reroute reported all {@link #ROWS} of them, having produced every one before {@code query()} returned.
+   */
+  @Test
+  void profiledExecutionStreamsInsteadOfDrainingThePlan() {
+    try (final ResultSet rs = database.query("opencypher", "MATCH (i:Item) RETURN i.idx AS idx",
+        Map.of("$profileExecution", true))) {
+
+      assertThat(rs.hasNext()).isTrue();
+      rs.next();
+
+      final Optional<ExecutionPlan> plan = rs.getExecutionPlan();
+      assertThat(plan).isPresent();
+      assertThat(plan.get().prettyPrint(0, 2)).contains("Rows Returned: 1");
+    }
+  }
+
+  /**
+   * Timing the statement must not change the answer it gives.
+   */
+  @Test
+  void profiledExecutionReturnsTheSameRowsAsAnUnprofiledOne() {
+    final long profiled = countRows(Map.of("$profileExecution", true));
+    final long plain = countRows(Map.of());
+
+    assertThat(profiled).isEqualTo(ROWS);
+    assertThat(plain).isEqualTo(ROWS);
+  }
+
+  /**
+   * And the diagnostic itself must still work: the plan is there, and it is built from the live step chain, so the
+   * elapsed it reports grows with what the caller actually consumed rather than being frozen before the first row.
+   */
+  @Test
+  void profiledExecutionStillCarriesAnExecutionPlanWithTheStepsThatRan() {
+    try (final ResultSet rs = database.query("opencypher", "MATCH (i:Item) RETURN i.idx AS idx",
+        Map.of("$profileExecution", true))) {
+
+      long consumed = 0;
+      while (rs.hasNext()) {
+        rs.next();
+        ++consumed;
+      }
+      assertThat(consumed).isEqualTo(ROWS);
+
+      final Optional<ExecutionPlan> plan = rs.getExecutionPlan();
+      assertThat(plan).isPresent();
+
+      final String text = plan.get().prettyPrint(0, 2);
+      assertThat(text).contains("OpenCypher Query Profile");
+      assertThat(text).contains("Rows Returned: " + ROWS);
+      assertThat(plan.get().getSteps()).isNotEmpty();
+    }
+  }
+
+  /**
+   * The explicit {@code PROFILE <statement>} keyword is a different request - the user asking, in the statement
+   * itself, for the whole execution to be run and summarised - and keeps the eager path. Neo4j's PROFILE executes
+   * fully too, so this is also the parity behaviour.
+   */
+  @Test
+  void theExplicitProfileKeywordStillExecutesEagerly() {
+    try (final ResultSet rs = database.query("opencypher", "PROFILE MATCH (i:Item) RETURN i.idx AS idx")) {
+      final Optional<ExecutionPlan> plan = rs.getExecutionPlan();
+      assertThat(plan).isPresent();
+      // Nothing has been pulled by this caller yet, and the profile already knows every row: that is the drain.
+      assertThat(plan.get().prettyPrint(0, 2)).contains("Rows Returned: " + ROWS);
+    }
+  }
+
+  private long countRows(final Map<String, Object> parameters) {
+    try (final ResultSet rs = database.query("opencypher", "MATCH (i:Item) RETURN i.idx AS idx", parameters)) {
+      long rows = 0;
+      while (rs.hasNext()) {
+        rs.next();
+        ++rows;
+      }
+      return rows;
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ContainerStepSelfCostIssue7329Test.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ContainerStepSelfCostIssue7329Test.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A step's {@code cost} is its SELF cost, so the costs of a plan partition its total instead of overlapping, and a
+ * consumer that walks the tree adding them up - which is exactly what the server profiler's aggregated step table
+ * does - cannot charge the same nanoseconds twice.
+ * <p>
+ * The three container steps ({@code FetchFromTypeExecutionStep}, {@code FetchFromTypeWithFilterStep},
+ * {@code FetchFromClustersExecutionStep}) used to return their children's sum from {@code getCost()} while
+ * {@code toResult()} emitted those same children, each with its own cost, in the same node. A plain type scan was
+ * therefore reported twice over and the step costs added up to more than the Engine total the Studio caption says
+ * contains them (issue #7329). The roll-up now travels separately as {@code totalCost}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class ContainerStepSelfCostIssue7329Test {
+  private static final String DATABASE_DIR = "./target/databases/testcontainer-step-self-cost-7329";
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    database = new DatabaseFactory(DATABASE_DIR).create();
+    database.getSchema().createDocumentType("Item");
+    database.transaction(() -> {
+      for (int i = 0; i < 200; i++)
+        database.newDocument("Item").set("idx", i).save();
+    });
+  }
+
+  @AfterEach
+  void cleanup() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void aContainerStepReportsNoSelfCostAndTheChildrenCarryTheTime() {
+    final JSONObject plan = profiledPlanOf("select from Item");
+
+    final JSONObject container = findStep(plan, "FetchFromTypeExecutionStep");
+    assertThat(container).as("the type scan container step must be in the plan").isNotNull();
+
+    // -1 is the engine's "not calculated": this step dispatches to its bucket sub-steps and times nothing itself.
+    assertThat(container.getLong("cost", 0)).isEqualTo(-1L);
+
+    final List<JSONObject> buckets = collectSteps(container.getJSONArray("subSteps"));
+    assertThat(buckets).as("the container must carry the bucket steps that do the timing").isNotEmpty();
+    assertThat(buckets.stream().anyMatch(s -> s.getLong("cost", -1) >= 0))
+        .as("at least one bucket step must have been timed").isTrue();
+  }
+
+  /**
+   * The roll-up did not disappear, it moved: {@code totalCost} is the subtree total, and it is what the EXPLAIN tree
+   * shows for a container. It is emitted under its own name precisely so an aggregator can tell it apart from a
+   * measured self cost.
+   */
+  @Test
+  void theContainerStillReportsTheSubtreeRollUpUnderTotalCost() {
+    final JSONObject plan = profiledPlanOf("select from Item");
+    final JSONObject container = findStep(plan, "FetchFromTypeExecutionStep");
+
+    // Direct children only: the container's total is its own (absent) cost plus each child's total, so summing a
+    // flattened tree here would count a grandchild inside its parent's total and again on its own.
+    long childrenTotal = 0;
+    final JSONArray buckets = container.getJSONArray("subSteps");
+    for (int i = 0; i < buckets.length(); i++) {
+      final long cost = buckets.getJSONObject(i).getLong("totalCost", -1);
+      if (cost >= 0)
+        childrenTotal += cost;
+    }
+
+    assertThat(container.getLong("totalCost", -1)).isEqualTo(childrenTotal);
+  }
+
+  /**
+   * The invariant the Studio caption states, checked the way the server profiler computes it: walk the whole tree
+   * adding every {@code cost}, and the answer must not exceed the plan's own subtree total. Before the fix the
+   * container's children were counted twice - once inside its derived {@code cost}, once on their own nodes - so
+   * the walk came out strictly larger.
+   */
+  @Test
+  void theSelfCostsOfTheWholeTreeDoNotExceedTheSubtreeTotal() {
+    final JSONObject plan = profiledPlanOf("select from Item");
+
+    long selfCostSum = 0;
+    long topLevelTotal = 0;
+    final JSONArray steps = plan.getJSONArray("steps");
+    for (int i = 0; i < steps.length(); i++) {
+      selfCostSum += sumSelfCosts(steps.getJSONObject(i));
+      final long total = steps.getJSONObject(i).getLong("totalCost", -1);
+      if (total >= 0)
+        topLevelTotal += total;
+    }
+
+    assertThat(topLevelTotal).as("the run must have been timed at all").isGreaterThan(0L);
+    assertThat(selfCostSum).isEqualTo(topLevelTotal);
+  }
+
+  private long sumSelfCosts(final JSONObject step) {
+    long total = 0;
+    final long cost = step.getLong("cost", -1);
+    if (cost >= 0)
+      total += cost;
+
+    if (step.has("subSteps") && step.get("subSteps") instanceof final JSONArray subSteps)
+      for (int i = 0; i < subSteps.length(); i++)
+        total += sumSelfCosts(subSteps.getJSONObject(i));
+
+    return total;
+  }
+
+  private JSONObject profiledPlanOf(final String query) {
+    try (final ResultSet rs = database.query("sql", query, Map.of("$profileExecution", true))) {
+      while (rs.hasNext())
+        rs.next();
+      return rs.getExecutionPlan().orElseThrow().toResult().toJSON();
+    }
+  }
+
+  private JSONObject findStep(final JSONObject plan, final String name) {
+    for (final JSONObject step : collectSteps(plan.getJSONArray("steps")))
+      if (name.equals(step.getString("name", "")))
+        return step;
+    return null;
+  }
+
+  /** Flattens a step array and everything nested under it, so a lookup does not depend on the plan's shape. */
+  private List<JSONObject> collectSteps(final JSONArray steps) {
+    final List<JSONObject> flattened = new ArrayList<>();
+    if (steps == null)
+      return flattened;
+
+    for (int i = 0; i < steps.length(); i++) {
+      final JSONObject step = steps.getJSONObject(i);
+      flattened.add(step);
+      if (step.has("subSteps") && step.get("subSteps") instanceof final JSONArray subSteps)
+        flattened.addAll(collectSteps(subSteps));
+    }
+    return flattened;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ProfileFlameGraphTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ProfileFlameGraphTest.java
@@ -144,11 +144,13 @@ class ProfileFlameGraphTest {
       final Result planResult = plan.toResult();
       final JSONObject planJson = planResult.toJSON();
 
-      // At least one step should have a positive cost when profiling is enabled
+      // At least one step should have a positive cost when profiling is enabled. Read from totalCost, the subtree
+      // roll-up: "cost" is a step's SELF cost, and the top-level step of a type scan is a container that dispatches
+      // to the bucket steps below it and so times nothing of its own (issue #7329).
       final JSONArray steps = planJson.getJSONArray("steps");
       boolean hasCost = false;
       for (int i = 0; i < steps.length(); i++) {
-        if (steps.getJSONObject(i).getLong("cost") > 0) {
+        if (steps.getJSONObject(i).getLong("totalCost") > 0) {
           hasCost = true;
           break;
         }

--- a/integration/src/main/java/com/arcadedb/integration/importer/ImporterContext.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/ImporterContext.java
@@ -18,6 +18,8 @@
  */
 package com.arcadedb.integration.importer;
 
+import com.arcadedb.database.Database;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -60,6 +62,30 @@ public class ImporterContext {
   public       long          lastVertices;
   public       long          lastEdges;
   public       long          lastLinkedEdges;
+
+  /**
+   * Whether the transaction the row loop about to run will use belongs to the import, as opposed to predating it -
+   * and therefore whether that loop may commit it, roll it back, and correct its own counters against it.
+   * <p>
+   * The single place this decision is made, so the five row loops that gate on it cannot each answer it slightly
+   * differently. The last time the answer was hand-applied per loop, one of the four operations in
+   * {@code RDFImporterFormat.load()} came apart from its siblings and committed the caller's transaction
+   * (issues #7272, #7328).
+   * <p>
+   * Two conditions, both meaning "not the caller's":
+   * <ul>
+   *   <li>{@link #callerTransactionActiveOnEntry} is false - nothing predating the import was ever there;</li>
+   *   <li>or it is true but no transaction is active any more. A caller transaction that has since been resolved
+   *   is not a caller transaction: the loop's own {@code begin()} pushes a fresh one, and calling that fresh one
+   *   the caller's would leave it on the stack with nothing allowed to resolve it - not the loop's gates, and not
+   *   {@code Importer.load()}'s own cleanup, which is gated on the same flag.</li>
+   * </ul>
+   * Call it once, immediately before the loop's {@code begin()}, and keep the answer in a local: after that
+   * {@code begin()} a transaction is always active, so asking again would always say "the caller's".
+   */
+  public boolean importOwnsTransaction(final Database database) {
+    return !callerTransactionActiveOnEntry || !database.isTransactionActive();
+  }
 
   public Map<String, Object> toMap() {
     final LinkedHashMap<String, Object> map = new LinkedHashMap<>();

--- a/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
@@ -21,7 +21,9 @@ package com.arcadedb.integration.importer;
 import com.arcadedb.Constants;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
+import com.arcadedb.database.TransactionContext;
 import com.arcadedb.graph.GraphBatch;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.query.opencypher.Labels;
@@ -344,6 +346,13 @@ public class Neo4jImporter {
       // (issue #7272).
       final boolean[] txOpen = { false };
 
+      // The transaction this method pushed, so the commit and the rollback below can prove that the live one is
+      // still it. The flag alone cannot prove that: parsingCallback belongs to the caller and runs inside the
+      // loop, so it can resolve this method's transaction and leave the flag set - and because begin() nests,
+      // what commit() would then find and resolve is the CALLER's outer transaction (issue #7328). Re-read after
+      // every begin(), never assumed to survive one.
+      final TransactionContext[] ownTx = { null };
+
       // Vertices an intermediate commit already made durable. context.createdVertices counts every vertex the
       // batch allocated, the ones still inside the transaction a failure rolls back included. Seeded from the
       // counter rather than from 0: the embedding constructor takes an ImporterContext from its caller, so a
@@ -357,6 +366,7 @@ public class Neo4jImporter {
 
       database.begin();
       txOpen[0] = true;
+      ownTx[0] = currentTransaction();
 
       try {
         readFileSimple(json -> {
@@ -406,6 +416,7 @@ public class Neo4jImporter {
               committedVertices[0] = context.createdVertices.get();
               database.begin();
               txOpen[0] = true;
+              ownTx[0] = currentTransaction();
             }
 
             break;
@@ -421,21 +432,22 @@ public class Neo4jImporter {
           return null;
         });
 
-        // Gated on this method's own txOpen, the same flag the rollback below uses, and NOT on the ambient
-        // database.isTransactionActive(): begin() nests, so a live transaction here is not evidence that the live
-        // one is the one this method pushed. Once that one is gone - a parsing callback of the caller's that
+        // Gated on this method's own transaction being the live one, and NOT on the ambient
+        // database.isTransactionActive(): begin() nests, so a live transaction here is no evidence that the live
+        // one is the one this method pushed. Once that one is gone - a parsingCallback of the caller's that
         // resolved it, say - the ambient test sees the CALLER's outer transaction instead and commits that
         // (issue #7328, the same asymmetry #7272 fixed on the four other row loops).
-        if (txOpen[0]) {
+        if (ownTransactionIsResolvable(txOpen[0], ownTx[0])) {
           txOpen[0] = false;
           database.commit();
         }
+        txOpen[0] = false;
         committedVertices[0] = context.createdVertices.get();
         completed = true;
       } finally {
         // In the finally rather than in a catch so that an Error - an OutOfMemoryError is the one a large import
         // can realistically raise - resolves the transaction too.
-        if (txOpen[0]) {
+        if (ownTransactionIsResolvable(txOpen[0], ownTx[0])) {
           txOpen[0] = false;
           try {
             database.rollback();
@@ -446,6 +458,7 @@ public class Neo4jImporter {
                 + "on the stack: %s", rollbackFailure.getMessage());
           }
         }
+        txOpen[0] = false;
 
         // Outside the txOpen branch above, because a commit() that threw has already popped its own transaction
         // and would otherwise leave the batch it failed to write counted as if it had survived.
@@ -698,12 +711,53 @@ public class Neo4jImporter {
    * Reads the JSONL file line by line, calling the callback for each valid JSON record.
    * Used by syncSchema (which only reads, no record creation) with its own transaction management.
    */
+  /**
+   * The transaction currently on top of this thread's stack, or {@code null} when there is none - and also when the
+   * {@link Database} implementation does not expose its stack at all (a remote database), which the guard below
+   * treats as "cannot tell" rather than as "not mine".
+   */
+  private TransactionContext currentTransaction() {
+    return database instanceof final DatabaseInternal internal ? internal.getTransactionIfExists() : null;
+  }
+
+  /**
+   * Whether a commit or a rollback issued right now would resolve THIS import's transaction, and not somebody
+   * else's.
+   * <p>
+   * The flag is not enough on its own. {@code begin()} nests, so the stack can hold a caller's transaction under
+   * this import's, and everything that runs inside the row loop - {@code parsingCallback} above all, which belongs
+   * to the caller - can resolve this import's transaction without the flag ever hearing about it. A commit issued
+   * on that stale flag pops and commits the caller's work instead, silently, which is the defect #7272 fixed on
+   * the other row loops and this one kept (issue #7328).
+   * <p>
+   * Identity plus liveness is what settles it: a resolved nested transaction is off the stack, so the top is a
+   * different object; a resolved bottom transaction is still there but inactive; and a fresh {@code begin()} by
+   * the callback pushes a new object rather than reviving this one. The only case identity cannot separate is a
+   * bottom transaction resolved and re-begun, and a bottom transaction means there is no caller transaction
+   * underneath to protect.
+   *
+   * @param txOpen        this loop's own flag: false once the loop has resolved its transaction itself
+   * @param ownTransaction the transaction the loop's last {@code begin()} left current, or {@code null} when the
+   *                       implementation does not expose it - in which case the flag is all there is, as before
+   */
+  private boolean ownTransactionIsResolvable(final boolean txOpen, final TransactionContext ownTransaction) {
+    if (!txOpen)
+      return false;
+    if (ownTransaction == null)
+      return database.isTransactionActive();
+    return ownTransaction.isActive() && currentTransaction() == ownTransaction;
+  }
+
   private void readFile(final Callable<Void, JSONObject> callback) throws IOException {
     database.begin();
     // Whether the transaction just opened is still the current one - cleared right before the commit below so a
     // rollback in the finally can never pop a transaction this method has already committed away, let alone the
     // caller's own (issue #7272).
     boolean txOpen = true;
+    // The transaction this method pushed, so the commit and the rollback below can prove the live one is still it.
+    // See the same pair in parseVertices(): begin() nests, and the callback can resolve this transaction from
+    // under us (issue #7328).
+    final TransactionContext ownTx = currentTransaction();
 
     try {
       try (InputStream inputStream = openInputStream()) {
@@ -730,17 +784,17 @@ public class Neo4jImporter {
         }
       }
 
-      // Gated on this method's own txOpen rather than on the ambient database.isTransactionActive(), for the
-      // reason spelled out at the same point in parseVertices(): begin() nests, so ambient liveness is not
-      // evidence that the live transaction is the one this method pushed (issue #7328).
-      if (txOpen) {
-        txOpen = false;
+      // Gated on this method's own transaction being the live one rather than on the ambient
+      // database.isTransactionActive(), for the reason spelled out at the same point in parseVertices(): begin()
+      // nests, so ambient liveness is no evidence that the live transaction is the one this method pushed
+      // (issue #7328).
+      if (ownTransactionIsResolvable(txOpen, ownTx))
         database.commit();
-      }
+      txOpen = false;
     } finally {
       // In the finally rather than in a catch so that an Error - an OutOfMemoryError is the one a large import
       // can realistically raise - resolves the transaction too.
-      if (txOpen && database.isTransactionActive()) {
+      if (ownTransactionIsResolvable(txOpen, ownTx)) {
         try {
           database.rollback();
         } catch (final Exception rollbackFailure) {

--- a/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
@@ -421,9 +421,15 @@ public class Neo4jImporter {
           return null;
         });
 
-        txOpen[0] = false;
-        if (database.isTransactionActive())
+        // Gated on this method's own txOpen, the same flag the rollback below uses, and NOT on the ambient
+        // database.isTransactionActive(): begin() nests, so a live transaction here is not evidence that the live
+        // one is the one this method pushed. Once that one is gone - a parsing callback of the caller's that
+        // resolved it, say - the ambient test sees the CALLER's outer transaction instead and commits that
+        // (issue #7328, the same asymmetry #7272 fixed on the four other row loops).
+        if (txOpen[0]) {
+          txOpen[0] = false;
           database.commit();
+        }
         committedVertices[0] = context.createdVertices.get();
         completed = true;
       } finally {
@@ -724,9 +730,13 @@ public class Neo4jImporter {
         }
       }
 
-      txOpen = false;
-      if (database.isTransactionActive())
+      // Gated on this method's own txOpen rather than on the ambient database.isTransactionActive(), for the
+      // reason spelled out at the same point in parseVertices(): begin() nests, so ambient liveness is not
+      // evidence that the live transaction is the one this method pushed (issue #7328).
+      if (txOpen) {
+        txOpen = false;
         database.commit();
+      }
     } finally {
       // In the finally rather than in a catch so that an Error - an OutOfMemoryError is the one a large import
       // can realistically raise - resolves the transaction too.

--- a/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
@@ -736,6 +736,13 @@ public class Neo4jImporter {
    * bottom transaction resolved and re-begun, and a bottom transaction means there is no caller transaction
    * underneath to protect.
    *
+   * The contract this puts on {@code parsingCallback}, which is the one thing running in here that the caller
+   * writes: it must not return with an extra transaction of its own left open. A callback that resolves this
+   * import's transaction is handled - that is the case this guard exists for - but one that pushes a transaction
+   * on top of it and never resolves that leaves the import's own buried, and the guard will then correctly refuse
+   * to touch what is on top rather than resolving the wrong one. Nothing here unwinds a stack somebody else grew:
+   * popping transactions this importer did not push is precisely the defect being fixed.
+   *
    * @param txOpen        this loop's own flag: false once the loop has resolved its transaction itself
    * @param ownTransaction the transaction the loop's last {@code begin()} left current, or {@code null} when the
    *                       implementation does not expose it - in which case the flag is all there is, as before

--- a/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
@@ -788,8 +788,15 @@ public class Neo4jImporter {
       // database.isTransactionActive(), for the reason spelled out at the same point in parseVertices(): begin()
       // nests, so ambient liveness is no evidence that the live transaction is the one this method pushed
       // (issue #7328).
-      if (ownTransactionIsResolvable(txOpen, ownTx))
+      //
+      // The flag is cleared BEFORE the commit, not after, and parseVertices() does the same: a commit that throws
+      // skips everything below it, so clearing afterwards would leave the flag set and hand the finally below a
+      // transaction this method no longer owns - which on a Database that does not expose its stack degrades to
+      // the ambient test and rolls back the CALLER's.
+      if (ownTransactionIsResolvable(txOpen, ownTx)) {
+        txOpen = false;
         database.commit();
+      }
       txOpen = false;
     } finally {
       // In the finally rather than in a catch so that an Error - an OutOfMemoryError is the one a large import

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
@@ -308,13 +308,16 @@ public class CSVImporterFormat extends AbstractImporterFormat {
   /**
    * {@code transactionActiveOnEntry}: the live transaction state, used by {@link #beginRowTransaction} to decide
    * whether to begin, reuse, or replace it. {@code ownsTransaction}: see
-   * {@link ImporterContext#callerTransactionActiveOnEntry}.
+   * {@link ImporterContext#importOwnsTransaction}.
    */
   private record TransactionOwnership(boolean transactionActiveOnEntry, boolean ownsTransaction) {
   }
 
   private TransactionOwnership computeTransactionOwnership(final Database database, final ImporterContext context) {
-    return new TransactionOwnership(database.isTransactionActive(), !context.callerTransactionActiveOnEntry);
+    // importOwnsTransaction() rather than the raw flag: a caller transaction recorded on entry that is no longer
+    // live leaves nothing for beginRowTransaction() to reuse, so the transaction it pushes instead is the import's
+    // own and has to be gated as such, or it stays on the stack with nothing allowed to resolve it (issue #7328).
+    return new TransactionOwnership(database.isTransactionActive(), context.importOwnsTransaction(database));
   }
 
   private void loadVertices(final SourceSchema sourceSchema, final Parser parser, final Database database,

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
@@ -127,6 +127,13 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
     if (skipOnRowError && context.callerTransactionActiveOnEntry)
       throw ImporterSettings.newExclusiveTransactionRequiredException();
 
+    // Whether the transaction the loop below will use belongs to the import, as opposed to predating it, and so
+    // whether the periodic commit, the rollback and the trailing commit may resolve it. Resolved once, here, rather
+    // than by re-reading callerTransactionActiveOnEntry at each of the three gates: the answer also depends on the
+    // transaction still being live, and after the begin() below one always is. Nothing between this line and that
+    // begin() touches the database, so this reading is the state that begin() will see (issue #7328).
+    final boolean ownsTransaction = context.importOwnsTransaction(database);
+
     try (final InputStreamReader inputFileReader = new InputStreamReader(parser.getInputStream(),
         DatabaseFactory.getDefaultCharset())) {
       context.startedOn = System.currentTimeMillis();
@@ -181,8 +188,8 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
         // and rolls back the whole in-flight batch anyway (see the ImportException catch below). Neither runs at
         // all when the caller already owns the active transaction (skip mode never reaches here - see the guard
         // above): a caller-managed transaction is never ours to commit piecemeal, only to accumulate into and hand
-        // back to whoever owns it (issue #6561).
-        if (!context.callerTransactionActiveOnEntry && (skipOnRowError || context.parsed.get() % COMMIT_EVERY == 0
+        // back to whoever owns it (issue #6561). ownsTransaction is that question, answered once above.
+        if (ownsTransaction && (skipOnRowError || context.parsed.get() % COMMIT_EVERY == 0
             || timeSeriesSamplesSinceCommit >= COMMIT_EVERY)) {
           database.commit();
           database.begin();
@@ -193,22 +200,22 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
       // Issue #6460: resolve any LINK / LIST-of-LINK / MAP-of-LINK property values that were still forward
       // references when their owning record was loaded (see the field comment on pendingLinkReconciliation).
       // Every RID mapping is known by now, so this is the only point where they can be reliably fixed up.
-      reconcileUnresolvedLinks(database, context, skipOnRowError);
+      reconcileUnresolvedLinks(database, context, skipOnRowError, ownsTransaction);
     } catch (ImportException e) {
       // A per-record failure in default "abort" mode must fail the whole import loudly (issue #6468): rolling
       // back the in-flight batch here - instead of committing it below - is what keeps a partial import from
-      // masquerading as a successful one, and the callerTransactionActiveOnEntry guard mirrors
-      // JSONImporterFormat's contract of never discarding a caller's own transaction.
-      if (!context.callerTransactionActiveOnEntry && database.isTransactionActive())
+      // masquerading as a successful one, and the ownsTransaction guard mirrors JSONImporterFormat's contract of
+      // never discarding a caller's own transaction.
+      if (ownsTransaction && database.isTransactionActive())
         database.rollback();
       throw e;
     } catch (ClassNotFoundException e) {
       throw new RuntimeException(e);
     } finally {
-      // Gated on callerTransactionActiveOnEntry exactly like the ImportException catch above (issue #6561): a
+      // Gated on ownsTransaction exactly like the ImportException catch above (issue #6561): a
       // transaction that predates this import is never ours to commit, on success or on failure - it's left open
       // for whoever owns it to decide.
-      if (!context.callerTransactionActiveOnEntry && database.isTransactionActive())
+      if (ownsTransaction && database.isTransactionActive())
         database.commit();
     }
     context.lastLapOn = System.currentTimeMillis();
@@ -816,7 +823,8 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
    * {@code context.errors}, and either aborted via {@link ImportException} or skipped per {@code skipOnRowError},
    * rather than propagating raw and uncounted past this method.
    */
-  private void reconcileUnresolvedLinks(final DatabaseInternal database, final ImporterContext context, final boolean skipOnRowError) {
+  private void reconcileUnresolvedLinks(final DatabaseInternal database, final ImporterContext context, final boolean skipOnRowError,
+      final boolean ownsTransaction) {
     if (pendingLinkReconciliation.isEmpty())
       return;
 
@@ -916,10 +924,10 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
       // already committed for the initial load, producing one very large WAL transaction for a restore with many
       // forward-referencing LINK properties. Skip mode commits every record individually, same reasoning as the
       // main loop: a failed record's rollback must never discard an earlier, already-reconciled one riding in the
-      // same batch. Same callerTransactionActiveOnEntry gate as load()'s own periodic commit, and for the same
+      // same batch. Same ownsTransaction gate as load()'s own periodic commit, and for the same
       // reason (issue #6561): skip mode never reaches here when the caller owns the transaction (rejected eagerly
       // in load()), and the default mode must not commit a transaction it doesn't own either.
-      if (!context.callerTransactionActiveOnEntry && (skipOnRowError || ++reconciled % 1000 == 0)) {
+      if (ownsTransaction && (skipOnRowError || ++reconciled % 1000 == 0)) {
         database.commit();
         database.begin();
       }

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java
@@ -59,8 +59,10 @@ public class RDFImporterFormat extends CSVImporterFormat {
     // reuses it. Rolling that one back on failure is still right - the import aborts with it either way, and
     // the alternative is AbstractImporter.closeDatabase() committing a half-finished import. What must never
     // be rolled back is a transaction that predates the import, which is exactly what
-    // ImporterContext#callerTransactionActiveOnEntry records.
-    final boolean ownsTransaction = !context.callerTransactionActiveOnEntry;
+    // ImporterContext#callerTransactionActiveOnEntry records, and which ImporterContext#importOwnsTransaction()
+    // answers for every row loop in one place rather than five times by hand (issue #7328). Read here, before the
+    // begin() below, because after that begin() a transaction is always active.
+    final boolean ownsTransaction = context.importOwnsTransaction(database);
 
     // Whether a transaction this call owns is still the current one. Cleared right before every commit -
     // LocalDatabase#commit() pops the transaction in a finally, so a commit that throws still leaves it off the

--- a/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterParseVerticesTransactionLeakTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterParseVerticesTransactionLeakTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -206,6 +207,60 @@ class Neo4jImporterParseVerticesTransactionLeakTest {
         .isFalse();
     assertThat(countOf("Marker"))
         .as("the caller's own record must be what its commit made durable")
+        .isEqualTo(1);
+  }
+
+  /**
+   * Issue #7328: {@code parsingCallback} belongs to the caller and runs inside the row loop, so it can resolve the
+   * transaction {@code parseVertices()} opened without the method's own {@code txOpen} flag hearing about it.
+   * Because {@code begin()} nests, the trailing commit issued on that stale flag then pops and commits whatever is
+   * left on top - the CALLER's transaction, with all of the caller's unrelated pending work in it.
+   * <p>
+   * Neither a liveness test nor the flag can tell that apart; only the identity of the transaction the loop itself
+   * opened can, which is what the commit and the rollback are now gated on.
+   */
+  @Test
+  void aCallbackResolvingTheImportTransactionDoesNotHandTheCallersToTheTrailingCommit() throws Throwable {
+    final ImporterContext context = new ImporterContext();
+    final Neo4jImporter importer = new Neo4jImporter(database, context);
+
+    final String lines = "{\"type\":\"node\",\"id\":\"1\",\"labels\":[\"Person\"]}\n"
+        + "{\"type\":\"node\",\"id\":\"2\",\"labels\":[\"Person\"]}\n"
+        + "{\"type\":\"node\",\"id\":\"3\",\"labels\":[\"Person\"]}\n";
+
+    // Large enough that the periodic commit never fires: the only commit inside the loop is the callback's.
+    setField(importer, "batchSize", 1_000);
+    setField(importer, "inputStream", new ByteArrayInputStream(lines.getBytes(StandardCharsets.UTF_8)));
+
+    final boolean[] resolvedOnce = { false };
+    importer.parsingCallback = json -> {
+      if (!resolvedOnce[0]) {
+        resolvedOnce[0] = true;
+        // What a caller's callback is free to do, and what leaves parseVertices()' flag stale: the transaction the
+        // loop opened is gone from here on, and the caller's is back on top.
+        database.commit();
+      }
+      return null;
+    };
+
+    // The caller's transaction, with pending work of its own that the import must never resolve.
+    database.begin();
+    database.newDocument("Marker").set("name", "caller").save();
+
+    invokeParseVertices(importer);
+
+    assertThat(resolvedOnce[0]).as("the callback must actually have run").isTrue();
+    assertThat(database.isTransactionActive())
+        .as("the caller's transaction is still the caller's: the import had nothing of its own left to commit")
+        .isTrue();
+
+    database.rollback();
+
+    assertThat(countOf("Marker"))
+        .as("the caller's own pending work must still have been the caller's to discard")
+        .isZero();
+    assertThat(countOf("Person"))
+        .as("only the vertex the callback's own commit made durable survives")
         .isEqualTo(1);
   }
 

--- a/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterReadFileTransactionLeakTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterReadFileTransactionLeakTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.integration.importer;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.exception.TransactionException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.Callable;
 import com.arcadedb.utility.FileUtils;
@@ -28,12 +29,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -192,6 +195,68 @@ class Neo4jImporterReadFileTransactionLeakTest {
         .isEqualTo(1);
     assertThat(countOf("Node"))
         .as("the importer's abandoned row must not ride out on the caller's commit")
+        .isZero();
+  }
+
+  /**
+   * What a real commit failure leaves behind: {@code LocalDatabase.commit()} pops the transaction inside its own
+   * {@code finally}, so the transaction this method opened is already gone and the caller's is back on top.
+   */
+  private Database databaseWhoseCommitFails() {
+    return (Database) Proxy.newProxyInstance(Database.class.getClassLoader(), new Class<?>[] { Database.class },
+        (proxy, method, args) -> {
+          if ("commit".equals(method.getName()) && (args == null || args.length == 0)) {
+            database.rollback();
+            throw new TransactionException("Simulated commit failure");
+          }
+          try {
+            return method.invoke(database, args);
+          } catch (final InvocationTargetException e) {
+            throw e.getCause();
+          }
+        });
+  }
+
+  /**
+   * Issue #7328: the trailing {@code commit()} must clear {@code txOpen} BEFORE it runs, not after. A commit that
+   * throws skips everything below it, so clearing afterwards leaves the flag set and hands the {@code finally} a
+   * transaction this method no longer owns.
+   * <p>
+   * Proved on a {@link Proxy} that implements {@link Database} but not {@code DatabaseInternal} - a remote database
+   * has the same shape - because that is the case where the guard cannot read the transaction stack and degrades
+   * to the ambient {@code isTransactionActive()}. The failed commit has already popped the import's own
+   * transaction, so what that ambient test sees is the CALLER's, and a rollback issued on it discards the caller's
+   * unrelated pending work.
+   */
+  @Test
+  void aFailedCommitDoesNotRollBackTheCallersTransaction() throws Throwable {
+    final Neo4jImporter importer = new Neo4jImporter(databaseWhoseCommitFails(), new ImporterContext());
+
+    // The input is fully readable: the only failure is the trailing commit itself.
+    setInputStream(importer,
+        new ByteArrayInputStream("{\"type\":\"node\",\"id\":\"1\"}\n".getBytes(StandardCharsets.UTF_8)));
+
+    final Callable<Void, JSONObject> callback = json -> {
+      database.newDocument("Node").set("marker", true).save();
+      return null;
+    };
+
+    database.begin();
+    database.newDocument("Marker").set("name", "caller").save();
+
+    assertThatThrownBy(() -> invokeReadFile(importer, callback)).isInstanceOf(TransactionException.class);
+
+    assertThat(database.isTransactionActive())
+        .as("the caller's transaction must have survived the import's failed commit")
+        .isTrue();
+
+    database.commit();
+
+    assertThat(countOf("Marker"))
+        .as("the caller's own record must be what its own commit made durable")
+        .isEqualTo(1);
+    assertThat(countOf("Node"))
+        .as("the failed commit made nothing of the import's own row durable")
         .isZero();
   }
 }

--- a/integration/src/test/java/com/arcadedb/integration/importer/format/RDFImporterFormatTransactionLeakTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/format/RDFImporterFormatTransactionLeakTest.java
@@ -101,8 +101,85 @@ class RDFImporterFormatTransactionLeakTest {
     return settings;
   }
 
+  private ImporterSettings settings() {
+    final ImporterSettings settings = new ImporterSettings();
+    settings.vertexTypeName = "Node";
+    settings.edgeTypeName = "Related";
+    settings.typeIdProperty = "id";
+    return settings;
+  }
+
   private long countOf(final String typeName) {
     return database.query("sql", "select count(*) as c from " + typeName).next().<Long>getProperty("c");
+  }
+
+  /**
+   * Issue #7328: the trailing {@code database.commit()} is the fourth of the four transaction operations
+   * {@code load()} gates on ownership, and it is the one that used to be ungated - so a successful import against a
+   * caller-managed transaction committed the caller's, silently, at a point of the importer's choosing. The import
+   * reported success and the caller had no signal that its own unit of work had been resolved out from under it.
+   * <p>
+   * Asserted by rolling the caller's transaction back afterwards: if the importer committed it, the caller's own
+   * pending record and the imported edges both survive that rollback.
+   */
+  @Test
+  void aSuccessfulImportNeverCommitsTheCallersTransaction() throws Exception {
+    final RDFImporterFormat format = new RDFImporterFormat();
+    final ImporterContext context = new ImporterContext();
+    context.callerTransactionActiveOnEntry = true;
+
+    database.begin();
+    database.newDocument("Marker").set("name", "caller").save();
+
+    format.load(null, null, rdfParser("""
+        s,p,o
+        v1,rel,v2
+        v3,rel,v4
+        """), (DatabaseInternal) database, context, settings());
+
+    assertThat(database.isTransactionActive())
+        .as("a transaction that predates the import is never the importer's to commit, success or not")
+        .isTrue();
+
+    // The caller's decision, exercised: everything staged inside its transaction - its own record and the edges the
+    // import accumulated into it - must still be discardable.
+    database.rollback();
+
+    assertThat(countOf("Marker"))
+        .as("the caller's own pending work must still be the caller's to discard")
+        .isZero();
+    assertThat(countOf("Node"))
+        .as("the import staged its edges in the caller's transaction, so the caller's rollback takes them too")
+        .isZero();
+  }
+
+  /**
+   * The other half of the same asymmetry: {@code callerTransactionActiveOnEntry} is a snapshot taken before the
+   * import began, and a caller transaction it recorded may already be resolved by the time a format's row loop
+   * runs. The transaction the loop then pushes is its own - and gating on the stale snapshot left it on the stack
+   * with nothing allowed to resolve it: not the loop's own commit or rollback, and not {@code Importer.load()}'s
+   * cleanup, which is gated on the same flag (issue #7328).
+   */
+  @Test
+  void theImportOwnsTheTransactionItPushesOnceTheCallersIsGone() throws Exception {
+    final RDFImporterFormat format = new RDFImporterFormat();
+    final ImporterContext context = new ImporterContext();
+    // Recorded on entry, but the caller has since resolved it: no transaction is active now.
+    context.callerTransactionActiveOnEntry = true;
+    assertThat(database.isTransactionActive()).isFalse();
+
+    format.load(null, null, rdfParser("""
+        s,p,o
+        v1,rel,v2
+        v3,rel,v4
+        """), (DatabaseInternal) database, context, settings());
+
+    assertThat(database.isTransactionActive())
+        .as("the transaction the import pushed is its own, and a successful import resolves it")
+        .isFalse();
+    assertThat(countOf("Node"))
+        .as("the import committed its own transaction, so its edges are durable")
+        .isEqualTo(4);
   }
 
   @Test

--- a/server/src/main/java/com/arcadedb/server/monitor/ServerQueryProfiler.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/ServerQueryProfiler.java
@@ -402,6 +402,11 @@ public class ServerQueryProfiler {
       final String name = rawName.isBlank() ? "unknown" : rawName;
       // Default to the same -1 the engine uses for "not calculated", so a plan that omits the field is classified
       // as untimed rather than as a step that measurably took no time at all.
+      //
+      // "cost" is the step's SELF cost and never the subtree roll-up: the roll-up travels as "totalCost" and is
+      // deliberately not read here. Reading it while also recursing into the children it already contains charged
+      // the same nanoseconds to both the container and the step that actually timed them, so a plain type scan
+      // showed up twice and the per-step totals added up to more than the Engine total (issue #7329).
       final long cost = step.getLong("cost", -1);
       stepCosts.computeIfAbsent(name, k -> new ArrayList<>()).add(cost);
 

--- a/server/src/test/java/com/arcadedb/server/ServerQueryProfilerTest.java
+++ b/server/src/test/java/com/arcadedb/server/ServerQueryProfilerTest.java
@@ -636,6 +636,103 @@ class ServerQueryProfilerTest extends StaticBaseServerTest {
     assertThat(findStep(steps, "unknown")).as("a blank step name must be labelled, not left empty").isNotNull();
   }
 
+  /**
+   * Issue #7329: a container step's cost used to be the sum of its children's, emitted as the container's own
+   * {@code cost} in the very node that also carries each child with its own {@code cost}. The recorder records the
+   * container and then recurses, so the same nanoseconds landed in the table twice and a plain type scan was
+   * counted twice over - which is what made the Studio caption ("contained in the Engine total") false.
+   * <p>
+   * A container has no self time, so it is now recorded as an occurrence with nothing measured, and the roll-up it
+   * used to claim travels separately as {@code totalCost}, which this table deliberately does not read.
+   */
+  @Test
+  void aContainerStepDoesNotDoubleCountItsChildrensTime() {
+    server.createDatabase("profiler-container-db", ComponentFile.MODE.READ_WRITE);
+    final ServerDatabase db = server.getDatabase("profiler-container-db");
+    try {
+      db.command("sql", "CREATE DOCUMENT TYPE Item");
+      db.transaction(() -> {
+        for (int i = 0; i < 200; i++)
+          db.command("sql", "INSERT INTO Item SET idx = " + i);
+      });
+
+      final ServerQueryProfiler profiler = server.getQueryProfiler();
+      profiler.start();
+      try (final ResultSet rs = db.query("sql", "SELECT FROM Item", Map.of())) {
+        while (rs.hasNext())
+          rs.next();
+      }
+
+      final JSONObject query = findQuery(profiler.stop(), "SELECT FROM Item");
+      assertThat(query).as("the profiled scan must have been recorded").isNotNull();
+      final JSONArray steps = query.getJSONArray("steps");
+
+      final JSONObject container = findStep(steps, "FetchFromTypeExecutionStep");
+      assertThat(container).as("the type scan container step must be in the aggregated table").isNotNull();
+      assertThat(container.getInt("executionCount")).as("the container is still an occurrence").isEqualTo(1);
+      assertThat(container.getInt("measuredCount")).as("but it times nothing of its own").isZero();
+      assertThat(container.getDouble("totalCostMs")).isZero();
+
+      final JSONObject buckets = findStep(steps, "FetchFromClusterExecutionStep");
+      assertThat(buckets).as("the bucket steps are the ones that carry the scan's time").isNotNull();
+      assertThat(buckets.getInt("measuredCount")).isPositive();
+
+      // The invariant the Studio caption states: the rows add up to at most the Engine total, never more. Before the
+      // fix the container claimed its children's time as well as the children, so the table came out roughly twice
+      // the scan's real cost and could exceed the total it is supposed to be contained in.
+      double stepsTotalMs = 0;
+      for (int i = 0; i < steps.length(); i++)
+        stepsTotalMs += steps.getJSONObject(i).getDouble("totalCostMs");
+
+      assertThat(stepsTotalMs).isGreaterThan(0d);
+      assertThat(query.getDouble("engineTotalTimeMs"))
+          .as("the summed step costs must be contained in the Engine total")
+          .isGreaterThanOrEqualTo(stepsTotalMs);
+    } finally {
+      db.getEmbedded().drop();
+      server.removeDatabase("profiler-container-db");
+    }
+  }
+
+  /**
+   * Issue #7330: while the profiler is recording, an OpenCypher statement used to be rerouted onto
+   * {@code CypherExecutionPlan.profile()}, which drains the whole plan into heap before returning. The reported
+   * cost then described a materialising execution the statement never performs otherwise, and every Cypher read on
+   * the server was materialised for the length of the recording window.
+   * <p>
+   * Probed by consuming exactly one row of many: a streaming run has produced one row at that point, a drained one
+   * had already produced them all before {@code query()} returned.
+   */
+  @Test
+  void recordingDoesNotTurnACypherReadIntoAnEagerDrain() {
+    server.createDatabase("profiler-cypher-streaming-db", ComponentFile.MODE.READ_WRITE);
+    final ServerDatabase db = server.getDatabase("profiler-cypher-streaming-db");
+    try {
+      db.command("sql", "CREATE VERTEX TYPE Item");
+      db.transaction(() -> {
+        for (int i = 0; i < 100; i++)
+          db.command("sql", "INSERT INTO Item SET idx = " + i);
+      });
+
+      final ServerQueryProfiler profiler = server.getQueryProfiler();
+      profiler.start();
+      try (final ResultSet rs = db.query("opencypher", "MATCH (i:Item) RETURN i.idx AS idx", Map.of())) {
+        assertThat(rs.hasNext()).isTrue();
+        rs.next();
+
+        assertThat(rs.getExecutionPlan()).isPresent();
+        assertThat(rs.getExecutionPlan().get().prettyPrint(0, 2))
+            .as("the profiled statement must describe the streaming run the caller drove, not a full drain")
+            .contains("Rows Returned: 1");
+      } finally {
+        profiler.stop();
+      }
+    } finally {
+      db.getEmbedded().drop();
+      server.removeDatabase("profiler-cypher-streaming-db");
+    }
+  }
+
   private static JSONObject findQuery(final JSONObject results, final String queryText) {
     final JSONArray queries = results.getJSONArray("queries");
     for (int i = 0; i < queries.length(); i++) {

--- a/studio/src/main/resources/static/profiler.html
+++ b/studio/src/main/resources/static/profiler.html
@@ -109,8 +109,10 @@
       <div id="profilerStepChart" style="min-height: 200px;"></div>
       <!-- Step table -->
       <p class="text-muted mb-1" style="font-size: 0.8rem;">
-        Step timings are the time each step spent in its own work, summed over every occurrence of that step across
-        all the executions above. They are contained in the Engine total, never larger than it.
+        Step timings are the time each step spent in its own work - never the time its sub-steps spent in theirs -
+        summed over every occurrence of that step across all the executions above. Because no step counts another
+        step's time, these rows add up to at most the Engine total and never more. A step whose whole job is to
+        dispatch to its sub-steps has no work of its own to time, so it appears with a Count but with no timings.
       </p>
       <table id="profilerStepTable" class="table table-sm" style="width: 100%; font-size: 0.85rem;">
         <thead>


### PR DESCRIPTION
Closes #7328, closes #7329, closes #7330.

## #7328 - importer transaction ownership

The defect as reported (RDF's trailing `commit()` ungated on `ownsTransaction`) **is already fixed on main**: #7318, landing the #7288 commit-boundary fix, added the `if (ownsTransaction)` gate as part of the same edit. What is added here is the regression test that locks it - the issue's own repro, which was the one shape the existing leak tests did not cover: a *successful* import against a caller-managed transaction.

The sweep the issue asked for found two more sites, and this PR does them:

**A shared helper rather than a sixth hand-applied gate.** The issue suggested "a shared helper that owns all four operations together". Owning all four is too large a change to land safely across eight loops with three different transaction models (the nesting loops in `CSVImporterFormat.loadEdges`, `OrientDBImporter` and `GraphImporter` deliberately always own theirs). What the five reuse-model loops actually kept getting wrong is the *predicate*, so that is what is now shared: `ImporterContext#importOwnsTransaction(Database)`, called once immediately before the loop's `begin()`.

It also closes a leak all five copies shared. `callerTransactionActiveOnEntry` is a snapshot taken before the import began; a caller transaction it recorded may already be resolved by the time a format's row loop runs. The loop's `begin()` was ungated, so it pushed a transaction, and the stale snapshot then said "the caller's" - leaving it on the stack with nothing allowed to resolve it: not the loop's commit, not its rollback, and not `Importer.load()`'s cleanup, which reads the same flag.

**`Neo4jImporter`'s two trailing commits** were the only resolve operations in the module guarded by the ambient `database.isTransactionActive()` rather than by the loop's own flag, while the sibling rollback three lines below was guarded correctly. `begin()` nests, so a live transaction is never evidence that the live one is the one this method pushed; once it is gone the ambient test sees the *caller's* outer transaction and commits that. Both now gate on `txOpen`, matching `CSVImporterFormat.loadEdges()`, `OrientDBImporter.updateDocumentLinks()` and `GraphImporter.processVertexSource()`.

## #7329 - the profiler counted a type scan twice

`getCost()` is documented as "the absolute cost of the execution of this step", and every timed step reports its own. The three container steps returned the *sum of their children* instead, while `toResult()` emitted those same children - each with its own cost - in the same JSON node, and `ServerQueryProfiler.extractStepCosts` records a step and then recurses into its sub-steps. So the scan's nanoseconds were charged to `FetchFromTypeExecutionStep` and again to the `FetchFromClusterExecutionStep` that actually timed them.

The issue offered two options and preferred (1), "give the container its own timer". Neither is taken as written, because both are worse than the third:

- (1) would time a pure dispatch loop. The measurement would be noise on a hot path, and it hides the useful number: the container currently prints the subtree total in EXPLAIN, which is exactly what a reader wants on that line.
- (2) marks the cost "derived" and has the recorder skip it, which fixes the sum but leaves `getCost()` meaning two different things depending on the step.

Instead the roll-up moves out of `getCost()` and gets a name: `ExecutionStep#getTotalCost()`, emitted as `totalCost` beside `cost`. `getCost()` is then self-time everywhere, with no exceptions, so the self costs of a plan partition its total - which is the property the aggregator needs and the one a future container cannot silently break. The three containers report -1 ("not calculated", the existing sentinel for an untimed step, already handled by the #7291 `measuredCount` machinery) and print `getTotalCostFormatted()` in EXPLAIN, so the tree output is unchanged. The recorder needed no change at all, which is the point.

The Studio caption now states the invariant that holds, rather than one that happened to be true.

## #7330 - recording changed the execution it was measuring

`ServerDatabase` injects `$profileExecution` into every `Map`-parameter command and query while the profiler is recording, and `OpenCypherQueryEngine` folded that straight into its `profile` flag - the same flag the explicit `PROFILE <statement>` keyword sets - which routes to `CypherExecutionPlan.profile()` and drains the whole plan into heap before returning. The Engine total therefore described a materialising execution the statement never performs otherwise, and turning the diagnostic on materialised every Cypher read on the server for the length of the recording window.

`$profileExecution` now means what it means on the SQL path, where `BasicCommandContext` has always simply turned per-step timing on: the statement runs as it always does, streaming, and the step timers accumulate during `syncPull` exactly as they do under `profile()`. The plan is rebuilt from the live step chain when a consumer asks for it - which `ProfilingResultSet` does at close and `PostCommandHandler` after draining - so the costs are the ones the run accumulated, and the report describes what the caller actually consumed.

The explicit `PROFILE` keyword keeps the eager path: a user asking in the statement for the whole execution to be run and summarised is a different request, and Neo4j's PROFILE executes fully too. `profile()`'s javadoc no longer claims results are discarded or that an `ExplainResultSet` comes back; neither was ever true of it.

One consequence worth calling out: the reroute had been bypassing `query()`'s idempotency gate, so on a recording server `db.query("cypher", "MATCH ... SET ...", params)` executed the write. Separating the flags restores the gate.

## Also fixed on the way

`BasicCommandContext#setInputParameters` stripped `$profileExecution` with an in-place `remove()`. That threw `UnsupportedOperationException` on an immutable caller map (`Map.of(...)`), and on a mutable one silently mutated the caller's own map - including the parameter map a cached execution plan holds, so a second run of the same plan no longer saw the flag. It now strips out of a copy, made only on the rare path that carries the flag.

## Tests

- `RDFImporterFormatTransactionLeakTest` +2: a successful import never commits the caller's transaction (the issue's repro); the import owns and resolves the transaction it pushes once the caller's is gone. The second fails without the fix.
- `ContainerStepSelfCostIssue7329Test` (new): the container reports no self cost while the buckets carry the time; the roll-up is still there under `totalCost`; the self costs of the whole tree sum to the subtree total. Two of the three fail without the fix.
- `CypherProfiledExecutionIsStreamingIssue7330Test` (new): consuming one row of 500 under `$profileExecution` reports one row returned, not 500; the rows and the plan are both intact; the explicit `PROFILE` keyword still drains.
- `ServerQueryProfilerTest` +2, end to end through the server: a real profiled type scan lists the container with `measuredCount` 0 and the summed step costs contained in the Engine total (fails without the fix); a Cypher read under an active recording still streams.

Engine (14,663) and integration (331) suites are green. In the server module, 30 HTTP tests failed locally against a foreign process already listening on 127.0.0.1:2480 - the documented port-conflict symptom, `403 "Too many failed authentication attempts"` - none of them in code this PR touches; the 924 others pass, `ServerQueryProfilerTest` included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query profiling now preserves streaming behavior while collecting execution timing.
  * Execution plans distinguish individual step costs from rolled-up total costs.
* **Bug Fixes**
  * Improved transaction handling during CSV, JSONL, RDF, and Neo4j imports to prevent unintended commits or rollbacks.
  * Profiling no longer double-counts time spent in nested execution steps.
* **Documentation**
  * Updated profiler guidance to clarify timing calculations and dispatch-only steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->