### PR TITLE
ci: mark in progress only the issues a pull request declares it closes

### DIFF
--- a/.github/workflows/label-issue-in-progress.yml
+++ b/.github/workflows/label-issue-in-progress.yml
@@ -1,14 +1,24 @@
-# Marks an issue as being worked on the moment a pull request references it.
+# Marks an issue as being worked on the moment a pull request declares it will close it.
 #
 # The "in progress" label is how the issue list says "someone already has this". Applying it by
 # hand is the step that gets skipped, so the same issue gets picked up twice. A pull request
-# that references the issue is the earliest reliable signal that work started, so that is the
+# that will close the issue is the earliest reliable signal that work started, so that is the
 # trigger.
+#
+# Only *closing* references count - "fixes #123", "resolves #123" - never a bare mention. A body
+# that says "unlike #123" or "see #123 for context" used to mark those issues in progress even
+# though nobody was working on them. The set of keywords, the accepted forms (`#123`, the full
+# issue URL, `owner/repo#123`) and the same-repository rule are not re-implemented here: the
+# `closingIssuesReferences` connection on the pull request is GitHub's own answer to "what does
+# this pull request close", so it cannot drift from what GitHub actually does on merge.
+#
+# Note this ignores the title: closing keywords in a pull request title close nothing on GitHub,
+# and do not appear in this connection either.
 #
 # `pull_request_target` rather than `pull_request` because a fork's `pull_request` run gets a
 # read-only token and could not label anything. Nothing from the pull request head is checked
-# out or executed here - the job only reads the title and body of the event payload and calls
-# the issues API - so the elevated token never touches contributor-controlled code.
+# out or executed here - the job only reads the event payload's pull request number and calls
+# the GitHub API - so the elevated token never touches contributor-controlled code.
 #
 # `edited` is included alongside `opened`: the reference is very often added to the body a minute
 # after the pull request is opened, and without that trigger those issues stay unlabelled.
@@ -20,6 +30,8 @@ on:
 
 permissions:
   issues: write
+  pull-requests: read
+  contents: read
 
 concurrency:
   group: label-in-progress-${{ github.event.pull_request.number }}
@@ -27,64 +39,61 @@ concurrency:
 
 jobs:
   label:
-    name: Add "in progress" to referenced issues
+    name: Add "in progress" to issues this pull request closes
     runs-on: ubuntu-latest
     steps:
-      - name: Label the issues this pull request references
+      - name: Label the issues this pull request closes
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const LABEL = 'in progress';
             const { owner, repo } = context.repo;
-            const pr = context.payload.pull_request;
-            const text = `${pr.title || ''}\n${pr.body || ''}`;
+            const number = context.payload.pull_request.number;
 
