### PR TITLE
fix(#7361,#7362,#7363): a graph persist waits on a bulk lock budget, records its own length, and a superseded page flush is quiet

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -935,6 +935,19 @@ public enum GlobalConfiguration {
       Recommended: 50MB for typical workloads, 100MB for high-memory systems, 25MB for constrained environments.""",
       Long.class, 50L),
 
+  INDEX_BUILD_COMMIT_LOCK_TIMEOUT("arcadedb.index.buildCommitLockTimeout", SCOPE.DATABASE,
+      """
+      Timeout in ms a bulk index build waits for the file locks of ONE of its chunk commits, replacing \
+      arcadedb.commitLockTimeout for those commits only. \
+      The default there is sized for an interactive transaction, where giving up quickly is right because the \
+      caller can retry cheaply. A vector graph persist is the opposite case: it follows a build that can cost tens \
+      of minutes, it commits every arcadedb.index.buildChunkSizeMB, and a single chunk that cannot take the lock \
+      discards the whole build (issue #7361) - while the contender it waits behind is an ordinary commit that will \
+      be done in milliseconds. Waiting is nearly free here; giving up is not. \
+      This bounds only how long the build WAITS, never how long it HOLDS, so raising it cannot make any other \
+      transaction slower. 0 or less waits indefinitely.""",
+      Long.class, 60_000L),
+
   INDEX_COMPACTION_RAM_MB("arcadedb.indexCompactionRAM", SCOPE.DATABASE, "Maximum amount of RAM to use for index compaction, in MB",
       Long.class, 300),
 

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -945,7 +945,9 @@ public enum GlobalConfiguration {
       discards the whole build (issue #7361) - while the contender it waits behind is an ordinary commit that will \
       be done in milliseconds. Waiting is nearly free here; giving up is not. \
       This bounds only how long the build WAITS, never how long it HOLDS, so raising it cannot make any other \
-      transaction slower. 0 or less waits indefinitely.""",
+      transaction slower. 0 or less waits indefinitely. \
+      The effective value is clamped to be at least arcadedb.commitLockTimeout, so this can never make a build \
+      give up sooner than it already would: setting it BELOW that one has no effect.""",
       Long.class, 60_000L),
 
   INDEX_COMPACTION_RAM_MB("arcadedb.indexCompactionRAM", SCOPE.DATABASE, "Maximum amount of RAM to use for index compaction, in MB",

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -186,6 +186,21 @@ public class TransactionContext implements Transaction {
   private       long                                 slotMergeMaxBytes;
   private       long                                 slotRebaseTrackedBytes;
   private       boolean                              useWAL;
+  /**
+   * Milliseconds this transaction's commit waits for its file locks, overriding
+   * {@link GlobalConfiguration#COMMIT_LOCK_TIMEOUT} when set; {@code null} to use the configured value.
+   * <p>
+   * Exists for work whose cost profile makes the interactive default the wrong answer (issue #7361): a bulk index
+   * or vector-graph persist follows a build that can cost tens of minutes and commits in chunks, so one chunk that
+   * gives up after the interactive 5s throws that whole build away, while the ordinary commit it queued behind
+   * would have released the file in milliseconds. It bounds only the WAIT, never how long the locks are HELD, so
+   * a longer budget here cannot make any other transaction slower.
+   * <p>
+   * Cleared by {@link #reset()} along with the rest of the per-transaction state, so a
+   * {@code TransactionContext} reused across begin()/commit() cycles does not carry one caller's budget into the
+   * next caller's commit.
+   */
+  private       Long                                 commitLockTimeout;
   // #5064: set by the HA layer AFTER the replication quorum durably committed this transaction and BEFORE
   // the local phase-2 apply. Shifts the durability boundary for the failure regimes in commit2ndPhase's
   // finally: a local failure past this point must never roll back user-held record identities (the cluster
@@ -403,6 +418,24 @@ public class TransactionContext implements Transaction {
   @Override
   public void setUseWAL(final boolean useWAL) {
     this.useWAL = useWAL;
+  }
+
+  /**
+   * Overrides, for THIS transaction only, how long its commit waits for the file locks it needs. See the
+   * {@code commitLockTimeout} field.
+   *
+   * @param timeoutMs milliseconds to wait, {@code 0} or less to wait indefinitely, {@code null} to go back to
+   *                  {@link GlobalConfiguration#COMMIT_LOCK_TIMEOUT}
+   */
+  public void setCommitLockTimeout(final Long timeoutMs) {
+    this.commitLockTimeout = timeoutMs;
+  }
+
+  /**
+   * @return the per-transaction commit lock budget in ms, or {@code null} when the configured one applies
+   */
+  public Long getCommitLockTimeout() {
+    return commitLockTimeout;
   }
 
   @Override
@@ -1536,6 +1569,7 @@ public class TransactionContext implements Transaction {
     updatedRecordsIndexSnapshot = null;
     newPageCounters.clear();
     immutablePages.clear();
+    commitLockTimeout = null;
   }
 
   /**
@@ -2172,6 +2206,7 @@ public class TransactionContext implements Transaction {
     newRecords.clear();
     afterCommitCallbacks = null;
     registeredCallbackKeys = null;
+    commitLockTimeout = null;
     txId = -1;
   }
 
@@ -2275,7 +2310,9 @@ public class TransactionContext implements Transaction {
   }
 
   private List<Integer> lockFilesInOrder(final IntHashSet files) {
-    return lockFilesInOrder(files, GlobalConfiguration.COMMIT_LOCK_TIMEOUT);
+    return lockFilesInOrder(files,
+        commitLockTimeout != null ? commitLockTimeout : database.getConfiguration()
+            .getValueAsLong(GlobalConfiguration.COMMIT_LOCK_TIMEOUT));
   }
 
   /**
@@ -2284,7 +2321,13 @@ public class TransactionContext implements Transaction {
    *                       {@link GlobalConfiguration#EXPLICIT_LOCK_TIMEOUT} for a lock the application asked for.
    */
   private List<Integer> lockFilesInOrder(final IntHashSet files, final GlobalConfiguration timeoutSetting) {
-    final long timeout = database.getConfiguration().getValueAsLong(timeoutSetting);
+    return lockFilesInOrder(files, database.getConfiguration().getValueAsLong(timeoutSetting));
+  }
+
+  /**
+   * @param timeout milliseconds to wait for each file lock; {@code 0} or less waits indefinitely
+   */
+  private List<Integer> lockFilesInOrder(final IntHashSet files, final long timeout) {
     final LocalSchema schema = database.getSchema().getEmbedded();
 
     // Work on a private copy so the caller's set is never mutated by the migration re-resolution below

--- a/engine/src/main/java/com/arcadedb/engine/ComponentFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/ComponentFile.java
@@ -120,11 +120,20 @@ public class ComponentFile {
   }
 
   public void drop() throws IOException {
-    // BEFORE close(), not after: see the field's note (issue #7363).
-    dropped = true;
+    markDropped();
     close();
     LogManager.instance().log(this, Level.FINE, "Deleting file %s (id=%d)...", null, filePath, fileId);
     Files.delete(Path.of(getFilePath()));
+  }
+
+  /**
+   * Says this file is being removed. The one place the "before the close" half of the {@code dropped} invariant
+   * lives, so that {@link FileManager#dropFile(int)} - which has to raise it before a DEFERRED drop that never
+   * calls {@link #drop()} - states the same thing by calling this rather than by writing the field itself.
+   */
+  void markDropped() {
+    // BEFORE close(), never after: see the field's note (issue #7363).
+    dropped = true;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/engine/ComponentFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/ComponentFile.java
@@ -42,7 +42,13 @@ public class ComponentFile {
   protected       int     version = 0;      // STARTING FROM 21.10.2 COMPONENTS HAVE VERSION IN THE FILE NAME
   protected       String  componentName;
   protected       String  fileExtension;
-  protected       boolean open;
+  /**
+   * Volatile because it is read without any of this file's locks by the async flush thread while {@code close()}
+   * writes it under the channel write lock. That was already a race before issue #7363; what makes the ordering
+   * matter now is that a reader which observes the close of a dropped file has to observe the drop as well - see
+   * {@code dropped} below, written first, so the pair reads consistently in that direction.
+   */
+  protected volatile boolean open;
   /**
    * Set by {@link #drop()} <b>before</b> the file is closed, and never cleared: this file has been deliberately
    * removed (an index compaction replacing a sub-index, a bucket or index drop), so anything still addressed to it
@@ -56,7 +62,9 @@ public class ComponentFile {
    * whichever side of the window it observes.
    * <p>
    * Volatile rather than guarded: it is read by the flush thread without any of this file's locks, precisely
-   * because the lock it would need is the one {@code close()} is holding.
+   * because the lock it would need is the one {@code close()} is holding. Written BEFORE {@code open} is cleared
+   * and both being volatile, a reader that sees {@code open == false} is guaranteed to see this {@code true} as
+   * well, which is what lets a writer decide "dropped" and "closed" from one consistent pair of reads.
    */
   protected volatile boolean dropped;
 

--- a/engine/src/main/java/com/arcadedb/engine/ComponentFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/ComponentFile.java
@@ -43,6 +43,22 @@ public class ComponentFile {
   protected       String  componentName;
   protected       String  fileExtension;
   protected       boolean open;
+  /**
+   * Set by {@link #drop()} <b>before</b> the file is closed, and never cleared: this file has been deliberately
+   * removed (an index compaction replacing a sub-index, a bucket or index drop), so anything still addressed to it
+   * is superseded rather than lost.
+   * <p>
+   * The ordering is the whole point (issue #7363). The async flush thread checks {@link #isOpen()} and then writes,
+   * and {@code close()} can run entirely between those two steps - which surfaced as
+   * {@code IllegalArgumentException: Cannot write page N because the file '...' is closed} logged at SEVERE by
+   * {@code PageManagerFlushThread}, on a path an operator watches for real corruption. Raising the flag first means
+   * a writer that loses that race can still tell "the file went away under me" from "a live file failed to write",
+   * whichever side of the window it observes.
+   * <p>
+   * Volatile rather than guarded: it is read by the flush thread without any of this file's locks, precisely
+   * because the lock it would need is the one {@code close()} is holding.
+   */
+  protected volatile boolean dropped;
 
   public ComponentFile() {
     this.mode = MODE.READ_ONLY;
@@ -96,9 +112,18 @@ public class ComponentFile {
   }
 
   public void drop() throws IOException {
+    // BEFORE close(), not after: see the field's note (issue #7363).
+    dropped = true;
     close();
     LogManager.instance().log(this, Level.FINE, "Deleting file %s (id=%d)...", null, filePath, fileId);
     Files.delete(Path.of(getFilePath()));
+  }
+
+  /**
+   * @return {@code true} once {@link #drop()} has started removing this file. See the {@code dropped} field.
+   */
+  public boolean isDropped() {
+    return dropped;
   }
 
   public String getFileName() {

--- a/engine/src/main/java/com/arcadedb/engine/FileManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/FileManager.java
@@ -348,7 +348,7 @@ public class FileManager {
         // Raised here as well as inside drop() so the deferred branch - where the physical delete is postponed but
         // the file has still left this manager - reads as dropped to a writer racing it (issue #7363). Before the
         // drop, so no window exists in which the file is being removed and does not say so.
-        file.dropped = true;
+        file.markDropped();
         if (handler == null || !handler.deferDrop(file))
           file.drop();
 

--- a/engine/src/main/java/com/arcadedb/engine/FileManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/FileManager.java
@@ -345,6 +345,10 @@ public class FileManager {
         // during a backup instead of being postponed for its whole duration. The file leaves this manager either
         // way - the LIVE database must see it as gone immediately.
         final DroppedFileHandler handler = droppedFileHandler;
+        // Raised here as well as inside drop() so the deferred branch - where the physical delete is postponed but
+        // the file has still left this manager - reads as dropped to a writer racing it (issue #7363). Before the
+        // drop, so no window exists in which the file is being removed and does not say so.
+        file.dropped = true;
         if (handler == null || !handler.deferDrop(file))
           file.drop();
 
@@ -421,6 +425,18 @@ public class FileManager {
       throw new IllegalArgumentException("File with id " + fileId + " was not found");
 
     return f;
+  }
+
+  /**
+   * Same lookup as {@link #getFile(int)} but answering {@code null} instead of throwing, for a caller that has to
+   * tolerate a file disappearing under it - the async flush thread, which resolves a file id long after the
+   * transaction that queued the page and can legitimately find it dropped by an index compaction meanwhile
+   * (issue #7363).
+   *
+   * @return the file registered under {@code fileId}, or {@code null} when nothing is
+   */
+  public ComponentFile getFileIfExists(final int fileId) {
+    return fileIdMap.get(fileId);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -1733,18 +1733,43 @@ public class PageManager extends LockContext {
     final int fileId = page.pageId.getFileId();
 
     if (fileManager.existsFile(fileId)) {
-      final PaginatedComponentFile file = (PaginatedComponentFile) fileManager.getFile(fileId);
+      final PaginatedComponentFile file = (PaginatedComponentFile) fileManager.getFileIfExists(fileId);
+      if (file == null || file.isDropped()) {
+        // The file left the manager, or is on its way out, between existsFile() above and now - the same
+        // superseded page the else branch below handles, observed one instant earlier (issue #7363).
+        discardPageOfDroppedFile(page, file);
+        return;
+      }
+
       if (!file.isOpen())
         throw new DatabaseMetadataException("Cannot flush pages on disk because file '" + file.getFileName() + "' is closed");
 
       LogManager.instance()
           .log(this, Level.FINE, "Flushing page %s to disk (threadId=%d)...", null, page, Thread.currentThread().threadId());
 
-      // ACQUIRE A LOCK ON THE I/O OPERATION TO AVOID PARTIAL READS/WRITES
-      concurrentPageAccess(page.pageId, true, () -> {
-        final int written = file.write(page);
-        totalPagesWrittenSize.addAndGet(written);
-      });
+      try {
+        // ACQUIRE A LOCK ON THE I/O OPERATION TO AVOID PARTIAL READS/WRITES
+        concurrentPageAccess(page.pageId, true, () -> {
+          final int written = file.write(page);
+          totalPagesWrittenSize.addAndGet(written);
+        });
+      } catch (final RuntimeException | IOException e) {
+        // An index compaction drops the sub-index file it replaced while this thread is between the isOpen()
+        // check above and the write. PaginatedComponentFile.close() nulls the channel under its own write lock,
+        // and write() then raises IllegalArgumentException, an UNCHECKED exception that used to escape every
+        // catch in PageManagerFlushThread and land on its top-level handler as
+        // "Error on processing page flush requests" at SEVERE (issue #7363). The checked half is the same event
+        // a moment later: a write already inside the channel gets ClosedChannelException, and the reopen that
+        // handles an accidental close correctly refuses to re-create a deleted file, so it comes back out as
+        // FileNotFoundException. Loud either way, and about a page that is superseded by construction - the file
+        // it belongs to has been deleted, so there is nowhere for it to go and nothing to lose.
+        // Re-checking isDropped() - raised BEFORE the close, see ComponentFile - is what separates that from a
+        // live file whose write genuinely failed, which still propagates with its own reporting intact.
+        if (!file.isDropped())
+          throw e;
+        discardPageOfDroppedFile(page, file);
+        return;
+      }
 
       try {
         final PaginatedComponent component = (PaginatedComponent) database.getSchema().getFileByIdIfExists(fileId);
@@ -1777,18 +1802,30 @@ public class PageManager extends LockContext {
           walFile.notifyPageFlushed();
       }
 
-    } else {
-      LogManager.instance()
-          .log(this, Level.FINE, "Cannot flush page %s because the file has been dropped (threadId=%d)...", null, page,
-              Thread.currentThread().threadId());
-      // The page will never be flushed and its content is irrelevant (the file is gone): release its WAL
-      // ack, or the stale pending count would make every later clean close preserve the WAL for nothing
-      // (the close-time ack gate, #4928). takeWALFile makes the release exactly-once against the racing
-      // dropped-file batch purge.
-      final WALFile walFile = page.takeWALFile();
-      if (walFile != null)
-        walFile.notifyPageFlushed();
-    }
+    } else
+      discardPageOfDroppedFile(page, null);
+  }
+
+  /**
+   * Quietly retires a page queued against a file that has been dropped - an index compaction replacing a
+   * sub-index, a bucket or index drop. The page will never be flushed and its content is irrelevant (the file is
+   * gone), so this is FINE and not a failure: the alternative, logging at SEVERE/WARNI on a path an operator
+   * watches for real corruption, is exactly what issue #7363 is about.
+   * <p>
+   * Its WAL ack is still released, or the stale pending count would make every later clean close preserve the WAL
+   * for nothing (the close-time ack gate, #4928). {@code takeWALFile} makes the release exactly-once against the
+   * racing dropped-file batch purge.
+   *
+   * @param file the file the page was addressed to, or {@code null} when it has already left the file manager
+   */
+  private void discardPageOfDroppedFile(final MutablePage page, final PaginatedComponentFile file) {
+    LogManager.instance()
+        .log(this, Level.FINE, "Cannot flush page %s because the file %shas been dropped (threadId=%d)...", null, page,
+            file != null ? "'" + file.getFileName() + "' " : "", Thread.currentThread().threadId());
+
+    final WALFile walFile = page.takeWALFile();
+    if (walFile != null)
+      walFile.notifyPageFlushed();
   }
 
   private CachedPage loadPage(final PageId pageId, final int size, final boolean createIfNotExists, final boolean cache)

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -1735,15 +1735,25 @@ public class PageManager extends LockContext {
 
     if (fileManager.existsFile(fileId)) {
       final PaginatedComponentFile file = (PaginatedComponentFile) fileManager.getFileIfExists(fileId);
-      if (file == null || file.isDropped()) {
-        // The file left the manager, or is on its way out, between existsFile() above and now - the same
-        // superseded page the else branch below handles, observed one instant earlier (issue #7363).
-        discardPageOfDroppedFile(page, file, null);
+      if (file == null) {
+        // The file left the manager between existsFile() above and now - the same superseded page the else
+        // branch below handles, observed one instant earlier (issue #7363).
+        discardPageOfDroppedFile(page, null, null);
         return;
       }
 
-      if (!file.isOpen())
+      if (file.isDropped() || !file.isOpen()) {
+        // ONE decision point for both facts, and isDropped() is what it turns on. Asking them separately - "is it
+        // dropped?" then, a few lines later, "is it closed?" - leaves a window in which a drop landing between the
+        // two reports a superseded page as a live file's failed write, which is the WARNI half of issue #7363.
+        // There is no such window here: drop() raises `dropped` BEFORE close() clears `open`, and both are
+        // volatile, so whichever of the two this thread observes first it sees a consistent pair.
+        if (file.isDropped()) {
+          discardPageOfDroppedFile(page, file, null);
+          return;
+        }
         throw new DatabaseMetadataException("Cannot flush pages on disk because file '" + file.getFileName() + "' is closed");
+      }
 
       LogManager.instance()
           .log(this, Level.FINE, "Flushing page %s to disk (threadId=%d)...", null, page, Thread.currentThread().threadId());
@@ -1769,7 +1779,10 @@ public class PageManager extends LockContext {
         // deleted, so there is nowhere for it to go and nothing to lose. Re-checking isDropped() - raised BEFORE
         // the close, see ComponentFile - is what separates that from a live file whose write genuinely failed,
         // which still propagates with its own reporting intact.
-        if (!file.isDropped())
+        // getPageNumber() >= 0 as well as isDropped(): write() raises IllegalArgumentException for an invalid
+        // page number too, which says nothing about the file and must not be absorbed just because the file
+        // happens to have been dropped at that instant.
+        if (!file.isDropped() || page.pageId.getPageNumber() < 0)
           throw e;
         discardPageOfDroppedFile(page, file, e);
         return;

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -1733,15 +1733,10 @@ public class PageManager extends LockContext {
     final FileManager fileManager = database.getFileManager();
     final int fileId = page.pageId.getFileId();
 
-    if (fileManager.existsFile(fileId)) {
-      final PaginatedComponentFile file = (PaginatedComponentFile) fileManager.getFileIfExists(fileId);
-      if (file == null) {
-        // The file left the manager between existsFile() above and now - the same superseded page the else
-        // branch below handles, observed one instant earlier (issue #7363).
-        discardPageOfDroppedFile(page, null, null);
-        return;
-      }
-
+    // ONE lookup, not an existsFile() followed by a get: they hit the same map, and the second answering null is
+    // the same "the file is gone" the first one used to report - now handled here rather than twice.
+    final PaginatedComponentFile file = (PaginatedComponentFile) fileManager.getFileIfExists(fileId);
+    if (file != null) {
       if (file.isDropped() || !file.isOpen()) {
         // ONE decision point for both facts, and isDropped() is what it turns on. Asking them separately - "is it
         // dropped?" then, a few lines later, "is it closed?" - leaves a window in which a drop landing between the

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -37,6 +37,7 @@ import com.arcadedb.utility.FileUtils;
 import com.arcadedb.utility.LockContext;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.nio.ByteBuffer;
@@ -1737,7 +1738,7 @@ public class PageManager extends LockContext {
       if (file == null || file.isDropped()) {
         // The file left the manager, or is on its way out, between existsFile() above and now - the same
         // superseded page the else branch below handles, observed one instant earlier (issue #7363).
-        discardPageOfDroppedFile(page, file);
+        discardPageOfDroppedFile(page, file, null);
         return;
       }
 
@@ -1753,21 +1754,24 @@ public class PageManager extends LockContext {
           final int written = file.write(page);
           totalPagesWrittenSize.addAndGet(written);
         });
-      } catch (final RuntimeException | IOException e) {
-        // An index compaction drops the sub-index file it replaced while this thread is between the isOpen()
-        // check above and the write. PaginatedComponentFile.close() nulls the channel under its own write lock,
-        // and write() then raises IllegalArgumentException, an UNCHECKED exception that used to escape every
-        // catch in PageManagerFlushThread and land on its top-level handler as
-        // "Error on processing page flush requests" at SEVERE (issue #7363). The checked half is the same event
-        // a moment later: a write already inside the channel gets ClosedChannelException, and the reopen that
-        // handles an accidental close correctly refuses to re-create a deleted file, so it comes back out as
-        // FileNotFoundException. Loud either way, and about a page that is superseded by construction - the file
-        // it belongs to has been deleted, so there is nowhere for it to go and nothing to lose.
-        // Re-checking isDropped() - raised BEFORE the close, see ComponentFile - is what separates that from a
-        // live file whose write genuinely failed, which still propagates with its own reporting intact.
+      } catch (final IllegalArgumentException | FileNotFoundException e) {
+        // The two - and only two - ways PaginatedComponentFile.write() reports "the file went away under me",
+        // caught by type rather than by catching everything and letting isDropped() decide: a coincidentally
+        // dropped file must not turn some unrelated failure into a FINE line and a released WAL ack.
+        //   IllegalArgumentException: an index compaction drops the sub-index file it replaced while this thread
+        // is between the isOpen() check above and the write, so close() has nulled the channel under its own
+        // write lock. Unchecked, so it used to escape every catch in PageManagerFlushThread and land on its
+        // top-level handler as "Error on processing page flush requests" at SEVERE (issue #7363).
+        //   FileNotFoundException: the same event a moment later. A write already inside the channel gets
+        // ClosedChannelException, and the reopen that correctly handles an ACCIDENTAL close refuses to re-create
+        // a file that was closed on purpose or already deleted, reporting it as this.
+        // Loud either way, and about a page that is superseded by construction - the file it belongs to has been
+        // deleted, so there is nowhere for it to go and nothing to lose. Re-checking isDropped() - raised BEFORE
+        // the close, see ComponentFile - is what separates that from a live file whose write genuinely failed,
+        // which still propagates with its own reporting intact.
         if (!file.isDropped())
           throw e;
-        discardPageOfDroppedFile(page, file);
+        discardPageOfDroppedFile(page, file, e);
         return;
       }
 
@@ -1803,7 +1807,7 @@ public class PageManager extends LockContext {
       }
 
     } else
-      discardPageOfDroppedFile(page, null);
+      discardPageOfDroppedFile(page, null, null);
   }
 
   /**
@@ -1816,12 +1820,16 @@ public class PageManager extends LockContext {
    * for nothing (the close-time ack gate, #4928). {@code takeWALFile} makes the release exactly-once against the
    * racing dropped-file batch purge.
    *
-   * @param file the file the page was addressed to, or {@code null} when it has already left the file manager
+   * @param file  the file the page was addressed to, or {@code null} when it has already left the file manager
+   * @param cause  what the write failed with, when the drop was observed by a failed write rather than up front;
+   *               reported so the FINE line still names it and this can never hide an unexpected failure silently
    */
-  private void discardPageOfDroppedFile(final MutablePage page, final PaginatedComponentFile file) {
+  private void discardPageOfDroppedFile(final MutablePage page, final PaginatedComponentFile file,
+      final Exception cause) {
     LogManager.instance()
-        .log(this, Level.FINE, "Cannot flush page %s because the file %shas been dropped (threadId=%d)...", null, page,
-            file != null ? "'" + file.getFileName() + "' " : "", Thread.currentThread().threadId());
+        .log(this, Level.FINE, "Cannot flush page %s because the file %shas been dropped (threadId=%d)%s", null, page,
+            file != null ? "'" + file.getFileName() + "' " : "", Thread.currentThread().threadId(),
+            cause != null ? ": " + cause.getClass().getSimpleName() + " - " + cause.getMessage() : "...");
 
     final WALFile walFile = page.takeWALFile();
     if (walFile != null)

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -897,14 +897,16 @@ public class PageManagerFlushThread extends Thread {
                   // once the read cache evicts it, readers see the stale on-disk version.
                   LogManager.instance().log(this, Level.SEVERE,
                       "Error on flushing page '%s' to disk, the page will be recovered from the WAL on restart", e, page);
-                } catch (final Throwable e) {
+                } catch (final RuntimeException e) {
                   // Same containment as the IOException above, for an UNCHECKED failure (issue #7363). Without it
                   // an IllegalArgumentException out of PaginatedComponentFile.write() - what a file closed under
                   // this thread by an index compaction used to raise - unwound past the whole batch, so every page
                   // after it kept its pageIndex entry and its WAL ack forever and
-                  // waitAllPagesOfDatabaseAreFlushed burned its full budget on close. Mirrors the catch-all
-                  // resumeFlushing()'s deferred-page loop has always had; the top-level handler in run() stays as
-                  // the last resort for anything raised OUTSIDE this loop.
+                  // waitAllPagesOfDatabaseAreFlushed burned its full budget on close.
+                  // RuntimeException and NOT Throwable: an Error is not something to keep flushing through, and
+                  // containing one here would swallow it for the life of the thread. Those keep going to the
+                  // top-level handler in run(), which is also the last resort for anything raised OUTSIDE this
+                  // loop, exactly as before.
                   LogManager.instance().log(this, Level.SEVERE,
                       "Unexpected error on flushing page '%s' to disk, the page will be recovered from the WAL on restart", e,
                       page);

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -897,6 +897,17 @@ public class PageManagerFlushThread extends Thread {
                   // once the read cache evicts it, readers see the stale on-disk version.
                   LogManager.instance().log(this, Level.SEVERE,
                       "Error on flushing page '%s' to disk, the page will be recovered from the WAL on restart", e, page);
+                } catch (final Throwable e) {
+                  // Same containment as the IOException above, for an UNCHECKED failure (issue #7363). Without it
+                  // an IllegalArgumentException out of PaginatedComponentFile.write() - what a file closed under
+                  // this thread by an index compaction used to raise - unwound past the whole batch, so every page
+                  // after it kept its pageIndex entry and its WAL ack forever and
+                  // waitAllPagesOfDatabaseAreFlushed burned its full budget on close. Mirrors the catch-all
+                  // resumeFlushing()'s deferred-page loop has always had; the top-level handler in run() stays as
+                  // the last resort for anything raised OUTSIDE this loop.
+                  LogManager.instance().log(this, Level.SEVERE,
+                      "Unexpected error on flushing page '%s' to disk, the page will be recovered from the WAL on restart", e,
+                      page);
                 } finally {
                   // Remove from index AFTER flushing: the page is now on disk and will be
                   // found in the read cache (putPageInReadCache was called at commit time).

--- a/engine/src/main/java/com/arcadedb/index/vector/ContiguousPageWriter.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/ContiguousPageWriter.java
@@ -33,6 +33,7 @@ import io.github.jbellis.jvector.disk.IndexWriter;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.logging.Level;
 
 import static java.util.logging.Level.FINE;
 
@@ -372,9 +373,11 @@ public class ContiguousPageWriter implements IndexWriter {
 
       return pages;
     } catch (final Exception e) {
-      LogManager.instance().log(ContiguousPageWriter.class, FINE,
-          "Could not establish the page count of file %d (%s): every page will be acquired as an existing one", fileId,
-          e.getMessage());
+      // WARNING and not FINE: this fallback puts the file back on the pre-issue-#7362 behaviour wholesale, so an
+      // exception here silently defeats the fix rather than degrading it. It has to be visible to an operator.
+      LogManager.instance().log(ContiguousPageWriter.class, Level.WARNING,
+          "Could not establish the page count of file %d (%s): every page will be acquired as an existing one, so the "
+              + "component's page count will not account for the pages this write appends", fileId, e.getMessage());
       return Integer.MAX_VALUE;
     }
   }

--- a/engine/src/main/java/com/arcadedb/index/vector/ContiguousPageWriter.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/ContiguousPageWriter.java
@@ -369,6 +369,9 @@ public class ContiguousPageWriter implements IndexWriter {
 
       final ComponentFile file = database.getFileManager().getFileIfExists(fileId);
       if (file instanceof final PaginatedComponentFile paginatedFile)
+        // The narrowing cast is the engine's existing ceiling, not a new one: PaginatedComponent tracks its page
+        // count in an AtomicInteger and PageId addresses pages by int, so a component cannot hold more than 2^31
+        // pages whatever this returns. Should that ever change, this and every other int page count change with it.
         pages = Math.max(pages, (int) paginatedFile.getTotalPages());
 
       return pages;

--- a/engine/src/main/java/com/arcadedb/index/vector/ContiguousPageWriter.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/ContiguousPageWriter.java
@@ -20,9 +20,14 @@ package com.arcadedb.index.vector;
 
 import com.arcadedb.database.Binary;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.TransactionContext;
 import com.arcadedb.engine.BasePage;
+import com.arcadedb.engine.Component;
+import com.arcadedb.engine.ComponentFile;
 import com.arcadedb.engine.MutablePage;
 import com.arcadedb.engine.PageId;
+import com.arcadedb.engine.PaginatedComponent;
+import com.arcadedb.engine.PaginatedComponentFile;
 import com.arcadedb.log.LogManager;
 import io.github.jbellis.jvector.disk.IndexWriter;
 
@@ -83,6 +88,20 @@ public class ContiguousPageWriter implements IndexWriter {
   private MutablePage currentPage;
   private int         currentPageNum;
 
+  /**
+   * Pages the file already held when this writer was created. A page number below it addresses a page that exists,
+   * whatever this writer does; one at or above it is an append. See {@link #ensurePageLoaded(int)}.
+   */
+  private final int existingPages;
+
+  /**
+   * Highest page number this writer has already acquired, across chunk commits. Writing is strictly sequential
+   * from logical position 0, so the first time a page number is seen it is the one being appended - and only that
+   * first sight may register it as new. Needed separately from {@code currentPageNum} because a chunk commit
+   * resets that to -1 and the next write re-acquires the same, now committed, page.
+   */
+  private int highestPageAcquired = -1;
+
   // Chunking support (for large bulk writes with WAL disabled)
   private long                 totalBytesWritten;   // Track bytes written in current chunk
   private final long           chunkSizeBytes;      // Chunk size in bytes (0 = no chunking)
@@ -115,6 +134,7 @@ public class ContiguousPageWriter implements IndexWriter {
     this.totalBytesWritten = 0;
     this.chunkSizeBytes = chunkSizeMB * 1024 * 1024;
     this.chunkCallback = chunkCallback;
+    this.existingPages = countExistingPages(database, fileId);
 
     // Allocate reusable buffer once (8 bytes for largest primitive type)
     this.buffer = new byte[Binary.LONG_SERIALIZED_SIZE];
@@ -276,19 +296,39 @@ public class ContiguousPageWriter implements IndexWriter {
   }
 
   /**
-   * Ensures a page is loaded for writing. Creates new pages as needed.
+   * Ensures a page is loaded for writing, appending one to the file when the logical address has run past its end.
+   * <p>
+   * An appended page MUST be registered with {@link TransactionContext#addPage}, not merely read and modified
+   * (issue #7362). {@code addPage} is the only thing that raises the transaction's page counter for this file, and
+   * that counter is what the commit hands to {@link PaginatedComponent#updatePageCount} - so it is what makes
+   * {@code getTotalPages()} answer for the pages this write just produced, both DURING the write and immediately
+   * after the commit. Until this fix the append went through {@code getPage() + getPageToModify()}, which never
+   * fails on a page past the end of the file: {@code getPage} asks the page manager with {@code createIfNotExists},
+   * so it invents a zero-filled page and the {@code addPage} fallback below was unreachable. Every graph page
+   * landed among the transaction's MODIFIED pages, no counter moved, and the component's page count was left to be
+   * raised asynchronously, one page at a time, by the flush thread. A graph persisted and reloaded in the same
+   * breath therefore measured itself against whatever the flusher happened to have written by then - which for a
+   * multi-GB graph is a length short by gigabytes, and a JVector footer read off the middle of the payload.
+   * <p>
+   * "Appended" is decided by two facts and not by a failed read: the page is past what the file held when this
+   * writer started, AND this writer has not already acquired it (a chunk commit resets {@code currentPageNum}, so
+   * the page a chunk boundary fell inside is re-acquired right after it was committed - existing, by then).
    */
   private void ensurePageLoaded(final int pageNum) throws IOException {
     if (pageNum != currentPageNum) {
       final PageId pageId = new PageId(database, fileId, pageNum);
+      final TransactionContext transaction = database.getTransaction();
 
-      // Try to get existing page, or create new one
-      try {
-        final var existingPage = database.getTransaction().getPage(pageId, pageSize);
-        currentPage = database.getTransaction().getPageToModify(existingPage);
-      } catch (final Exception e) {
-        // Page doesn't exist, create new one
-        currentPage = database.getTransaction().addPage(pageId, pageSize);
+      if (pageNum > highestPageAcquired && pageNum >= existingPages)
+        currentPage = transaction.addPage(pageId, pageSize);
+      else {
+        try {
+          final BasePage existingPage = transaction.getPage(pageId, pageSize);
+          currentPage = transaction.getPageToModify(existingPage);
+        } catch (final Exception e) {
+          // Page doesn't exist, create new one
+          currentPage = transaction.addPage(pageId, pageSize);
+        }
       }
 
       if (currentPage == null) {
@@ -296,6 +336,46 @@ public class ContiguousPageWriter implements IndexWriter {
       }
 
       currentPageNum = pageNum;
+      if (pageNum > highestPageAcquired)
+        highestPageAcquired = pageNum;
+    }
+  }
+
+  /**
+   * Pages the file behind {@code fileId} holds right now, as the largest of the two counts that can answer it: the
+   * physical file (which lags a committed page until the flush thread writes it) and the component's own counter
+   * (which lags a page this very writer appended, until the commit). Overestimating is the safe direction - a page
+   * wrongly judged to exist is merely read and modified instead of appended, which is what the whole file used to
+   * do - while underestimating would let {@link TransactionContext#addPage} replace a page holding real bytes with
+   * an empty one.
+   * <p>
+   * A file with no {@link PaginatedComponent} registered against it answers {@link Integer#MAX_VALUE}, which turns
+   * the append path off entirely for it. Nothing is lost: the transaction page counter this whole change exists to
+   * raise is consumed at commit as {@code getFileById(id).updatePageCount(...)}, so for a file the schema does not
+   * own there is nothing on the other end to receive it - and a counter naming an unregistered file is a
+   * deliberately loud failure on that path, which this must not start triggering.
+   *
+   * @return the page count, or {@link Integer#MAX_VALUE} when it cannot be established or has nowhere to go, so
+   * nothing is ever appended blind
+   */
+  private static int countExistingPages(final DatabaseInternal database, final int fileId) {
+    try {
+      final Component component = database.getSchema().getFileByIdIfExists(fileId);
+      if (!(component instanceof final PaginatedComponent paginatedComponent))
+        return Integer.MAX_VALUE;
+
+      int pages = paginatedComponent.getTotalPages();
+
+      final ComponentFile file = database.getFileManager().getFileIfExists(fileId);
+      if (file instanceof final PaginatedComponentFile paginatedFile)
+        pages = Math.max(pages, (int) paginatedFile.getTotalPages());
+
+      return pages;
+    } catch (final Exception e) {
+      LogManager.instance().log(ContiguousPageWriter.class, FINE,
+          "Could not establish the page count of file %d (%s): every page will be acquired as an existing one", fileId,
+          e.getMessage());
+      return Integer.MAX_VALUE;
     }
   }
 }

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -3550,6 +3550,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
           // write when the failure came from in there. Cheap, and on a path already logged as SEVERE.
           if (!graphCertified) {
             gf.getManifest().markUnusable("graph persist failed: " + e);
+            // And the in-memory length with it. The failure may be the commit above, which writeGraph() has
+            // already returned from, so it is the only one able to drop what that write recorded (issue #7362).
+            gf.discardRecordedGraphBytes();
             // The replacement never got certified, so it was never dropped above either: restore the stale
             // file as the active graph rather than leaving the index with no usable persisted graph at all.
             // gf itself is now unreachable from any field - drop it here (outside any lock, same reasoning as
@@ -3668,8 +3671,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
    */
   private void markGraphManifestUnusable(final Exception cause) {
     final LSMVectorIndexGraphFile gf = graphFile;
-    if (gf != null)
+    if (gf != null) {
       gf.getManifest().markUnusable("index build failed: " + cause);
+      gf.discardRecordedGraphBytes();
+    }
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -8345,6 +8345,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
           // Every commit of this build - the vector-data chunks, the graph persist chunks, and the final one -
           // waits on the bulk budget rather than the interactive default (issue #7361). Set here rather than
           // only where the graph is persisted: it is one build, and the transaction is this one throughout.
+          // Captured and restored in the finally exactly like originalWAL above, and for the same reason: when
+          // this build did NOT open the transaction it is running in (build() is public and an embedded caller
+          // may hold one), the caller's own later commit must not inherit a budget meant for a bulk build.
+          final Long originalCommitLockTimeout = db.getTransaction().getCommitLockTimeout();
           db.getTransaction().setCommitLockTimeout(getGraphPersistCommitLockTimeout());
 
           LogManager.instance().log(this, Level.INFO,
@@ -8402,6 +8406,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
           } finally {
             // RESTORE WAL setting
             db.getTransaction().setUseWAL(originalWAL);
+            db.getTransaction().setCommitLockTimeout(originalCommitLockTimeout);
           }
 
         } finally {
@@ -8530,7 +8535,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // transaction this runs in, so startedTransaction is false on the real path - gating the budget on it left
     // the first chunk commit, and a whole single-chunk persist, back on the interactive 5s default (issue #7361).
     // Applying it to whichever transaction is current is right either way: this method is a bulk persist, and the
-    // budget is a property of what the commit is FOR, not of who opened it.
+    // budget is a property of what the commit is FOR, not of who opened it. Restored in the finally below for the
+    // same reason build() restores its own: a transaction this method did not open outlives it.
+    final Long originalCommitLockTimeout = db.getTransaction().getCommitLockTimeout();
     db.getTransaction().setCommitLockTimeout(commitLockTimeout);
 
     try {
@@ -8578,6 +8585,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
       if (startedTransaction)
         db.rollback();
       throw e;
+    } finally {
+      db.getTransaction().setCommitLockTimeout(originalCommitLockTimeout);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -8342,6 +8342,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
           // Save original WAL setting and disable for bulk load
           final boolean originalWAL = db.getConfiguration().getValueAsBoolean(GlobalConfiguration.TX_WAL);
           db.getTransaction().setUseWAL(false);
+          // Every commit of this build - the vector-data chunks, the graph persist chunks, and the final one -
+          // waits on the bulk budget rather than the interactive default (issue #7361). Set here rather than
+          // only where the graph is persisted: it is one build, and the transaction is this one throughout.
+          db.getTransaction().setCommitLockTimeout(getGraphPersistCommitLockTimeout());
 
           LogManager.instance().log(this, Level.INFO,
               "Building vector index '%s' with WAL disabled and transaction chunking...", indexName);
@@ -8474,6 +8478,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
         db.getWrappedDatabaseInstance().commit();
         db.getWrappedDatabaseInstance().begin();
         db.getTransaction().setUseWAL(false); // Re-disable WAL for new transaction
+        db.getTransaction().setCommitLockTimeout(getGraphPersistCommitLockTimeout()); // and re-apply the bulk lock budget
 
         bytesInCurrentChunk.set(0);
       }
@@ -8520,9 +8525,13 @@ public class LSMVectorIndex implements Index, IndexInternal {
     if (startedTransaction) {
       db.begin();
       db.getTransaction().setUseWAL(false);
-      // Same reasoning as the rebuild path: a chunk of a bulk persist waits on the bulk budget (issue #7361).
-      db.getTransaction().setCommitLockTimeout(commitLockTimeout);
     }
+    // OUTSIDE the branch above, deliberately. The only caller is build(), whose PHASE 1 has already begun the
+    // transaction this runs in, so startedTransaction is false on the real path - gating the budget on it left
+    // the first chunk commit, and a whole single-chunk persist, back on the interactive 5s default (issue #7361).
+    // Applying it to whichever transaction is current is right either way: this method is a bulk persist, and the
+    // budget is a property of what the commit is FOR, not of who opened it.
+    db.getTransaction().setCommitLockTimeout(commitLockTimeout);
 
     try {
       // Build graph from scratch (already reads from pages)

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -3418,10 +3418,19 @@ public class LSMVectorIndex implements Index, IndexInternal {
         // is reused across begin()/commit() cycles (nothing to pop), with one it is a fresh object every time.
         final long chunkSizeMB = getTxChunkSize();
 
+        // Every commit below - the per-chunk ones and the final one - waits for the vecgraph file lock on the
+        // bulk budget rather than on the interactive one (issue #7361). It has to: an ordinary insert commit takes
+        // that file's lock too, because LSMVectorIndex.getFileIds() puts the companion graph file in every one of
+        // its lock sets (#4937), so under a live ingest this persist queues behind the loader routinely. On the
+        // 5s interactive default one such wait discarded a graph build that had cost 27 minutes, to spare a wait
+        // of about seven seconds.
+        final long commitLockTimeout = getGraphPersistCommitLockTimeout();
+
         final TransactionContext[] persistTransaction = new TransactionContext[1];
         database.begin();
         persistTransaction[0] = database.getTransaction();
         persistTransaction[0].setUseWAL(false);
+        persistTransaction[0].setCommitLockTimeout(commitLockTimeout);
 
         final ChunkCommitCallback chunkCallback = bytesWritten -> {
           LogManager.instance().log(this, Level.INFO,
@@ -3434,6 +3443,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
           database.begin();
           persistTransaction[0] = database.getTransaction();
           persistTransaction[0].setUseWAL(false);
+          persistTransaction[0].setCommitLockTimeout(commitLockTimeout);
         };
 
         // Flipped the moment the manifest certifies the committed pages. Everything after that point - the
@@ -3684,9 +3694,42 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // the answer: the connectivity walk runs over the graph object, not over anything on disk.
     final int[] unreachable = graphUnreachableOrdinals;
 
+    // The length the write ended on, so the next session measures the JVector footer from what was actually
+    // written instead of re-deriving it from a page count that the async flush thread is still catching up to
+    // (issue #7362).
     persistedTo.getManifest().write(graphOrdinalToVectorId.length,
         LSMVectorIndexGraphManifest.fingerprintOf(graphOrdinalToVectorId, vectorIndex()::getRid),
-        unreachable != null ? unreachable : EMPTY_ORDINALS);
+        unreachable != null ? unreachable : EMPTY_ORDINALS,
+        persistedTo.getLastWrittenGraphBytes());
+  }
+
+  /**
+   * How long one commit of a bulk graph persist waits for its file locks (issue #7361).
+   * <p>
+   * {@link GlobalConfiguration#COMMIT_LOCK_TIMEOUT} is sized for an interactive transaction, where giving up fast
+   * is right because the caller retries cheaply. Nothing about a graph persist fits that: it commits once per
+   * {@link GlobalConfiguration#INDEX_BUILD_CHUNK_SIZE_MB}, each of those commits is a step of a build that already
+   * cost minutes, and losing any one of them discards the build and marks the pages unusable. Falls back to the
+   * commit default only if the bulk budget is configured smaller, so this can never make the persist give up
+   * sooner than it does today.
+   */
+  private long getGraphPersistCommitLockTimeout() {
+    final ContextConfiguration configuration = getDatabase().getConfiguration();
+    final long bulkTimeout = configuration.getValueAsLong(GlobalConfiguration.INDEX_BUILD_COMMIT_LOCK_TIMEOUT);
+    if (bulkTimeout <= 0)
+      // Wait indefinitely, as the LockManager reads it.
+      return bulkTimeout;
+
+    final long commitTimeout = configuration.getValueAsLong(GlobalConfiguration.COMMIT_LOCK_TIMEOUT);
+    return commitTimeout <= 0 ? commitTimeout : Math.max(bulkTimeout, commitTimeout);
+  }
+
+  /**
+   * @return the component this index's persisted graph lives on, or {@code null} when it has none yet. Package
+   * private: for tests that have to inspect the persisted graph directly, nothing else.
+   */
+  LSMVectorIndexGraphFile getGraphFile() {
+    return graphFile;
   }
 
   private long getTxChunkSize() {
@@ -8473,9 +8516,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
     // Track if we started the transaction (for graph building)
     final boolean startedTransaction = db.getTransaction().getStatus() != TransactionContext.STATUS.BEGUN;
+    final long commitLockTimeout = getGraphPersistCommitLockTimeout();
     if (startedTransaction) {
       db.begin();
       db.getTransaction().setUseWAL(false);
+      // Same reasoning as the rebuild path: a chunk of a bulk persist waits on the bulk budget (issue #7361).
+      db.getTransaction().setCommitLockTimeout(commitLockTimeout);
     }
 
     try {
@@ -8494,6 +8540,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
         // Start new transaction and disable WAL
         db.begin();
         db.getTransaction().setUseWAL(false);
+        db.getTransaction().setCommitLockTimeout(commitLockTimeout);
       };
 
       // Create vector values accessor for graph serialization

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphFile.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphFile.java
@@ -183,8 +183,8 @@ public class LSMVectorIndexGraphFile extends PaginatedComponent {
    * - Caller is responsible for committing the transaction
    * - Graph data starts at page 0 (no metadata page needed - JVector format is self-describing)
    */
-  public long writeGraph(final ImmutableGraphIndex graph, final RandomAccessVectorValues vectors) {
-    return writeGraph(graph, vectors, 0, null, null, null);
+  public void writeGraph(final ImmutableGraphIndex graph, final RandomAccessVectorValues vectors) {
+    writeGraph(graph, vectors, 0, null, null, null);
   }
 
   /**
@@ -204,9 +204,9 @@ public class LSMVectorIndexGraphFile extends PaginatedComponent {
    * @param chunkSizeMB    Chunk size in MB (0 = no chunking)
    * @param chunkCallback  Callback to invoke when chunk is complete (can be null if chunkSizeMB=0)
    */
-  public long writeGraph(final ImmutableGraphIndex graph, final RandomAccessVectorValues vectors,
+  public void writeGraph(final ImmutableGraphIndex graph, final RandomAccessVectorValues vectors,
                          final long chunkSizeMB, final ChunkCommitCallback chunkCallback) {
-    return writeGraph(graph, vectors, chunkSizeMB, chunkCallback, null, null);
+    writeGraph(graph, vectors, chunkSizeMB, chunkCallback, null, null);
   }
 
   /**
@@ -214,7 +214,7 @@ public class LSMVectorIndexGraphFile extends PaginatedComponent {
    * When PQ data is provided, PQ codes are stored inline with graph nodes so that during
    * search traversal, approximate distances are computed without separate I/O.
    */
-  public long writeGraph(final ImmutableGraphIndex graph, final RandomAccessVectorValues vectors,
+  public void writeGraph(final ImmutableGraphIndex graph, final RandomAccessVectorValues vectors,
                          final long chunkSizeMB, final ChunkCommitCallback chunkCallback,
                          final ProductQuantization pq, final PQVectors pqVectors) {
 
@@ -333,8 +333,6 @@ public class LSMVectorIndexGraphFile extends PaginatedComponent {
                 graph.getIdUpperBound(), totalBytes, getTotalPages());
       }
 
-      return totalBytes;
-
     } catch (final Exception e) {
       // Dropped with the manifest and for the same reason: past a failure the manifest is the sole authority on
       // these pages, and recordedGraphBytes() prefers this field over it. A failure landing after the position
@@ -395,6 +393,17 @@ public class LSMVectorIndexGraphFile extends PaginatedComponent {
    */
   public long getLastWrittenGraphBytes() {
     return lastWrittenGraphBytes;
+  }
+
+  /**
+   * Drops the in-memory record of the last write's length, for a persist failure {@link #writeGraph} cannot
+   * observe: the FINAL commit is the caller's, and it happens after that method has returned. A failure there
+   * leaves this object as the one the next search loads from - a rebuild in place reuses the same instance - with
+   * a length {@link #recordedGraphBytes()} would prefer over the manifest the caller has just marked unusable.
+   * Pairs with {@code markUnusable()} at every call site that has to refuse these pages (issue #7362).
+   */
+  public void discardRecordedGraphBytes() {
+    lastWrittenGraphBytes = -1L;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphFile.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphFile.java
@@ -65,6 +65,15 @@ public class LSMVectorIndexGraphFile extends PaginatedComponent {
   private LSMVectorIndex mainIndex;
 
   /**
+   * Bytes the last {@link #writeGraph} on this object wrote, in the gap-free logical address space
+   * {@code ContiguousPageWriter} provides - i.e. the exact length {@code OnDiskGraphIndex.load()} has to measure
+   * its footer back from (issue #7362). Handed to the manifest once the caller has committed, since the manifest
+   * is what carries the fact into the next session; kept here because the two happen at different moments and on
+   * different objects.
+   */
+  private volatile long lastWrittenGraphBytes = -1L;
+
+  /**
    * Says which records the graph on these pages was built over. The graph itself is addressed by ordinal and carries
    * nothing that identifies them, so this is what makes reusing it safe (issue #6106).
    */
@@ -104,19 +113,38 @@ public class LSMVectorIndexGraphFile extends PaginatedComponent {
     this.mainIndex = mainIndex;
   }
 
+  /**
+   * Length of the JVector payload on these pages.
+   * <p>
+   * Taken from the manifest whenever it records one, because that is the number the write actually ended on
+   * (issue #7362). The page-count derivation below it stays as the answer for a graph persisted before that was
+   * recorded, and it is only ever an approximation of the truth: the component's page count is raised
+   * asynchronously by the flush thread while a multi-GB persist is still running, so a graph reloaded in the same
+   * breath as it was written measured itself gigabytes short and JVector read its footer magic off the middle of
+   * the payload; and the count can only grow, so a generation smaller than the one it replaced is measured with
+   * its predecessor's size.
+   */
   private long computeTotalGraphBytes() throws IOException {
-    final int totalPages = getTotalPages();
-    if (totalPages == 0)
-      return 0;
-
     final int usablePageSize = pageSize - BasePage.PAGE_HEADER_SIZE;
 
-    // Load last page to get actual content size.
-    // The page count reported by the component can be ahead of what is actually on disk when the
-    // graph file has been truncated or the page was never flushed/evicted. In that case the page
-    // manager either returns null or raises IllegalArgumentException ("page does not exist").
-    // Treat the persisted graph as absent (return 0) so loadGraph() falls through to the
-    // "rebuild graph from scratch" recovery path instead of aborting startup.
+    final long recorded = recordedGraphBytes();
+    final int totalPages;
+    if (recorded > 0)
+      // Ceiling division: the last byte of the payload sits on page (recorded - 1) / usablePageSize.
+      totalPages = (int) ((recorded + usablePageSize - 1) / usablePageSize);
+    else {
+      totalPages = getTotalPages();
+      if (totalPages == 0)
+        return 0;
+    }
+
+    // Load the last page. Whichever number named it, the pages have to be there: the count reported by the
+    // component can be ahead of what is actually on disk when the graph file has been truncated or the page was
+    // never flushed/evicted, and a recorded length can outlive the pages it described just as easily (a restore
+    // that brought the manifest and a truncated file, a file damaged after the persist). In that case the page
+    // manager either returns null or raises IllegalArgumentException ("page does not exist"). Treat the persisted
+    // graph as absent (return 0) so loadGraph() falls through to the "rebuild graph from scratch" recovery path
+    // instead of aborting startup.
     final int lastPageId = totalPages - 1;
     final BasePage lastPage;
     try {
@@ -136,6 +164,9 @@ public class LSMVectorIndexGraphFile extends PaginatedComponent {
       return 0;
     }
 
+    if (recorded > 0)
+      return recorded;
+
     // Compute contiguous logical size (excluding headers from logical address space)
     // Each full page contributes usablePageSize bytes, last page contributes its actual content
     return (long) usablePageSize * (totalPages - 1L) + lastPage.getContentSize();
@@ -152,8 +183,8 @@ public class LSMVectorIndexGraphFile extends PaginatedComponent {
    * - Caller is responsible for committing the transaction
    * - Graph data starts at page 0 (no metadata page needed - JVector format is self-describing)
    */
-  public void writeGraph(final ImmutableGraphIndex graph, final RandomAccessVectorValues vectors) {
-    writeGraph(graph, vectors, 0, null, null, null);
+  public long writeGraph(final ImmutableGraphIndex graph, final RandomAccessVectorValues vectors) {
+    return writeGraph(graph, vectors, 0, null, null, null);
   }
 
   /**
@@ -173,9 +204,9 @@ public class LSMVectorIndexGraphFile extends PaginatedComponent {
    * @param chunkSizeMB    Chunk size in MB (0 = no chunking)
    * @param chunkCallback  Callback to invoke when chunk is complete (can be null if chunkSizeMB=0)
    */
-  public void writeGraph(final ImmutableGraphIndex graph, final RandomAccessVectorValues vectors,
+  public long writeGraph(final ImmutableGraphIndex graph, final RandomAccessVectorValues vectors,
                          final long chunkSizeMB, final ChunkCommitCallback chunkCallback) {
-    writeGraph(graph, vectors, chunkSizeMB, chunkCallback, null, null);
+    return writeGraph(graph, vectors, chunkSizeMB, chunkCallback, null, null);
   }
 
   /**
@@ -183,7 +214,7 @@ public class LSMVectorIndexGraphFile extends PaginatedComponent {
    * When PQ data is provided, PQ codes are stored inline with graph nodes so that during
    * search traversal, approximate distances are computed without separate I/O.
    */
-  public void writeGraph(final ImmutableGraphIndex graph, final RandomAccessVectorValues vectors,
+  public long writeGraph(final ImmutableGraphIndex graph, final RandomAccessVectorValues vectors,
                          final long chunkSizeMB, final ChunkCommitCallback chunkCallback,
                          final ProductQuantization pq, final PQVectors pqVectors) {
 
@@ -197,6 +228,7 @@ public class LSMVectorIndexGraphFile extends PaginatedComponent {
     // which the load path reads as "cannot be verified" and judges by node count - so any failure this method can
     // still observe replaces it with a manifest that refuses the pages outright (see the catch below).
     manifest.invalidate();
+    lastWrittenGraphBytes = -1L;
 
     try {
       if (chunkSizeMB > 0 && chunkCallback != null) {
@@ -283,16 +315,25 @@ public class LSMVectorIndexGraphFile extends PaginatedComponent {
       writer.close();
 
       final long totalBytes = writer.position();
+      lastWrittenGraphBytes = totalBytes;
 
       if (storeVectors) {
+        // The inline vectors are float32 whatever the index quantization is: JVector's InlineVectors feature
+        // reserves dimension * Float.BYTES per node and ArcadePageVectorValues hands it dequantized floats, so
+        // naming the quantization on this line read as a claim about the bytes it had just counted (issue #7362).
+        // The quantization is still worth reporting - it is what the delta scan and the PQ file use - but as the
+        // index setting it is, next to the size the inline vectors actually cost.
         LogManager.instance().log(this, Level.INFO,
-                "Graph written to pages (sequential): %d nodes, %d bytes, %d pages (WITH inline vectors, quantization=%s)",
-                graph.getIdUpperBound(), totalBytes, getTotalPages(), mainIndex.metadata.quantizationType);
+                "Graph written to pages (sequential): %d nodes, %d bytes, %d pages (WITH inline vectors, float32 x %d dims; "
+                    + "index quantization=%s applies to the index data, not to these inline vectors)",
+                graph.getIdUpperBound(), totalBytes, getTotalPages(), storedDimension, mainIndex.metadata.quantizationType);
       } else {
         LogManager.instance().log(this, Level.INFO,
                 "Graph written to pages (sequential): %d nodes, %d bytes, %d pages (topology only, vectors in documents)",
                 graph.getIdUpperBound(), totalBytes, getTotalPages());
       }
+
+      return totalBytes;
 
     } catch (final Exception e) {
       // The caller rolls back and carries on without a persisted graph. Whatever the rollback leaves on these
@@ -309,9 +350,11 @@ public class LSMVectorIndexGraphFile extends PaginatedComponent {
    * Load a graph from pages as OnDiskGraphIndex for lazy-loading.
    */
   public OnDiskGraphIndex loadGraph() throws IOException {
-    final int totalPages = getTotalPages();
+    // The length alone decides whether there is a graph here: computeTotalGraphBytes() already answers 0 for
+    // "no pages" and for "the pages this length describes are not readable", and gating on the component's page
+    // count on top of it would put the very counter issue #7362 is about back on the load path.
     final long totalBytes = computeTotalGraphBytes();
-    if (totalPages == 0 || totalBytes == 0)
+    if (totalBytes == 0)
       return null;
 
     try {
@@ -338,5 +381,29 @@ public class LSMVectorIndexGraphFile extends PaginatedComponent {
    */
   public boolean hasPersistedGraph() {
     return getTotalPages() > 0;
+  }
+
+  /**
+   * @return bytes the last {@link #writeGraph} on this object wrote, or {@code -1} when none has run (or the last
+   * one failed). Read by the persist once it has committed, to hand the length to the manifest.
+   */
+  public long getLastWrittenGraphBytes() {
+    return lastWrittenGraphBytes;
+  }
+
+  /**
+   * The graph length as recorded, preferring what this session's own write measured over what the manifest on disk
+   * says: within a session the two agree, but the field is the one that is right during the window between the
+   * write and the manifest being written (issue #7362).
+   *
+   * @return the recorded length, or {@code 0} when nothing recorded one
+   */
+  private long recordedGraphBytes() {
+    final long written = lastWrittenGraphBytes;
+    if (written > 0)
+      return written;
+
+    final LSMVectorIndexGraphManifest.Content content = manifest.read();
+    return content != null ? content.graphBytes() : 0L;
   }
 }

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphFile.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphFile.java
@@ -336,6 +336,12 @@ public class LSMVectorIndexGraphFile extends PaginatedComponent {
       return totalBytes;
 
     } catch (final Exception e) {
+      // Dropped with the manifest and for the same reason: past a failure the manifest is the sole authority on
+      // these pages, and recordedGraphBytes() prefers this field over it. A failure landing after the position
+      // was captured - the logging below it, say - would otherwise leave a length in here that outlives the
+      // markUnusable() on the next line and lets a later loadGraph() in this session trust pages the manifest
+      // has just refused (issue #7362).
+      lastWrittenGraphBytes = -1L;
       // The caller rolls back and carries on without a persisted graph. Whatever the rollback leaves on these
       // pages - the previous generation untouched, or a partial rewrite whose earlier chunks already committed -
       // nothing here knows which, so the manifest must refuse them rather than be simply absent: absent means

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
@@ -95,7 +95,7 @@ public class LSMVectorIndexGraphManifest {
    * @param closeDeferredRebuild {@code true} when the pages this manifest describes are known stale because the
    *                             most recent {@code close()} chose to defer the rebuild that would otherwise have
    *                             brought them up to date (issue #6657), rather than run it synchronously. Always
-   *                             {@code false} again once a build actually completes - {@link #write(int, long, int[])}
+   *                             {@code false} again once a build actually completes - {@link #write(int, long, int[], long)}
    *                             and {@link #markUnusable(String)} both clear it - so it answers specifically "did the
    *                             last close skip a rebuild", not the broader "is a rebuild owed" that
    *                             {@code vectorCount}/{@code fingerprint} against the live index already answers.
@@ -106,9 +106,18 @@ public class LSMVectorIndexGraphManifest {
    *                             heap of the session that built the graph. Recording the set here is what lets a
    *                             reopened session make the same one, instead of leaving those vectors unreachable by
    *                             any search while {@code totalVectors} still counts them.
+   * @param graphBytes          exact length, in the graph file's gap-free logical address space, of the JVector
+   *                             payload the pages next to this manifest hold - the writer position the persist
+   *                             ended on - or {@code 0} when this manifest records none: every manifest written
+   *                             before issue #7362, and every {@link #markUnusable} one. That length is what
+   *                             {@code OnDiskGraphIndex.load()} measures its footer back from, and recording it
+   *                             here makes it a fact about the write rather than a quantity re-derived from the
+   *                             component's page count - a count that lags the async flush thread by an unbounded
+   *                             margin during a persist, and that can only ever grow, so a generation smaller than
+   *                             the one it replaced would be measured with its predecessor's size.
    */
   public record Content(int formatVersion, int vectorCount, long fingerprint, boolean closeDeferredRebuild,
-                        int[] unreachableOrdinals) {
+                        int[] unreachableOrdinals, long graphBytes) {
   }
 
   private final Path path;
@@ -195,7 +204,7 @@ public class LSMVectorIndexGraphManifest {
    * @param reason human-readable note stored in the file; nothing reads it back
    */
   public void markUnusable(final String reason) {
-    write(UNUSABLE_VECTOR_COUNT, 0L, reason, false, NO_UNREACHABLE_ORDINALS);
+    write(UNUSABLE_VECTOR_COUNT, 0L, reason, false, NO_UNREACHABLE_ORDINALS, 0L);
   }
 
   /**
@@ -205,9 +214,11 @@ public class LSMVectorIndexGraphManifest {
    * this call completed, so whatever a previous {@code close()} deferred has now been paid for.
    *
    * @param unreachableOrdinals see {@link Content#unreachableOrdinals()}; {@code null} is read as none
+   * @param graphBytes          see {@link Content#graphBytes()}; {@code 0} records none
    */
-  public void write(final int vectorCount, final long fingerprint, final int[] unreachableOrdinals) {
-    write(vectorCount, fingerprint, null, false, unreachableOrdinals);
+  public void write(final int vectorCount, final long fingerprint, final int[] unreachableOrdinals,
+      final long graphBytes) {
+    write(vectorCount, fingerprint, null, false, unreachableOrdinals, graphBytes);
   }
 
   /**
@@ -217,7 +228,7 @@ public class LSMVectorIndexGraphManifest {
    * or falls back to {@link #UNUSABLE_VECTOR_COUNT} when nothing has ever been persisted here, so a first-ever
    * build that a large index's close deferred is recorded too.
    * <p>
-   * Cleared automatically the next time {@link #write(int, long, int[])} or {@link #markUnusable(String)} runs,
+   * Cleared automatically the next time {@link #write(int, long, int[], long)} or {@link #markUnusable(String)} runs,
    * which is exactly when a rebuild - deferred or not - actually completes.
    * <p>
    * {@code read() == null} is treated as "nothing persisted yet" and takes the {@link #UNUSABLE_VECTOR_COUNT}
@@ -240,7 +251,9 @@ public class LSMVectorIndexGraphManifest {
     // Carried over with the count and the fingerprint, for the same reason they are: this is a note about pages
     // that have not changed, so what those pages leave unreachable has not changed either (issue #7190).
     write(vectorCount, fingerprint, null, true,
-        existing != null ? existing.unreachableOrdinals() : NO_UNREACHABLE_ORDINALS);
+        existing != null ? existing.unreachableOrdinals() : NO_UNREACHABLE_ORDINALS,
+        // Carried over for the same reason: the pages have not changed, so neither has their length (issue #7362).
+        existing != null ? existing.graphBytes() : 0L);
   }
 
   /**
@@ -251,7 +264,7 @@ public class LSMVectorIndexGraphManifest {
    * manifest. A unique name costs nothing and removes the assumption.
    */
   private void write(final int vectorCount, final long fingerprint, final String reason,
-      final boolean closeDeferredRebuild, final int[] unreachableOrdinals) {
+      final boolean closeDeferredRebuild, final int[] unreachableOrdinals, final long graphBytes) {
     final Path temporary = path.resolveSibling(
         path.getFileName() + "." + Long.toHexString(System.nanoTime()) + ".tmp");
     try {
@@ -272,6 +285,12 @@ public class LSMVectorIndexGraphManifest {
       // As a string: a 64-bit fingerprint is not representable in the double a JSON number decodes to.
       json.put("fingerprint", Long.toString(fingerprint));
       json.put("closeDeferredRebuild", closeDeferredRebuild);
+      // As a string, for the same reason the fingerprint is one: a length past 2^53 is not representable in the
+      // double a JSON number decodes to, and this value is exactly the one a multi-GB graph makes large.
+      // Written only when there is one, and without a FORMAT_VERSION bump, so an older build simply ignores the
+      // key and keeps deriving the length from the page count, as it always did (issue #7362).
+      if (graphBytes > 0)
+        json.put("graphBytes", Long.toString(graphBytes));
       // Written only when there is something to say, and as a bare int array rather than as a new formatVersion:
       // an older build reads the keys it knows and ignores this one, which leaves it exactly at its own
       // pre-issue-#7190 behaviour instead of forcing every existing index to rebuild on the first open after an
@@ -343,7 +362,8 @@ public class LSMVectorIndexGraphManifest {
       return new Content(formatVersion, json.getInt("vectorCount", -1),
           Long.parseLong(json.getString("fingerprint", "0")),
           json.getBoolean("closeDeferredRebuild", false),
-          unreachableOrdinalsOf(json));
+          unreachableOrdinalsOf(json),
+          Long.parseLong(json.getString("graphBytes", "0")));
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.WARNING, "Could not read the vector graph manifest '%s': %s", path,
           e.getMessage());

--- a/engine/src/test/java/com/arcadedb/engine/Issue7363DroppedFileFlushIsQuietTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue7363DroppedFileFlushIsQuietTest.java
@@ -24,6 +24,7 @@ import com.arcadedb.log.WarningCapture;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.logging.Level;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -71,7 +72,7 @@ class Issue7363DroppedFileFlushIsQuietTest extends TestHelper {
     assertThat(db.getFileManager().existsFile(file.getFileId()))
         .as("dropping the file object alone leaves it registered - the window the report caught").isTrue();
 
-    final List<WarningCapture.LogLine> lines = WarningCapture.capture(java.util.logging.Level.WARNING,
+    final List<WarningCapture.LogLine> lines = WarningCapture.capture(Level.WARNING,
         () -> assertThatCode(() -> PageManager.INSTANCE.flushPage(page))
             .as("a page addressed to a deleted file must not fail the flush of the batch it is in")
             .doesNotThrowAnyException());
@@ -99,7 +100,7 @@ class Issue7363DroppedFileFlushIsQuietTest extends TestHelper {
     db.getFileManager().dropFile(file.getFileId());
     assertThat(db.getFileManager().existsFile(file.getFileId())).isFalse();
 
-    final List<WarningCapture.LogLine> lines = WarningCapture.capture(java.util.logging.Level.WARNING,
+    final List<WarningCapture.LogLine> lines = WarningCapture.capture(Level.WARNING,
         () -> assertThatCode(() -> PageManager.INSTANCE.flushPage(page)).doesNotThrowAnyException());
 
     assertThat(lines).as("got: %s", lines)

--- a/engine/src/test/java/com/arcadedb/engine/Issue7363DroppedFileFlushIsQuietTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue7363DroppedFileFlushIsQuietTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.log.WarningCapture;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Issue #7363: during a long ingest the async flush thread repeatedly reported, at SEVERE and at WARNI, that it
+ * could not write pages to a sub-index file an index compaction had since closed:
+ * <pre>
+ * SEVER [PageManagerFlushThread] Error on processing page flush requests
+ * java.lang.IllegalArgumentException: Cannot write page 8 because the file '...umtidx' is closed
+ * WARNI [PageManagerFlushThread] Error on flushing page 'PageId(citation_graph/27/9) v=1' to disk
+ * com.arcadedb.exception.DatabaseMetadataException: Cannot flush pages on disk because file '...umtidx' is closed
+ * </pre>
+ * Those pages are superseded by construction - the file they belong to has been replaced and deleted, so there is
+ * nowhere for them to go and nothing to lose - and {@code flushPage} has always had a quiet FINE path for exactly
+ * that, taken when the file has already left the {@code FileManager}. What it did not have was a way to recognise
+ * the same situation one instant EARLIER, while the file is on its way out: still registered, closed or closing.
+ * So the identical, harmless event was reported at the two levels an operator watches for real corruption.
+ * <p>
+ * The {@code IllegalArgumentException} variant was worse than noise. It is unchecked, so it escaped every per-page
+ * catch in the flush loop, abandoning the rest of the batch: those pages kept their {@code pageIndex} entries and
+ * their WAL acks forever, and {@code waitAllPagesOfDatabaseAreFlushed} then burned its whole budget on the next
+ * close.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7363DroppedFileFlushIsQuietTest extends TestHelper {
+  private static final int PAGE_SIZE = 65536;
+
+  /**
+   * The exact window the report caught: the file has been dropped (closed, deleted) but is still registered, so
+   * every "does this file exist" check the flush path makes still says yes.
+   */
+  @Test
+  void aPageOfADroppedButStillRegisteredFileIsDiscardedQuietly() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    final PaginatedComponentFile file = scratchFile(db, "issue7363-dropped");
+    final MutablePage page = new MutablePage(new PageId(db, file.getFileId(), 0), PAGE_SIZE);
+    page.writeInt(0, 0xDEAD);
+
+    file.drop();
+
+    assertThat(file.isDropped()).as("drop() has to say so, and say so before it closes the channel").isTrue();
+    assertThat(db.getFileManager().existsFile(file.getFileId()))
+        .as("dropping the file object alone leaves it registered - the window the report caught").isTrue();
+
+    final List<WarningCapture.LogLine> lines = WarningCapture.capture(java.util.logging.Level.WARNING,
+        () -> assertThatCode(() -> PageManager.INSTANCE.flushPage(page))
+            .as("a page addressed to a deleted file must not fail the flush of the batch it is in")
+            .doesNotThrowAnyException());
+
+    assertThat(lines)
+        .as("a superseded page is a FINE event, not a SEVERE/WARNI one on a path watched for corruption; got: %s",
+            lines)
+        .noneMatch(line -> line.message().contains("Cannot write page")
+            || line.message().contains("Cannot flush pages on disk")
+            || line.message().contains("Error on flushing page")
+            || line.message().contains("Error on processing page flush requests"));
+  }
+
+  /**
+   * The same page, once the file has also left the {@code FileManager}: quiet before this change too, and it has
+   * to stay quiet - the two are the same event observed on either side of one non-atomic drop.
+   */
+  @Test
+  void aPageOfAFullyUnregisteredFileStaysQuietToo() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    final PaginatedComponentFile file = scratchFile(db, "issue7363-unregistered");
+    final MutablePage page = new MutablePage(new PageId(db, file.getFileId(), 0), PAGE_SIZE);
+
+    db.getFileManager().dropFile(file.getFileId());
+    assertThat(db.getFileManager().existsFile(file.getFileId())).isFalse();
+
+    final List<WarningCapture.LogLine> lines = WarningCapture.capture(java.util.logging.Level.WARNING,
+        () -> assertThatCode(() -> PageManager.INSTANCE.flushPage(page)).doesNotThrowAnyException());
+
+    assertThat(lines).as("got: %s", lines)
+        .noneMatch(line -> line.message().contains("Cannot write page")
+            || line.message().contains("Cannot flush pages on disk"));
+  }
+
+  /**
+   * A file that is merely CLOSED and not dropped is a different thing entirely - the engine writing to a live
+   * component whose channel it lost - and must still be reported. Silencing that along with the dropped case would
+   * trade a false alarm for a missed one.
+   */
+  @Test
+  void aPageOfAClosedButNotDroppedFileIsStillReported() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    final PaginatedComponentFile file = scratchFile(db, "issue7363-closed");
+    final MutablePage page = new MutablePage(new PageId(db, file.getFileId(), 0), PAGE_SIZE);
+
+    file.close();
+    assertThat(file.isDropped()).isFalse();
+
+    assertThatCode(() -> PageManager.INSTANCE.flushPage(page))
+        .as("nothing says these pages are superseded, so this failure must reach the caller")
+        .hasMessageContaining("is closed");
+
+    // Leave nothing half-open behind for the fixture's own close.
+    db.getFileManager().dropFile(file.getFileId());
+  }
+
+  /**
+   * A page-backed file registered with the {@code FileManager} but backed by no schema component: enough for the
+   * flush path, which resolves the file by id, and detached from everything the fixture's own close touches.
+   */
+  private static PaginatedComponentFile scratchFile(final DatabaseInternal db, final String componentName)
+      throws Exception {
+    final int fileId = db.getFileManager().newFileId();
+    final String path = db.getDatabasePath() + "/" + componentName + "." + fileId + "." + PAGE_SIZE + ".v0.scratch";
+    return (PaginatedComponentFile) db.getFileManager()
+        .getOrCreateFile(componentName, path, ComponentFile.MODE.READ_WRITE);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue7361GraphPersistCommitLockTimeoutTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue7361GraphPersistCommitLockTimeoutTest.java
@@ -25,6 +25,7 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.exception.LockTimeoutException;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.schema.TypeLSMVectorIndexBuilder;
+import com.arcadedb.utility.LockManager;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -32,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.TimeUnit;
 
@@ -136,6 +138,7 @@ class Issue7361GraphPersistCommitLockTimeoutTest extends TestHelper {
     final CountDownLatch held = new CountDownLatch(1);
     final CountDownLatch release = new CountDownLatch(1);
     final Object holder = new Object();
+    final AtomicBoolean contended = new AtomicBoolean();
 
     // Stands in for the importer thread of the report: it holds the vecgraph file - which every commit touching
     // this index locks (#4937) - for far longer than the interactive budget, and far less than the bulk one.
@@ -155,14 +158,21 @@ class Issue7361GraphPersistCommitLockTimeoutTest extends TestHelper {
 
     assertThat(held.await(30, TimeUnit.SECONDS)).isTrue();
 
-    // Releases the file a beat after the persist has started queueing for it, so the persist genuinely waits past
-    // the interactive budget instead of never contending at all.
+    // Releases the file only once the persist is OBSERVABLY queued behind it, so the test cannot pass for the
+    // wrong reason - a sleep long enough on a fast machine is not long enough on a loaded CI runner, and the
+    // persist would then take an uncontended lock and prove nothing.
     final Thread releaser = new Thread(() -> {
-      try {
-        Thread.sleep(1_000);
-      } catch (final InterruptedException e) {
-        Thread.currentThread().interrupt();
+      while (waitersOn(db, graphFileId) == 0) {
+        if (release.getCount() == 0)
+          return;
+        try {
+          Thread.sleep(5);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return;
+        }
       }
+      contended.set(true);
       release.countDown();
     }, "issue7361-releaser");
     releaser.setDaemon(true);
@@ -182,6 +192,63 @@ class Issue7361GraphPersistCommitLockTimeoutTest extends TestHelper {
     assertThat(graphFile.getManifest().read()).isNotNull();
     assertThat(graphFile.getManifest().read().vectorCount())
         .as("and its manifest vouches for the pages rather than refusing them").isEqualTo(LIVE);
+    assertThat(contended.get())
+        .as("the persist has to have actually queued behind the holder, or this proves nothing").isTrue();
+  }
+
+  /**
+   * The other branch of the budget: {@code 0} is the lock manager's "wait indefinitely", and it has to survive
+   * the clamp against {@code arcadedb.commitLockTimeout} rather than being read as "smaller, so use the other
+   * one". The clamp exists so the budget can never make a build give up SOONER than today, and waiting forever
+   * is the opposite of sooner.
+   */
+  @Test
+  void anIndefiniteBulkBudgetIsNotClampedAwayByTheCommitDefault() {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    db.getConfiguration().setValue(GlobalConfiguration.COMMIT_LOCK_TIMEOUT, 5_000L);
+    db.getConfiguration().setValue(GlobalConfiguration.INDEX_BUILD_COMMIT_LOCK_TIMEOUT, 0L);
+
+    createSchema();
+    insertDocs(8);
+
+    final List<Long> observed = new ArrayList<>();
+
+    database.begin();
+    try {
+      vectorIndex().build((document, totalIndexed) -> observed.add(db.getTransaction().getCommitLockTimeout()), null);
+    } finally {
+      if (database.isTransactionActive())
+        database.commit();
+    }
+
+    assertThat(observed).isNotEmpty();
+    assertThat(observed).as("0 means wait indefinitely, and no positive commit default outranks it").containsOnly(0L);
+
+    // And a negative value, which the lock manager reads the same way, is carried through just as it is.
+    db.getConfiguration().setValue(GlobalConfiguration.INDEX_BUILD_COMMIT_LOCK_TIMEOUT, -1L);
+    observed.clear();
+
+    database.begin();
+    try {
+      vectorIndex().build((document, totalIndexed) -> observed.add(db.getTransaction().getCommitLockTimeout()), null);
+    } finally {
+      if (database.isTransactionActive())
+        database.commit();
+    }
+
+    assertThat(observed).isNotEmpty();
+    assertThat(observed).as("anything <= 0 is the same 'wait indefinitely' to the lock manager").containsOnly(-1L);
+  }
+
+  /**
+   * @return how many requesters are queued behind whoever holds {@code fileId} right now
+   */
+  private static int waitersOn(final DatabaseInternal db, final int fileId) {
+    for (final LockManager.LockStats stats : db.getTransactionManager().getLockStats())
+      if (String.valueOf(fileId).equals(stats.resource()))
+        return stats.waiters();
+    return 0;
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue7361GraphPersistCommitLockTimeoutTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue7361GraphPersistCommitLockTimeoutTest.java
@@ -28,6 +28,7 @@ import com.arcadedb.schema.TypeLSMVectorIndexBuilder;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
@@ -180,6 +181,43 @@ class Issue7361GraphPersistCommitLockTimeoutTest extends TestHelper {
     assertThat(graphFile.getManifest().read()).isNotNull();
     assertThat(graphFile.getManifest().read().vectorCount())
         .as("and its manifest vouches for the pages rather than refusing them").isEqualTo(LIVE);
+  }
+
+  /**
+   * The ordinary bulk build path - {@code build()}, what {@code CREATE INDEX ... TYPE LSM_VECTOR} runs - and not
+   * only the rebuild one. {@code build()} opens the transaction the whole build runs in before anything under it
+   * gets a say, so a budget applied only by a nested method that thinks it opened its own transaction never
+   * applies at all: the first chunk commit, and a whole single-chunk persist, stayed on the interactive default.
+   * <p>
+   * Asserted on the transaction itself rather than through contention, because that is the fact that decides it
+   * and it holds for every commit of the build, not only for one that happens to be contended.
+   */
+  @Test
+  void theOrdinaryBulkBuildRunsItsCommitsOnTheBulkBudgetToo() {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    db.getConfiguration().setValue(GlobalConfiguration.COMMIT_LOCK_TIMEOUT, 100L);
+    db.getConfiguration().setValue(GlobalConfiguration.INDEX_BUILD_COMMIT_LOCK_TIMEOUT, 30_000L);
+
+    createSchema();
+    insertDocs(LIVE);
+
+    final List<Long> observed = new ArrayList<>();
+
+    database.begin();
+    try {
+      // Every record of the bulk load is indexed inside the transaction build() itself opened and commits.
+      vectorIndex().build((document, totalIndexed) -> observed.add(db.getTransaction().getCommitLockTimeout()), null);
+    } finally {
+      if (database.isTransactionActive())
+        database.commit();
+    }
+
+    assertThat(observed).as("the build has to have indexed something for this to say anything").isNotEmpty();
+    assertThat(observed)
+        .as("every commit of a bulk build waits on the bulk budget, from the first one: the transaction it all "
+            + "runs in is opened by build() itself, so nothing under it can be the thing that sets this")
+        .containsOnly(30_000L);
   }
 
   // ------------------------------------------------------------------------------------------------- helpers

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue7361GraphPersistCommitLockTimeoutTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue7361GraphPersistCommitLockTimeoutTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.exception.LockTimeoutException;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.TypeLSMVectorIndexBuilder;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7361: a vector graph build that had cost 27 minutes was thrown away because ONE of its persist chunk
+ * commits could not take the vecgraph file lock inside the interactive 5s default:
+ * <pre>
+ * Timeout on locking file 6 (..._vecgraph...) during commit (timeout=5000ms, heldBy='Thread[#1,main]' for 7271ms)
+ * PERSIST: Failed to persist graph for ... (nodes=1600000): IndexException - Error writing graph to pages
+ * </pre>
+ * <b>Why anything else holds that file.</b> {@code LSMVectorIndex.getFileIds()} puts the companion graph file in
+ * the lock set of EVERY commit that touched the index (issue #4937), so an ordinary insert commit - which writes no
+ * graph page at all - takes it. That is deliberate and stays: it is what keeps a transaction that does write graph
+ * pages from passing the commit version checks without the file lock held. The consequence is that a graph persist
+ * running alongside a live ingest queues behind the loader as a matter of course.
+ * <p>
+ * <b>Why giving up after 5s is the wrong answer there.</b> {@code arcadedb.commitLockTimeout} is sized for an
+ * interactive transaction, where a fast failure is right because the caller retries cheaply. A graph persist is the
+ * opposite: it commits once per {@code arcadedb.index.buildChunkSizeMB}, every one of those commits is a step of a
+ * build that already cost minutes, and losing any one of them discards the build and marks the pages unusable -
+ * to spare a wait of about seven seconds. The persist now waits on
+ * {@code arcadedb.index.buildCommitLockTimeout} instead, which bounds only how long it WAITS and never how long it
+ * HOLDS, so no other transaction is slowed by it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("vector")
+class Issue7361GraphPersistCommitLockTimeoutTest extends TestHelper {
+  private static final int DIMENSIONS = 32;
+  private static final int LIVE       = 150;
+
+  /**
+   * The plumbing, on its own: a transaction can be given a commit lock budget of its own, and it is that budget -
+   * not the configured one - that bounds its wait.
+   */
+  @Test
+  void aTransactionCanBeGivenACommitLockBudgetOfItsOwn() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    database.getSchema().createDocumentType("Doc");
+
+    final int fileId = database.getSchema().getType("Doc").getBuckets(false).getFirst().getFileId();
+
+    final CountDownLatch held = new CountDownLatch(1);
+    final CountDownLatch release = new CountDownLatch(1);
+    final Object holder = new Object();
+
+    final Thread contender = new Thread(() -> {
+      db.getTransactionManager().tryLockFiles(List.of(fileId), 0, holder);
+      held.countDown();
+      try {
+        release.await(30, TimeUnit.SECONDS);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } finally {
+        db.getTransactionManager().unlockFilesInOrder(List.of(fileId), holder);
+      }
+    }, "issue7361-lock-holder");
+    contender.setDaemon(true);
+    contender.start();
+
+    assertThat(held.await(30, TimeUnit.SECONDS)).isTrue();
+    try {
+      database.begin();
+      db.getTransaction().setCommitLockTimeout(50L);
+      database.newDocument("Doc").set("v", 1).save();
+
+      assertThatThrownBy(database::commit)
+          .as("50ms is the budget this transaction asked for, whatever the configured one is")
+          .isInstanceOf(LockTimeoutException.class)
+          .hasMessageContaining("timeout=50ms");
+    } finally {
+      release.countDown();
+      contender.join(TimeUnit.SECONDS.toMillis(30));
+    }
+
+    assertThat(database.isTransactionActive()).isFalse();
+  }
+
+  /**
+   * The behaviour the issue is about: a persist whose chunk commit queues behind an ordinary commit that holds the
+   * vecgraph file for longer than the interactive default must wait for it, not discard the build.
+   * <p>
+   * The interactive budget is set far below the hold time so a persist running on it is certain to fail, and the
+   * bulk budget far above it so one running on the bulk budget is certain to succeed. What separates the two is
+   * which budget the persist uses, which is what this asserts.
+   */
+  @Test
+  void aPersistChunkWaitsOnTheBulkBudgetRatherThanDiscardingTheBuild() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    db.getConfiguration().setValue(GlobalConfiguration.COMMIT_LOCK_TIMEOUT, 100L);
+    db.getConfiguration().setValue(GlobalConfiguration.INDEX_BUILD_COMMIT_LOCK_TIMEOUT, 30_000L);
+
+    createSchema();
+    insertDocs(LIVE);
+
+    final int graphFileId = graphFileOf(vectorIndex()).getFileId();
+
+    final CountDownLatch held = new CountDownLatch(1);
+    final CountDownLatch release = new CountDownLatch(1);
+    final Object holder = new Object();
+
+    // Stands in for the importer thread of the report: it holds the vecgraph file - which every commit touching
+    // this index locks (#4937) - for far longer than the interactive budget, and far less than the bulk one.
+    final Thread importer = new Thread(() -> {
+      db.getTransactionManager().tryLockFiles(List.of(graphFileId), 0, holder);
+      held.countDown();
+      try {
+        release.await(30, TimeUnit.SECONDS);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } finally {
+        db.getTransactionManager().unlockFilesInOrder(List.of(graphFileId), holder);
+      }
+    }, "issue7361-importer");
+    importer.setDaemon(true);
+    importer.start();
+
+    assertThat(held.await(30, TimeUnit.SECONDS)).isTrue();
+
+    // Releases the file a beat after the persist has started queueing for it, so the persist genuinely waits past
+    // the interactive budget instead of never contending at all.
+    final Thread releaser = new Thread(() -> {
+      try {
+        Thread.sleep(1_000);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      release.countDown();
+    }, "issue7361-releaser");
+    releaser.setDaemon(true);
+    releaser.start();
+
+    try {
+      vectorIndex().buildVectorGraphNow();
+    } finally {
+      release.countDown();
+      importer.join(TimeUnit.SECONDS.toMillis(30));
+      releaser.join(TimeUnit.SECONDS.toMillis(30));
+    }
+
+    final LSMVectorIndexGraphFile graphFile = graphFileOf(vectorIndex());
+    assertThat(graphFile.getLastWrittenGraphBytes())
+        .as("the persist waited for the file instead of discarding a completed build").isGreaterThan(0L);
+    assertThat(graphFile.getManifest().read()).isNotNull();
+    assertThat(graphFile.getManifest().read().vectorCount())
+        .as("and its manifest vouches for the pages rather than refusing them").isEqualTo(LIVE);
+  }
+
+  // ------------------------------------------------------------------------------------------------- helpers
+
+  private void createSchema() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.id STRING");
+      database.command("sql", "CREATE PROPERTY Doc.embedding ARRAY_OF_FLOATS");
+
+      final TypeLSMVectorIndexBuilder builder = (TypeLSMVectorIndexBuilder) database.getSchema()
+          .buildTypeIndex("Doc", new String[] { "embedding" }).withLSMVectorType();
+      builder.withDimensions(DIMENSIONS).withStoreVectorsInGraph(true).create();
+    });
+  }
+
+  private void insertDocs(final int count) {
+    database.transaction(() -> {
+      for (int i = 0; i < count; i++)
+        database.command("sql", "INSERT INTO Doc SET id = ?, embedding = ?", "doc" + i, embedding(i));
+    });
+  }
+
+  private static float[] embedding(final int doc) {
+    final Random random = new Random(0x7361L * 31 + doc);
+    final float[] v = new float[DIMENSIONS];
+    for (int j = 0; j < DIMENSIONS; j++)
+      v[j] = (float) random.nextGaussian();
+    return v;
+  }
+
+  private LSMVectorIndex vectorIndex() {
+    return vectorIndexOf(database);
+  }
+
+  private static LSMVectorIndex vectorIndexOf(final Database db) {
+    return (LSMVectorIndex) ((TypeIndex) db.getSchema().getIndexByName("Doc[embedding]")).getIndexesOnBuckets()[0];
+  }
+
+  private static LSMVectorIndexGraphFile graphFileOf(final LSMVectorIndex index) {
+    final LSMVectorIndexGraphFile graphFile = index.getGraphFile();
+    assertThat(graphFile).as("the index must have a graph file").isNotNull();
+    return graphFile;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue7361GraphPersistCommitLockTimeoutTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue7361GraphPersistCommitLockTimeoutTest.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -204,10 +205,13 @@ class Issue7361GraphPersistCommitLockTimeoutTest extends TestHelper {
 
     final List<Long> observed = new ArrayList<>();
 
+    final AtomicReference<Long> budgetAfterBuild = new AtomicReference<>(-1L);
+
     database.begin();
     try {
       // Every record of the bulk load is indexed inside the transaction build() itself opened and commits.
       vectorIndex().build((document, totalIndexed) -> observed.add(db.getTransaction().getCommitLockTimeout()), null);
+      budgetAfterBuild.set(db.getTransaction().getCommitLockTimeout());
     } finally {
       if (database.isTransactionActive())
         database.commit();
@@ -218,6 +222,10 @@ class Issue7361GraphPersistCommitLockTimeoutTest extends TestHelper {
         .as("every commit of a bulk build waits on the bulk budget, from the first one: the transaction it all "
             + "runs in is opened by build() itself, so nothing under it can be the thing that sets this")
         .containsOnly(30_000L);
+    assertThat(budgetAfterBuild.get())
+        .as("and the budget is put back the way the WAL setting is: build() is public, so a caller that already "
+            + "had a transaction open must not have its own later commit inherit a bulk build's budget")
+        .isNull();
   }
 
   // ------------------------------------------------------------------------------------------------- helpers

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue7362PersistedGraphLengthTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue7362PersistedGraphLengthTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.BasePage;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.TypeLSMVectorIndexBuilder;
+import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7362: a persisted vector graph could not be reloaded as an {@code OnDiskGraphIndex}, because the length
+ * the load measured its JVector footer back from was re-derived from the component's page count instead of being
+ * the length the write actually ended on.
+ * <p>
+ * Two independent defects fed that, and both are covered here.
+ * <p>
+ * <b>The page count did not count the pages.</b> {@code ContiguousPageWriter} appended pages through
+ * {@code TransactionContext.getPage() + getPageToModify()}. That never fails past the end of a file - {@code getPage}
+ * asks the page manager with {@code createIfNotExists}, so it invents a zero-filled page - which made the
+ * {@code addPage()} fallback next to it unreachable. {@code addPage} is the only thing that raises the transaction's
+ * page counter, so no counter moved, and the component's count was left to be raised one page at a time, later, by
+ * the async flush thread. A graph written and reloaded in the same breath therefore measured itself against
+ * whatever the flusher had got through: in the report, 7,601 pages for 3,148,792,924 bytes actually written, a
+ * length short by more than a gigabyte, and a footer magic read off the middle of the payload.
+ * <p>
+ * <b>The page count could not have answered it anyway.</b> {@code updatePageCount} is monotonic, so once a file has
+ * held a large generation of the graph its count never comes back down: a smaller generation written over it is
+ * measured with its predecessor's size. The length is now recorded by the write, in the manifest, and read back
+ * from there.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("vector")
+class Issue7362PersistedGraphLengthTest extends TestHelper {
+  private static final int DIMENSIONS = 32;
+  private static final int LIVE       = 200;
+  private static final int PAGE_SIZE  = 65536;
+
+  /**
+   * The root defect, in isolation and without a graph in sight: pages appended to a component file must be visible
+   * in its page count as soon as they are written, and not only once the flush thread has caught up.
+   */
+  @Test
+  void appendedPagesAreCountedBeforeTheCommitAndNotOnlyAfterTheAsyncFlush() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int usablePageSize = PAGE_SIZE - BasePage.PAGE_HEADER_SIZE;
+    final int pagesToWrite = 5;
+
+    database.begin();
+    try {
+      final LSMVectorIndexGraphFile graphFile = new LSMVectorIndexGraphFile(db, "test-7362-counting",
+          db.getDatabasePath() + "/test-7362-counting", ComponentFile.MODE.READ_WRITE, PAGE_SIZE);
+      db.getSchema().getEmbedded().registerFile(graphFile);
+
+      final ContiguousPageWriter writer = new ContiguousPageWriter(db, graphFile.getFileId(), PAGE_SIZE);
+
+      // usablePageSize is a multiple of 4, so this lands exactly on a page boundary: pages [0, pagesToWrite).
+      final long target = (long) usablePageSize * pagesToWrite;
+      while (writer.position() < target)
+        writer.writeInt(0xC0FFEE);
+      assertThat(writer.position()).isEqualTo(target);
+      writer.close();
+
+      assertThat(graphFile.getTotalPages())
+          .as("the %d pages just appended must be counted while the transaction that wrote them is still open: "
+              + "everything that asks how big the persisted graph is asks this", pagesToWrite)
+          .isEqualTo(pagesToWrite);
+
+      database.commit();
+
+      assertThat(graphFile.getTotalPages())
+          .as("and still be counted right after the commit, with the async flush thread not necessarily done")
+          .isEqualTo(pagesToWrite);
+    } finally {
+      if (database.isTransactionActive())
+        database.rollback();
+    }
+  }
+
+  /**
+   * The write records the length it ended on, and the load uses that rather than re-deriving one. Verified against
+   * a page count deliberately inflated past the truth - which is the state a file that once held a larger
+   * generation of the graph is permanently in, {@code updatePageCount} being monotonic.
+   */
+  @Test
+  void theGraphIsLoadedWithTheLengthTheWriteRecordedNotWithOneDerivedFromThePageCount() throws Exception {
+    createSchema();
+    insertDocs(LIVE);
+    vectorIndex().buildVectorGraphNow();
+
+    final LSMVectorIndexGraphFile graphFile = graphFileOf(vectorIndex());
+    final long written = graphFile.getLastWrittenGraphBytes();
+
+    assertThat(written).as("the persist must report the length it ended on").isGreaterThan(0L);
+    assertThat(graphFile.getManifest().read()).isNotNull();
+    assertThat(graphFile.getManifest().read().graphBytes())
+        .as("and record it next to the pages, so the next session does not have to re-derive it")
+        .isEqualTo(written);
+
+    // What a file that once held a bigger graph looks like forever after: a page count that no longer describes
+    // its contents, and that cannot be lowered.
+    graphFile.updatePageCount(graphFile.getTotalPages() * 4 + 128);
+
+    try (final OnDiskGraphIndex reloaded = graphFile.loadGraph()) {
+      assertThat(reloaded)
+          .as("the recorded length is a fact about the write, so an inflated page count cannot break the reload")
+          .isNotNull();
+      assertThat(reloaded.getIdUpperBound()).isEqualTo(LIVE);
+    }
+  }
+
+  /**
+   * The same length has to survive the session that wrote it: on a reopen there is no in-memory record of the
+   * write left, only the manifest.
+   */
+  @Test
+  void theRecordedLengthSurvivesAReopen() throws Exception {
+    createSchema();
+    insertDocs(LIVE);
+    vectorIndex().buildVectorGraphNow();
+
+    final long written = graphFileOf(vectorIndex()).getLastWrittenGraphBytes();
+    assertThat(written).isGreaterThan(0L);
+
+    reopenDatabase();
+
+    final LSMVectorIndexGraphFile graphFile = graphFileOf(vectorIndex());
+    assertThat(graphFile.getLastWrittenGraphBytes())
+        .as("nothing in this session wrote the graph, so the length can only come from the manifest").isEqualTo(-1L);
+    assertThat(graphFile.getManifest().read().graphBytes()).isEqualTo(written);
+
+    graphFile.updatePageCount(graphFile.getTotalPages() * 4 + 128);
+
+    try (final OnDiskGraphIndex reloaded = graphFile.loadGraph()) {
+      assertThat(reloaded).isNotNull();
+      assertThat(reloaded.getIdUpperBound()).isEqualTo(LIVE);
+    }
+  }
+
+  /**
+   * A manifest written before issue #7362 carries no length, and must keep being read - and keep falling back to
+   * the page-count derivation - rather than being refused wholesale.
+   */
+  @Test
+  void aManifestWithoutARecordedLengthStillReads() throws Exception {
+    createSchema();
+    insertDocs(LIVE);
+    vectorIndex().buildVectorGraphNow();
+
+    final LSMVectorIndexGraphManifest manifest = graphFileOf(vectorIndex()).getManifest();
+    final LSMVectorIndexGraphManifest.Content before = manifest.read();
+    assertThat(before).isNotNull();
+
+    // Exactly what an older build wrote: same manifest, without the key.
+    manifest.write(before.vectorCount(), before.fingerprint(), before.unreachableOrdinals(), 0L);
+
+    final LSMVectorIndexGraphManifest.Content after = manifest.read();
+    assertThat(after).as("an older manifest is still a readable one").isNotNull();
+    assertThat(after.vectorCount()).isEqualTo(before.vectorCount());
+    assertThat(after.fingerprint()).isEqualTo(before.fingerprint());
+    assertThat(after.graphBytes()).as("it simply records no length").isZero();
+  }
+
+  // ------------------------------------------------------------------------------------------------- helpers
+
+  private void createSchema() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.id STRING");
+      database.command("sql", "CREATE PROPERTY Doc.embedding ARRAY_OF_FLOATS");
+
+      final TypeLSMVectorIndexBuilder builder = (TypeLSMVectorIndexBuilder) database.getSchema()
+          .buildTypeIndex("Doc", new String[] { "embedding" }).withLSMVectorType();
+      // Inline vectors are what makes the persisted graph big enough for its length to matter at all, and they are
+      // the configuration the report ran with.
+      builder.withDimensions(DIMENSIONS).withStoreVectorsInGraph(true).create();
+    });
+  }
+
+  private void insertDocs(final int count) {
+    database.transaction(() -> {
+      for (int i = 0; i < count; i++)
+        database.command("sql", "INSERT INTO Doc SET id = ?, embedding = ?", "doc" + i, embedding(i));
+    });
+  }
+
+  private static float[] embedding(final int doc) {
+    final Random random = new Random(0x7362L * 31 + doc);
+    final float[] v = new float[DIMENSIONS];
+    for (int j = 0; j < DIMENSIONS; j++)
+      v[j] = (float) random.nextGaussian();
+    return v;
+  }
+
+  private LSMVectorIndex vectorIndex() {
+    return vectorIndexOf(database);
+  }
+
+  private static LSMVectorIndex vectorIndexOf(final Database db) {
+    return (LSMVectorIndex) ((TypeIndex) db.getSchema().getIndexByName("Doc[embedding]")).getIndexesOnBuckets()[0];
+  }
+
+  private static LSMVectorIndexGraphFile graphFileOf(final LSMVectorIndex index) {
+    final LSMVectorIndexGraphFile graphFile = index.getGraphFile();
+    assertThat(graphFile).as("the index must have persisted its graph").isNotNull();
+    return graphFile;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifestTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifestTest.java
@@ -50,7 +50,7 @@ class LSMVectorIndexGraphManifestTest {
     final long fingerprint = LSMVectorIndexGraphManifest.fingerprintOf(new int[] { 0, 1, 2 },
         id -> new RID(3, id * 10L));
 
-    manifest.write(3, fingerprint, LSMVectorIndexGraphManifest.NO_UNREACHABLE_ORDINALS);
+    manifest.write(3, fingerprint, LSMVectorIndexGraphManifest.NO_UNREACHABLE_ORDINALS, 0L);
 
     assertThat(manifest.exists()).isTrue();
     final LSMVectorIndexGraphManifest.Content content = manifest.read();
@@ -69,7 +69,7 @@ class LSMVectorIndexGraphManifestTest {
     final LSMVectorIndexGraphManifest manifest = manifest();
     final long awkward = -6_148_914_691_236_517_206L; // 0xAAAA...AAAA
 
-    manifest.write(7, awkward, LSMVectorIndexGraphManifest.NO_UNREACHABLE_ORDINALS);
+    manifest.write(7, awkward, LSMVectorIndexGraphManifest.NO_UNREACHABLE_ORDINALS, 0L);
 
     assertThat(manifest.read().fingerprint()).isEqualTo(awkward);
   }
@@ -78,7 +78,7 @@ class LSMVectorIndexGraphManifestTest {
   @Test
   void anUnusableManifestCannotBeMatchedByAnyLiveSet() {
     final LSMVectorIndexGraphManifest manifest = manifest();
-    manifest.write(12, 1234L, LSMVectorIndexGraphManifest.NO_UNREACHABLE_ORDINALS);
+    manifest.write(12, 1234L, LSMVectorIndexGraphManifest.NO_UNREACHABLE_ORDINALS, 0L);
 
     manifest.markUnusable("simulated persist failure");
 
@@ -91,7 +91,7 @@ class LSMVectorIndexGraphManifestTest {
   @Test
   void aTruncatedOrCorruptedManifestReadsAsAbsent() throws Exception {
     final LSMVectorIndexGraphManifest manifest = manifest();
-    manifest.write(5, 99L, LSMVectorIndexGraphManifest.NO_UNREACHABLE_ORDINALS);
+    manifest.write(5, 99L, LSMVectorIndexGraphManifest.NO_UNREACHABLE_ORDINALS, 0L);
 
     Files.writeString(manifestPath(), "{\"formatVersion\": 1, \"vectorCou", StandardCharsets.UTF_8);
 
@@ -122,7 +122,7 @@ class LSMVectorIndexGraphManifestTest {
   @Test
   void invalidateRemovesTheManifestSoNothingVouchesForThePages() {
     final LSMVectorIndexGraphManifest manifest = manifest();
-    manifest.write(4, 7L, LSMVectorIndexGraphManifest.NO_UNREACHABLE_ORDINALS);
+    manifest.write(4, 7L, LSMVectorIndexGraphManifest.NO_UNREACHABLE_ORDINALS, 0L);
 
     manifest.invalidate();
 
@@ -141,7 +141,7 @@ class LSMVectorIndexGraphManifestTest {
     Files.writeString(leftover, "half written", StandardCharsets.UTF_8);
     Files.writeString(unrelated, "the graph itself", StandardCharsets.UTF_8);
 
-    manifest().write(1, 1L, LSMVectorIndexGraphManifest.NO_UNREACHABLE_ORDINALS);
+    manifest().write(1, 1L, LSMVectorIndexGraphManifest.NO_UNREACHABLE_ORDINALS, 0L);
 
     assertThat(leftover).as("the sweep must remove an abandoned temporary of this manifest").doesNotExist();
     assertThat(unrelated).as("and must match by name, so it cannot reach anything else").exists();
@@ -160,7 +160,7 @@ class LSMVectorIndexGraphManifestTest {
   void unreachableOrdinalsSurviveTheRoundTrip() {
     final LSMVectorIndexGraphManifest manifest = manifest();
 
-    manifest.write(50_000, 42L, new int[] { 7, 39_896, 49_999 });
+    manifest.write(50_000, 42L, new int[] { 7, 39_896, 49_999 }, 0L);
 
     assertThat(manifest.read().unreachableOrdinals()).containsExactly(7, 39_896, 49_999);
   }
@@ -169,7 +169,7 @@ class LSMVectorIndexGraphManifestTest {
   void aManifestWithoutUnreachableOrdinalsReadsAsNoneRatherThanNull() {
     final LSMVectorIndexGraphManifest manifest = manifest();
 
-    manifest.write(10, 5L, LSMVectorIndexGraphManifest.NO_UNREACHABLE_ORDINALS);
+    manifest.write(10, 5L, LSMVectorIndexGraphManifest.NO_UNREACHABLE_ORDINALS, 0L);
 
     assertThat(manifest.read().unreachableOrdinals())
         .as("callers walk this array; an absent entry must read as empty, never as null").isEmpty();
@@ -222,7 +222,7 @@ class LSMVectorIndexGraphManifestTest {
   @Test
   void markingACloseAsDeferredKeepsTheUnreachableOrdinals() {
     final LSMVectorIndexGraphManifest manifest = manifest();
-    manifest.write(1_000, 11L, new int[] { 3, 4 });
+    manifest.write(1_000, 11L, new int[] { 3, 4 }, 3_148_792_924L);
 
     manifest.markCloseDeferred();
 
@@ -230,15 +230,17 @@ class LSMVectorIndexGraphManifestTest {
     assertThat(content.closeDeferredRebuild()).isTrue();
     assertThat(content.vectorCount()).isEqualTo(1_000);
     assertThat(content.unreachableOrdinals()).containsExactly(3, 4);
+    assertThat(content.graphBytes())
+        .as("the pages have not changed, so neither has their length (issue #7362)").isEqualTo(3_148_792_924L);
   }
 
   /** A completed build supersedes whatever the previous one orphaned - a Vamana build orphans a fresh set. */
   @Test
   void aLaterWriteReplacesThePreviousUnreachableOrdinals() {
     final LSMVectorIndexGraphManifest manifest = manifest();
-    manifest.write(1_000, 11L, new int[] { 3, 4 });
+    manifest.write(1_000, 11L, new int[] { 3, 4 }, 0L);
 
-    manifest.write(1_000, 12L, new int[] { 9 });
+    manifest.write(1_000, 12L, new int[] { 9 }, 0L);
 
     assertThat(manifest.read().unreachableOrdinals()).containsExactly(9);
   }


### PR DESCRIPTION
Closes #7361, closes #7362, closes #7363. All three split out of #7357 (discussion #7333), all on the path a bulk load with an `LSM_VECTOR` index takes.

## #7362 - a persisted graph could not be reloaded as `OnDiskGraphIndex`

**The page count did not count the pages.** `ContiguousPageWriter` appended pages through `TransactionContext.getPage() + getPageToModify()`. That never fails past the end of a file - `getPage` asks the page manager with `createIfNotExists`, so it invents a zero-filled page - which made the `addPage()` fallback next to it **unreachable**. `addPage` is the only thing that raises the transaction's page counter, so no counter moved, and the component's count was left to be raised one page at a time, later, by the async flush thread.

A graph written and reloaded in the same breath therefore measured itself against whatever the flusher had got through: in the report, **7,601 pages for 3,148,792,924 bytes actually written** - a length short by more than a gigabyte, and a JVector footer magic read off the middle of the payload.

**The page count could not have answered it anyway.** `updatePageCount` is monotonic, so once a file has held a large generation of the graph its count never comes back down: a smaller generation written over it is measured with its predecessor's size.

So the fix is both halves:
- appended pages are registered with `addPage`, which is what makes `getTotalPages()` answer for them during the write and right after the commit;
- the write **records the length it ended on**, in the manifest, and the load reads it back instead of re-deriving one. The last-page readability check is kept for the recorded length too, so a truncated file still falls through to the rebuild path rather than aborting. A manifest written before this carries no length and keeps using the page-count derivation.

Also corrected the write log line. It said `quantization=INT8` next to a byte count produced by float32 inline vectors: JVector's `InlineVectors` reserves `dimension * Float.BYTES` per node and `ArcadePageVectorValues` hands it dequantized floats, so the quantization is real but says nothing about those bytes. It now reports the inline vector size for what it is and labels the quantization as the index setting it is. (Making the inline vectors themselves quantized is a format change, not a fix - out of scope here.)

## #7361 - a completed build discarded on a 5s lock timeout

**Why anything else holds the vecgraph file** (the issue's first question): `LSMVectorIndex.getFileIds()` puts the companion graph file in the lock set of **every** commit that touched the index (#4937), so an ordinary insert commit - which writes no graph page at all - takes it. That is deliberate and stays: it is what keeps a transaction that does write graph pages from passing the commit version checks without the file lock held. The consequence is that a persist running alongside a live ingest queues behind the loader as a matter of course. The holder in the report being `main` is expected, not a bug.

**Why giving up after 5s is the wrong answer there.** `arcadedb.commitLockTimeout` is sized for an interactive transaction, where a fast failure is right because the caller retries cheaply. A graph persist is the opposite: it commits once per `arcadedb.index.buildChunkSizeMB`, every one of those commits is a step of a build that already cost minutes, and losing any one of them discards the build and marks the pages unusable - to spare a wait of about seven seconds.

A retry of the failed commit is not available: `LocalDatabase.commit()` pops the transaction in its `finally`, and the lock timeout leaves it in `COMMIT_1ST_PHASE`, so there is nothing left to re-commit. What the persist needs is a **budget sized for what it is**, which is what this adds: a per-transaction commit lock timeout, and `arcadedb.index.buildCommitLockTimeout` (default 60s, `0` waits indefinitely) that the graph persist sets on its own transaction and on every chunk transaction after it. It bounds only how long the persist **waits**, never how long it **holds**, so raising it cannot slow any other transaction down; the lock manager's queue is FIFO with fair hand-off, so the wait is bounded by the contenders ahead of it. It never shortens the current behaviour either - it falls back to the commit default if configured smaller.

## #7363 - SEVER/WARNI for pages of a file compaction has closed

Answering the issue's question 1: **the pages are genuinely superseded**, not live pages being dropped. The file they belong to has been replaced and deleted, so there is nowhere for them to go and nothing to lose, and `PageManager.deleteFile` has already purged the queue, the deferred batches and the page index for that file. `flushPage` has always had a quiet FINE path for exactly this, taken once the file has left the `FileManager`. What it did not have was a way to recognise the same situation **one instant earlier**, while the file is on its way out: still registered, closed or closing. So the identical, harmless event was reported at the two levels an operator watches for real corruption.

`ComponentFile` now raises a `dropped` flag **before** closing - the ordering is the point, since `close()` can run entirely between the flush thread's `isOpen()` check and its write - and `flushPage` takes the quiet path (WAL ack included, per #4928/#6440) whenever the file it failed on says it was dropped. A live file whose write genuinely failed still propagates with its reporting intact, which the tests pin.

The `IllegalArgumentException` variant was worse than noise: unchecked, it escaped every per-page catch in the flush loop and abandoned the rest of the batch, whose pages then kept their `pageIndex` entries and WAL acks forever - so `waitAllPagesOfDatabaseAreFlushed` burned its whole budget on the next close. The per-page loop gains the same catch-all `resumeFlushing()`'s deferred-page loop has always had.

## Verification

Three regression tests, each confirmed to **fail** with the corresponding fix reverted and pass with it:
- `Issue7362PersistedGraphLengthTest` - appended pages counted before the commit; the recorded length survives an inflated page count and a reopen; a manifest with no recorded length still reads.
- `Issue7361GraphPersistCommitLockTimeoutTest` - a transaction honours its own lock budget; a persist whose chunk queues behind a holder outlasting the interactive budget completes instead of discarding the build.
- `Issue7363DroppedFileFlushIsQuietTest` - a dropped-but-still-registered file's page is discarded quietly; an unregistered one stays quiet; a merely closed (not dropped) file is still reported.

Full engine unit lane green: `mvn -o -pl engine -am verify -DexcludedGroups=benchmark,slow` - **14768 tests, 0 failures, 0 errors**. Full reactor builds.

## Note on scope

The in-flight flush batch (`nextPagesToFlush`) is deliberately **not** purged on `deleteFile`. It adds nothing now that `flushPage` handles those pages quietly and acks their WAL, and it would make `deleteFile` block on a batch mid-I/O while introducing a lock-order inversion (the flush thread takes the batch monitor and then the schema's `files` monitor).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable lock-wait timeouts for bulk vector index builds and individual transactions.
  * Persisted exact vector graph sizes for more accurate loading and page tracking.

* **Bug Fixes**
  * Improved reliability when vector indexes are built while files are locked.
  * Corrected page tracking for newly appended vector-index data.
  * Prevented dropped-file cleanup from producing unnecessary flush errors.
  * Improved recovery after unexpected page-flush failures.
  * Preserved compatibility when loading older vector graph manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->