### PR TITLE
fix(#7322): TimeSeries 'latest' asks for one row instead of the whole series

### DIFF
--- a/docs/7322-timeseries-latest-bounded-query.md
+++ b/docs/7322-timeseries-latest-bounded-query.md
@@ -1,0 +1,212 @@
+# #7322 - TimeSeries `latest` scans the whole series to return one row
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/7322
+Type: bug (performance)
+Branch: `fix/7322-timeseries-latest-bounded-query`
+
+## Problem
+
+`TimeSeriesGateway.latest(engine, tagFilter)` answered "the newest sample" with:
+
+```java
+final List<Object[]> rows = engine.query(Long.MIN_VALUE, Long.MAX_VALUE, null, tagFilter);
+return rows.isEmpty() ? null : rows.get(rows.size() - 1);
+```
+
+`TimeSeriesEngine.query` merges every shard's full range into one `ArrayList` and sorts it, so a
+type holding N samples costs O(N) heap and O(N log N) time to answer a question about one row.
+`TimeSeriesEngine.queryDescending(from, to, cols, tagFilter, limit, metrics)` - added in #5414 /
+#5416 for exactly this shape - answers it in O(shards x blocks touched).
+
+## Root cause
+
+`latest` was extracted verbatim from `GetTimeSeriesLatestHandler` in #7305; #7305's goal was that
+HTTP and gRPC answer *identically* against a known baseline, so the code was moved, not changed.
+The bounded form was left for this issue because it changes which row wins a tie at the newest
+timestamp.
+
+## Analysis
+
+`queryDescending` accumulates shard-by-shard in shard order and calls
+`TimeSeriesSealedStore.trimToDescendingLimit(merged, need)`, which is a **stable** descending sort
+followed by `removeLast()`. With `need == 1` the surviving row is therefore the first row in
+insertion order among those sharing the maximum timestamp - i.e. the one from the earliest shard
+that holds a row at that timestamp.
+
+`query()` is the mirror image: a stable **ascending** sort of the same shard-ordered list, then
+`rows.get(size - 1)`, which is the **last** of the tied rows.
+
+So the two disagree exactly on ties, and only on ties. Nothing specified either answer.
+
+## Decision on the tie-break
+
+`latest` now returns **the row the newest-first scan yields first**. The javadoc states the
+contract as: the timestamp is the guarantee; among rows sharing it the descending scan's first row
+wins, which for a tie spread across shards is the lowest-numbered shard's row. A caller that needs
+to disambiguate tied samples narrows the selection with tags.
+
+This is a deliberate, documented change from the pre-#7322 answer (last of the tied rows in
+ascending merge order), pinned by `Issue7322LatestBoundedTest`.
+
+## Completeness
+
+### Invariant
+
+> Answering "the newest sample of this selection" never materialises more of the series than the
+> blocks and pages the newest-first scan has to touch.
+
+### Enumeration
+
+Callers of the changed method:
+
+```
+$ grep -rn "TimeSeriesGateway.latest" --include="*.java" */src/main/java
+server/src/main/java/com/arcadedb/server/http/handler/GetTimeSeriesLatestHandler.java:81
+grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java:3645
+```
+
+Every "newest sample" surface in the tree:
+
+```
+$ grep -rniE "ts/.*latest|timeSeriesLatest" --include="*.java" --include="*.proto" */src/main
+grpc/src/main/proto/arcadedb-server.proto:197   rpc TimeSeriesLatest
+server/src/main/java/com/arcadedb/server/http/HttpServer.java:261  .get("/ts/{database}/latest", ...)
+grpc-client/.../RemoteGrpcDatabase.java:2437    client stub -> gRPC RPC above
+network/.../RemoteDatabase.java:990             client stub -> HTTP endpoint above
+```
+
+The two client stubs are transport shells over the two server entry points; they hold no query
+logic. The SQL path (`FetchFromTimeSeriesStep`) already uses `queryDescending`.
+
+Siblings - other `engine.query(...)` call sites in main sources:
+
+```
+$ grep -rn "engine\.query(" --include="*.java" */src/main/java
+engine/.../TimeSeriesGateway.java:279                     <- fixed here
+server/.../PostGrafanaQueryHandler.java:141               bounded range, returns the rows
+server/.../GetPromQLLabelValuesHandler.java:93            UNBOUNDED, discards the rows -> #7371
+server/.../PostTimeSeriesQueryHandler.java:117            bounded range, returns the rows
+server/.../PostPrometheusReadHandler.java:157             bounded range, returns the rows
+server/.../GetPromQLSeriesHandler.java:103                bounded range, discards the rows -> #7371
+```
+
+### Coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| `GET /api/v1/ts/{database}/latest` -> `GetTimeSeriesLatestHandler` -> `TimeSeriesGateway.latest` | yes | yes |
+| gRPC `TimeSeriesLatest` -> `ArcadeDbGrpcService.timeSeriesLatest` -> `TimeSeriesGateway.latest` | yes | yes |
+| `RemoteDatabase.timeSeriesLatest` (HTTP client stub) | yes (transport over row 1) | yes |
+| `RemoteGrpcDatabase.timeSeriesLatest` (gRPC client stub) | yes (transport over row 2) | yes |
+| SQL `SELECT ... ORDER BY ts DESC LIMIT n` -> `FetchFromTimeSeriesStep` | n/a - already bounded | pre-existing |
+| PromQL label/series discovery -> `engine.query` over the full range | **no** | no - filed as #7371 |
+| `/ts/query`, `/ts/grafana`, Prometheus remote-read | argued: the range is caller-bounded and every row is returned, so the materialisation is the answer, not waste | n/a |
+
+### Residual risk
+
+The fix does not change any endpoint that legitimately returns the rows it materialises. It does
+change which row `latest` returns when several samples share the newest timestamp; that case was
+unspecified before and is now specified and tested.
+
+## Change
+
+`engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesGateway.java`
+
+```java
+final List<Object[]> newest = engine.queryDescending(Long.MIN_VALUE, Long.MAX_VALUE, null, tagFilter, 1, null);
+return newest.isEmpty() ? null : newest.getFirst();
+```
+
+The javadoc now states the cost, the tie-break and the fact that both protocols call this method and
+nothing else. `GetTimeSeriesLatestHandler`'s comment, which described the old whole-range scan, was
+updated to match; no other call-site logic changed.
+
+## Reachability
+
+Both call sites are on live paths, verified by grep rather than recalled:
+
+- `HttpServer.java:261` registers `.get("/ts/{database}/latest", new GetTimeSeriesLatestHandler(this))`
+  on the running route table.
+- `arcadedb-server.proto:197` declares `rpc TimeSeriesLatest`, implemented at
+  `ArcadeDbGrpcService.java:3631`.
+
+Neither is behind a feature flag.
+
+## Test results
+
+`engine/src/test/java/com/arcadedb/engine/timeseries/Issue7322LatestBoundedTest.java` - 6 tests.
+
+Against the **unfixed** tree, `aTieAtTheNewestTimestampGoesToTheRowTheNewestFirstScanYieldsFirst`
+failed with `expected: [.., "in_shard_0", 1.0] but was: [.., "in_shard_1", 2.0]` - the old ascending
+scan answered the last of the tied rows. The other five passed on both trees; they are the
+correctness guard that the swap did not change the non-tie answer.
+
+```
+mvn -o -pl engine -am test -Dtest='TimeSeries*,Issue5414*,Issue5416*,Issue7322*'
+  Tests run: 278, Failures: 0, Errors: 0, Skipped: 0     BUILD SUCCESS
+```
+
+That run includes `Issue5414LastPointTest` (22) and `Issue5416DescendingTailTest`, which own the
+bounded scan this fix now depends on.
+
+```
+mvn -o test-compile -pl server,grpcw -am                 BUILD SUCCESS
+mvn -o test -pl server -Dtest='TimeSeriesTagFilterBuilderTest,TimeSeriesApiSpecTest'
+  Tests run: 21, Failures: 0, Errors: 0, Skipped: 0      BUILD SUCCESS
+```
+
+**Not run:** `TimeSeriesQueryHandlerIT` and `Issue7305TimeSeriesGrpcIT`, the protocol-level tests
+that drive the two entry points. They bind hard-coded ports 2480/2481
+(`"http://127.0.0.1:248" + serverIndex + ...`), and `lsof -nP -iTCP:2480 -sTCP:LISTEN` showed both
+held by concurrent builds for the whole of this session. Running them would have answered against
+someone else's server and produced a meaningless result in either direction. Their assertions
+(`latestValue` pins ts 3000, `latestWithTagFilter` pins ts 2000, `Issue7305TimeSeriesGrpcIT`
+cross-checks HTTP against gRPC) are all non-tie cases, which the engine-level suite covers
+identically; CI runs them on free ports.
+
+## Adversarial pass
+
+The orchestrator's Phase 1.5 spawns an independent subagent for this. **No `Task` tool exists in
+this environment**, so the pass was run inline - which is weaker, because the reviewer had already
+been convinced by its own reasoning. Recorded as a known reduction in the gate's value, not as a
+pass.
+
+**1. Does any existing protocol test assert a `latest` answer where the newest timestamp is TIED?**
+Real and load-bearing: those are precisely the tests the port conflict stopped me running, so a tie
+in one of their fixtures would have been an undetected break. Checked every fixture that reaches
+`latest`:
+
+| Fixture | Timestamps | Tie at max? |
+|---|---|---|
+| `TimeSeriesQueryHandlerIT.createTypeAndIngestData` | 1000, 2000, 3000 | no |
+| `Issue7305TimeSeriesGrpcIT.threeSamples` | 1000, 2000, 3000 | no |
+| `Issue7305TimeSeriesGrpcIT.aNonFiniteLatestSampleIsNullOnBothProtocols` | 1000, 2000 | no |
+| `Issue7305RemoteDatabaseTimeSeriesIT` | 1000, 2000, 3000 | no |
+| `Issue7305TimeSeriesGrpcAclIT` / `TimeSeriesPerTypeAclIT` | 1000, 2000 | no |
+
+Every one is a distinct-timestamp fixture, so none of them can observe the tie-break change. The
+cross-protocol agreement assertions (`assertValuesAgree(latestHttp.latest(), latestGrpc.latest())`)
+hold by construction either way: both protocols call this one method and nothing else.
+
+**2. A no-match tag filter still walks every block.** Real, and deliberately not fixed. When the
+filter matches nothing, no shard ever collects a row, so the running lower bound never tightens and
+each shard walks its whole range - the caveat `queryDescending`'s own javadoc records from #5416.
+It is a change in *which* resource is spent, not a regression: the old path walked everything AND
+allocated an `Object[]` per row, which is the cost this issue is about. Fixing it needs a per-shard
+tag index, which is a different piece of work. Covered for correctness by
+`latestIsNullWhenTheSelectionHoldsNoRow`.
+
+**3. Does the NaN path survive the swap?** `Issue7305TimeSeriesGrpcIT` stores a NaN sample and
+asserts both protocols render it as null. The descending walk prunes on timestamps only and boxes
+values through the same codec as the ascending one, so the rendered row is unchanged;
+`TimeSeriesAccuracyTest` (6 tests) and the 278-test engine suite cover the codec.
+
+## Residual risk
+
+- The tie-break at the newest timestamp changed, deliberately and by the issue's own request. No
+  existing test observes it (evidence: the table above); the new one pins it.
+- A `latest` call whose tag filter matches nothing reads every block of every shard. Pre-existing
+  in `queryDescending`, shared with the SQL `ORDER BY ts DESC LIMIT n` path, unchanged by this fix.
+- PromQL label/series discovery still materialises whole series - filed as #7371.
+- `TimeSeriesQueryHandlerIT` and `Issue7305TimeSeriesGrpcIT` were not run locally (ports held). CI
+  runs them.