-            // Bare "#123" plus the full issue URL, which is what a paste of the address bar
-            // leaves in the body. Only this repository's URLs count: a cross-repository
-            // reference is not ours to label.
-            const numbers = new Set();
-            for (const m of text.matchAll(/(?:^|[\s([{,;:])#(\d+)\b/g))
-              numbers.add(Number(m[1]));
-            const urlPattern = new RegExp(
-              `https?://github\\.com/${owner}/${repo}/issues/(\\d+)`, 'gi');
-            for (const m of text.matchAll(urlPattern))
-              numbers.add(Number(m[1]));
+            // The labels come back with the issues, so no follow-up REST call is needed to know
+            // which ones are already marked. 50 closing references is far past anything real.
+            const query = `
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    closingIssuesReferences(first: 50) {
+                      nodes {
+                        number
+                        state
+                        repository { nameWithOwner }
+                        labels(first: 100) { nodes { name } }
+                      }
+                    }
+                  }
+                }
+              }`;
 
-            numbers.delete(pr.number);
+            const result = await github.graphql(query, { owner, repo, number });
+            const nodes = result.repository.pullRequest.closingIssuesReferences.nodes;
 
-            if (numbers.size === 0) {
-              core.info('No issue reference found in the title or body.');
+            if (nodes.length === 0) {
+              core.info('No closing issue reference found in the body.');
               return;
             }
 
-            for (const number of [...numbers].sort((a, b) => a - b)) {
-              let issue;
-              try {
-                issue = (await github.rest.issues.get({ owner, repo, issue_number: number })).data;
-              } catch (error) {
-                // A number that matches nothing, or a private cross-reference: not an error
-                // worth failing the run over.
-                core.info(`#${number}: not readable (${error.status}), skipped.`);
+            const here = `${owner}/${repo}`;
+            for (const issue of nodes.sort((a, b) => a.number - b.number)) {
+              // A cross-repository reference is not ours to label.
+              if (issue.repository.nameWithOwner !== here) {
+                core.info(`${issue.repository.nameWithOwner}#${issue.number}: other repository, skipped.`);
                 continue;
               }
-
-              // The issues API answers for pull requests too; a pull request referencing a
-              // pull request is not an issue to mark in progress.
-              if (issue.pull_request) {
-                core.info(`#${number}: is a pull request, skipped.`);
+              if (issue.state !== 'OPEN') {
+                core.info(`#${issue.number}: closed, skipped.`);
                 continue;
               }
-              if (issue.state !== 'open') {
-                core.info(`#${number}: closed, skipped.`);
-                continue;
-              }
-              if (issue.labels.some(l => (l.name || l) === LABEL)) {
-                core.info(`#${number}: already labelled "${LABEL}".`);
+              if (issue.labels.nodes.some(l => l.name === LABEL)) {
+                core.info(`#${issue.number}: already labelled "${LABEL}".`);
                 continue;
               }
 
               await github.rest.issues.addLabels({
-                owner, repo, issue_number: number, labels: [LABEL],
+                owner, repo, issue_number: issue.number, labels: [LABEL],
               });
-              core.info(`#${number}: added "${LABEL}".`);
+              core.info(`#${issue.number}: added "${LABEL}".`);
             }


### PR DESCRIPTION
## Problem

`label-issue-in-progress.yml` matched any `#123` in the pull request title or body, so a *mention* was treated the same as a *closing reference*. A pull request that says "unlike #123", "follow-up filed as #123" or "see #123 for context" marked those issues as being worked on, which is exactly the signal the label exists to give.

That is the common case on this repo, not an edge case. Checking three recent pull requests, mentions vs. what they actually close:

| PR | `#N` found by the old regex | actually closes |
|----|------------------------------|-----------------|
| #7349 | 7316, 7250, 7339 | **7316** |
| #7348 | 7315, 6946 | **7315** |
| #7344 | 7313, 7341, 7342 | **7313** |

Every number in the middle column that is not in the right one was labelled "in progress" while nobody was working on it.

## Fix

Ask GitHub what the pull request closes rather than re-deriving it. The `closingIssuesReferences` connection on the pull request is the same answer GitHub acts on at merge time, so the nine closing keywords, the accepted reference forms (`#123`, the full issue URL, `owner/repo#123`) and the same-repository rule cannot drift from what GitHub actually does.

Falling out of that:

- the per-issue `issues.get` REST call is gone - `state` and `labels` come back with the issues
- the "the issues API answers for pull requests too" guard is gone - a pull request is never a closing reference
- the title is no longer scanned. Closing keywords in a title close nothing on GitHub and do not appear in the connection. This is a deliberate behaviour change
- `pull-requests: read` and `contents: read` added to `permissions`; `issues: write` unchanged

The `pull_request_target` trigger and its safety note are unchanged: still nothing from the head is checked out or executed, so the elevated token never touches contributor-controlled code.

## Verification

- the GraphQL query was run as written against a real merged pull request (#7352) and returns the shape the script consumes
- mentions-vs-closes was measured on #7349 / #7348 / #7344, the table above
- the step's script was executed against stubbed `github`/`context`/`core` objects covering: no closing reference, a mix of open, already-labelled, closed, and cross-repository issues. Only the open, unlabelled, same-repository issues reach `addLabels`, in ascending order

```
case: nothing closed
   No closing issue reference found in the body.
case: mixed
   #10: added "in progress".
   #20: closed, skipped.
   #30: added "in progress".
   #40: already labelled "in progress".
   other/repo#50: other repository, skipped.
addLabels calls: [ '10:in progress', '30:in progress' ]
```

## Not in this PR

A pull request that is closed without merging leaves the issue labelled "in progress" forever. That wants a `closed` trigger that strips the label, and is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gFn49YUM7FwCZ8JGP3HTr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Issue labeling now applies only to issues that a pull request explicitly closes.
  - References in pull request descriptions or titles without closing keywords no longer trigger labeling.
  - Closed issues, cross-repository issues, and issues already labeled “in progress” are skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->