### PR TITLE
fix(#7357): bulk load with an LSM_VECTOR index keeps a second copy of the corpus on the heap and rebuilds the graph once per stall

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -119,6 +119,7 @@ public enum GlobalConfiguration {
         // VECTOR_INDEX_LOCATION_CACHE_SIZE is deliberately NOT capped here: it is not a cache, and bounding it
         // made this profile drop live vectors from searches (issue #5568).
         VECTOR_INDEX_SEARCH_CACHE_SIZE.setValue(10_000);
+        VECTOR_INDEX_DELTA_CACHE_SIZE.setValue(10_000);
 
         POLYGLOT_ENGINE_ENABLED.setValue(false);
 
@@ -1045,6 +1046,28 @@ public enum GlobalConfiguration {
       Ignored when the cache size is set explicitly. Values above 90 are clamped to 90: no cache is allowed to \
       plan on the whole heap.""",
       Integer.class, 25),
+
+  VECTOR_INDEX_DELTA_CACHE_SIZE("arcadedb.vectorIndex.deltaCacheSize", SCOPE.DATABASE,
+      """
+      Maximum number of vectors buffered since the last graph rebuild that keep their payload on the heap. \
+      Every write appends an entry to that delta buffer so the vector is searchable before it reaches the HNSW \
+      graph, and the entry used to carry the whole vector: an ingest that outruns the rebuilds therefore held a \
+      second full copy of the corpus in RAM, and a 4.2M x 768-dimension load died of it at -Xmx16g (issue #7357). \
+      The vector is already persisted before the entry is buffered, so entries past this cap keep only their id \
+      and RID and the delta scan reads the payload back from the pages. \
+      RAM usage = deltaCacheSize * (dimensions * 4 + 64) bytes. \
+      0 (default) sizes it automatically from arcadedb.vectorIndex.deltaCacheMaxHeapPercent. -1 keeps every \
+      buffered payload on the heap, which is the pre-#7357 behaviour and is unbounded.""",
+      Integer.class, 0),
+
+  VECTOR_INDEX_DELTA_CACHE_MAX_HEAP_PERCENT("arcadedb.vectorIndex.deltaCacheMaxHeapPercent", SCOPE.DATABASE,
+      """
+      Share of the JVM heap ceiling (percentage) the automatically sized delta payload cache may use (see \
+      arcadedb.vectorIndex.deltaCacheSize). Ignored when that size is set explicitly. Taken as this percent of \
+      -Xmx and then capped at 90% of the heap currently AVAILABLE, the same denominator the graph-build cache \
+      uses, so a rebuild holding the old graph and an ingest filling the buffer cannot both plan on the same \
+      free heap. Values above 90 are clamped to 90.""",
+      Integer.class, 10),
 
   VECTOR_INDEX_SEARCHER_POOL_SIZE("arcadedb.vectorIndex.searcherPoolSize", SCOPE.DATABASE,
       """

--- a/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
@@ -554,6 +554,8 @@ public class GraphBatch implements AutoCloseable {
     int count = 0;
     for (final Index idx : all) {
       try {
+        // Every index type in the tree implements IndexInternal, so this cast does not fail today: the catch is
+        // future-proofing for an implementation that does not, not cover for one that exists (PR #7360 review).
         final IndexInternal index = (IndexInternal) idx;
         index.suspendBackgroundMaintenance();
         suspended[count++] = index;

--- a/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
@@ -372,6 +372,17 @@ public class GraphBatch implements AutoCloseable {
    */
   private int[] flushDurableOutRanges;
 
+  /**
+   * The indexes whose speculative background maintenance this batch suspended for the duration of the load
+   * (issue #7357), and the guard that makes resuming them happen exactly once.
+   * <p>
+   * Captured at construction rather than looked up again on the way out: an index dropped mid-load must still have
+   * its suspension lifted, and looking the list up again would silently leak the count of one that is no longer in
+   * the schema.
+   */
+  private final IndexInternal[] maintenanceSuspendedIndexes;
+  private final AtomicBoolean   maintenanceResumed = new AtomicBoolean();
+
   // --- Saved state for restore after close ---
   private final boolean savedReadYourWrites;
   private final boolean savedUseWAL;
@@ -507,6 +518,71 @@ public class GraphBatch implements AutoCloseable {
     } else {
       savedAsyncUseWAL = false;
       savedAsyncWALFlush = null;
+    }
+
+    // LAST: nothing below can throw, so a suspension taken here always has a live instance to lift it. Held for as
+    // long as this batch is open (issue #7357). The maintenance that matters today is the LSM vector index's
+    // inactivity graph rebuild: it reads the index going quiet as "the writer is done", which during a bulk load is
+    // produced by the load stalling on a compaction or a flush burst, and the rebuild it starts then covers only
+    // what has been loaded so far and is superseded by the rest of the load. A 4.2M-record load paid four full
+    // graph rebuilds that way and had not finished after six and a half hours; the same load with no vector index
+    // took twenty-six minutes. Suspending is a pure deferral - the writes stay searchable through the index's own
+    // delta path meanwhile - and close()/abandon() resume it, which is when the one rebuild the load is actually
+    // worth gets scheduled.
+    maintenanceSuspendedIndexes = suspendIndexBackgroundMaintenance();
+  }
+
+  /**
+   * Suspends the speculative background maintenance of every index of this database, returning the ones that were
+   * actually asked so {@link #resumeIndexBackgroundMaintenance()} can lift exactly those.
+   * <p>
+   * A failure to suspend one index must not leave the batch half-suspended and must not fail the load either - the
+   * suspension is an optimization, not a correctness requirement - so whatever was taken before the failure is
+   * given straight back and the batch proceeds with none.
+   */
+  private IndexInternal[] suspendIndexBackgroundMaintenance() {
+    final Index[] all = database.getSchema().getIndexes();
+    final IndexInternal[] suspended = new IndexInternal[all.length];
+    int count = 0;
+    try {
+      for (final Index idx : all) {
+        final IndexInternal index = (IndexInternal) idx;
+        index.suspendBackgroundMaintenance();
+        suspended[count++] = index;
+      }
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.WARNING,
+          "GraphBatch: could not suspend the background maintenance of the indexes for the bulk load: %s", e,
+          e.getMessage());
+      for (int i = 0; i < count; i++)
+        resumeQuietly(suspended[i]);
+      return new IndexInternal[0];
+    }
+    return count == suspended.length ? suspended : Arrays.copyOf(suspended, count);
+  }
+
+  /**
+   * Lifts the suspensions {@link #suspendIndexBackgroundMaintenance()} took, once. Idempotent because
+   * {@link #abandon()} and {@link #close()} can both reach it, and a second lift would decrement a count this
+   * batch no longer holds - handing another batch's suspension away with it.
+   */
+  private void resumeIndexBackgroundMaintenance() {
+    if (!maintenanceResumed.compareAndSet(false, true))
+      return;
+    for (final IndexInternal index : maintenanceSuspendedIndexes)
+      resumeQuietly(index);
+  }
+
+  /**
+   * One index's resume, never allowed to throw: a batch on its way out must lift every OTHER suspension it holds
+   * whatever one index does, and an index dropped mid-load is the ordinary way this fails.
+   */
+  private void resumeQuietly(final IndexInternal index) {
+    try {
+      index.resumeBackgroundMaintenance();
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.FINE,
+          "GraphBatch: could not resume the background maintenance of index %s: %s", index.getName(), e.getMessage());
     }
   }
 
@@ -1412,6 +1488,7 @@ public class GraphBatch implements AutoCloseable {
   public void abandon() {
     database.setReadYourWrites(savedReadYourWrites);
     restoreAsyncSettings();
+    resumeIndexBackgroundMaintenance();
     releaseBatchGuard();
   }
 
@@ -1432,6 +1509,7 @@ public class GraphBatch implements AutoCloseable {
   private void restoreDatabaseSettings() {
     database.setReadYourWrites(savedReadYourWrites);
     restoreAsyncSettings();
+    resumeIndexBackgroundMaintenance();
 
     // If the thread still has no TransactionContext (the batch never began a transaction), nothing leaked.
     final TransactionContext tx = database.getTransactionIfExists();

--- a/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
@@ -1439,17 +1439,22 @@ public class GraphBatch implements AutoCloseable {
     try {
       RuntimeException flushFailure = null;
 
-      // Flush any remaining outgoing edges. Capture rather than rethrow so we can still drain the
-      // deferred IN buffer for previously-flushed edges; otherwise a unique-constraint violation
-      // on the trailing buffer (issue #4113) would leave already-persisted edges with no
-      // back-pointer and trip the database integrity checker.
       try {
-        flush();
-      } catch (final RuntimeException e) {
-        flushFailure = e;
-      }
+        // Flush any remaining outgoing edges. Capture rather than rethrow so we can still drain the
+        // deferred IN buffer for previously-flushed edges; otherwise a unique-constraint violation
+        // on the trailing buffer (issue #4113) would leave already-persisted edges with no
+        // back-pointer and trip the database integrity checker.
+        //
+        // INSIDE the try whose finally restores the settings, not before it (PR #7360 review). Only a
+        // RuntimeException is caught here, so an Error out of flush() used to skip the restore entirely and leave
+        // this database with a relaxed WAL policy, read-your-writes off, and - since issue #7357 - the vector
+        // indexes' background rebuilds suspended, silently, until the process reopened it.
+        try {
+          flush();
+        } catch (final RuntimeException e) {
+          flushFailure = e;
+        }
 
-      try {
         // Connect all deferred incoming edges in one sorted pass. On a large load this is minutes of work and it
         // runs on the way out of a FAILED batch too - it has to, or the edges already persisted keep no back-pointer
         // and the integrity checker trips (see #4113 above). That is why a rejected batch can take a while to answer

--- a/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
@@ -581,6 +581,11 @@ public class GraphBatch implements AutoCloseable {
   /**
    * One index's resume, never allowed to throw: a batch on its way out must lift every OTHER suspension it holds
    * whatever one index does, and an index dropped mid-load is the ordinary way this fails.
+   * <p>
+   * Logged at WARNING, the same level a failed suspension gets, and deliberately not lower (PR #7360 review): the
+   * two failures are not equally harmless. A suspension that could not be taken costs an optimization; one that
+   * could not be LIFTED strands that index's background maintenance off until the process reopens the database,
+   * and does it silently. That is worth seeing even when the cause turns out to be an index dropped mid-load.
    *
    * @param index the index to resume
    */
@@ -588,8 +593,9 @@ public class GraphBatch implements AutoCloseable {
     try {
       index.resumeBackgroundMaintenance();
     } catch (final Exception e) {
-      LogManager.instance().log(this, Level.FINE,
-          "GraphBatch: could not resume the background maintenance of index %s: %s", index.getName(), e.getMessage());
+      LogManager.instance().log(this, Level.WARNING,
+          "GraphBatch: could not resume the background maintenance of index %s, it stays suspended until this "
+              + "database is reopened: %s", e, index.getName(), e.getMessage());
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
@@ -537,26 +537,31 @@ public class GraphBatch implements AutoCloseable {
    * actually asked so {@link #resumeIndexBackgroundMaintenance()} can lift exactly those.
    * <p>
    * A failure to suspend one index must not leave the batch half-suspended and must not fail the load either - the
-   * suspension is an optimization, not a correctness requirement - so whatever was taken before the failure is
-   * given straight back and the batch proceeds with none.
+   * suspension is an optimization, not a correctness requirement - so an index that cannot be asked is skipped and
+   * the rest are still suspended. Caught per index rather than around the loop for exactly that reason (PR #7360
+   * review): the cast is the failure this is most likely to see, and one {@code Index} that does not implement
+   * {@link IndexInternal} must not cost every OTHER index of the database its suspension.
+   * <p>
+   * The list is a snapshot. An index created while this batch is open runs its background maintenance as usual -
+   * an acceptable gap, since creating an index in the middle of a bulk load is not a shape worth complicating the
+   * lifetime of these suspensions for, and the maintenance it would do is over a corpus it has just been built on.
+   *
+   * @return the indexes actually suspended, empty when none was
    */
   private IndexInternal[] suspendIndexBackgroundMaintenance() {
     final Index[] all = database.getSchema().getIndexes();
     final IndexInternal[] suspended = new IndexInternal[all.length];
     int count = 0;
-    try {
-      for (final Index idx : all) {
+    for (final Index idx : all) {
+      try {
         final IndexInternal index = (IndexInternal) idx;
         index.suspendBackgroundMaintenance();
         suspended[count++] = index;
+      } catch (final Exception e) {
+        LogManager.instance().log(this, Level.WARNING,
+            "GraphBatch: could not suspend the background maintenance of index %s for the bulk load: %s", e,
+            idx.getName(), e.getMessage());
       }
-    } catch (final Exception e) {
-      LogManager.instance().log(this, Level.WARNING,
-          "GraphBatch: could not suspend the background maintenance of the indexes for the bulk load: %s", e,
-          e.getMessage());
-      for (int i = 0; i < count; i++)
-        resumeQuietly(suspended[i]);
-      return new IndexInternal[0];
     }
     return count == suspended.length ? suspended : Arrays.copyOf(suspended, count);
   }
@@ -576,6 +581,8 @@ public class GraphBatch implements AutoCloseable {
   /**
    * One index's resume, never allowed to throw: a batch on its way out must lift every OTHER suspension it holds
    * whatever one index does, and an index dropped mid-load is the ordinary way this fails.
+   *
+   * @param index the index to resume
    */
   private void resumeQuietly(final IndexInternal index) {
     try {

--- a/engine/src/main/java/com/arcadedb/index/IndexInternal.java
+++ b/engine/src/main/java/com/arcadedb/index/IndexInternal.java
@@ -177,6 +177,32 @@ public interface IndexInternal extends Index {
   }
 
   /**
+   * Asks the index to hold off the maintenance it starts on its own initiative, for the duration of a bulk load.
+   * <p>
+   * "On its own initiative" is the whole distinction: work a read or a write NEEDS is not affected, and neither is
+   * anything a caller asked for explicitly. What is suspended is the speculative kind - maintenance an index
+   * schedules because it guessed the moment was a good one. During a bulk load that guess is systematically wrong,
+   * because the signal it reads (the index going quiet) is produced by the load itself stalling on a compaction, a
+   * flush burst or a GC pause, and the maintenance it triggers is then superseded by the rest of the load and has
+   * to be done again. On an LSM vector index that mistake costs a full graph rebuild per stall (issue #7357).
+   * <p>
+   * Reference-counted: every call must be matched by exactly one {@link #resumeBackgroundMaintenance()}, and
+   * overlapping suspensions compose rather than cancel each other. Most indexes run no such maintenance and both
+   * methods are no-ops for them.
+   */
+  default void suspendBackgroundMaintenance() {
+  }
+
+  /**
+   * Lifts one {@link #suspendBackgroundMaintenance()}. The suspended maintenance resumes once the last one lifts,
+   * and an index with work waiting is expected to schedule it then rather than wait for the next mutation.
+   * <p>
+   * Safe to call without a matching suspension: the count never goes below zero.
+   */
+  default void resumeBackgroundMaintenance() {
+  }
+
+  /**
    * Closes the index files. The caller must guarantee that every page committed against this index has already
    * reached disk (e.g. {@code PageManager.INSTANCE.waitAllPagesOfDatabaseAreFlushed(database)}) before calling
    * this: a page still queued for asynchronous flush (the default, see {@code TransactionContext.asyncFlush})

--- a/engine/src/main/java/com/arcadedb/index/IndexInternal.java
+++ b/engine/src/main/java/com/arcadedb/index/IndexInternal.java
@@ -191,6 +191,7 @@ public interface IndexInternal extends Index {
    * methods are no-ops for them.
    */
   default void suspendBackgroundMaintenance() {
+    // No-op: an index that schedules nothing on its own initiative has nothing to hold off.
   }
 
   /**
@@ -200,6 +201,7 @@ public interface IndexInternal extends Index {
    * Safe to call without a matching suspension: the count never goes below zero.
    */
   default void resumeBackgroundMaintenance() {
+    // No-op, for the same reason suspendBackgroundMaintenance() is one.
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/vector/GrowableVectorValues.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/GrowableVectorValues.java
@@ -19,9 +19,6 @@
 package com.arcadedb.index.vector;
 
 import com.arcadedb.database.DatabaseInternal;
-import com.arcadedb.database.Document;
-import com.arcadedb.database.RID;
-import com.arcadedb.log.LogManager;
 
 import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
@@ -30,7 +27,6 @@ import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Level;
 
 /**
  * A growable RandomAccessVectorValues with lazy disk fallback.
@@ -136,54 +132,19 @@ class GrowableVectorValues implements RandomAccessVectorValues {
       return cached;
 
     // Slow path: lazy-load from disk and cache
-    if (vectorIndex == null || database == null)
+    if (vectorIndex == null || database == null || lsmIndex == null)
       return null;
 
-    // One lookup, one word: nothing is materialized for an ordinal that turns out not to be live (issue #5588).
-    final long offsetAndFlag = vectorIndex.getOffsetAndFlag(ordinal);
-    if (offsetAndFlag == VectorLocationIndex.ABSENT)
+    // The read-back itself, and the validation of what comes back, belong to the index that persisted it: see
+    // LSMVectorIndex.readPersistedVectorArray(). What stays here is the caching policy, which is this cache's own.
+    final float[] vector = lsmIndex.readPersistedVectorArray(ordinal);
+    if (vector == null)
       return null;
 
-    try {
-      float[] vector = null;
-
-      // Try quantized pages first (INT8/BINARY)
-      if (lsmIndex != null)
-        vector = lsmIndex.readVectorFromOffset(VectorLocationIndex.offsetOf(offsetAndFlag),
-            VectorLocationIndex.isCompactedOf(offsetAndFlag));
-
-      // Fall back to document lookup. WARNING on unsupported types so an INT8 index silently
-      // losing vectors during search is observable, matching ArcadePageVectorValues.
-      if (vector == null && vectorPropertyName != null) {
-        final RID rid = vectorIndex.getRid(ordinal);
-        if (rid == null)
-          return null;
-        final var record = database.lookupByRID(rid, false);
-        final Document doc = (Document) record;
-        final Object raw = doc.get(vectorPropertyName);
-        if (raw != null) {
-          try {
-            vector = VectorUtils.toFloatArray(raw, lsmIndex != null ? lsmIndex.getMetadata().encoding : VectorEncoding.FLOAT32);
-          } catch (final IllegalArgumentException e) {
-            LogManager.instance().log(this, Level.WARNING,
-                "Vector property '%s' has unsupported type %s (RID=%s, ordinal=%d): %s",
-                vectorPropertyName, raw.getClass().getName(), rid, ordinal, e.getMessage());
-          }
-        }
-      }
-
-      if (vector != null && vector.length == dimensions && !VectorUtils.isZeroVector(vector)) {
-        final VectorFloat<?> vf = vts.createFloatVector(vector);
-        if (vectors.size() < maxCacheSize)
-          vectors.put(ordinal, vf); // Cache for next access while under the cap (issue #3144)
-        return vf;
-      }
-    } catch (final Exception e) {
-      LogManager.instance().log(this, Level.FINE,
-          "Could not lazy-load vector ordinal=%d: %s", ordinal, e.getMessage());
-    }
-
-    return null;
+    final VectorFloat<?> vf = vts.createFloatVector(vector);
+    if (vectors.size() < maxCacheSize)
+      vectors.put(ordinal, vf); // Cache for next access while under the cap (issue #3144)
+    return vf;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/index/vector/GrowableVectorValues.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/GrowableVectorValues.java
@@ -18,7 +18,6 @@
  */
 package com.arcadedb.index.vector;
 
-import com.arcadedb.database.DatabaseInternal;
 
 import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
@@ -51,33 +50,29 @@ class GrowableVectorValues implements RandomAccessVectorValues {
   // of the whole vector set during bulk ingest). Evicted/never-cached ordinals are re-read lazily.
   private final int maxCacheSize;
 
-  // Lazy-load support: when a vector is not in the map, read from disk
-  private final VectorLocationIndex vectorIndex;
+  /**
+   * The index that persisted these vectors, or {@code null} in simple mode (no disk fallback).
+   * <p>
+   * The only collaborator left: this used to carry a {@code VectorLocationIndex}, a {@code DatabaseInternal} and
+   * the vector property name as well, so that it could resolve an evicted ordinal itself. That resolution now
+   * lives on the index, as {@link LSMVectorIndex#readPersistedVectorArray(int)}, which is where the delta scan
+   * reaches it too (issue #7357) - and the three fields went with it (PR #7360 review). They were always passed
+   * all-or-nothing with this one, so nothing that used to have a fallback has lost it.
+   */
   private final LSMVectorIndex lsmIndex;
-  private final DatabaseInternal database;
-  private final String vectorPropertyName;
 
   /**
    * Simple mode: no disk fallback (used in tests and when all vectors are in memory).
    */
   GrowableVectorValues(final int dimensions) {
-    this(dimensions, 1024, null, null, null, null, Integer.MAX_VALUE);
+    this(dimensions, 1024, null, Integer.MAX_VALUE);
   }
 
   /**
    * Simple mode with initial capacity.
    */
   GrowableVectorValues(final int dimensions, final int initialCapacity) {
-    this(dimensions, initialCapacity, null, null, null, null, Integer.MAX_VALUE);
-  }
-
-  /**
-   * Full mode with lazy disk fallback for existing vectors and an unbounded cache.
-   */
-  GrowableVectorValues(final int dimensions, final int initialCapacity,
-      final VectorLocationIndex vectorIndex, final LSMVectorIndex lsmIndex,
-      final DatabaseInternal database, final String vectorPropertyName) {
-    this(dimensions, initialCapacity, vectorIndex, lsmIndex, database, vectorPropertyName, Integer.MAX_VALUE);
+    this(dimensions, initialCapacity, null, Integer.MAX_VALUE);
   }
 
   /**
@@ -87,16 +82,17 @@ class GrowableVectorValues implements RandomAccessVectorValues {
    * number of vectors held on-heap; once the cap is reached new vectors are not cached and are
    * re-read from disk on next access via {@link #getVector}. This only makes sense when a disk
    * fallback is configured - callers using simple mode must leave the cache unbounded.
+   *
+   * @param dimensions     arity of every vector held here
+   * @param initialCapacity initial size of the backing map
+   * @param lsmIndex       the index to re-read an evicted ordinal from, or {@code null} for simple mode
+   * @param maxCacheSize   upper bound on the vectors kept on-heap; {@code <= 0} means unbounded
    */
-  GrowableVectorValues(final int dimensions, final int initialCapacity,
-      final VectorLocationIndex vectorIndex, final LSMVectorIndex lsmIndex,
-      final DatabaseInternal database, final String vectorPropertyName, final int maxCacheSize) {
+  GrowableVectorValues(final int dimensions, final int initialCapacity, final LSMVectorIndex lsmIndex,
+      final int maxCacheSize) {
     this.dimensions = dimensions;
     this.vectors = new ConcurrentHashMap<>(Math.max(16, Math.min(initialCapacity, maxCacheSize <= 0 ? initialCapacity : maxCacheSize)));
-    this.vectorIndex = vectorIndex;
     this.lsmIndex = lsmIndex;
-    this.database = database;
-    this.vectorPropertyName = vectorPropertyName;
     this.maxCacheSize = maxCacheSize <= 0 ? Integer.MAX_VALUE : maxCacheSize;
   }
 
@@ -131,8 +127,8 @@ class GrowableVectorValues implements RandomAccessVectorValues {
     if (cached != null)
       return cached;
 
-    // Slow path: lazy-load from disk and cache
-    if (vectorIndex == null || database == null || lsmIndex == null)
+    // Slow path: lazy-load from disk and cache. Simple mode has nothing to read from.
+    if (lsmIndex == null)
       return null;
 
     // The read-back itself, and the validation of what comes back, belong to the index that persisted it: see

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -8446,6 +8446,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // outruns the rebuilds and the payload budget starts declining vectors (issue #7357).
     stats.put("deltaResidentVectors", (long) deltaResidentPayloads.get());
     stats.put("deltaResidentVectorsCapacity", (long) deltaPayloadCapacity());
+    // Bulk loads currently holding this index's speculative rebuild off (issue #7357). Exposed because a
+    // suspension that is never lifted is otherwise invisible: the index simply stops rebuilding, with nothing in
+    // the logs and no gauge moving, until the database is reopened.
+    stats.put("backgroundMaintenanceSuspensions", (long) backgroundMaintenanceSuspensions.get());
 
     // Nodes the build that produced the current graph could not link, which no beam search can return at any
     // efSearch and which the delta scan therefore has to serve (issues #5615, #7190). Answered from the field

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -3941,10 +3941,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
       liveVectorValues = new GrowableVectorValues(
           metadata.dimensions,
           Math.max(1024, Math.min(vectorIndex().size(), liveCacheSize <= 0 ? vectorIndex().size() : liveCacheSize)),
-          vectorIndex(),
           this,
-          getDatabase(),
-          vectorProp,
           liveCacheSize
       );
 
@@ -4974,6 +4971,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // Asserted rather than merely documented: the invariant is invisible from the call site, and a future caller
     // that appends without the lock would not fail here - it would corrupt the accounting quietly, which is the
     // kind of bug this counter exists to prevent (PR #7360 review).
+    //
+    // An assertion and not a hard check because this runs once per written record, and because the audience for it
+    // is the test suite rather than production: Surefire sets enableAssertions by default, so every `mvn test` run
+    // of this repository executes with -ea and a caller added without the lock trips here before it can ship. A
+    // production JVM without -ea would not, which is the accepted trade - the alternative is a lock-state read on
+    // the hot path of every insert, to guard against a mistake that only a code change can introduce.
     assert lock.isWriteLockedByCurrentThread() : "queueDeltaEntry() without the write lock";
     deltaVectors.add(entry);
     if (entry.vector != null)

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1765,8 +1765,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // Rebuild ordinalToVectorId from vectorIndex
       // IMPORTANT: Must match the validation logic used during graph building
       final String vectorProp =
-          metadata.propertyNames != null && !metadata.propertyNames.isEmpty() ?
-              metadata.propertyNames.getFirst() : "vector";
+          vectorPropertyName();
 
       // One read of the location index for the whole walk, both because a per-element accessor call would
       // re-check the materialisation flag on every live vector and because a compaction swaps the instance
@@ -2704,8 +2703,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
           // Scan all documents in the associated bucket to find vectors missing from the page-parsed set
           final String vectorProp =
-              metadata.propertyNames != null && !metadata.propertyNames.isEmpty() ? metadata.propertyNames.getFirst() :
-                  "vector";
+              vectorPropertyName();
           database.scanBucket(bucket.getName(), record -> {
             final Document doc = (Document) record;
             final RID rid = doc.getIdentity();
@@ -2819,8 +2817,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
     {
       // Create a SNAPSHOT of vectorIndex for JVector to use safely
       final String vectorProp =
-          metadata.propertyNames != null && !metadata.propertyNames.isEmpty() ? metadata.propertyNames.get(0) :
-              "vector";
+          vectorPropertyName();
 
       // CRITICAL FIX: Validate vectors before building graph to filter out deleted documents
       // When a document is deleted, getVector() returns null which breaks JVector index building
@@ -3927,9 +3924,6 @@ public class LSMVectorIndex implements Index, IndexInternal {
       return;
 
     try {
-      final String vectorProp = metadata.propertyNames != null && !metadata.propertyNames.isEmpty() ?
-          metadata.propertyNames.getFirst() : "vector";
-
       // Create GrowableVectorValues with lazy disk fallback — vectors are loaded from
       // ArcadeDB pages/documents on first access and cached in the ConcurrentHashMap.
       // This avoids the O(n) pre-loading that was the bottleneck at 1M+ scale.
@@ -5073,6 +5067,23 @@ public class LSMVectorIndex implements Index, IndexInternal {
   }
 
   /**
+   * The name of the property these vectors are indexed on.
+   * <p>
+   * Six places resolved this inline with the same expression, and the seventh - {@link #readPersistedVectorArray}
+   * as first written - defaulted to {@code null} instead of {@code "vector"} and so gave up on the document lookup
+   * for an index whose metadata carries no property names (PR #7360 review). That is not a hypothetical state:
+   * indexes migrated from older metadata reach here with an empty list, and for those the new shared read-back
+   * would have dropped from search results a vector every other path in this class still finds. One expression,
+   * one default.
+   *
+   * @return the property name, never {@code null}
+   */
+  private String vectorPropertyName() {
+    return metadata.propertyNames != null && !metadata.propertyNames.isEmpty() ?
+        metadata.propertyNames.getFirst() : "vector";
+  }
+
+  /**
    * Reads a live vector back from where it was persisted, by vector id rather than by file offset.
    * <p>
    * The vector of every indexed record is on disk before anything on the heap is allowed to forget it: an
@@ -5106,10 +5117,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
           VectorLocationIndex.isCompactedOf(offsetAndFlag));
 
       if (vector == null) {
-        final String vectorProp = metadata.propertyNames != null && !metadata.propertyNames.isEmpty() ?
-            metadata.propertyNames.getFirst() : null;
-        if (vectorProp == null)
-          return null;
+        final String vectorProp = vectorPropertyName();
         final RID rid = locations.getRid(vectorId);
         if (rid == null)
           return null;
@@ -5332,7 +5340,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
       return liveVectorValues;
 
     final String vectorProp =
-        metadata.propertyNames != null && !metadata.propertyNames.isEmpty() ? metadata.propertyNames.getFirst() : "vector";
+        vectorPropertyName();
     return ArcadePageVectorValues.forSearch(getDatabase(), metadata.dimensions, vectorProp, vectorIndex(), ordinalMap,
         this, getSearchVectorCache());
   }
@@ -8791,8 +8799,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
       // Create vector values accessor for graph serialization
       final String vectorProp =
-          metadata.propertyNames != null && !metadata.propertyNames.isEmpty() ? metadata.propertyNames.getFirst() :
-              "vector";
+          vectorPropertyName();
       // Serialization walks every ordinal exactly once, so feed the shared search cache while doing it: the
       // index comes out of a rebuild with its working set already resident instead of cold (issue #5412).
       final RandomAccessVectorValues vectors = ArcadePageVectorValues.forSearch(getDatabase(), metadata.dimensions,

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -4956,6 +4956,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * @return {@code vector} to keep it resident, or {@code null} to queue an id-only entry
    */
   private VectorFloat<?> retainDeltaPayload(final VectorFloat<?> vector) {
+    assert lock.isWriteLockedByCurrentThread() : "retainDeltaPayload() without the write lock";
     return deltaResidentPayloads.get() >= deltaPayloadCapacity() ? null : vector;
   }
 
@@ -4966,8 +4967,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * The single door in, so that {@link #deltaResidentPayloads} cannot drift from what the buffer actually holds:
    * the accounting is what decides whether the next write keeps its payload, and a path that appended around it
    * would leave that decision reading a number nobody maintains.
+   *
+   * @param entry the entry to append
    */
   private void queueDeltaEntry(final DeltaVectorEntry entry) {
+    // Asserted rather than merely documented: the invariant is invisible from the call site, and a future caller
+    // that appends without the lock would not fail here - it would corrupt the accounting quietly, which is the
+    // kind of bug this counter exists to prevent (PR #7360 review).
+    assert lock.isWriteLockedByCurrentThread() : "queueDeltaEntry() without the write lock";
     deltaVectors.add(entry);
     if (entry.vector != null)
       deltaResidentPayloads.incrementAndGet();
@@ -4978,6 +4985,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * <b>The caller must hold {@link #lock}'s write lock.</b>
    */
   private void recountDeltaResidentPayloads() {
+    assert lock.isWriteLockedByCurrentThread() : "recountDeltaResidentPayloads() without the write lock";
     int resident = 0;
     for (final DeltaVectorEntry e : deltaVectors)
       if (e.vector != null)
@@ -5015,8 +5023,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * something else pays a page read per scored entry for a bound it does not need. Otherwise the budget is the
    * configured share of the heap ceiling, capped at what is currently available, divided by what one cached
    * vector of this arity costs: the same arithmetic and the same denominator
-   * {@link #computeGraphBuildCacheCapacity} uses, so the two caches cannot each plan on the whole of the same
-   * free heap.
+   * {@link #computeGraphBuildCacheCapacity} uses.
+   * <p>
+   * Sharing the denominator is NOT a reservation, and nothing here should be read as one (PR #7360 review): this
+   * cache and the build cache each take their percent of the same {@code availableHeapBytes()} reading, so within
+   * one TTL window both can size themselves against heap the other is about to take. What makes it converge is
+   * that a payload kept here becomes live heap, which lowers the next reading for both. The percents are a margin
+   * against that lag, not a partition of the heap - which is why the default is a modest 10 and why the ceiling
+   * that matters is the one an operator sets when they know what else is running.
    *
    * @return the capacity, never negative
    */
@@ -5041,6 +5055,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
   /**
    * The vector of a buffered entry: the payload it carries, or a read of the pages it was persisted to when the
    * heap budget declined to keep one (issue #7357).
+   *
+   * @param entry the buffered entry to resolve
    *
    * @return the vector, or {@code null} when it can no longer be read back - the entry must then be skipped
    */
@@ -9697,6 +9713,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * Clears {@code task} as the armed one, so the index is free to arm another. A no-op when a later task has
    * already replaced it, which is what makes a task cancelled by {@link #cancelInactivityRebuildTimer()} and
    * running anyway unable to disarm its successor.
+   *
+   * @param task the task that is standing down
    */
   private synchronized void disarmInactivityRebuild(final TimerTask task) {
     if (inactivityRebuildTask == task)

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -3399,10 +3399,16 @@ public class LSMVectorIndex implements Index, IndexInternal {
         // ("would rebuild itself forever"); the state flag was not.
         final boolean hasPendingWrites = !remaining.isEmpty();
 
-        remaining.addAll(unreachableEntries);
-
+        // The survivors are published FIRST, and the orphans queued through the door afterwards, rather than the
+        // one addAll() this replaces (PR #7360 review). addAll() went around queueDeltaEntry(), so the payload
+        // budget did not reach these entries - the third site with that shape, after the write path and the
+        // stale-prefix gap. It is also the worst of the three to leave uncapped: a Vamana build orphans a FRESH
+        // set every time, so this count does not converge downwards (issue #7190), and on a corpus that keeps
+        // re-triggering rebuilds it would keep adding full payloads to a buffer nothing else was allowed to grow.
         this.deltaVectors = remaining;
         recountDeltaResidentPayloads();
+        for (final DeltaVectorEntry unreachable : unreachableEntries)
+          queueDeltaEntry(unreachable);
 
         // Subtract only mutations present at build start, preserving concurrent ones
         mutationsSinceSerialize.addAndGet(-mutationsAtBuildStart);
@@ -7497,10 +7503,22 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
           // Remove matching entries from delta buffer
           if (!deltaVectors.isEmpty()) {
-            deltaVectors.removeIf(entry -> entry.rid.equals(rid));
             // The payloads those entries held are gone with them, so the heap accounting has to give them back:
             // leaving it high would keep declining payloads for writes the buffer now has room for (issue #7357).
-            recountDeltaResidentPayloads();
+            // Counted inside the predicate rather than by a recount afterwards, because this runs on every delete
+            // and not only during a bulk load, and a recount walks the whole buffer a second time right after
+            // removeIf() has already walked it (PR #7360 review). The holder array is what a lambda needs to
+            // accumulate; the write lock is held throughout, so nothing else is reading the counter meanwhile.
+            final int[] releasedPayloads = new int[1];
+            deltaVectors.removeIf(entry -> {
+              if (!entry.rid.equals(rid))
+                return false;
+              if (entry.vector != null)
+                releasedPayloads[0]++;
+              return true;
+            });
+            if (releasedPayloads[0] > 0)
+              deltaResidentPayloads.addAndGet(-releasedPayloads[0]);
           }
 
           // Phase 5+: Periodic rebuild strategy (amortizes cost over many operations)

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -344,11 +344,25 @@ public class LSMVectorIndex implements Index, IndexInternal {
   // Delta vectors inserted since last graph build, cached in RAM for brute-force scan during search.
   // Writers (put/remove/rebuild) hold write lock; readers (search) take a volatile snapshot.
   private static final class DeltaVectorEntry {
-    final int             vectorId;
-    final RID             rid;
-    // Stored already converted to the JVector representation: the delta buffer is scanned in full on every
-    // search, so converting once at insert time (instead of once per entry per query) removes a per-query
-    // allocation of the entire delta buffer - the dominant source of GC pressure at scale (issue #5391).
+    final int vectorId;
+    final RID rid;
+    /**
+     * The vector, already converted to the JVector representation - or {@code null} when the buffer's heap budget
+     * declined to keep it.
+     * <p>
+     * Holding it is a CACHE, not the record of it: {@code put()} persists the vector before it queues the entry, so
+     * the payload here only saves the delta scan a read. Converting once at insert time instead of once per entry
+     * per query is what removes a per-query allocation of the whole buffer, the dominant source of GC pressure at
+     * scale (issue #5391), so it is kept whenever there is room for it.
+     * <p>
+     * There is not always room. The buffer holds everything written since the last graph rebuild, and nothing
+     * bounds how much that is - an ingest that outruns the rebuilds keeps appending - so a full payload per entry
+     * is a second complete copy of the corpus on the heap, exactly the copy issue #3144 removed from
+     * {@link GrowableVectorValues}. A 4.2M-record load of 768-dimension embeddings needs 12.9 GB for it alone and
+     * died of that at {@code -Xmx16g} (issue #7357). Past
+     * {@code arcadedb.vectorIndex.deltaCacheSize} the entry keeps only its id and RID - 32 bytes rather than
+     * {@code dimensions * 4} - and {@link #deltaVectorOf} reads the payload back from the pages.
+     */
     final VectorFloat<?> vector;
 
     DeltaVectorEntry(final int vectorId, final RID rid, final VectorFloat<?> vector) {
@@ -359,6 +373,19 @@ public class LSMVectorIndex implements Index, IndexInternal {
   }
 
   private volatile List<DeltaVectorEntry> deltaVectors = new ArrayList<>();
+
+  /**
+   * How many entries of {@link #deltaVectors} are currently holding their payload, i.e. what the buffer costs the
+   * heap. Not derivable from the buffer size, which counts entries whose payload was declined too.
+   */
+  private final AtomicInteger deltaResidentPayloads = new AtomicInteger();
+
+  /** Cached answer of {@link #computeDeltaPayloadCapacity()}, and when it was last computed. */
+  private volatile int  deltaPayloadCapacity      = -1;
+  private volatile long deltaPayloadCapacityAtMs  = 0L;
+
+  /** How long a computed delta payload capacity is reused before the heap is measured again. */
+  private static final long DELTA_PAYLOAD_CAPACITY_TTL_MS = 1_000L;
 
   /**
    * Ordinals of the RESIDENT graph that no path from its entry node reaches (issue #5615), or {@code null} when
@@ -392,6 +419,28 @@ public class LSMVectorIndex implements Index, IndexInternal {
   // a timer triggers an async rebuild after a period of inactivity.
   private volatile TimerTask inactivityRebuildTask;
   private volatile Timer     inactivityTimer;
+
+  /**
+   * {@link System#nanoTime()} of the most recent mutation, which is what the inactivity window is measured
+   * against.
+   * <p>
+   * The window used to be measured by CANCELLING and rescheduling the timer task on every mutation. That is a
+   * monitor acquisition, a {@code Timer.purge()} of the task queue under the timer's own lock, and a fresh
+   * {@code TimerTask} allocation, all on the path that runs once per written record - which on the 4.2M-record
+   * load of issue #7357 is 4.2M of each, to move a deadline. Writing a timestamp costs one volatile store, and
+   * the armed task checks the deadline when it fires and re-arms itself for the remainder if it is early. Same
+   * window, same semantics, one task per quiet period instead of one per write.
+   */
+  private volatile long lastMutationNanos = System.nanoTime();
+
+  /**
+   * How many bulk loads have suspended this index's speculative background maintenance (issue #7357), zero when
+   * none has.
+   * <p>
+   * Counted rather than flagged so overlapping suspensions compose: a caller that suspends must be able to resume
+   * without cancelling somebody else's suspension.
+   */
+  private final AtomicInteger backgroundMaintenanceSuspensions = new AtomicInteger();
 
   // Compaction support
   private final    AtomicInteger           currentMutablePages;
@@ -2159,7 +2208,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
     int added = 0;
     for (final DeltaVectorEntry entry : entries)
       if (queued.add(entry.vectorId)) {
-        this.deltaVectors.add(entry);
+        queueDeltaEntry(entry);
         added++;
       }
     return added;
@@ -2820,8 +2869,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
       else {
         final List<DeltaVectorEntry> deltaSnapshot = deltaVectors;
         deltaSnapshotById = new HashMap<>(deltaSnapshot.size() * 4 / 3 + 1);
+        // Only the entries that still carry a payload: this map exists to save the validation below a record read
+        // it can perform perfectly well itself, so reading a declined payload back from the pages here would move
+        // the read rather than avoid it, and would do it for every buffered vector instead of on demand.
         for (final DeltaVectorEntry e : deltaSnapshot)
-          deltaSnapshotById.put(e.vectorId, e.vector);
+          if (e.vector != null)
+            deltaSnapshotById.put(e.vectorId, e.vector);
       }
 
       // Progress tracking for validation phase
@@ -3352,6 +3405,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
         remaining.addAll(unreachableEntries);
 
         this.deltaVectors = remaining;
+        recountDeltaResidentPayloads();
 
         // Subtract only mutations present at build start, preserving concurrent ones
         mutationsSinceSerialize.addAndGet(-mutationsAtBuildStart);
@@ -4886,6 +4940,185 @@ public class LSMVectorIndex implements Index, IndexInternal {
   }
 
   /**
+   * Wraps a vector about to be queued into the delta buffer, returning it when the buffer can afford to keep it on
+   * the heap and {@code null} when it cannot (issue #7357).
+   * <p>
+   * <b>The caller must hold {@link #lock}'s write lock</b>, which is what makes the read-then-increment below
+   * safe: every path that queues an entry already holds it, and every path that drains the buffer takes it too.
+   * <p>
+   * Declining is always safe and never loses a vector: {@code persistVectorWithLocation()} has already written it,
+   * so {@link #deltaVectorOf} can read it back. The cost of declining is a page read per scored entry per query,
+   * which is why the budget is heap-relative rather than a flat count - an index whose whole buffer fits keeps
+   * behaving exactly as it did before this existed.
+   *
+   * @param vector the vector to queue, never {@code null}
+   *
+   * @return {@code vector} to keep it resident, or {@code null} to queue an id-only entry
+   */
+  private VectorFloat<?> retainDeltaPayload(final VectorFloat<?> vector) {
+    return deltaResidentPayloads.get() >= deltaPayloadCapacity() ? null : vector;
+  }
+
+  /**
+   * Appends one entry to the delta buffer and charges the heap accounting for it.
+   * <b>The caller must hold {@link #lock}'s write lock.</b>
+   * <p>
+   * The single door in, so that {@link #deltaResidentPayloads} cannot drift from what the buffer actually holds:
+   * the accounting is what decides whether the next write keeps its payload, and a path that appended around it
+   * would leave that decision reading a number nobody maintains.
+   */
+  private void queueDeltaEntry(final DeltaVectorEntry entry) {
+    deltaVectors.add(entry);
+    if (entry.vector != null)
+      deltaResidentPayloads.incrementAndGet();
+  }
+
+  /**
+   * Recomputes {@link #deltaResidentPayloads} from the buffer, after a rebuild has replaced it wholesale.
+   * <b>The caller must hold {@link #lock}'s write lock.</b>
+   */
+  private void recountDeltaResidentPayloads() {
+    int resident = 0;
+    for (final DeltaVectorEntry e : deltaVectors)
+      if (e.vector != null)
+        resident++;
+    deltaResidentPayloads.set(resident);
+  }
+
+  /**
+   * The number of buffered payloads the heap can afford, cached for {@value #DELTA_PAYLOAD_CAPACITY_TTL_MS} ms.
+   * <p>
+   * Re-measuring the heap on every insert is not affordable on a path that runs once per written record, and
+   * caching it forever is not correct either - the capacity has to fall when a rebuild starts holding the old
+   * graph alongside the new one, which is precisely when the buffer must stop growing. A one-second window is
+   * short next to how long it takes an ingest to fill a budget and long next to the cost of measuring it.
+   *
+   * @return the capacity, {@code 0} when nothing may be cached, {@link Integer#MAX_VALUE} when caching is unbounded
+   */
+  private int deltaPayloadCapacity() {
+    final long now = System.currentTimeMillis();
+    final int cached = deltaPayloadCapacity;
+    if (cached >= 0 && now - deltaPayloadCapacityAtMs < DELTA_PAYLOAD_CAPACITY_TTL_MS)
+      return cached;
+
+    final int computed = computeDeltaPayloadCapacity();
+    deltaPayloadCapacity = computed;
+    deltaPayloadCapacityAtMs = now;
+    return computed;
+  }
+
+  /**
+   * Computes how many buffered vectors may keep their payload on the heap.
+   * <p>
+   * An explicit {@code arcadedb.vectorIndex.deltaCacheSize} wins, with a negative value meaning "keep every
+   * payload" - the behaviour before issue #7357, kept reachable because an index whose ingest is bounded by
+   * something else pays a page read per scored entry for a bound it does not need. Otherwise the budget is the
+   * configured share of the heap ceiling, capped at what is currently available, divided by what one cached
+   * vector of this arity costs: the same arithmetic and the same denominator
+   * {@link #computeGraphBuildCacheCapacity} uses, so the two caches cannot each plan on the whole of the same
+   * free heap.
+   *
+   * @return the capacity, never negative
+   */
+  private int computeDeltaPayloadCapacity() {
+    final ContextConfiguration configuration = mutable.getDatabase().getConfiguration();
+
+    final int configured = configuration.getValueAsInteger(GlobalConfiguration.VECTOR_INDEX_DELTA_CACHE_SIZE);
+    if (configured < 0)
+      return Integer.MAX_VALUE;
+    if (configured > 0)
+      return configured;
+
+    final int heapPercent = configuration.getValueAsInteger(GlobalConfiguration.VECTOR_INDEX_DELTA_CACHE_MAX_HEAP_PERCENT);
+    if (heapPercent <= 0)
+      return 0;
+
+    final long heapBudget = VectorHeapBudget.buildCacheBudgetBytes(heapPercent);
+    final long affordable = heapBudget / VectorHeapBudget.bytesPerCachedVector(metadata.dimensions);
+    return (int) Math.max(0L, Math.min(affordable, Integer.MAX_VALUE / 2));
+  }
+
+  /**
+   * The vector of a buffered entry: the payload it carries, or a read of the pages it was persisted to when the
+   * heap budget declined to keep one (issue #7357).
+   *
+   * @return the vector, or {@code null} when it can no longer be read back - the entry must then be skipped
+   */
+  private VectorFloat<?> deltaVectorOf(final DeltaVectorEntry entry) {
+    final VectorFloat<?> cached = entry.vector;
+    if (cached != null)
+      return cached;
+
+    final float[] raw = readPersistedVectorArray(entry.vectorId);
+    return raw == null ? null : vts.createFloatVector(raw);
+  }
+
+  /**
+   * Reads a live vector back from where it was persisted, by vector id rather than by file offset.
+   * <p>
+   * The vector of every indexed record is on disk before anything on the heap is allowed to forget it: an
+   * inline-quantized index holds it in its own pages, and a document-backed one in the source record. This is the
+   * single place that knows both, so a caller that dropped an on-heap copy has one way to get it back rather than
+   * two nearly-identical ones - {@link GrowableVectorValues#getVector(int)} lazy-loads an evicted ordinal through
+   * it (issue #3144) and the delta scan reads back an entry whose payload the buffer's heap budget declined to
+   * keep (issue #7357).
+   * <p>
+   * Validated here rather than by each caller, because an unusable read has exactly one right answer everywhere:
+   * a vector of the wrong arity, or an all-zero one (which is what a torn or never-written region reads back as),
+   * is not a vector this index can score against and must be skipped, not scored as if it were at the origin.
+   *
+   * @param vectorId the live vector id to read
+   *
+   * @return the vector, or {@code null} when the id is no longer live or the payload cannot be read back
+   */
+  float[] readPersistedVectorArray(final int vectorId) {
+    final VectorLocationIndex locations = vectorIndex();
+    if (locations == null)
+      return null;
+
+    // One lookup, one word: nothing is materialized for an id that turns out not to be live (issue #5588).
+    final long offsetAndFlag = locations.getOffsetAndFlag(vectorId);
+    if (offsetAndFlag == VectorLocationIndex.ABSENT)
+      return null;
+
+    try {
+      // Quantized pages first (INT8/BINARY); returns null when the index stores no vector of its own.
+      float[] vector = readVectorFromOffset(VectorLocationIndex.offsetOf(offsetAndFlag),
+          VectorLocationIndex.isCompactedOf(offsetAndFlag));
+
+      if (vector == null) {
+        final String vectorProp = metadata.propertyNames != null && !metadata.propertyNames.isEmpty() ?
+            metadata.propertyNames.getFirst() : null;
+        if (vectorProp == null)
+          return null;
+        final RID rid = locations.getRid(vectorId);
+        if (rid == null)
+          return null;
+        final Document doc = (Document) getDatabase().lookupByRID(rid, false);
+        final Object raw = doc.get(vectorProp);
+        if (raw == null)
+          return null;
+        try {
+          vector = VectorUtils.toFloatArray(raw, metadata.encoding);
+        } catch (final IllegalArgumentException e) {
+          // WARNING, not FINE: an index whose vectors cannot be read back is silently losing rows from searches.
+          LogManager.instance().log(this, Level.WARNING,
+              "Vector property '%s' has unsupported type %s (RID=%s, vectorId=%d): %s",
+              vectorProp, raw.getClass().getName(), rid, vectorId, e.getMessage());
+          return null;
+        }
+      }
+
+      if (vector != null && vector.length == metadata.dimensions && !VectorUtils.isZeroVector(vector))
+        return vector;
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.FINE,
+          "Could not read back vector id=%d of index '%s': %s", vectorId, indexName, e.getMessage());
+    }
+    return null;
+  }
+
+  /**
    * Reads a quantized vector from a file offset and dequantizes it.
    * This method reads the quantized vector data stored in index pages and converts it back to float[].
    *
@@ -5118,7 +5351,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
         final VectorFloat<?> vector = values.getVector(ordinal);
         if (vector == null)
           return -1;
-        deltaVectors.add(new DeltaVectorEntry(vectorId, rid, vector));
+        queueDeltaEntry(new DeltaVectorEntry(vectorId, rid, vector));
         return ordinal;
       }
       return -1;
@@ -5145,7 +5378,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * can grow to hundreds of thousands of entries. The scan therefore keeps a bounded top-k heap and prunes on
    * the current k-th distance instead of appending every candidate and sorting the whole list: allocation is
    * O(k) per query rather than O(delta), and the sort is O(delta log k) rather than O(delta log delta)
-   * (issue #5391). Entries are already stored as {@link VectorFloat}, so scoring allocates nothing at all.
+   * (issue #5391). Scoring an entry that still carries its payload allocates nothing at all; one whose payload
+   * the buffer's heap budget declined costs a page read and one conversion here instead (issue #7357).
    */
   private void mergeWithDeltaScan(final VectorFloat<?> queryVectorFloat, final int k,
       final Set<RID> allowedRIDs, final List<Pair<RID, Float>> results) {
@@ -5189,8 +5423,22 @@ public class LSMVectorIndex implements Index, IndexInternal {
       if (filtered && !allowedRIDs.contains(delta.rid))
         continue;
 
+      // An entry that still carries its payload takes exactly the path it always did. One whose payload the heap
+      // budget declined costs a page read to score (issue #7357), which inverts the ordering argument below: a
+      // read is orders of magnitude dearer than the two hash lookups, so for THAT entry they are worth asking
+      // first even though they cannot change the admitted set. An entry that cannot be read back at all is
+      // skipped like a tombstoned one, rather than scored against a vector that is not its own.
+      VectorFloat<?> deltaVector = delta.vector;
+      if (deltaVector == null) {
+        if (seenRIDs.contains(delta.rid) || (anyDeleted && locations.isDeleted(delta.vectorId)))
+          continue;
+        deltaVector = deltaVectorOf(delta);
+        if (deltaVector == null)
+          continue;
+      }
+
       compared++;
-      final float score = similarity.compare(queryVectorFloat, delta.vector);
+      final float score = similarity.compare(queryVectorFloat, deltaVector);
       final float distance = scoreToDistance(similarity, score);
 
       // Prune before allocating: a candidate no better than the current k-th best cannot make the result set.
@@ -5344,15 +5592,22 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // Parallel primitive/reference arrays rather than a list of holder objects: this runs on the microsecond path,
     // and both are at most `unresolved.size()` long.
     final int[] positions = new int[unresolved.size()];
-    final DeltaVectorEntry[] entries = new DeltaVectorEntry[unresolved.size()];
     int rescored = 0;
 
+    // The vectors, not the entries: an entry whose payload the buffer declined is read back here (issue #7357),
+    // once, rather than at the encode loop below where the array index no longer says which entry it came from.
+    // One that cannot be read back keeps the exact score the first stage gave it - see the note above on why a
+    // row missing from the buffer is better left mis-scaled than dropped.
+    final VectorFloat<?>[] vectors = new VectorFloat<?>[unresolved.size()];
     for (final DeltaVectorEntry entry : currentDelta) {
       final Integer position = unresolved.remove(entry.rid);
       if (position == null)
         continue;
+      final VectorFloat<?> vector = deltaVectorOf(entry);
+      if (vector == null)
+        continue;
       positions[rescored] = position;
-      entries[rescored] = entry;
+      vectors[rescored] = vector;
       rescored++;
       if (unresolved.isEmpty())
         break;
@@ -5373,7 +5628,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
     final ByteSequence<?>[] chunk = { vts.createByteSequence(rescored * pq.compressedVectorSize()) };
     final PQVectors scratch = new ImmutablePQVectors(pq, chunk, rescored, rescored);
     for (int j = 0; j < rescored; j++)
-      pq.encodeTo(entries[j].vector, scratch.get(j));
+      pq.encodeTo(vectors[j], scratch.get(j));
 
     final ScoreFunction.ApproximateScoreFunction pqScore =
         scratch.precomputedScoreFunctionFor(queryVectorFloat, metadata.similarityFunction);
@@ -6460,9 +6715,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * there is nothing in it this query can use (issue #6501).
    * <p>
    * The whole buffer is scored, not a top-k slice of it: see {@link ScoredCandidateCursor}'s javadoc for why the
-   * group cap makes a bounded heap lose rows the answer needs. Scoring allocates nothing - delta entries are stored
-   * already converted to {@link VectorFloat} for exactly this reason (issue #5391) - and the two arrays handed to
-   * the cursor are the only per-query allocation, at 8 bytes per buffered vector.
+   * group cap makes a bounded heap lose rows the answer needs. Scoring an entry that still carries its payload
+   * allocates nothing - delta entries are stored already converted to {@link VectorFloat} for exactly this reason
+   * (issue #5391) - and the two arrays handed to the cursor are the only per-query allocation, at 8 bytes per
+   * buffered vector. An entry whose payload the heap budget declined costs a page read and one conversion of its
+   * own (issue #7357).
    */
   private ScoredCandidateCursor scoreDeltaCandidates(final VectorFloat<?> queryVectorFloat, final Set<RID> allowedRIDs,
       final List<DeltaVectorEntry> deltaSnapshot) {
@@ -6488,7 +6745,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // its javadoc for why a resident location cannot answer it and why it stays despite being unreachable today.
       if (anyDeleted && locations.isDeleted(entry.vectorId))
         continue;
-      distances[kept] = scoreToDistance(similarity, similarity.compare(queryVectorFloat, entry.vector));
+      // Read back when the buffer declined to keep the payload, skipped when even that fails - the same answer
+      // mergeWithDeltaScan gives, for the same reason (issue #7357).
+      final VectorFloat<?> vector = deltaVectorOf(entry);
+      if (vector == null)
+        continue;
+      distances[kept] = scoreToDistance(similarity, similarity.compare(queryVectorFloat, vector));
       positions[kept] = i;
       kept++;
     }
@@ -6982,7 +7244,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
           // Skipping expensive O(log n) HNSW graph inserts during commit replay (issue #3864):
           // the inactivity rebuild timer will incorporate delta vectors into the graph.
           // The already-converted VectorFloat is reused so the search path never re-converts (issue #5391).
-          deltaVectors.add(new DeltaVectorEntry(id, rid, vf));
+          queueDeltaEntry(new DeltaVectorEntry(id, rid, retainDeltaPayload(vf)));
 
           if (graphState == GraphState.IMMUTABLE || graphState == GraphState.LOADING)
             this.graphState = GraphState.MUTABLE;
@@ -7104,7 +7366,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
         // Add to delta buffer for search visibility via mergeWithDeltaScan, reusing the already-converted
         // VectorFloat so the search path never re-converts the whole buffer per query (issue #5391).
-        deltaVectors.add(new DeltaVectorEntry(id, rid, vf));
+        queueDeltaEntry(new DeltaVectorEntry(id, rid, retainDeltaPayload(vf)));
 
         mutationsSinceSerialize.incrementAndGet();
       }
@@ -7188,8 +7450,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
           persistDeletionTombstones(deletedIds, rid);
 
           // Remove matching entries from delta buffer
-          if (!deltaVectors.isEmpty())
+          if (!deltaVectors.isEmpty()) {
             deltaVectors.removeIf(entry -> entry.rid.equals(rid));
+            // The payloads those entries held are gone with them, so the heap accounting has to give them back:
+            // leaving it high would keep declining payloads for writes the buffer now has room for (issue #7357).
+            recountDeltaResidentPayloads();
+          }
 
           // Phase 5+: Periodic rebuild strategy (amortizes cost over many operations)
           if (graphState == GraphState.IMMUTABLE || graphState == GraphState.LOADING) {
@@ -8157,6 +8423,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
     // Delta vectors cached in RAM for brute-force scan between rebuilds
     stats.put("deltaVectorsCount", (long) deltaVectors.size());
+    // What the buffer costs the heap, as opposed to how many entries it holds: the two diverge once ingest
+    // outruns the rebuilds and the payload budget starts declining vectors (issue #7357).
+    stats.put("deltaResidentVectors", (long) deltaResidentPayloads.get());
+    stats.put("deltaResidentVectorsCapacity", (long) deltaPayloadCapacity());
 
     // Nodes the build that produced the current graph could not link, which no beam search can return at any
     // efSearch and which the delta scan therefore has to serve (issues #5615, #7190). Answered from the field
@@ -9328,75 +9598,82 @@ public class LSMVectorIndex implements Index, IndexInternal {
   }
 
   /**
-   * Schedule or reset the inactivity rebuild timer (issue #3737).
-   * Called after each mutation when mutations are below the rebuild threshold.
-   * If a timer is already scheduled, it is cancelled and a new one is started,
-   * effectively resetting the inactivity window.
-   * When the timer fires, it triggers a rebuild for any pending mutation count on a small graph, or
-   * once pending mutations reach {@link #inactivityRebuildIsWorthIt() a threshold-derived floor} on a
-   * large one (issue #6496) - see that method for why the two cases are treated differently.
+   * {@inheritDoc}
+   * <p>
+   * On this index the maintenance in question is the speculative graph rebuild the inactivity timer starts
+   * (issue #7357). That rebuild is triggered by the index going quiet, which during a bulk load means nothing:
+   * a loader stalls for an index compaction, a page-flush burst or a long GC, and any of those outlast the
+   * window. The rebuild that starts then covers the corpus loaded SO FAR, takes minutes on a large one, and is
+   * already stale when it lands, so the next quiet moment starts another over a larger set. The reporter's load
+   * paid {@code build(1M) + build(1.6M) + build(2.6M) + build(4.2M)} and had not finished after six and a half
+   * hours; the same load with no vector index took twenty-six minutes.
+   * <p>
+   * Writes are unaffected: they keep going into the delta buffer and stay searchable through the delta scan
+   * exactly as they do between two rebuilds at any other time. Only the speculative rebuild waits.
    */
-  private synchronized void scheduleInactivityRebuild() {
+  @Override
+  public void suspendBackgroundMaintenance() {
+    backgroundMaintenanceSuspensions.incrementAndGet();
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * Arms the inactivity timer again as the last suspension lifts, so the one rebuild the whole load is worth
+   * starts as soon as the index is genuinely quiet rather than waiting for another write that may never come.
+   */
+  @Override
+  public void resumeBackgroundMaintenance() {
+    final int remaining = backgroundMaintenanceSuspensions.updateAndGet(current -> current > 0 ? current - 1 : 0);
+    if (remaining > 0)
+      return;
+
+    // The window starts now: what the load left behind is exactly what a rebuild should cover, and the timer is
+    // measuring quiet from the last write, which may be some way back.
+    if (mutationsSinceSerialize.get() > 0)
+      scheduleInactivityRebuild();
+  }
+
+  /**
+   * Records a mutation against the inactivity rebuild window (issue #3737), arming the timer if it is not already.
+   * Called after each mutation.
+   * <p>
+   * The window is measured from {@link #lastMutationNanos} rather than by rescheduling the task, so this costs one
+   * volatile store on the write path and touches the timer only when nothing is armed - see that field for why the
+   * difference matters at ingest scale (issue #7357). The gate that decides whether a rebuild is worth running at
+   * all has moved to the moment the task fires for the same reason: asked here it ran once per written record,
+   * asked there it runs once per quiet period, and the answer that counts is the one at fire time anyway.
+   * <p>
+   * When the task fires it triggers a rebuild for any pending mutation count on a small graph, or once pending
+   * mutations reach {@link #inactivityRebuildIsWorthIt() a threshold-derived floor} on a large one (issue #6496) -
+   * see that method for why the two cases are treated differently.
+   */
+  private void scheduleInactivityRebuild() {
+    lastMutationNanos = System.nanoTime();
+    if (inactivityRebuildTask == null)
+      armInactivityRebuild(getInactivityRebuildTimeoutMs());
+  }
+
+  /**
+   * Arms the inactivity rebuild task to fire in {@code delayMs}, unless one is already armed.
+   *
+   * @param delayMs delay in milliseconds; a non-positive value means the feature is disabled and arms nothing
+   */
+  private synchronized void armInactivityRebuild(final long delayMs) {
+    if (inactivityRebuildTask != null)
+      return; // Already armed: it re-arms itself for the remainder if it fires early
+
     if (!isValid())
       return; // Index closed or dropped - no point scheduling
 
-    final int timeoutMs = getInactivityRebuildTimeoutMs();
-    if (timeoutMs <= 0)
+    if (delayMs <= 0)
       return; // Disabled
-
-    if (!inactivityRebuildIsWorthIt())
-      return; // Nothing worth rebuilding (issue #6496)
-
-    // Cancel any previously scheduled task (reset on new mutation) and purge the cancelled
-    // entry from the Timer's queue so a high write rate does not let cancelled tasks pile up.
-    final TimerTask existing = inactivityRebuildTask;
-    if (existing != null) {
-      existing.cancel();
-      if (inactivityTimer != null)
-        inactivityTimer.purge();
-    }
 
     final TimerTask task = new TimerTask() {
       @Override
       public void run() {
-        // Double-check: only rebuild if there are still enough pending mutations
-        // to justify a full O(N) rebuild (issue #6496)
-        if (!inactivityRebuildIsWorthIt())
-          return;
-
-        LogManager.instance().log(this, Level.INFO,
-            "Inactivity timeout expired (%d ms), triggering graph rebuild for %d pending mutations (index: %s)",
-            timeoutMs, mutationsSinceSerialize.get(), indexName);
-
         try {
-          // Asked again rather than reusing what inactivityRebuildIsWorthIt() just computed: the two questions
-          // are "is a rebuild worth it" and "which arm", and answering the second from a value read before the
-          // first would pin the arm to a graph size that a concurrent rebuild may already have moved on from.
-          // O(1) either way - see inactivityRebuildScopeSize() on why it does not walk anything.
-          if (inactivityRebuildScopeSize() >= ASYNC_REBUILD_MIN_GRAPH_SIZE) {
-            // Large graph: async rebuild (semaphore acquired inside the async thread).
-            // Asked through inactivityRebuildScopeSize() so a large graph this session has never loaded takes
-            // this arm rather than the synchronous one below (issue #6798) - the timer thread is shared with
-            // every other index's inactivity task, and a full O(N) build on it stalls all of them.
-            startAsyncGraphRebuild();
-          } else {
-            // Small graph: synchronous rebuild on the timer thread.
-            // Use tryAcquire to avoid blocking the timer thread indefinitely.
-            // If another rebuild holds the permit, re-arm the timer so this index
-            // retries at the next interval rather than staying stuck with pending mutations.
-            if (REBUILD_SEMAPHORE.tryAcquire()) {
-              try {
-                buildGraphFromScratch();
-              } finally {
-                REBUILD_SEMAPHORE.release();
-              }
-            } else {
-              LogManager.instance().log(this, Level.FINE,
-                  "Skipping inactivity rebuild for index %s: another rebuild is already in progress, will retry in %d ms",
-                  indexName, timeoutMs);
-              scheduleInactivityRebuild();
-            }
-          }
+          runInactivityRebuild(this);
         } catch (final Throwable e) {
           // Throwable, not just Exception|AssertionError: an OutOfMemoryError from a rebuild that no longer fits
           // (issue #6503) is an Error too. AssertionError already mattered here because JVector validates with
@@ -9413,7 +9690,89 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
     if (inactivityTimer == null)
       inactivityTimer = new Timer("VectorIndex-InactivityTimer-" + indexName, true);
-    inactivityTimer.schedule(task, timeoutMs);
+    inactivityTimer.schedule(task, delayMs);
+  }
+
+  /**
+   * Clears {@code task} as the armed one, so the index is free to arm another. A no-op when a later task has
+   * already replaced it, which is what makes a task cancelled by {@link #cancelInactivityRebuildTimer()} and
+   * running anyway unable to disarm its successor.
+   */
+  private synchronized void disarmInactivityRebuild(final TimerTask task) {
+    if (inactivityRebuildTask == task)
+      inactivityRebuildTask = null;
+  }
+
+  /**
+   * The inactivity rebuild task's body, running on the shared timer thread.
+   *
+   * @param self the task that fired, so it can stand down before deciding whether to arm a successor
+   */
+  private void runInactivityRebuild(final TimerTask self) {
+    final int timeoutMs = getInactivityRebuildTimeoutMs();
+
+    // Spent from here on, whatever this call decides: every arm below goes through armInactivityRebuild(), which
+    // declines while a task is still armed.
+    disarmInactivityRebuild(self);
+
+    if (timeoutMs <= 0)
+      return; // Disabled since this task was armed
+
+    // The deadline is read here, not enforced by the scheduling: a write that landed after this task was armed
+    // moved it, and the remaining wait is what is left of the window from that write (issue #7357).
+    final long quietMs = (System.nanoTime() - lastMutationNanos) / 1_000_000L;
+    if (quietMs < timeoutMs) {
+      armInactivityRebuild(timeoutMs - quietMs);
+      return;
+    }
+
+    // A bulk load is open on this index, so the quiet window means nothing: a loader pauses for a compaction, a
+    // page-flush burst or a long GC, and reading that as "the load is over" is what made an inactivity rebuild
+    // start over a partial corpus and then be superseded by the next one, over and over, for a load that never
+    // completed (issue #7357). Keep waiting instead; resumeBackgroundMaintenance() arms this again at the end.
+    if (backgroundMaintenanceSuspensions.get() > 0) {
+      armInactivityRebuild(timeoutMs);
+      return;
+    }
+
+    // Only rebuild if there are enough pending mutations to justify a full O(N) rebuild (issue #6496). Staying
+    // disarmed on a "no" is deliberate: nothing about the answer changes until the next mutation, and that
+    // mutation arms this again.
+    if (!inactivityRebuildIsWorthIt())
+      return;
+
+    LogManager.instance().log(this, Level.INFO,
+        "Inactivity timeout expired (%d ms), triggering graph rebuild for %d pending mutations (index: %s)",
+        timeoutMs, mutationsSinceSerialize.get(), indexName);
+
+    // Asked again rather than reusing what inactivityRebuildIsWorthIt() just computed: the two questions
+    // are "is a rebuild worth it" and "which arm", and answering the second from a value read before the
+    // first would pin the arm to a graph size that a concurrent rebuild may already have moved on from.
+    // O(1) either way - see inactivityRebuildScopeSize() on why it does not walk anything.
+    if (inactivityRebuildScopeSize() >= ASYNC_REBUILD_MIN_GRAPH_SIZE) {
+      // Large graph: async rebuild (semaphore acquired inside the async thread).
+      // Asked through inactivityRebuildScopeSize() so a large graph this session has never loaded takes
+      // this arm rather than the synchronous one below (issue #6798) - the timer thread is shared with
+      // every other index's inactivity task, and a full O(N) build on it stalls all of them.
+      startAsyncGraphRebuild();
+    } else {
+      // Small graph: synchronous rebuild on the timer thread.
+      // Use tryAcquire to avoid blocking the timer thread indefinitely.
+      // If another rebuild holds the permit, re-arm the timer so this index
+      // retries at the next interval rather than staying stuck with pending mutations.
+      if (REBUILD_SEMAPHORE.tryAcquire()) {
+        try {
+          buildGraphFromScratch();
+        } finally {
+          REBUILD_SEMAPHORE.release();
+        }
+      } else {
+        LogManager.instance().log(this, Level.FINE,
+            "Skipping inactivity rebuild for index %s: another rebuild is already in progress, will retry in %d ms",
+            indexName, timeoutMs);
+        armInactivityRebuild(timeoutMs);
+      }
+    }
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -9643,8 +9643,13 @@ public class LSMVectorIndex implements Index, IndexInternal {
    */
   @Override
   public void resumeBackgroundMaintenance() {
-    final int remaining = backgroundMaintenanceSuspensions.updateAndGet(current -> current > 0 ? current - 1 : 0);
-    if (remaining > 0)
+    final int before = backgroundMaintenanceSuspensions.getAndUpdate(current -> current > 0 ? current - 1 : 0);
+
+    // Only the call that lifts the LAST suspension arms anything. The two other cases return without touching the
+    // timer, and the first of them is why this reads the count BEFORE the decrement rather than after (PR #7360
+    // review): an unpaired resume must be a true no-op, and arming here would reset lastMutationNanos and so push
+    // the inactivity deadline out by a whole window - a side effect the javadoc promises this does not have.
+    if (before != 1)
       return;
 
     // The window starts now: what the load left behind is exactly what a rebuild should cover, and the timer is

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -5032,6 +5032,25 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * @return the capacity, never negative
    */
   private int computeDeltaPayloadCapacity() {
+    return computeDeltaPayloadCapacity(VectorHeapBudget.maxHeapBytes(), VectorHeapBudget.availableHeapBytes());
+  }
+
+  /**
+   * Same decision as {@link #computeDeltaPayloadCapacity()}, with the heap figures supplied so a test can pin the
+   * auto-sizing branch instead of relying on whatever the live JVM happens to have free (PR #7360 review).
+   * <p>
+   * The auto-sized branch is what an installation that never touches either new setting gets, so it is the one
+   * that most needs pinning - and it is the only one of the three whose answer a test cannot otherwise predict.
+   * Package-private and mirroring
+   * {@link VectorHeapBudget#buildCacheBudgetBytes(int, long, long)}'s existing seam rather than inventing a new
+   * shape for it.
+   *
+   * @param maxHeap       the heap ceiling to size against
+   * @param availableHeap the heap currently free, which caps the answer
+   *
+   * @return the capacity, never negative
+   */
+  int computeDeltaPayloadCapacity(final long maxHeap, final long availableHeap) {
     final ContextConfiguration configuration = mutable.getDatabase().getConfiguration();
 
     final int configured = configuration.getValueAsInteger(GlobalConfiguration.VECTOR_INDEX_DELTA_CACHE_SIZE);
@@ -5044,7 +5063,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
     if (heapPercent <= 0)
       return 0;
 
-    final long heapBudget = VectorHeapBudget.buildCacheBudgetBytes(heapPercent);
+    final long heapBudget = VectorHeapBudget.buildCacheBudgetBytes(heapPercent, maxHeap, availableHeap);
     final long affordable = heapBudget / VectorHeapBudget.bytesPerCachedVector(metadata.dimensions);
     return (int) Math.max(0L, Math.min(affordable, Integer.MAX_VALUE / 2));
   }

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -4937,33 +4937,25 @@ public class LSMVectorIndex implements Index, IndexInternal {
   }
 
   /**
-   * Wraps a vector about to be queued into the delta buffer, returning it when the buffer can afford to keep it on
-   * the heap and {@code null} when it cannot (issue #7357).
-   * <p>
+   * Appends one entry to the delta buffer, dropping its payload when the buffer's heap budget cannot afford to
+   * keep it (issue #7357), and charging the accounting for what it actually kept.
    * <b>The caller must hold {@link #lock}'s write lock</b>, which is what makes the read-then-increment below
    * safe: every path that queues an entry already holds it, and every path that drains the buffer takes it too.
    * <p>
-   * Declining is always safe and never loses a vector: {@code persistVectorWithLocation()} has already written it,
-   * so {@link #deltaVectorOf} can read it back. The cost of declining is a page read per scored entry per query,
-   * which is why the budget is heap-relative rather than a flat count - an index whose whole buffer fits keeps
-   * behaving exactly as it did before this existed.
-   *
-   * @param vector the vector to queue, never {@code null}
-   *
-   * @return {@code vector} to keep it resident, or {@code null} to queue an id-only entry
-   */
-  private VectorFloat<?> retainDeltaPayload(final VectorFloat<?> vector) {
-    assert lock.isWriteLockedByCurrentThread() : "retainDeltaPayload() without the write lock";
-    return deltaResidentPayloads.get() >= deltaPayloadCapacity() ? null : vector;
-  }
-
-  /**
-   * Appends one entry to the delta buffer and charges the heap accounting for it.
-   * <b>The caller must hold {@link #lock}'s write lock.</b>
+   * The single door in, and the single place the budget is applied. It was briefly two - a {@code
+   * retainDeltaPayload()} consulted by {@code put()}/{@code putBatch()} before constructing the entry, plus this
+   * counting the result - and the split had a hole in it (PR #7360 review): {@link #readDeltaEntriesFor} builds
+   * entries with full payloads for the two paths that RE-QUEUE vectors rather than write them, the stale prefix's
+   * gap ({@link #reuseStalePrefixGraph}) and the unreachable-ordinal re-queue, and neither went past the gate. The
+   * gap is "everything written since the persisted graph was built", which on a session reopened after an
+   * interrupted load is the whole load - so the one arrival that most needed the bound was the one exempt from it.
+   * A budget enforced at the door cannot be walked around by a producer added later.
    * <p>
-   * The single door in, so that {@link #deltaResidentPayloads} cannot drift from what the buffer actually holds:
-   * the accounting is what decides whether the next write keeps its payload, and a path that appended around it
-   * would leave that decision reading a number nobody maintains.
+   * Declining is always safe and never loses a vector: every entry reaching here has its vector on disk already -
+   * {@code put()} persists before it queues, and a re-queued entry was read off the pages to begin with - so
+   * {@link #deltaVectorOf} can read it again. The cost of declining is a page read per scored entry per query,
+   * which is why the budget is heap-relative rather than a flat count: an index whose whole buffer fits keeps
+   * behaving exactly as it did before this existed.
    *
    * @param entry the entry to append
    */
@@ -4978,8 +4970,16 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // production JVM without -ea would not, which is the accepted trade - the alternative is a lock-state read on
     // the hot path of every insert, to guard against a mistake that only a code change can introduce.
     assert lock.isWriteLockedByCurrentThread() : "queueDeltaEntry() without the write lock";
-    deltaVectors.add(entry);
-    if (entry.vector != null)
+
+    DeltaVectorEntry queued = entry;
+    if (entry.vector != null && deltaResidentPayloads.get() >= deltaPayloadCapacity())
+      // Re-wrapped rather than mutated, so the entry stays immutable and safe to publish to the lock-free readers
+      // of the buffer. Allocated only on the over-budget path, where it replaces a `dimensions * 4` byte retention
+      // with a 32-byte object - the trade is decisively in its favour exactly when it is made.
+      queued = new DeltaVectorEntry(entry.vectorId, entry.rid, null);
+
+    deltaVectors.add(queued);
+    if (queued.vector != null)
       deltaResidentPayloads.incrementAndGet();
   }
 
@@ -7263,7 +7263,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
           // Skipping expensive O(log n) HNSW graph inserts during commit replay (issue #3864):
           // the inactivity rebuild timer will incorporate delta vectors into the graph.
           // The already-converted VectorFloat is reused so the search path never re-converts (issue #5391).
-          queueDeltaEntry(new DeltaVectorEntry(id, rid, retainDeltaPayload(vf)));
+          queueDeltaEntry(new DeltaVectorEntry(id, rid, vf));
 
           if (graphState == GraphState.IMMUTABLE || graphState == GraphState.LOADING)
             this.graphState = GraphState.MUTABLE;
@@ -7385,7 +7385,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
         // Add to delta buffer for search visibility via mergeWithDeltaScan, reusing the already-converted
         // VectorFloat so the search path never re-converts the whole buffer per query (issue #5391).
-        queueDeltaEntry(new DeltaVectorEntry(id, rid, retainDeltaPayload(vf)));
+        queueDeltaEntry(new DeltaVectorEntry(id, rid, vf));
 
         mutationsSinceSerialize.incrementAndGet();
       }

--- a/engine/src/test/java/com/arcadedb/index/vector/GrowableVectorValuesBoundedCacheTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/GrowableVectorValuesBoundedCacheTest.java
@@ -59,7 +59,7 @@ class GrowableVectorValuesBoundedCacheTest {
     final int cap = 100;
     final int n = 1_000;
     // Bounded cache, no disk fallback wired: this exercises the cap mechanics in isolation.
-    final GrowableVectorValues values = new GrowableVectorValues(DIMENSIONS, 16, null, null, null, null, cap);
+    final GrowableVectorValues values = new GrowableVectorValues(DIMENSIONS, 16, null, cap);
 
     final Random rng = new Random(2);
     for (int i = 0; i < n; i++)
@@ -77,7 +77,7 @@ class GrowableVectorValuesBoundedCacheTest {
   @Test
   void nonPositiveCapMeansUnbounded() {
     // maxCacheSize <= 0 is the backward-compatible "unlimited" escape hatch.
-    final GrowableVectorValues values = new GrowableVectorValues(DIMENSIONS, 16, null, null, null, null, -1);
+    final GrowableVectorValues values = new GrowableVectorValues(DIMENSIONS, 16, null, -1);
     final int n = 2_000;
     final Random rng = new Random(3);
     for (int i = 0; i < n; i++)
@@ -91,7 +91,7 @@ class GrowableVectorValuesBoundedCacheTest {
   void addVectorToleratesNullWithoutCaching() {
     // ensureLiveBuilder touches the max ordinal with a possibly-null vector to fix size(); it must
     // advance the count without inserting a null into the map (ConcurrentHashMap forbids nulls).
-    final GrowableVectorValues values = new GrowableVectorValues(DIMENSIONS, 16, null, null, null, null, 100);
+    final GrowableVectorValues values = new GrowableVectorValues(DIMENSIONS, 16, null, 100);
     values.addVector(42, null);
     assertThat(values.size()).isEqualTo(43);
     assertThat(values.vectorCount()).isEqualTo(0);

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue7357BulkLoadSuspendsRebuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue7357BulkLoadSuspendsRebuildTest.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.GraphBatch;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.StallAwareStopwatch;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7357: an inactivity graph rebuild fired in the middle of a bulk load.
+ * <p>
+ * The trigger is the index going quiet for {@code inactivityRebuildTimeoutMs}, which is meant to read as "the
+ * writer is done". During a bulk load it does not: a loader stalls for an LSM index compaction, a page-flush burst
+ * or a long GC, and any of those outlast the window. The rebuild that starts then covers the corpus loaded SO FAR,
+ * takes minutes on a large one, and is superseded by the rest of the load - so the next stall starts another over a
+ * larger set. The reporter's 4.2M-record load paid {@code build(1M) + build(1.6M) + build(2.6M) + build(4.2M)} and
+ * had not finished after six and a half hours; the same load with the vector index removed took twenty-six minutes.
+ * <p>
+ * {@link GraphBatch} already tells the engine it is a bulk load - it relaxes WAL and async durability for its
+ * duration and puts them back on close. Speculative index maintenance belongs in exactly that scope, so this pins
+ * that it is suspended while the batch is open and that the one rebuild the load is worth happens when it closes.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+// Waits out several inactivity windows and then a graph build, so most of its time goes on work
+// LSMVectorIndex.REBUILD_SEMAPHORE serializes JVM-wide - see CLAUDE.md's @Tag("vector") note.
+@Tag("vector")
+class Issue7357BulkLoadSuspendsRebuildTest {
+  private static final String DB_ROOT    = "target/test-databases/Issue7357BulkLoadSuspendsRebuildTest";
+  private static final int    DIMENSIONS = 16;
+  private static final int    RECORDS    = 200;
+  private static final int    TIMEOUT_MS = 300;
+
+  private static final Duration REBUILD_SETTLE_TIMEOUT =
+      Duration.ofMillis(GlobalConfiguration.VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS.getValueAsLong() + 60_000L);
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  /**
+   * The load stalls for several inactivity windows in the middle of the batch, which is what a compaction or a GC
+   * pause looks like from inside the index. Nothing may rebuild until the batch closes.
+   */
+  @Test
+  void aStallInsideABulkLoadMustNotTriggerARebuild() {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        createSchema(db);
+        final LSMVectorIndex index = vectorIndex(db);
+
+        try (final GraphBatch batch = GraphBatch.builder(db).build()) {
+          insert(db, 0, RECORDS);
+
+          assertThat(index.getStats().get("mutationsSinceRebuild"))
+              .as("precondition: the load left work a rebuild would pick up")
+              .isEqualTo((long) RECORDS);
+
+          idleFor(TIMEOUT_MS * 6L);
+
+          assertThat(index.getStats().get("graphRebuildCount"))
+              .as("a stall inside a bulk load is not the end of the load, and must not start a graph rebuild "
+                  + "over the part of the corpus loaded so far (issue #7357)")
+              .isZero();
+          assertThat(index.getStats().get("asyncRebuildInProgress"))
+              .as("neither arm of the timer may have been taken")
+              .isZero();
+          assertThat(index.getStats().get("mutationsSinceRebuild"))
+              .as("and the writes are still pending, served by the delta scan as they are between any two rebuilds")
+              .isEqualTo((long) RECORDS);
+
+          // Note the batch is still open here: close() is what lifts the suspension, and the await below is the
+          // positive control that says the timer was alive all along and simply declined.
+          batch.close();
+        }
+
+        Awaitility.await("closing the batch releases the one rebuild the load is worth")
+            .atMost(REBUILD_SETTLE_TIMEOUT)
+            .pollInterval(Duration.ofMillis(50))
+            .untilAsserted(() -> assertThat(index.getStats().get("graphRebuildCount")).isPositive());
+
+        Awaitility.await("the rebuild settles before the drop")
+            .atMost(REBUILD_SETTLE_TIMEOUT)
+            .pollInterval(Duration.ofMillis(50))
+            .untilAsserted(() -> assertThat(index.getStats().get("asyncRebuildInProgress")).isZero());
+
+        assertThat(index.getStats().get("graphNodeCount"))
+            .as("and it covers every vector the load wrote, in one build rather than one per stall")
+            .isEqualTo((long) RECORDS);
+        assertThat(index.getStats().get("graphRebuildCount"))
+            .as("exactly one build, not one per stall")
+            .isEqualTo(1L);
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  /**
+   * The control. The identical write-then-stall sequence with no batch open must rebuild during the stall, or the
+   * test above would hold on a build where the inactivity timer never fired at all.
+   */
+  @Test
+  void theSameStallOutsideABulkLoadStillRebuilds() {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        createSchema(db);
+        final LSMVectorIndex index = vectorIndex(db);
+
+        insert(db, 0, RECORDS);
+
+        Awaitility.await("with no bulk load open the inactivity timer rebuilds as it always did")
+            .atMost(REBUILD_SETTLE_TIMEOUT)
+            .pollInterval(Duration.ofMillis(50))
+            .untilAsserted(() -> assertThat(index.getStats().get("graphRebuildCount")).isPositive());
+
+        Awaitility.await("the rebuild settles before the drop")
+            .atMost(REBUILD_SETTLE_TIMEOUT)
+            .pollInterval(Duration.ofMillis(50))
+            .untilAsserted(() -> assertThat(index.getStats().get("asyncRebuildInProgress")).isZero());
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  /**
+   * Suspensions are reference-counted, so a second one taken while the first is open keeps the index suspended
+   * until BOTH lift. A batch that resumed on the first close would hand another loader's suspension away.
+   */
+  @Test
+  void overlappingSuspensionsCompose() {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        createSchema(db);
+        final LSMVectorIndex index = vectorIndex(db);
+
+        index.suspendBackgroundMaintenance();
+        index.suspendBackgroundMaintenance();
+
+        insert(db, 0, RECORDS);
+        idleFor(TIMEOUT_MS * 6L);
+        assertThat(index.getStats().get("graphRebuildCount"))
+            .as("two suspensions are open")
+            .isZero();
+
+        index.resumeBackgroundMaintenance();
+        idleFor(TIMEOUT_MS * 6L);
+        assertThat(index.getStats().get("graphRebuildCount"))
+            .as("one is still open")
+            .isZero();
+
+        index.resumeBackgroundMaintenance();
+        Awaitility.await("the last one lifts and the rebuild runs")
+            .atMost(REBUILD_SETTLE_TIMEOUT)
+            .pollInterval(Duration.ofMillis(50))
+            .untilAsserted(() -> assertThat(index.getStats().get("graphRebuildCount")).isPositive());
+
+        Awaitility.await("the rebuild settles before the drop")
+            .atMost(REBUILD_SETTLE_TIMEOUT)
+            .pollInterval(Duration.ofMillis(50))
+            .untilAsserted(() -> assertThat(index.getStats().get("asyncRebuildInProgress")).isZero());
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  /**
+   * Idles for {@code effectiveMs} of RUNNING time.
+   * <p>
+   * Measured with {@link StallAwareStopwatch} rather than slept through, because the assertions that follow are
+   * negative ones: a plain sleep returns on wall clock, and a stop-the-world pause covering most of it would leave
+   * the timer no CPU to fire on, so "nothing rebuilt" would hold because nothing ran rather than because the
+   * suspension declined.
+   */
+  private static void idleFor(final long effectiveMs) {
+    final StallAwareStopwatch idle = StallAwareStopwatch.start();
+    while (idle.effectiveMs() < effectiveMs) {
+      try {
+        Thread.sleep(25);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return;
+      }
+    }
+  }
+
+  private static void createSchema(final Database db) {
+    db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS, TIMEOUT_MS);
+    // The mutation threshold must stay out of reach so the inactivity timer is the only trigger under test.
+    db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD, 10);
+    db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_REBUILD_GRAPH_RATIO, 0f);
+
+    db.transaction(() -> {
+      final var type = db.getSchema().createVertexType("Doc");
+      type.createProperty("id", Type.INTEGER);
+      type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+      db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+          + ", \"similarity\": \"EUCLIDEAN\" }");
+    });
+  }
+
+  private static void insert(final Database db, final int fromInclusive, final int toExclusive) {
+    db.begin();
+    for (int i = fromInclusive; i < toExclusive; i++)
+      db.newVertex("Doc").set("id", i).set("vector", embedding(i)).save();
+    db.commit();
+  }
+
+  /** Deterministic per-id embedding, so a fixture is reproducible run to run. */
+  private static float[] embedding(final int id) {
+    final Random random = new Random(0x7357L * 17 + id);
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = random.nextFloat();
+    return vector;
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue7357BulkLoadSuspendsRebuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue7357BulkLoadSuspendsRebuildTest.java
@@ -212,6 +212,65 @@ class Issue7357BulkLoadSuspendsRebuildTest {
   }
 
   /**
+   * The race the whole fix turns on, driven directly: the inactivity timer fires WHILE the last suspension is
+   * being lifted.
+   * <p>
+   * {@code runInactivityRebuild()} reads the suspension count and {@code resumeBackgroundMaintenance()} decrements
+   * it to zero, on two different threads, with no ordering between them. Both outcomes must be correct: the timer
+   * reading a non-zero count re-arms and the resume arms too (only one task is actually scheduled, because
+   * {@code armInactivityRebuild()} declines while one is armed), and the timer reading zero proceeds to rebuild
+   * while the resume finds nothing left to arm. What must never happen is the pair settling into "neither armed
+   * anything", which would leave the load's writes in the delta buffer with no rebuild ever coming.
+   * <p>
+   * Driven by hammering the boundary rather than by pinning one interleaving: with a {@value #TIMEOUT_MS} ms
+   * window and a resume landing at an arbitrary point inside it, repeating the open/write/close cycle lands on
+   * both sides of the read over the run. Each iteration asserts the invariant that matters - the index does not
+   * end up quiet with work pending - which is the property, not one particular schedule.
+   */
+  @Test
+  void closingABatchWhileTheTimerFiresStillLeavesARebuildComing() {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        createSchema(db);
+        final LSMVectorIndex index = vectorIndex(db);
+
+        for (int round = 0; round < 8; round++) {
+          final int from = round * 20;
+          try (final GraphBatch batch = GraphBatch.builder(db).build()) {
+            insert(db, from, from + 20);
+            // Land the close somewhere inside the inactivity window, so across the rounds the resume falls both
+            // before and after the timer thread reads the suspension count.
+            idleFor(TIMEOUT_MS - 50L + round * 15L);
+            batch.close();
+          }
+
+          final int written = from + 20;
+          Awaitility.await("round " + round + ": the write that outlived the batch still reaches the graph")
+              .atMost(REBUILD_SETTLE_TIMEOUT)
+              .pollInterval(Duration.ofMillis(25))
+              .untilAsserted(() -> assertThat(index.getStats().get("mutationsSinceRebuild")).isZero());
+
+          Awaitility.await("round " + round + ": the rebuild settles before the next round")
+              .atMost(REBUILD_SETTLE_TIMEOUT)
+              .pollInterval(Duration.ofMillis(25))
+              .untilAsserted(() -> assertThat(index.getStats().get("asyncRebuildInProgress")).isZero());
+
+          assertThat(index.getStats().get("graphNodeCount"))
+              .as("round %d: and it covers every vector written so far", round)
+              .isEqualTo((long) written);
+        }
+
+        assertThat(index.getStats().get("deltaVectorsCount"))
+            .as("nothing is left stranded in the buffer after eight rounds of racing the boundary")
+            .isZero();
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  /**
    * Idles for {@code effectiveMs} of RUNNING time.
    * <p>
    * Measured with {@link StallAwareStopwatch} rather than slept through, because the assertions that follow are

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue7357BulkLoadSuspendsRebuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue7357BulkLoadSuspendsRebuildTest.java
@@ -21,7 +21,10 @@ package com.arcadedb.index.vector;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
+import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.graph.GraphBatch;
+import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.utility.FileUtils;
 import com.arcadedb.utility.StallAwareStopwatch;
@@ -38,6 +41,7 @@ import java.time.Duration;
 import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Regression test for issue #7357: an inactivity graph rebuild fired in the middle of a bulk load.
@@ -271,6 +275,91 @@ class Issue7357BulkLoadSuspendsRebuildTest {
   }
 
   /**
+   * The invariant a stranded suspension would break, asserted on every way out of a batch (PR #7360 review).
+   * <p>
+   * This is the one failure in the whole mechanism that is completely silent: an index whose suspension is never
+   * lifted simply stops rebuilding - no exception, no log line, no gauge moving - until the database is reopened.
+   * Pinned on all three exits a caller can actually reach: a clean close, a close whose {@code flush()} throws (a
+   * duplicate on a unique edge index, the issue #4113 shape), and an {@link GraphBatch#abandon()} followed by a
+   * {@code close()} that must not double-lift.
+   * <p>
+   * The fourth exit - an {@code Error} out of {@code flush()}, which used to escape the {@code catch
+   * (RuntimeException)} and skip the restore entirely - is closed by construction rather than by this test:
+   * {@code flush()} now sits inside the try whose {@code finally} restores. Injecting an {@code Error} there would
+   * mean a production test hook for a path a code shape already forecloses, which is a worse trade than saying so
+   * here.
+   */
+  @Test
+  void everyWayOutOfABatchLiftsTheSuspension() {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        createSchema(db);
+        final LSMVectorIndex index = vectorIndex(db);
+
+        assertThat(index.getStats().get("backgroundMaintenanceSuspensions"))
+            .as("precondition: nothing is suspended before the first batch")
+            .isZero();
+
+        // 1. The ordinary exit.
+        try (final GraphBatch batch = GraphBatch.builder(db).build()) {
+          insert(db, 0, 10);
+          assertThat(index.getStats().get("backgroundMaintenanceSuspensions"))
+              .as("an open batch holds exactly one suspension")
+              .isEqualTo(1L);
+          batch.close();
+        }
+        assertThat(index.getStats().get("backgroundMaintenanceSuspensions"))
+            .as("a clean close lifts it").isZero();
+
+        // 2. The exit that throws. flush() fails on the duplicate, and the restore has to run anyway.
+        final RID[] rids = new RID[2];
+        db.transaction(() -> {
+          rids[0] = db.newVertex("Doc").set("id", 900).set("vector", embedding(900)).save().getIdentity();
+          rids[1] = db.newVertex("Doc").set("id", 901).set("vector", embedding(901)).save().getIdentity();
+        });
+
+        assertThatThrownBy(() -> {
+          try (final GraphBatch batch = GraphBatch.builder(db).withLightEdges(false).build()) {
+            batch.newEdge(rids[0], "Link", rids[1], "from_id", "a", "to_id", "b");
+            batch.newEdge(rids[0], "Link", rids[1], "from_id", "a", "to_id", "b");
+          }
+        }).isInstanceOf(DuplicatedKeyException.class);
+
+        assertThat(index.getStats().get("backgroundMaintenanceSuspensions"))
+            .as("a batch that fails on the way out still lifts it - otherwise this index stops rebuilding "
+                + "silently until the database is reopened")
+            .isZero();
+
+        // 3. abandon() lifts it, and the close() that follows must not lift it a second time and hand away a
+        // suspension this batch no longer holds.
+        final GraphBatch abandoned = GraphBatch.builder(db).build();
+        assertThat(index.getStats().get("backgroundMaintenanceSuspensions")).isEqualTo(1L);
+        abandoned.abandon();
+        assertThat(index.getStats().get("backgroundMaintenanceSuspensions"))
+            .as("abandon() lifts it").isZero();
+        abandoned.close();
+        assertThat(index.getStats().get("backgroundMaintenanceSuspensions"))
+            .as("and the close() after it is idempotent, not a second decrement")
+            .isZero();
+
+        // A suspension count of zero is only meaningful if the index still rebuilds, so end on that.
+        Awaitility.await("the index is genuinely unsuspended, not merely reading zero")
+            .atMost(REBUILD_SETTLE_TIMEOUT)
+            .pollInterval(Duration.ofMillis(50))
+            .untilAsserted(() -> assertThat(index.getStats().get("graphRebuildCount")).isPositive());
+
+        Awaitility.await("the rebuild settles before the drop")
+            .atMost(REBUILD_SETTLE_TIMEOUT)
+            .pollInterval(Duration.ofMillis(50))
+            .untilAsserted(() -> assertThat(index.getStats().get("asyncRebuildInProgress")).isZero());
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  /**
    * Idles for {@code effectiveMs} of RUNNING time.
    * <p>
    * Measured with {@link StallAwareStopwatch} rather than slept through, because the assertions that follow are
@@ -302,6 +391,13 @@ class Issue7357BulkLoadSuspendsRebuildTest {
       type.createProperty("vector", Type.ARRAY_OF_FLOATS);
       db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
           + ", \"similarity\": \"EUCLIDEAN\" }");
+
+      // An edge type carrying a unique index, so a batch can be made to fail on its way out (issue #4113 shape).
+      final var edge = db.getSchema().createEdgeType("Link");
+      edge.createProperty("from_id", Type.STRING);
+      edge.createProperty("to_id", Type.STRING);
+      db.getSchema().buildTypeIndex("Link", new String[] { "from_id", "to_id" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).create();
     });
   }
 

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue7357DeltaBufferHeapBoundTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue7357DeltaBufferHeapBoundTest.java
@@ -283,6 +283,68 @@ class Issue7357DeltaBufferHeapBoundTest {
     }
   }
 
+  /**
+   * The auto-sized branch, which is what every installation that never touches either new setting gets, and the
+   * only one of the three whose answer a test cannot otherwise predict (PR #7360 review).
+   * <p>
+   * The heap figures are pinned rather than read off the live JVM - the same seam
+   * {@code VectorHeapBudget.buildCacheBudgetBytes(percent, maxHeap, availableHeap)} already provides for the
+   * graph-build cache - because a budget derived from whatever a CI runner happens to have free is not an
+   * assertion about anything. Three readings, one per arm of the arithmetic:
+   * <ul>
+   *   <li>a roomy heap, where the ceiling percentage is what binds;</li>
+   *   <li>a heap an online rebuild has nearly filled, where the 90%-of-available cap binds instead and the buffer
+   *       is told to stop growing - which is exactly when it must be (issue #6503's lesson applied here);</li>
+   *   <li>the reporter's own shape, where the answer has to be far below the corpus or the bound does nothing.</li>
+   * </ul>
+   */
+  @Test
+  void theAutoSizedBudgetIsAShareOfTheCeilingCappedByWhatIsFree() {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        createSchema(db, 0); // 0 = auto-size, the default
+        final LSMVectorIndex index = vectorIndex(db);
+
+        final long bytesPerVector = VectorHeapBudget.bytesPerCachedVector(DIMENSIONS);
+        assertThat(bytesPerVector)
+            .as("precondition: the per-entry cost the budget divides by")
+            .isEqualTo((long) DIMENSIONS * Float.BYTES + 64);
+
+        final long maxHeap = 16L * 1024 * 1024 * 1024;
+
+        // 1. Roomy heap: 10% of the 16 GB ceiling, since 90% of 12 GB free is far more than that.
+        final long roomy = index.computeDeltaPayloadCapacity(maxHeap, 12L * 1024 * 1024 * 1024);
+        assertThat(roomy)
+            .as("the ceiling share binds while there is headroom")
+            .isEqualTo((int) (maxHeap / 100 * 10 / bytesPerVector));
+
+        // 2. A rebuild holding the old graph has left 512 MB. The available cap has to bind now, or the buffer
+        // would keep growing into heap the rebuild is about to need.
+        final long tight = index.computeDeltaPayloadCapacity(maxHeap, 512L * 1024 * 1024);
+        assertThat(tight)
+            .as("90%% of what is actually free binds when the heap is tight, not the ceiling share")
+            .isEqualTo((int) (512L * 1024 * 1024 / 100 * 90 / bytesPerVector));
+        assertThat(tight)
+            .as("and it is a real reduction, not a formality")
+            .isLessThan(roomy);
+
+        // 3. The reporter's shape. At 768 dimensions the whole 4.2M-record buffer is 12.9 GB, so an auto-sized
+        // budget on a 16 GB heap has to come out far below that or the bound accomplishes nothing.
+        final long reporterBytesPerVector = VectorHeapBudget.bytesPerCachedVector(768);
+        final long reporterCapacity = maxHeap / 100 * 10 / reporterBytesPerVector;
+        assertThat(reporterCapacity * reporterBytesPerVector)
+            .as("the default budget on the reported heap is a fraction of the 12.9 GB the buffer used to hold")
+            .isLessThan(2L * 1024 * 1024 * 1024);
+        assertThat(reporterCapacity)
+            .as("and it still keeps a useful number of payloads resident")
+            .isGreaterThan(100_000L);
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
   private static void createSchema(final Database db, final int deltaCacheSize) {
     db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_DELTA_CACHE_SIZE, deltaCacheSize);
     // No rebuild may drain the buffer while the assertions look at it: the inactivity timer is off and the

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue7357DeltaBufferHeapBoundTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue7357DeltaBufferHeapBoundTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.Pair;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7357: the delta buffer held a full copy of every vector written since the last graph
+ * rebuild, on the heap, with nothing bounding it.
+ * <p>
+ * Every write appends an entry to that buffer so the vector is searchable before it reaches the HNSW graph, and the
+ * entry carried the whole vector. Only a rebuild drains the buffer, and a rebuild is triggered by the index going
+ * quiet - so an ingest that never goes quiet grows a second complete copy of the corpus in RAM. At the reporter's
+ * scale, 4.2M records of 768-dimension embeddings, that copy is 12.9 GB and it was two thirds of what killed a
+ * {@code -Xmx16g} load. It is the same second copy issue #3144 removed from {@link GrowableVectorValues}, on the
+ * one path that still had it.
+ * <p>
+ * The vector is persisted before the entry is queued, so the payload in the entry is a cache and nothing more. Past
+ * the budget the entry keeps only its id and RID, and the delta scan reads the vector back from the pages.
+ * <p>
+ * Three things are pinned:
+ * <ul>
+ *   <li>the number of payloads held on the heap stops at the budget while the buffer itself keeps growing;</li>
+ *   <li>searches still find the buffered rows, and rank them the same way, once the payloads are gone - which is
+ *       the whole correctness question, because a bound that quietly dropped rows from results would satisfy the
+ *       first assertion perfectly;</li>
+ *   <li>{@code deltaCacheSize = -1} still keeps every payload, so the bound is opt-out rather than imposed.</li>
+ * </ul>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7357DeltaBufferHeapBoundTest {
+  private static final String DB_ROOT    = "target/test-databases/Issue7357DeltaBufferHeapBoundTest";
+  private static final int    DIMENSIONS = 16;
+  /** Kept under {@code ASYNC_REBUILD_MIN_GRAPH_SIZE} so no rebuild drains the buffer behind the assertions. */
+  private static final int    RECORDS    = 400;
+  private static final int    BUDGET     = 50;
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @Test
+  void theBufferStopsHoldingPayloadsAtTheBudgetAndStillAnswersSearches() {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        createSchema(db, BUDGET);
+        insert(db, 0, RECORDS);
+
+        final LSMVectorIndex index = vectorIndex(db);
+
+        assertThat(index.getStats().get("deltaVectorsCount"))
+            .as("precondition: nothing has drained the buffer, so it holds every written vector")
+            .isEqualTo((long) RECORDS);
+        assertThat(index.getStats().get("deltaResidentVectorsCapacity"))
+            .as("precondition: the explicit budget is the one in force")
+            .isEqualTo((long) BUDGET);
+
+        assertThat(index.getStats().get("deltaResidentVectors"))
+            .as("the buffer's heap footprint stops at the budget even though it keeps accepting entries "
+                + "(issue #7357)")
+            .isEqualTo((long) BUDGET);
+
+        // The assertion the bound is actually for. Every one of these rows is served ONLY by the delta scan -
+        // there is no graph yet - and all but the first BUDGET of them now carry no vector at all, so a scan that
+        // could not read them back would return the wrong rows rather than fail.
+        for (final int probe : new int[] { 3, BUDGET, BUDGET + 1, RECORDS / 2, RECORDS - 1 }) {
+          final List<Pair<RID, Float>> hits = search(db, embedding(probe), 1);
+          assertThat(hits)
+              .as("a search for the exact vector of record %d must find it", probe)
+              .isNotEmpty();
+          assertThat(idOf(db, hits.getFirst().getFirst()))
+              .as("record %d is the nearest neighbour of its own vector, payload on the heap or not", probe)
+              .isEqualTo(probe);
+        }
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  /**
+   * The opt-out. {@code deltaCacheSize = -1} is the behaviour before this fix, kept reachable for an index whose
+   * ingest is bounded by something else and that would rather not pay a page read per scored entry.
+   */
+  @Test
+  void aNegativeBudgetKeepsEveryPayloadOnTheHeap() {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        createSchema(db, -1);
+        insert(db, 0, RECORDS);
+
+        final LSMVectorIndex index = vectorIndex(db);
+        assertThat(index.getStats().get("deltaVectorsCount")).isEqualTo((long) RECORDS);
+        assertThat(index.getStats().get("deltaResidentVectors"))
+            .as("an explicitly negative budget declines nothing")
+            .isEqualTo((long) RECORDS);
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  /**
+   * Deleting the records the buffer holds must give their heap budget back, or an index that churns would decline
+   * payloads for room it has.
+   */
+  @Test
+  void deletingBufferedRecordsGivesTheirBudgetBack() {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        createSchema(db, BUDGET);
+        insert(db, 0, RECORDS);
+
+        final LSMVectorIndex index = vectorIndex(db);
+        assertThat(index.getStats().get("deltaResidentVectors")).isEqualTo((long) BUDGET);
+
+        // Every row, not a prefix of them: which entries ended up holding a payload follows the order the
+        // transaction applies its index writes in, which is not the order the documents were created in.
+        db.transaction(() -> db.command("sql", "DELETE FROM Doc"));
+
+        assertThat(index.getStats().get("deltaVectorsCount"))
+            .as("precondition: the deletions really did empty the buffer")
+            .isZero();
+        assertThat(index.getStats().get("deltaResidentVectors"))
+            .as("the payloads of the deleted rows are no longer charged to the buffer")
+            .isZero();
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  private static void createSchema(final Database db, final int deltaCacheSize) {
+    db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_DELTA_CACHE_SIZE, deltaCacheSize);
+    // No rebuild may drain the buffer while the assertions look at it: the inactivity timer is off and the
+    // mutation threshold is out of reach.
+    db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS, 0);
+    db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD, Integer.MAX_VALUE);
+
+    db.transaction(() -> {
+      final var type = db.getSchema().createDocumentType("Doc");
+      type.createProperty("id", Type.INTEGER);
+      type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+      db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+          + ", \"similarity\": \"EUCLIDEAN\" }");
+    });
+  }
+
+  private static void insert(final Database db, final int fromInclusive, final int toExclusive) {
+    db.begin();
+    for (int i = fromInclusive; i < toExclusive; i++)
+      db.newDocument("Doc").set("id", i).set("vector", embedding(i)).save();
+    db.commit();
+  }
+
+  private static List<Pair<RID, Float>> search(final Database db, final float[] query, final int k) {
+    final List<Pair<RID, Float>> hits = new ArrayList<>();
+    db.transaction(() -> hits.addAll(vectorIndex(db).findNeighborsFromVector(query, k)));
+    return hits;
+  }
+
+  private static int idOf(final Database db, final RID rid) {
+    return db.lookupByRID(rid, true).asDocument().getInteger("id");
+  }
+
+  /** Deterministic per-id embedding, so a fixture is reproducible run to run. */
+  private static float[] embedding(final int id) {
+    final Random random = new Random(0x7357L * 31 + id);
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = random.nextFloat();
+    return vector;
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue7357DeltaBufferHeapBoundTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue7357DeltaBufferHeapBoundTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.index.vector;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
 import com.arcadedb.schema.Type;
 import com.arcadedb.utility.FileUtils;
@@ -28,6 +29,7 @@ import com.arcadedb.utility.Pair;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -69,6 +71,14 @@ class Issue7357DeltaBufferHeapBoundTest {
   /** Kept under {@code ASYNC_REBUILD_MIN_GRAPH_SIZE} so no rebuild drains the buffer behind the assertions. */
   private static final int    RECORDS    = 400;
   private static final int    BUDGET     = 50;
+
+  /**
+   * Fixture for the re-queue path: above {@code ASYNC_REBUILD_MIN_GRAPH_SIZE} so the persisted graph is treated as
+   * a large one and the stale-prefix reuse is reachable at all.
+   */
+  private static final int PERSISTED_VECTORS = 1_200;
+  /** Records written after the persisted graph, i.e. the gap the reuse re-queues. Must exceed {@link #BUDGET}. */
+  private static final int GAP_VECTORS       = 200;
 
   private String dbPath;
 
@@ -177,6 +187,102 @@ class Issue7357DeltaBufferHeapBoundTest {
     }
   }
 
+  /**
+   * The re-queue path, which is where the bound was first walked around (PR #7360 review).
+   * <p>
+   * {@code readDeltaEntriesFor()} builds delta entries carrying full payloads for the vectors a stale persisted
+   * prefix does not cover, and hands them to the buffer. Those entries never write anything - they are read back
+   * off the pages - so they did not pass through the write path's gate, and the budget did not apply to them. The
+   * quantity involved is the worst possible one to exempt: the gap is "everything written since the persisted
+   * graph was built", which for a session reopened after an interrupted load is the entire load. That is precisely
+   * run 1 of the report, the one that OOM'd and left the database fenced for recovery.
+   * <p>
+   * The fix moves the budget to the door every entry goes through, so this pins the outcome rather than the
+   * mechanism: after a reuse re-queues a gap four times the budget, the buffer holds all of it and the heap holds
+   * only what the budget allows.
+   */
+  @Test
+  @Tag("vector")
+  void aReQueuedGapHonoursTheSameBudgetAsAWrite() {
+    buildStalePersistedGraphFixture();
+
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_DELTA_CACHE_SIZE, BUDGET);
+        // The reuse only folds its gap into a rebuild once the gap crosses the ratio-scaled threshold; disabling
+        // the scaling leaves the absolute floor, which is what this fixture is sized against (issue #7183).
+        db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_REBUILD_GRAPH_RATIO, 0f);
+
+        final LSMVectorIndex index = vectorIndex(db);
+        assertThat(index.getStats().get("deltaVectorsCount"))
+            .as("precondition: this session has buffered nothing of its own")
+            .isZero();
+
+        // The rebuild the reuse dispatches would drain the buffer out from under the assertions, so the sole
+        // JVM-wide rebuild permit is held for the observation window. No search path takes a permit, so the query
+        // below still runs.
+        LSMVectorIndex.acquireAllRebuildPermitsForTest();
+        try {
+          // The search is what triggers the reuse, and with it the gap re-queue this test is about.
+          index.findNeighborsFromVector(embedding(0), 5);
+
+          assertThat(index.getStats().get("stalePrefixGraphReuses"))
+              .as("precondition: the reuse must actually have run, or nothing re-queued a gap and this test "
+                  + "asserts nothing")
+              .isEqualTo(1L);
+          assertThat(index.getStats().get("deltaVectorsCount"))
+              .as("precondition: the whole gap is buffered - the bound drops payloads, never entries")
+              .isEqualTo((long) GAP_VECTORS);
+
+          assertThat(index.getStats().get("deltaResidentVectors"))
+              .as("a re-queued gap is charged the same heap budget as a write: %d entries, at most %d payloads",
+                  GAP_VECTORS, BUDGET)
+              .isLessThanOrEqualTo((long) BUDGET);
+        } finally {
+          LSMVectorIndex.releaseAllRebuildPermitsForTest();
+        }
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  /**
+   * Session 1 builds and persists a graph over {@value #PERSISTED_VECTORS} records and closes cleanly; session 2
+   * writes {@value #GAP_VECTORS} more and is killed rather than closed, so the persisted graph and its manifest
+   * still describe only the first batch while the live vector set has moved on. The same fixture shape
+   * {@code Issue6772WriteBeforeSearchPrefixReuseTest} uses, at a size that keeps this test cheap.
+   */
+  private void buildStalePersistedGraphFixture() {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        createSchema(db, -1);
+        insert(db, 0, PERSISTED_VECTORS);
+        vectorIndex(db).buildVectorGraphNow();
+        assertThat(vectorIndex(db).getStats().get("graphState"))
+            .as("precondition: the graph must be built and IMMUTABLE before the close that persists it")
+            .isEqualTo(1L); // GraphState.IMMUTABLE
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        insert(db, PERSISTED_VECTORS, PERSISTED_VECTORS + GAP_VECTORS);
+        ((DatabaseInternal) db).kill();
+        db.close();
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+  }
+
   private static void createSchema(final Database db, final int deltaCacheSize) {
     db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_DELTA_CACHE_SIZE, deltaCacheSize);
     // No rebuild may drain the buffer while the assertions look at it: the inactivity timer is off and the
@@ -185,6 +291,8 @@ class Issue7357DeltaBufferHeapBoundTest {
     db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD, Integer.MAX_VALUE);
 
     db.transaction(() -> {
+      if (db.getSchema().existsType("Doc"))
+        return;
       final var type = db.getSchema().createDocumentType("Doc");
       type.createProperty("id", Type.INTEGER);
       type.createProperty("vector", Type.ARRAY_OF_FLOATS);

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue7357DeltaBufferHeapBoundTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue7357DeltaBufferHeapBoundTest.java
@@ -80,6 +80,10 @@ class Issue7357DeltaBufferHeapBoundTest {
   /** Records written after the persisted graph, i.e. the gap the reuse re-queues. Must exceed {@link #BUDGET}. */
   private static final int GAP_VECTORS       = 200;
 
+  /** Fixture for the orphan re-queue: a graph small enough to build quickly, a budget well under it. */
+  private static final int ORPHAN_RECORDS = 120;
+  private static final int ORPHAN_BUDGET  = 10;
+
   private String dbPath;
 
   @BeforeEach
@@ -284,6 +288,59 @@ class Issue7357DeltaBufferHeapBoundTest {
   }
 
   /**
+   * The orphan re-queue, the third producer of buffered payloads (PR #7360 review).
+   * <p>
+   * A build re-queues the vectors of every node it left unreachable, carrying their payloads, and that append used
+   * to go around the budget. It is the worst of the three to leave uncapped, because a Vamana build orphans a
+   * FRESH set each time and the count does not converge downwards (issue #7190), so a corpus that keeps
+   * re-triggering rebuilds would keep adding full payloads to a buffer nothing else is allowed to grow.
+   * <p>
+   * Driven through {@code requeueIntoDeltaBufferForTest()}, which puts the index into exactly that state, because
+   * whether a build orphans a node is decided between the data and JVector's diversity heuristic and cannot be
+   * demanded from the public API - which is why that hook exists at all. What is asserted is the property the fix
+   * establishes: a re-queue is charged the budget like any other arrival, whoever produced it.
+   */
+  @Test
+  @Tag("vector")
+  void aReQueuedOrphanHonoursTheSameBudgetAsAWrite() {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        createSchema(db, ORPHAN_BUDGET);
+        insert(db, 0, ORPHAN_RECORDS);
+
+        final LSMVectorIndex index = vectorIndex(db);
+        index.buildVectorGraphNow();
+
+        assertThat(index.getStats().get("deltaVectorsCount"))
+            .as("precondition: the build drained the buffer, so what follows is only the re-queue")
+            .isZero();
+        assertThat(index.getStats().get("deltaResidentVectors"))
+            .as("precondition: and gave every payload back")
+            .isZero();
+
+        int requeued = 0;
+        for (int id = 0; id < ORPHAN_RECORDS && requeued < ORPHAN_BUDGET * 3; id++) {
+          if (index.requeueIntoDeltaBufferForTest(ridOf(db, id)) >= 0)
+            requeued++;
+        }
+
+        assertThat(requeued)
+            .as("precondition: enough orphans re-queued to exceed the budget of %d", ORPHAN_BUDGET)
+            .isGreaterThan(ORPHAN_BUDGET);
+        assertThat(index.getStats().get("deltaVectorsCount"))
+            .as("every re-queued orphan is buffered - the bound drops payloads, never entries")
+            .isEqualTo((long) requeued);
+        assertThat(index.getStats().get("deltaResidentVectors"))
+            .as("but the heap holds at most the budget, the same as for a write (issue #7357)")
+            .isLessThanOrEqualTo((long) ORPHAN_BUDGET);
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  /**
    * The auto-sized branch, which is what every installation that never touches either new setting gets, and the
    * only one of the three whose answer a test cannot otherwise predict (PR #7360 review).
    * <p>
@@ -374,6 +431,16 @@ class Issue7357DeltaBufferHeapBoundTest {
     final List<Pair<RID, Float>> hits = new ArrayList<>();
     db.transaction(() -> hits.addAll(vectorIndex(db).findNeighborsFromVector(query, k)));
     return hits;
+  }
+
+  private static RID ridOf(final Database db, final int id) {
+    final RID[] rid = new RID[1];
+    db.transaction(() -> {
+      try (final var rs = db.query("sql", "SELECT @rid FROM Doc WHERE id = ?", id)) {
+        rid[0] = rs.hasNext() ? rs.next().getProperty("@rid") : null;
+      }
+    });
+    return rid[0];
   }
 
   private static int idOf(final Database db, final RID rid) {


### PR DESCRIPTION
Fixes #7357, reported in discussion #7333 by @warframesam.

## The report

| Run | Vector index | Heap | Outcome |
| --- | --- | --- | --- |
| 1 | yes | `-Xmx16g` | OOM, **database fenced for recovery** |
| 2 | yes | `-Xmx32g` | 6.5h in, still in pass 2, persist failures, IDE killed |
| 3 | **no** | `-Xmx8g` | success in 1593s |

4.2M records of 768-dimension embeddings plus 125M edges through `GraphImporter`. With an `LSM_VECTOR` index on the
type it does not complete; without one it completes in 26 minutes on a third of the heap.

Two independent defects, either of which is enough on its own.

## 1. The delta buffer was a second full copy of the corpus, on the heap, unbounded

Every write appends a `DeltaVectorEntry` so the vector is searchable before it reaches the HNSW graph, and the entry
carried the whole `VectorFloat`. Only a rebuild drains that buffer, so an ingest that outruns the rebuilds grows it
without limit. At the reported scale that is `4.2M x 768 x 4 B` = **12.9 GB**, two thirds of what killed the 16 GB
run. `arcadedb.vectorIndex.maxPendingMutations`' own javadoc already said so: *"Nothing here bounds the buffer."*

It is the same second copy issue #3144 removed from `GrowableVectorValues`, on the one path that still had it.

The vector is persisted by `persistVectorWithLocation()` **before** the entry is queued, so the payload in the entry
is a cache and nothing more. Past `arcadedb.vectorIndex.deltaCacheSize` the entry keeps only its id and RID (32
bytes instead of `dimensions * 4`) and the delta scan reads the payload back from the pages. The read-back is the
one `GrowableVectorValues.getVector()` already performed for an evicted ordinal, extracted as
`LSMVectorIndex.readPersistedVectorArray()` and now shared by both.

Two new settings, shaped like the graph-build and search caches next to them:

- `arcadedb.vectorIndex.deltaCacheSize` (default `0` = auto; `-1` = keep every payload, the previous behaviour)
- `arcadedb.vectorIndex.deltaCacheMaxHeapPercent` (default `10`), taken off `-Xmx` and capped at 90% of the heap
  currently available - the same arithmetic and the same denominator `computeGraphBuildCacheCapacity()` uses.
  To be precise about what that does and does not buy (raised in review): it is a **margin, not a reservation**.
  Neither cache reserves from the other, so within one TTL window both can size against the same
  `availableHeapBytes()` reading. What makes it converge is that a kept payload becomes live heap and lowers the
  next reading for both. The modest default is the margin against that lag.

`low-ram` pins it to 10,000, next to the search cache.

## 2. The inactivity rebuild fired in the middle of the load, repeatedly

Its trigger is the index going quiet for `inactivityRebuildTimeoutMs`, which is meant to read as "the writer is
done". During a bulk load it does not: a stall for an LSM compaction, a page-flush burst or a long GC outlasts the
window, and the rebuild that starts then covers the corpus loaded SO FAR, takes minutes on a large one, and is
superseded by the rest of the load - so the next stall starts another over a larger set.

```
05:25:04 Inactivity timeout expired (15000 ms), triggering graph rebuild for 1000000 pending mutations
05:29:16 ... built (248593 ms)              <- 1.0M nodes
05:29:31 Inactivity timeout expired ... 600000 pending mutations
05:56:53 ... built (1632060 ms)             <- 1.6M nodes, then discarded on a 5s lock timeout
05:57:04 Starting async graph rebuild (accumulated 1000000 mutations)
07:52:52 ... built (6903286 ms)             <- 2.6M nodes
...                                          <- 4.24M nodes, still running at 11:49
```

The last of those ran concurrently with the edge pass: **7,056 edges/sec** against **174,658 edges/sec** in the run
with no vector index. On 16 GB the first one simply OOM'd, on the importer's own commit, past the WAL commit point,
which fenced the database and lost the load.

`GraphBatch` already tells the engine it is a bulk load - it relaxes WAL and async durability for its duration and
restores them on close. Speculative index maintenance belongs in exactly that scope:

- `IndexInternal` gains `suspendBackgroundMaintenance()` / `resumeBackgroundMaintenance()`, no-ops for every index
  but `LSMVectorIndex`, reference-counted so overlapping suspensions compose.
- `GraphBatch` takes one for every index of the database at construction and lifts it in `close()`/`abandon()`.
- Only the **speculative** rebuild waits. Search-driven (`rebuildGraphBeforeSearch`) and explicitly requested
  (`buildVectorGraphNow`) rebuilds are untouched, and writes stay searchable through the delta scan throughout,
  exactly as they are between any two rebuilds.

`GraphImporter` opens one batch per pass, so the vertex pass and the edge pass are both covered and the single
rebuild lands after the edges rather than fighting them for heap and CPU.

## 3. Per-write timer churn (same code, worth its own line)

The inactivity window was measured by CANCELLING and rescheduling the timer task on every mutation: a monitor
acquisition, a `Timer.purge()` of the task queue under the timer's own lock, and a fresh `TimerTask` allocation, on
the path that runs once per written record. 4.2M of each, to move a deadline.

It is now a `volatile long` timestamp. The armed task reads the deadline when it fires and re-arms itself for the
remainder if it is early: same window, same semantics, one task per quiet period instead of one per write. The "is
a rebuild worth it" gate moves to fire time with it, off the write path, where it belongs anyway - the answer that
counts is the one at fire time.

## Tests

`Issue7357DeltaBufferHeapBoundTest`
- the heap footprint stops at the budget while the buffer keeps growing;
- **searches still return and rank the buffered rows correctly once their payloads are gone** - the whole
  correctness question, since a bound that quietly dropped rows would satisfy the first assertion perfectly;
- `deltaCacheSize = -1` still keeps every payload;
- deleting the buffered rows gives their budget back.

`Issue7357BulkLoadSuspendsRebuildTest` (`@Tag("vector")`)
- a stall inside an open batch rebuilds nothing and leaves the writes pending;
- closing the batch releases exactly **one** build, covering every vector;
- the same stall outside a batch still rebuilds (the control - without it the first test would hold on a build
  where the timer never fired);
- overlapping suspensions compose.

Both verified non-vacuous by neutering the fix: 2 of 3 and the bound assertion fail.

Green: 484 vector tests, 1,398 graph + index tests, the whole `engine` module (14,659; the one red is
`ParallelScanSafetyTest.abandonedResultSetReleasesProducersAndSurfacesFailure`, the known #6526 flake, green in
isolation), and 329 `integration` tests.

## Not in this PR

Three further defects are visible in the same log and want their own issues rather than a guess here:

1. **A completed 1.6M-node build discarded on a 5-second file lock timeout.**
   `Timeout on locking file 6 (..._vecgraph) during commit (timeout=5000ms, heldBy='Thread[#1,main]' for 7271ms)`
   -> `PERSIST: Failed to persist graph for ... (nodes=1600000)`. 27 minutes of build thrown away because one chunk
   commit could not take the lock. Much less likely once the load is not racing a rebuild, but the persist of a
   multi-minute build should not be all-or-nothing on a 5s timeout.
2. **A persisted graph larger than 2 GB does not reload.** After
   `Graph written to pages (sequential): 1000000 nodes, 3148792924 bytes, 7601 pages` the next line is
   `Could not reload graph as OnDiskGraphIndex (will use in-memory graph): Error loading graph from pages`. 7601
   pages cannot hold 3.1 GB, so the byte count and the page count disagree; the arithmetic in
   `computeTotalGraphBytes()` and `PaginatedComponentFile.write()` is `long`-clean, so the divergence is elsewhere.
3. **`PageManagerFlushThread` logs SEVER/WARNI for pages queued against a sub-index file compaction has closed**:
   `Cannot write page 8 because the file 'WORK_0_24276288377800.25...umtidx' is closed`.

Also worth noting for the reporter: the 49,904,703 skipped edges appear identically in the successful run, so they
are dangling citations in the dataset, not a defect.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable memory limits for vector-index delta caches, including automatic heap-based sizing.
  * Added low-memory profile support for limiting vector-index cache usage.
  * Vector searches continue to find and rank entries when cached payloads exceed the configured memory budget.

* **Performance & Reliability**
  * Bulk graph loads now defer background vector-index maintenance until loading completes.
  * Improved vector-index rebuild scheduling and memory accounting.

* **Bug Fixes**
  * Improved loading of persisted vectors during vector-index operations.
  * Ensured bulk-load settings are restored even when flushing encounters an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->