--- a/docs/7322-timeseries-latest-bounded-query.md
+++ b/docs/7322-timeseries-latest-bounded-query.md
@@ -210,3 +210,22 @@ values through the same codec as the ascending one, so the rendered row is uncha
 - PromQL label/series discovery still materialises whole series - filed as #7371.
 - `TimeSeriesQueryHandlerIT` and `Issue7305TimeSeriesGrpcIT` were not run locally (ports held). CI
   runs them.
+
+## Review cycle 1 - `bf280e89`
+
+`claude` reviewed on the PR issue-comment surface. No blocking findings; the review traced the
+stable-sort tie-break, the round-robin routing the tie test depends on, and the `lowerBound`
+inclusivity end-to-end rather than taking the write-up at face value, and confirmed both protocols
+call the gateway method and nothing else.
+
+| Comment | Disposition |
+|---|---|
+| The `boundedNewest` test helper duplicates the expression under test, so those assertions are "closer to A equals A than an independent check" | **Applied.** Real, and worth fixing even though the review called it non-blocking: an assertion that cannot fail is not coverage. Replaced with `exhaustiveNewest`, the pre-#7322 ascending scan, which is a genuinely independent implementation of the same question. The helper now also asserts the newest timestamp is unique in the selection, so a fixture later edited into a tie fails loudly instead of silently comparing against the wrong row. Removed from the tie test entirely - the tie is the one case where the two implementations disagree by design, so the expected row is spelled out there. |
+| Confirm the two port-blocked ITs are green in CI before merge | **Handed to the developer**, with the check names, in the PR. Nothing to change in the branch; CI runs them on free ports. |
+| The new javadoc is long, if the team prefers terser | **Skipped, with reason.** The review itself judged the length appropriate for a previously-unspecified tie-break contract, and this is the only place that contract is written down. Trimming it would delete the answer to the question the next reader will have. |
+
+Re-verified after the change: `Issue7322LatestBoundedTest` 6/6 green on the fixed tree, and still
+**red on the unfixed one** - reverting `TimeSeriesGateway.latest` to `engine.query(...)` fails
+`aTieAtTheNewestTimestampGoesToTheRowTheNewestFirstScanYieldsFirst` with
+`expected: "in_shard_0" but was: "in_shard_1"`. The oracle swap did not weaken the pin.
+Full suite re-run: 278 tests, 0 failures.

--- a/docs/7322-timeseries-latest-bounded-query.md
+++ b/docs/7322-timeseries-latest-bounded-query.md
@@ -229,3 +229,37 @@ Re-verified after the change: `Issue7322LatestBoundedTest` 6/6 green on the fixe
 `aTieAtTheNewestTimestampGoesToTheRowTheNewestFirstScanYieldsFirst` with
 `expected: "in_shard_0" but was: "in_shard_1"`. The oracle swap did not weaken the pin.
 Full suite re-run: 278 tests, 0 failures.
+
+## Review cycle 2 - `ee07eac1`
+
+`claude` re-reviewed and closed with **"No blocking issues found."** It re-traced the stable-sort
+tie-break, the inclusive `lowerBound` pruning and the single-gateway claim independently, and
+called the oracle replacement "exactly the kind of self-correction that should happen in response
+to review feedback."
+
+Three non-blocking notes, none of them changes to this branch:
+
+| Comment | Disposition |
+|---|---|
+| A non-matching tag filter still forces a full walk | Already documented as out of scope; the review agreed it is a pre-existing `queryDescending` limitation shared with the SQL path, not a regression. |
+| Confirm the two port-blocked ITs are green in CI before merge | For the developer. They are the only tests exercising the real HTTP/gRPC entry points end to end. |
+| The tracking doc is long for the size of the code change | Noted by the review itself as consistent with the repo's `docs/73xx-*.md` convention. No change. |
+
+**No deferred items.** `docs/review-deferred-47afd7da.md` in this worktree is not from this run - it
+came in on `main` with #7210 (`git log -1 --format=%H -- docs/review-deferred-47afd7da.md` is an
+ancestor of `main`). This branch touches exactly four files.
+
+## Outcome
+
+- PR: https://github.com/ArcadeData/arcadedb/pull/7376
+- Final state: **clean-approval** after 2 review cycles.
+- Follow-up filed: #7371 (PromQL discovery still materialises whole series).
+- Merge belongs to the developer.
+
+### Ledger
+
+- [x] Move `TimeSeriesGateway.latest` onto `queryDescending(from, to, null, tagFilter, 1, null)` - done.
+- [x] Decide and document the tie-break - done: the timestamp is the guarantee; among rows sharing
+      it the newest-first scan's first row wins. Stated in the javadoc.
+- [x] Add a test that pins it - `aTieAtTheNewestTimestampGoesToTheRowTheNewestFirstScanYieldsFirst`,
+      verified red against the unfixed tree both before and after the review change.

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesGateway.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesGateway.java
@@ -269,15 +269,25 @@ public final class TimeSeriesGateway {
   /**
    * The newest sample matching {@code tagFilter}, or {@code null} when the selection holds none.
    * <p>
-   * This scans the whole range and takes the last row, which is what the HTTP {@code /ts/{database}/latest}
-   * endpoint has always done and therefore what the gRPC {@code TimeSeriesLatest} RPC must answer identically.
-   * {@link TimeSeriesEngine#queryDescending} would answer the same question in O(shards x blocks touched)
-   * instead of O(series) - that is a change of behaviour in the tie case, so it is tracked separately rather
-   * than smuggled in here (see the follow-up named in the PR).
+   * Asks {@link TimeSeriesEngine#queryDescending} for a single row, so the cost is O(shards x blocks touched)
+   * rather than O(series): each shard stops walking blocks as soon as its own limit is satisfied, and the
+   * running lower bound prunes the shards visited after the first hit. Until #7322 this merged every shard's
+   * whole range into one list and sorted it, which meant a type holding millions of samples allocated all of
+   * them to answer a question about one row - on the endpoint a Grafana single-stat panel polls.
+   * <p>
+   * <b>Tie-break.</b> The guarantee is the timestamp: the returned row's timestamp is the newest in the
+   * selection. When several samples share it, the row the newest-first scan yields first wins. Both this scan
+   * and the whole-series scan it replaced sort stably over the same shard-ordered list, in opposite
+   * directions, so the two disagree on exactly that case and only on it - the pre-#7322 answer was the last of
+   * the tied rows, this one is the first. Nothing specified either. A caller that must distinguish samples
+   * sharing a timestamp narrows the selection with tags instead.
+   * <p>
+   * Both the HTTP {@code GET /ts/{database}/latest} endpoint and the gRPC {@code TimeSeriesLatest} RPC call
+   * this method and nothing else, so the two protocols cannot answer different rows (issue #7305).
    */
   public static Object[] latest(final TimeSeriesEngine engine, final TagFilter tagFilter) throws IOException {
-    final List<Object[]> rows = engine.query(Long.MIN_VALUE, Long.MAX_VALUE, null, tagFilter);
-    return rows.isEmpty() ? null : rows.get(rows.size() - 1);
+    final List<Object[]> newest = engine.queryDescending(Long.MIN_VALUE, Long.MAX_VALUE, null, tagFilter, 1, null);
+    return newest.isEmpty() ? null : newest.getFirst();
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue7322LatestBoundedTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue7322LatestBoundedTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7322: {@code TimeSeriesGateway.latest} answered "the newest sample" by merging every shard's whole
+ * range into one list, sorting it and keeping the last row - O(series) heap and O(series log series) time for
+ * a question about one row, on the endpoint a Grafana single-stat panel polls. It now asks
+ * {@link TimeSeriesEngine#queryDescending} for a single row, which stops walking blocks as soon as its own
+ * limit is satisfied.
+ * <p>
+ * The two forms disagree on exactly one thing, and only on that: which row wins when several samples share the
+ * newest timestamp. The whole-series scan sorted ascending (stably) and took the last of the tied rows; the
+ * newest-first scan sorts descending (stably) and keeps the first. That change is deliberate and is pinned
+ * below - it is the reason the swap was tracked as its own issue rather than folded into #7305.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue7322LatestBoundedTest extends TestHelper {
+
+  private static final long BASE_TS = 1_700_000_000_000L;
+  private static final long STEP_MS = 1_000L;
+
+  private TimeSeriesEngine createType(final String name, final int shards) {
+    database.command("sql",
+        "CREATE TIMESERIES TYPE " + name + " TIMESTAMP ts TAGS (host STRING) FIELDS (value DOUBLE) SHARDS " + shards);
+    return ((LocalTimeSeriesType) database.getSchema().getType(name)).getEngine();
+  }
+
+  /**
+   * Appends {@code ticks} samples for each of {@code hosts}, one tick per {@link #STEP_MS}.
+   */
+  private void append(final TimeSeriesEngine engine, final int ticks, final String... hosts) throws IOException {
+    final int rows = ticks * hosts.length;
+    final long[] timestamps = new long[rows];
+    final Object[] hostValues = new Object[rows];
+    final Object[] values = new Object[rows];
+
+    int i = 0;
+    for (int t = 0; t < ticks; t++)
+      for (final String host : hosts) {
+        timestamps[i] = BASE_TS + (long) t * STEP_MS;
+        hostValues[i] = host;
+        values[i] = (double) i;
+        i++;
+      }
+    engine.appendBatch(timestamps, new Object[][] { hostValues, values });
+  }
+
+  /**
+   * {@code Object[].equals} is identity, so rows are compared by content.
+   */
+  private static List<Object> content(final Object[] row) {
+    return row == null ? null : Arrays.asList(row);
+  }
+
+  /**
+   * The answer the bounded scan gives, which is what {@code latest} must now be.
+   */
+  private Object[] boundedNewest(final TimeSeriesEngine engine, final TagFilter tagFilter) throws IOException {
+    final List<Object[]> rows = engine.queryDescending(Long.MIN_VALUE, Long.MAX_VALUE, null, tagFilter, 1, null);
+    return rows.isEmpty() ? null : rows.getFirst();
+  }
+
+  @Test
+  void latestIsTheNewestRowOnASingleShard() throws Exception {
+    final TimeSeriesEngine engine = createType("Single", 1);
+    append(engine, 500, "host_0");
+
+    final Object[] latest = TimeSeriesGateway.latest(engine, null);
+
+    assertThat(latest).isNotNull();
+    assertThat((long) latest[0]).isEqualTo(BASE_TS + 499 * STEP_MS);
+    assertThat(content(latest)).isEqualTo(content(boundedNewest(engine, null)));
+  }
+
+  /**
+   * One host only, so every timestamp appears exactly once and the answer is a single row rather than a tie -
+   * this test is about merging the two storage layers of four shards, not about the tie-break.
+   */
+  @Test
+  void latestIsTheNewestRowAcrossShardsAndAcrossBothStorageLayers() throws Exception {
+    final TimeSeriesEngine engine = createType("Layers", 4);
+    append(engine, 400, "host_0");
+    // Everything appended so far moves to the sealed layer; the tail that follows stays mutable, so the
+    // newest-first walk has to merge both layers of every shard - and the newest row is in the SEALED one,
+    // which is the direction a walk that stops at the first mutable row it finds would get wrong.
+    engine.compactAll();
+    append(engine, 40, "host_0");
+
+    final Object[] latest = TimeSeriesGateway.latest(engine, null);
+
+    assertThat(latest).isNotNull();
+    // Ticks restart at 0 on the second append, so the newest timestamp is the older, now-sealed run's last tick.
+    assertThat((long) latest[0]).isEqualTo(BASE_TS + 399 * STEP_MS);
+    assertThat(content(latest)).isEqualTo(content(boundedNewest(engine, null)));
+  }
+
+  @Test
+  void latestHonoursTheTagFilter() throws Exception {
+    final TimeSeriesEngine engine = createType("Tagged", 2);
+    append(engine, 300, "host_0", "host_1");
+    // host_2 stops earlier, so a filter on it must not answer with the other hosts' newer samples.
+    append(engine, 100, "host_2");
+
+    final TagFilter onlyHost2 = TagFilter.eq(0, "host_2");
+    final Object[] latest = TimeSeriesGateway.latest(engine, onlyHost2);
+
+    assertThat(latest).isNotNull();
+    assertThat(latest[1]).isEqualTo("host_2");
+    assertThat((long) latest[0]).isEqualTo(BASE_TS + 99 * STEP_MS);
+    assertThat(content(latest)).isEqualTo(content(boundedNewest(engine, onlyHost2)));
+  }
+
+  @Test
+  void latestIsNullWhenTheSelectionHoldsNoRow() throws Exception {
+    final TimeSeriesEngine engine = createType("Empty", 2);
+
+    assertThat(TimeSeriesGateway.latest(engine, null)).isNull();
+
+    append(engine, 10, "host_0");
+    assertThat(TimeSeriesGateway.latest(engine, TagFilter.eq(0, "absent"))).isNull();
+  }
+
+  /**
+   * The documented tie-break, and the one behavioural difference this issue introduces.
+   * <p>
+   * The tied pair is appended FIRST, while the type's round-robin append counter is still 0, so sample
+   * {@code i} lands in shard {@code i} - the placement the assertions below depend on, and asserted rather
+   * than assumed. Both shards then hold a row at the newest timestamp.
+   * <p>
+   * {@code TimeSeriesEngine.query} sorts the shard-ordered list ascending and the old {@code latest} took the
+   * LAST of the tied rows - shard 1's. {@code queryDescending} sorts it descending, and both sorts are stable,
+   * so the survivor at limit 1 is the FIRST in shard order - shard 0's. Asserting both halves is what makes
+   * this test fail against the old implementation rather than pass against either.
+   */
+  @Test
+  void aTieAtTheNewestTimestampGoesToTheRowTheNewestFirstScanYieldsFirst() throws Exception {
+    final TimeSeriesEngine engine = createType("Tied", 2);
+
+    final long tiedTs = BASE_TS + 100 * STEP_MS;
+    engine.appendBatch(new long[] { tiedTs, tiedTs },
+        new Object[][] { new Object[] { "in_shard_0", "in_shard_1" }, new Object[] { 1.0d, 2.0d } });
+    // Older filler, so the answer is not simply "the only row there is".
+    append(engine, 5, "older");
+
+    // The placement the rest of this test reads as "shard order", checked rather than inferred.
+    assertThat(engine.getShard(0).scanRange(tiedTs, tiedTs, null, null)).singleElement()
+        .satisfies(row -> assertThat(row[1]).isEqualTo("in_shard_0"));
+    assertThat(engine.getShard(1).scanRange(tiedTs, tiedTs, null, null)).singleElement()
+        .satisfies(row -> assertThat(row[1]).isEqualTo("in_shard_1"));
+
+    final Object[] latest = TimeSeriesGateway.latest(engine, null);
+
+    assertThat(latest).isNotNull();
+    assertThat((long) latest[0]).isEqualTo(tiedTs);
+    assertThat(content(latest)).isEqualTo(content(boundedNewest(engine, null)));
+
+    // What the bounded scan yields first, spelled out rather than left to the helper.
+    assertThat(latest[1]).isEqualTo("in_shard_0");
+
+    // And it is NOT what the whole-series ascending scan used to answer. This assertion is the regression
+    // guard: restoring engine.query(...).get(size - 1) makes it fail.
+    final List<Object[]> everything = engine.query(Long.MIN_VALUE, Long.MAX_VALUE, null, null);
+    assertThat(everything.getLast()[1]).isEqualTo("in_shard_1");
+    assertThat(content(latest)).isNotEqualTo(content(everything.getLast()));
+  }
+
+  /**
+   * A tie-break nobody can rely on is not a tie-break: repeated calls against an unchanged layout must answer
+   * the same row, and sealing the tied rows must not move the answer either.
+   */
+  @Test
+  void theTieBreakIsStableAcrossCallsAndAcrossCompaction() throws Exception {
+    final TimeSeriesEngine engine = createType("StableTie", 2);
+    final long tiedTs = BASE_TS + 7 * STEP_MS;
+    engine.appendBatch(new long[] { tiedTs, tiedTs },
+        new Object[][] { new Object[] { "shard0", "shard1" }, new Object[] { 1.0d, 2.0d } });
+
+    final Object[] first = TimeSeriesGateway.latest(engine, null);
+    final Object[] second = TimeSeriesGateway.latest(engine, null);
+    assertThat(content(first)).isEqualTo(content(second));
+
+    engine.compactAll();
+
+    final Object[] afterCompaction = TimeSeriesGateway.latest(engine, null);
+    assertThat(content(afterCompaction)).isEqualTo(content(first));
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue7322LatestBoundedTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue7322LatestBoundedTest.java
@@ -81,11 +81,24 @@ class Issue7322LatestBoundedTest extends TestHelper {
   }
 
   /**
-   * The answer the bounded scan gives, which is what {@code latest} must now be.
+   * An INDEPENDENT oracle: the exhaustive ascending scan, which is the implementation {@code latest} used
+   * before #7322. Deliberately not {@code queryDescending(..., 1, ...)} - that is the expression under test,
+   * and comparing the two would assert that A equals A (claude-review on PR #7376). The two implementations
+   * agree on every selection whose newest timestamp is unique, which is what the callers below construct, so
+   * this is a real cross-check between two different ways of finding the same row.
+   * <p>
+   * Uniqueness is asserted rather than assumed: a fixture edited into a tie would otherwise start comparing
+   * against the wrong row in silence, since the two implementations part company on exactly that case.
    */
-  private Object[] boundedNewest(final TimeSeriesEngine engine, final TagFilter tagFilter) throws IOException {
-    final List<Object[]> rows = engine.queryDescending(Long.MIN_VALUE, Long.MAX_VALUE, null, tagFilter, 1, null);
-    return rows.isEmpty() ? null : rows.getFirst();
+  private Object[] exhaustiveNewest(final TimeSeriesEngine engine, final TagFilter tagFilter) throws IOException {
+    final List<Object[]> all = engine.query(Long.MIN_VALUE, Long.MAX_VALUE, null, tagFilter);
+    if (all.isEmpty())
+      return null;
+
+    final Object[] newest = all.getLast();
+    assertThat(all).as("this oracle is only valid where the newest timestamp is unique")
+        .filteredOn(row -> (long) row[0] == (long) newest[0]).hasSize(1);
+    return newest;
   }
 
   @Test
@@ -97,7 +110,7 @@ class Issue7322LatestBoundedTest extends TestHelper {
 
     assertThat(latest).isNotNull();
     assertThat((long) latest[0]).isEqualTo(BASE_TS + 499 * STEP_MS);
-    assertThat(content(latest)).isEqualTo(content(boundedNewest(engine, null)));
+    assertThat(content(latest)).isEqualTo(content(exhaustiveNewest(engine, null)));
   }
 
   /**
@@ -119,7 +132,7 @@ class Issue7322LatestBoundedTest extends TestHelper {
     assertThat(latest).isNotNull();
     // Ticks restart at 0 on the second append, so the newest timestamp is the older, now-sealed run's last tick.
     assertThat((long) latest[0]).isEqualTo(BASE_TS + 399 * STEP_MS);
-    assertThat(content(latest)).isEqualTo(content(boundedNewest(engine, null)));
+    assertThat(content(latest)).isEqualTo(content(exhaustiveNewest(engine, null)));
   }
 
   @Test
@@ -135,7 +148,7 @@ class Issue7322LatestBoundedTest extends TestHelper {
     assertThat(latest).isNotNull();
     assertThat(latest[1]).isEqualTo("host_2");
     assertThat((long) latest[0]).isEqualTo(BASE_TS + 99 * STEP_MS);
-    assertThat(content(latest)).isEqualTo(content(boundedNewest(engine, onlyHost2)));
+    assertThat(content(latest)).isEqualTo(content(exhaustiveNewest(engine, onlyHost2)));
   }
 
   @Test
@@ -180,9 +193,9 @@ class Issue7322LatestBoundedTest extends TestHelper {
 
     assertThat(latest).isNotNull();
     assertThat((long) latest[0]).isEqualTo(tiedTs);
-    assertThat(content(latest)).isEqualTo(content(boundedNewest(engine, null)));
 
-    // What the bounded scan yields first, spelled out rather than left to the helper.
+    // No oracle here: the tie is the one case where the two implementations disagree by design, so the
+    // expected row is spelled out instead.
     assertThat(latest[1]).isEqualTo("in_shard_0");
 
     // And it is NOT what the whole-series ascending scan used to answer. This assertion is the regression

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetTimeSeriesLatestHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetTimeSeriesLatestHandler.java
@@ -76,8 +76,9 @@ public class GetTimeSeriesLatestHandler extends AbstractServerHttpHandler {
     // Build tag filter from query param
     final TagFilter tagFilter = buildTagFilter(exchange, columns);
 
-    // Query full range and take last element, through the same helper the gRPC TimeSeriesLatest RPC calls
-    // (issue #7305) so the two protocols cannot answer different rows.
+    // A bounded newest-first scan for a single row (issue #7322), through the same helper the gRPC
+    // TimeSeriesLatest RPC calls (issue #7305) so the two protocols cannot answer different rows. The helper
+    // owns the tie-break for samples sharing the newest timestamp; see its javadoc.
     final Object[] lastRow = TimeSeriesGateway.latest(engine, tagFilter);
 
     // Build column names


### PR DESCRIPTION
Closes #7322

## Summary

`TimeSeriesGateway.latest` merged every shard's full range into one `ArrayList`, sorted it, and kept
the last row - O(series) heap and O(series log series) time to answer a question about a single
sample, on the endpoint a Grafana single-stat panel or a health check polls on every refresh. It now
calls `queryDescending(from, to, null, tagFilter, 1, null)`, the bounded form added for exactly this
shape in #5414/#5416: each shard stops walking blocks as soon as its own limit is satisfied, and the
running lower bound prunes the shards visited after the first hit, so the cost is
O(shards x blocks touched). Both `GET /api/v1/ts/{database}/latest` and the gRPC `TimeSeriesLatest`
RPC call this one method and nothing else, so both pick the change up at once.

## The tie-break, decided and documented

The two scans disagree on exactly one case and only on it: which row wins when several samples share
the newest timestamp. Both sort **stably** over the same shard-ordered list, in opposite directions,
so the old ascending scan answered the **last** of the tied rows and the bounded one answers the
**first**. That asymmetry is why the swap was tracked as its own issue rather than folded into #7305.

The javadoc now states the contract: **the timestamp is the guarantee** - the returned row's
timestamp is the newest in the selection - and among rows sharing it, the row the newest-first scan
yields first wins. Nothing specified either answer before. A caller that must distinguish samples
sharing a timestamp narrows the selection with tags.

`aTieAtTheNewestTimestampGoesToTheRowTheNewestFirstScanYieldsFirst` pins it, and asserts both halves
(what the new scan answers *and* what the old one did) so it fails against either implementation
alone rather than passing against both. Against the unfixed tree it fails with
`expected: [.., "in_shard_0", 1.0] but was: [.., "in_shard_1", 2.0]`.

**No existing test observes the change.** Every fixture that reaches `latest` uses distinct
timestamps - `TimeSeriesQueryHandlerIT` (1000/2000/3000), `Issue7305TimeSeriesGrpcIT` (same, and
1000/2000 for the NaN case), `Issue7305RemoteDatabaseTimeSeriesIT`, `Issue7305TimeSeriesGrpcAclIT`,
`TimeSeriesPerTypeAclIT` - so none of them can see a tie. The cross-protocol agreement assertions
hold by construction either way, since both protocols call the same method.

## Test plan

- [x] `Issue7322LatestBoundedTest` (6 tests, new): newest row on one shard; across 4 shards with the
      answer in the **sealed** layer under a mutable tail; tag filter honoured; `null` on an empty
      selection; the tie-break; and the tie-break stable across repeated calls and across compaction.
- [x] Verified the new tests **fail before the fix and pass after** - one failure, for the right
      reason, with the other five green on both trees as the no-regression guard.
- [x] `mvn -o -pl engine -am test -Dtest='TimeSeries*,Issue5414*,Issue5416*,Issue7322*'` ->
      **278 tests, 0 failures**, including `Issue5414LastPointTest` (22) and
      `Issue5416DescendingTailTest`, which own the bounded scan this now depends on.
- [x] `mvn -o test-compile -pl server,grpcw -am` -> BUILD SUCCESS.
- [x] `mvn -o test -pl server -Dtest='TimeSeriesTagFilterBuilderTest,TimeSeriesApiSpecTest'` ->
      21 tests, 0 failures.
- [ ] `TimeSeriesQueryHandlerIT` / `Issue7305TimeSeriesGrpcIT` **not run locally**: they bind
      hard-coded ports 2480/2481 and `lsof -nP -iTCP:2480 -sTCP:LISTEN` showed both held by
      concurrent builds throughout. Running them would have answered against another server and been
      meaningless in either direction. Their assertions are all non-tie cases (see above); CI runs
      them on free ports.

## Coverage

| Entry point | Covered |
|---|---|
| `GET /api/v1/ts/{database}/latest` -> `GetTimeSeriesLatestHandler` -> `TimeSeriesGateway.latest` | yes |
| gRPC `TimeSeriesLatest` -> `ArcadeDbGrpcService.timeSeriesLatest` -> `TimeSeriesGateway.latest` | yes |
| `RemoteDatabase.timeSeriesLatest` / `RemoteGrpcDatabase.timeSeriesLatest` | yes - transport shells over the two rows above, no query logic |
| SQL `ORDER BY ts DESC LIMIT n` -> `FetchFromTimeSeriesStep` | already bounded; unchanged |

Both call sites are reachable on live paths, checked rather than recalled: `HttpServer.java:261`
registers the route, `arcadedb-server.proto:197` declares the RPC. Neither is behind a flag.

### Known gaps

- **#7371** - `GetPromQLLabelValuesHandler` and `GetPromQLSeriesHandler` still materialise whole
  series to collect distinct tag values, then discard the rows. Found by this issue's completeness
  sweep, filed before this PR opened. `iterateQuery` is the fix; out of scope here because it is a
  different question (all rows vs. one row) on different endpoints.
- **A no-match tag filter still walks every block.** When the filter matches nothing no shard ever
  collects a row, so the running lower bound never tightens - the caveat `queryDescending`'s own
  javadoc records from #5416, shared with the SQL path. Not a regression: the old path walked
  everything *and* allocated an `Object[]` per row. Fixing it needs a per-shard tag index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwTsBYjyoDn2vKXQGmt5bK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Time-series “latest” queries now return results more efficiently, particularly for large datasets.
  - Requests retrieve only the newest matching sample instead of processing the entire time range.

- **Behavior**
  - When multiple samples share the newest timestamp, the result now follows a consistent newest-first ordering.
  - Existing support for shard combinations, tag filters, empty results, and storage compaction is covered by expanded validation.

- **Documentation**
  - Updated time-series API documentation to describe query behavior, ordering, and performance characteristics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->