### PR TITLE
fix(#7320): the gRPC client names its database, and a header-less call authenticates at server level

### DIFF
--- a/docs/7320-grpc-client-database-header.md
+++ b/docs/7320-grpc-client-database-header.md
@@ -1,0 +1,206 @@
+# #7320 - gRPC client sends no database header, so every call authenticates against "default"
+
+## Problem
+
+`GrpcAuthInterceptor` authenticates every data-plane call against the database named in the
+`x-arcade-database` request metadata, falling back to the literal name `"default"` when the header
+is absent:
+
+```java
+// grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java:154
+String database = headers.get(DATABASE_HEADER);
+if (database == null || database.isEmpty())
+  database = "default";
+...
+if (!validateCredentials(username, password, database))
+  call.close(Status.UNAUTHENTICATED.withDescription("Invalid credentials"), new Metadata());
+```
+
+`ServerSecurity.authenticate` enforces the grant when `databaseName != null`:
+
+```java
+// server/src/main/java/com/arcadedb/server/security/ServerSecurity.java:236
+if (databaseName != null) {
+  final Set<String> allowedDatabases = su.getAuthorizedDatabases();
+  if (!allowedDatabases.contains(SecurityManager.ANY) && !su.getAuthorizedDatabases().contains(databaseName))
+    throw new ServerSecurityException("User has not access to database '" + databaseName + "'");
+}
+```
+
+`RemoteGrpcServer` never sends that header, so every call from `RemoteGrpcDatabase` was authenticated
+against `"default"` - a database the caller never named and, on almost every deployment, one that
+does not exist. Only a principal granted `"*"` (in practice `root`) could connect at all.
+
+## Root cause
+
+Two independent defects, one on each side of the wire:
+
+1. **Client half.** `RemoteGrpcServer.createCredentials()` puts four keys on every call
+   (`username`, `password`, `x-arcade-user`, `x-arcade-password`) and no database key. The class is
+   server-scoped and never knew the target database; `RemoteGrpcDatabase`, which does, had no way to
+   pass it.
+2. **Server half.** The `"default"` fallback authenticates against a name the caller never sent.
+   Failing this way is not even a conservative default: it refuses every correctly-granted principal
+   while granting nothing extra, because per-database authorization is separately enforced downstream
+   against the *request-body* database.
+
+## Invariant the fix establishes
+
+A gRPC call is authenticated against the database it actually targets, or against no database at
+all - never against a database name the caller never sent.
+
+Two halves:
+- (a) the shipped client puts `x-arcade-database` on every data-plane call, set to the database the
+  `RemoteGrpcDatabase` targets;
+- (b) when a call carries no database header, the interceptor authenticates the credentials at server
+  level (`database == null`) instead of against the literal name `"default"`.
+
+## Completeness
+
+### Readers of the header (server side)
+
+```
+$ grep -rn "DATABASE_HEADER" --include="*.java" grpcw/src/main grpc-client/src/main server/src/main
+grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java:51:  private static final Metadata.Key<String> DATABASE_HEADER      =
+grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java:154:      String database = headers.get(DATABASE_HEADER);
+```
+
+One reader, one use site.
+
+### Writers of call metadata in the shipped client
+
+```
+$ grep -rn "Metadata.Key.of" --include="*.java" grpc-client/src/main
+grpc-client/.../GrpcClientErrorMapper.java:48:  static final Metadata.Key<String> EXCEPTION_CLASS_KEY = ...
+grpc-client/.../GrpcClientErrorMapper.java:50:  static final Metadata.Key<String> DUP_INDEX_KEY        = ...
+grpc-client/.../GrpcClientErrorMapper.java:52:  static final Metadata.Key<String> DUP_KEYS_KEY         = ...
+grpc-client/.../RemoteGrpcServer.java:593-596:  (createCallCredentials: username/password/x-arcade-user/x-arcade-password)
+grpc-client/.../RemoteGrpcServer.java:613-616:  (createCredentials:     username/password/x-arcade-user/x-arcade-password)
+```
+
+`GrpcClientErrorMapper`'s three keys are *trailer* keys read off a failed response, not request
+metadata - they cannot carry a database. The two `CallCredentials` factories are the whole set of
+request-metadata writers.
+
+### Stub construction in the shipped client
+
+```
+$ grep -rn "ArcadeDbServiceGrpc.new\|ArcadeDbAdminServiceGrpc.new" --include="*.java" grpc-client/src/main grpcw/src/main
+grpc-client/.../RemoteGrpcServer.java:224:    return ArcadeDbServiceGrpc.newBlockingV2Stub(channel())        -> createCredentials()
+grpc-client/.../RemoteGrpcServer.java:232:    return ArcadeDbServiceGrpc.newStub(channel())                  -> createCredentials()
+grpc-client/.../RemoteGrpcServer.java:242:    ... = ArcadeDbAdminServiceGrpc.newBlockingV2Stub(channel())    -> createCallCredentials()
+```
+
+### Callers of the data-plane stub factories
+
+```
+$ grep -rn "createBlockingStub\|createAsyncStub" --include="*.java" . | grep -v target
+grpc-client/.../RemoteGrpcDatabase.java:156:    this.blockingStub = createBlockingStub();
+grpc-client/.../RemoteGrpcDatabase.java:157:    this.asyncStub = createAsyncStub();
+grpc-client/.../RemoteGrpcDatabase.java:164:  protected ... createBlockingStub() {
+grpc-client/.../RemoteGrpcDatabase.java:168:  protected ... createAsyncStub() {
+```
+
+`RemoteGrpcDatabase` is the only in-tree caller, and the only in-tree subclass
+(`RemoteGrpcDatabaseWithCompression`) overrides neither. Both factories stay `protected` so an
+out-of-tree subclass that overrides them keeps working.
+
+### Sibling clients in other languages
+
+```
+$ grep -rln "x-arcade-user" --include="*.py" --include="*.go" --include="*.js" --include="*.ts" --include="*.cs" . | grep -v target
+(no output)
+```
+
+No other in-repo client authenticates over gRPC, so the client half of the fix has exactly one site.
+Third-party clients that send no header are covered by the server half instead.
+
+### Does dropping the `"default"` check widen access?
+
+No. The check it removes was never the authorization gate, and the callers it now lets past the
+interceptor are authorized per-RPC one layer down.
+
+Every data-plane RPC resolves its target database through one of two gates, both of which call
+`ArcadeDbGrpcService.validateCredentials(credentials, databaseName)`:
+
+```
+$ grep -n "^  public void \|^  public StreamObserver" grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+665 executeCommand   985 createRecord    1125 lookupByRid     1197 updateRecord   1388 deleteRecord
+1492 executeQuery    1723 beginTransaction  1863 commitTransaction  1949 rollbackTransaction
+2026 streamQuery     2610 bulkInsert      2685 insertStream    3036 graphBatchLoad
+3404 insertBidirectional
+```
+
+- `getDatabase(databaseName, credentials)` (line 4637) - `validateDatabaseName` then
+  `validateCredentials(credentials, databaseName)` at line 4644, before `arcadeServer.getDatabase`.
+- `authorizeTransactionAccess(txCtx, credentials)` (line 466) - `validateCredentials(credentials,
+  txCtx.db.getName())` at line 468, against the transaction's REAL database.
+
+The streaming RPCs reach the first gate through `InsertContext`, which is easy to miss because the
+constructor is 1000 lines away from the RPC:
+
+```
+$ grep -n "InsertContext(InsertOptions opts)" -A 5 grpcw/.../ArcadeDbGrpcService.java
+4406:    InsertContext(InsertOptions opts) {
+4410:      this.db = getDatabase(opts.getDatabase(), opts.getCredentials());
+```
+
+Before the fix the interceptor authorized `"default"` - never the RPC's actual target - so the only
+principals it ever admitted were those granted `"*"`, who are authorized everywhere anyway. Removing
+it therefore grants no principal access to any database the layer below would not already grant.
+
+### Entry-point coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| `RemoteGrpcServer.newBlockingStub` -> `createCredentials` (data-plane blocking stub) | yes | yes - `Issue7320GrpcDatabaseHeaderTest.blockingStubCredentialsCarryTheTargetDatabase`, `Issue7320ScopedUserGrpcIT.scopedUserCanQueryOverGrpc` |
+| `RemoteGrpcServer.newAsyncStub` -> `createCredentials` (data-plane async/streaming stub) | yes | yes - `Issue7320GrpcDatabaseHeaderTest.asyncStubCredentialsCarryTheTargetDatabase`, `Issue7320ScopedUserGrpcIT.scopedUserCanIngestOverTheAsyncStub` |
+| `RemoteGrpcServer.adminServiceBlockingV2Stub` -> `createCallCredentials` (admin plane) | **argued** - admin RPCs take the `com.arcadedb.grpc.ArcadeDbAdminService/` branch of `interceptCall`, which returns before line 154 and never reads `DATABASE_HEADER`; it authenticates from the request body via `authenticateAdminRequest` -> `validateCredentials(user, pass, null)`, already database-less | n/a |
+| `GrpcAuthInterceptor` basic-auth branch with **no** database header (any third-party client) | yes - authenticates at server level instead of against `"default"` | yes - `Issue7320GrpcAuthInterceptorDatabaseHeaderTest.absentHeaderAuthenticatesAtServerLevel` |
+| `GrpcAuthInterceptor` basic-auth branch **with** a database header | yes - unchanged behaviour, plus the refusal now names the database | yes - `Issue7320GrpcAuthInterceptorDatabaseHeaderTest.presentHeaderStillAuthenticatesAgainstThatDatabase` / `...refusalNamesTheDatabaseThatWasChecked` |
+| `GrpcAuthInterceptor` bearer-token branch | **argued** - `getValidSession(token, database)` uses `database` only in two `Level.FINE` log messages; no grant check ever ran there, so the fallback value was never load-bearing on this path | n/a (existing `GrpcAuthInterceptorTest` token cases stay green) |
+
+No blank rows, so no follow-up issue was filed from this sweep.
+
+### Reachability
+
+- `RemoteGrpcServer.newBlockingStub` / `newAsyncStub` are called from `RemoteGrpcDatabase`'s
+  constructor (lines 156-157), which every gRPC client path goes through - not behind a flag.
+- `GrpcAuthInterceptor` is installed by `GrpcServerPlugin` on the live server; the changed line is on
+  the basic-auth path every data-plane RPC takes when security is enabled.
+- Both halves are exercised against a real server by `Issue7320ScopedUserGrpcIT`, which fails on the
+  pre-fix tree.
+
+## Residual risk
+
+- The header is attached per **stub**, captured when `RemoteGrpcDatabase` is constructed. A caller
+  that obtains a stub from `RemoteGrpcServer.newBlockingStub(timeout)` directly (the no-database
+  overload, kept for source compatibility) still sends no header - and is then authenticated at
+  server level by the server half rather than refused. That is the intended pairing, not a gap.
+- Per-database authorization is unchanged: it is enforced in
+  `ArcadeDbGrpcService.validateCredentials(credentials, databaseName)` against the **request-body**
+  database (`getDatabase` chokepoint, line 4644), which is what `Issue4794GrpcPerDbAuthorizationIT`
+  pins. Dropping the `"default"` fallback removes a check that was never the authorization gate.
+
+## Adversarial pass
+
+The orchestrator's Phase 1.5 spawns an isolated subagent to write the follow-up issue it would file
+against this patch. No `Task` tool was available in this session, so the pass was run by the author
+against the diff instead - weaker, because it was already convinced. Recorded here so the gap is
+visible rather than silently skipped.
+
+| Objection | Verdict | Evidence |
+|---|---|---|
+| "Dropping the `"default"` grant check widens who reaches the service layer." | Real but not a defect - see *Does dropping the `"default"` check widen access?* above. Every one of the 14 data-plane RPCs authorizes the request-body database via `getDatabase` or `authorizeTransactionAccess`, and the removed check only ever admitted `"*"` principals. | audit above |
+| "`insertBidirectional` never calls the authorization gate." | Not real. It reaches it through `new InsertContext(opts)` -> `getDatabase(opts.getDatabase(), opts.getCredentials())` (line 4410), 1000 lines from the RPC. | `grep -n "InsertContext(InsertOptions opts)" -A 5` |
+| "The header is captured once at stub construction, so a `RemoteGrpcDatabase` re-pointed at another database would send a stale name." | Not real. `RemoteDatabase.databaseName` is assigned once in the constructor (`network/.../RemoteDatabase.java:100`) and there is no setter; `RemoteGrpcDatabase.databaseName` is `final`. | `grep -rn "setDatabase\b\|databaseName =" network/.../RemoteDatabase.java` |
+| "`e.getMessage()` can be null, and a null failure reads as success." | Real, and fixed in this branch before the PR opened: `authenticationFailure` falls back to `"Invalid credentials"` on a null or blank message rather than returning null. | `GrpcAuthInterceptor.authenticationFailure` |
+| "The end-to-end IT passes with only the server half applied, so it does not prove the client sends anything." | Real, and answered by construction: `Issue7320GrpcDatabaseHeaderTest` reads the metadata back off the very stub `RemoteGrpcDatabase` builds, so the client half has its own assertion independent of the IT. | `Issue7320GrpcDatabaseHeaderTest` |
+
+Nothing survived as an out-of-scope defect, so no follow-up issue was filed.
+
+## Drive-by
+
+`RemoteGrpcServer.createCredentials()` carried a commented-out `curl`-style example containing a
+password-shaped literal (`x-arcade-password: oY9uU2uJ8nD8iY7t`). The comment described the very header
+this issue is about, and the replacement code names the key explicitly, so the comment went with it.

--- a/docs/7320-grpc-client-database-header.md
+++ b/docs/7320-grpc-client-database-header.md
@@ -7,7 +7,7 @@
 is absent:
 
 ```java
-// grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java:154
+// grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java (pre-fix)
 String database = headers.get(DATABASE_HEADER);
 if (database == null || database.isEmpty())
   database = "default";
@@ -62,7 +62,7 @@ Two halves:
 ```
 $ grep -rn "DATABASE_HEADER" --include="*.java" grpcw/src/main grpc-client/src/main server/src/main
 grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java:51:  private static final Metadata.Key<String> DATABASE_HEADER      =
-grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java:154:      String database = headers.get(DATABASE_HEADER);
+grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java:163:      final String database = normalizeDatabase(headers.get(DATABASE_HEADER));
 ```
 
 One reader, one use site.
@@ -74,8 +74,8 @@ $ grep -rn "Metadata.Key.of" --include="*.java" grpc-client/src/main
 grpc-client/.../GrpcClientErrorMapper.java:48:  static final Metadata.Key<String> EXCEPTION_CLASS_KEY = ...
 grpc-client/.../GrpcClientErrorMapper.java:50:  static final Metadata.Key<String> DUP_INDEX_KEY        = ...
 grpc-client/.../GrpcClientErrorMapper.java:52:  static final Metadata.Key<String> DUP_KEYS_KEY         = ...
-grpc-client/.../RemoteGrpcServer.java:593-596:  (createCallCredentials: username/password/x-arcade-user/x-arcade-password)
-grpc-client/.../RemoteGrpcServer.java:613-616:  (createCredentials:     username/password/x-arcade-user/x-arcade-password)
+grpc-client/.../RemoteGrpcServer.java (createCallCredentials -> credentials(): username/password/x-arcade-user/x-arcade-password)
+grpc-client/.../RemoteGrpcServer.java (createCredentials     -> credentials(): the same four, plus x-arcade-database)
 ```
 
 `GrpcClientErrorMapper`'s three keys are *trailer* keys read off a failed response, not request
@@ -86,19 +86,19 @@ request-metadata writers.
 
 ```
 $ grep -rn "ArcadeDbServiceGrpc.new\|ArcadeDbAdminServiceGrpc.new" --include="*.java" grpc-client/src/main grpcw/src/main
-grpc-client/.../RemoteGrpcServer.java:224:    return ArcadeDbServiceGrpc.newBlockingV2Stub(channel())        -> createCredentials()
-grpc-client/.../RemoteGrpcServer.java:232:    return ArcadeDbServiceGrpc.newStub(channel())                  -> createCredentials()
-grpc-client/.../RemoteGrpcServer.java:242:    ... = ArcadeDbAdminServiceGrpc.newBlockingV2Stub(channel())    -> createCallCredentials()
+grpc-client/.../RemoteGrpcServer.java:259:    return ArcadeDbServiceGrpc.newBlockingV2Stub(channel())        -> createCredentials(database)
+grpc-client/.../RemoteGrpcServer.java:277:    return ArcadeDbServiceGrpc.newStub(channel())                  -> createCredentials(database)
+grpc-client/.../RemoteGrpcServer.java:287:    ... = ArcadeDbAdminServiceGrpc.newBlockingV2Stub(channel())    -> createCallCredentials()
 ```
 
 ### Callers of the data-plane stub factories
 
 ```
 $ grep -rn "createBlockingStub\|createAsyncStub" --include="*.java" . | grep -v target
-grpc-client/.../RemoteGrpcDatabase.java:156:    this.blockingStub = createBlockingStub();
-grpc-client/.../RemoteGrpcDatabase.java:157:    this.asyncStub = createAsyncStub();
-grpc-client/.../RemoteGrpcDatabase.java:164:  protected ... createBlockingStub() {
-grpc-client/.../RemoteGrpcDatabase.java:168:  protected ... createAsyncStub() {
+grpc-client/.../RemoteGrpcDatabase.java:181:    this.blockingStub = createBlockingStub();
+grpc-client/.../RemoteGrpcDatabase.java:182:    this.asyncStub = createAsyncStub();
+grpc-client/.../RemoteGrpcDatabase.java:194:  protected ... createBlockingStub() {
+grpc-client/.../RemoteGrpcDatabase.java:201:  protected ... createAsyncStub() {
 ```
 
 `RemoteGrpcDatabase` is the only in-tree caller, and the only in-tree subclass
@@ -117,27 +117,62 @@ Third-party clients that send no header are covered by the server half instead.
 
 ### Does dropping the `"default"` check widen access?
 
-No. The check it removes was never the authorization gate, and the callers it now lets past the
-interceptor are authorized per-RPC one layer down.
+No. The check it removes was never the authorization gate, and every caller it now lets past the
+interceptor is authorized per-RPC one layer down, against the database the request body names.
 
-Every data-plane RPC resolves its target database through one of two gates, both of which call
-`ArcadeDbGrpcService.validateCredentials(credentials, databaseName)`:
+The gate itself, read in full:
 
 ```
-$ grep -n "^  public void \|^  public StreamObserver" grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
-665 executeCommand   985 createRecord    1125 lookupByRid     1197 updateRecord   1388 deleteRecord
-1492 executeQuery    1723 beginTransaction  1863 commitTransaction  1949 rollbackTransaction
-2026 streamQuery     2610 bulkInsert      2685 insertStream    3036 graphBatchLoad
-3404 insertBidirectional
+$ sed -n '/private .*void validateCredentials(/,/^  }/p' grpcw/.../ArcadeDbGrpcService.java
+private void validateCredentials(final DatabaseCredentials credentials, final String databaseName) {
+  final String authenticatedUser = resolvedUsername(credentials);
+  if (authenticatedUser == null)
+    throw Status.UNAUTHENTICATED...
+  ...
+    final Set<String> allowedDatabases = user.getAuthorizedDatabases();
+    if (!allowedDatabases.contains(SecurityManager.ANY) && !allowedDatabases.contains(databaseName))
+      throw Status.PERMISSION_DENIED.withDescription("User has not access to database '" + databaseName + "'")
+  ...
+    } else {  // no interceptor context: authenticate AND authorize from the body credentials
+      security.authenticate(authenticatedUser, password, databaseName);
 ```
 
-- `getDatabase(databaseName, credentials)` (line 4637) - `validateDatabaseName` then
-  `validateCredentials(credentials, databaseName)` at line 4644, before `arcadeServer.getDatabase`.
-- `authorizeTransactionAccess(txCtx, credentials)` (line 466) - `validateCredentials(credentials,
-  txCtx.db.getName())` at line 468, against the transaction's REAL database.
+Both of its branches enforce the per-database grant. What had to be checked is that every RPC
+reaches it. There are 22 data-plane RPCs on this service - eight more than when this branch was cut,
+because #7305 and #7306 landed in between - so the audit was scripted rather than eyeballed:
 
-The streaming RPCs reach the first gate through `InsertContext`, which is easy to miss because the
-constructor is 1000 lines away from the RPC:
+```
+$ python3 - <<'EOF'   # every "public void|StreamObserver" member of ArcadeDbGrpcService, and its gate
+...
+EOF
+executeCommand           line   677  getDatabase
+createRecord             line   997  getDatabase
+lookupByRid              line  1137  getDatabase
+updateRecord             line  1209  getDatabase
+deleteRecord             line  1400  getDatabase
+executeQuery             line  1504  getDatabase
+beginTransaction         line  1735  getDatabase
+commitTransaction        line  1875  authorizeTransactionAccess
+rollbackTransaction      line  1961  authorizeTransactionAccess
+streamQuery              line  2038  getDatabase
+bulkInsert               line  2622  InsertContext->getDatabase
+insertStream             line  2697  getDatabase+InsertContext->getDatabase
+graphBatchLoad           line  3048  getDatabase
+timeSeriesWrite          line  3272  getDatabase
+timeSeriesWriteStream    line  3299  getDatabase
+timeSeriesQuery          line  3400  getDatabase
+timeSeriesLatest         line  3631  getDatabase
+insertBidirectional      line  3841  getDatabase+InsertContext->getDatabase
+vectorSearch             line  5085  getDatabase
+hybridSearch             line  5095  getDatabase
+fullTextSearch           line  5105  getDatabase+validateCredentials
+```
+
+No row is ungated. `getDatabase(databaseName, credentials)` calls `validateDatabaseName` and then
+`validateCredentials(credentials, databaseName)` before it touches the server;
+`authorizeTransactionAccess(txCtx, credentials)` calls it against the transaction's REAL database.
+The streaming RPCs reach the first through `InsertContext`, whose constructor is a thousand lines
+from the RPC:
 
 ```
 $ grep -n "InsertContext(InsertOptions opts)" -A 5 grpcw/.../ArcadeDbGrpcService.java
@@ -148,6 +183,7 @@ $ grep -n "InsertContext(InsertOptions opts)" -A 5 grpcw/.../ArcadeDbGrpcService
 Before the fix the interceptor authorized `"default"` - never the RPC's actual target - so the only
 principals it ever admitted were those granted `"*"`, who are authorized everywhere anyway. Removing
 it therefore grants no principal access to any database the layer below would not already grant.
+`Issue4794GrpcPerDbAuthorizationIT` pins that layer and stays green (4/4, run below).
 
 ### Entry-point coverage table
 
@@ -155,21 +191,66 @@ it therefore grants no principal access to any database the layer below would no
 |---|---|---|
 | `RemoteGrpcServer.newBlockingStub` -> `createCredentials` (data-plane blocking stub) | yes | yes - `Issue7320GrpcDatabaseHeaderTest.blockingStubCredentialsCarryTheTargetDatabase`, `Issue7320ScopedUserGrpcIT.scopedUserCanQueryOverGrpc` |
 | `RemoteGrpcServer.newAsyncStub` -> `createCredentials` (data-plane async/streaming stub) | yes | yes - `Issue7320GrpcDatabaseHeaderTest.asyncStubCredentialsCarryTheTargetDatabase`, `Issue7320ScopedUserGrpcIT.scopedUserCanIngestOverTheAsyncStub` |
-| `RemoteGrpcServer.adminServiceBlockingV2Stub` -> `createCallCredentials` (admin plane) | **argued** - admin RPCs take the `com.arcadedb.grpc.ArcadeDbAdminService/` branch of `interceptCall`, which returns before line 154 and never reads `DATABASE_HEADER`; it authenticates from the request body via `authenticateAdminRequest` -> `validateCredentials(user, pass, null)`, already database-less | n/a |
-| `GrpcAuthInterceptor` basic-auth branch with **no** database header (any third-party client) | yes - authenticates at server level instead of against `"default"` | yes - `Issue7320GrpcAuthInterceptorDatabaseHeaderTest.absentHeaderAuthenticatesAtServerLevel` |
-| `GrpcAuthInterceptor` basic-auth branch **with** a database header | yes - unchanged behaviour, plus the refusal now names the database | yes - `Issue7320GrpcAuthInterceptorDatabaseHeaderTest.presentHeaderStillAuthenticatesAgainstThatDatabase` / `...refusalNamesTheDatabaseThatWasChecked` |
-| `GrpcAuthInterceptor` bearer-token branch | **argued** - `getValidSession(token, database)` uses `database` only in two `Level.FINE` log messages; no grant check ever ran there, so the fallback value was never load-bearing on this path | n/a (existing `GrpcAuthInterceptorTest` token cases stay green) |
+| `RemoteGrpcServer.adminServiceBlockingV2Stub` -> `createCallCredentials` (admin plane) | **argued** - admin RPCs take the `com.arcadedb.grpc.ArcadeDbAdminService/` branch of `interceptCall`, which returns before the `DATABASE_HEADER` read and authenticates from the request body via `authenticateAdminRequest` -> `validateCredentials(user, pass, null)`, already database-less | n/a - `Issue7304GrpcControlPlaneAuthorizationIT` (49/49) and `Issue5039GrpcAdminAuthorizationIT` (3/3) stay green |
+| `GrpcAuthInterceptor` basic-auth branch with **no** database header (any third-party client) | yes - authenticates at server level instead of against `"default"` | yes - `Issue7320GrpcAuthInterceptorDatabaseHeaderTest.absentHeaderAuthenticatesAtServerLevel` / `.emptyHeaderAuthenticatesAtServerLevel` |
+| `GrpcAuthInterceptor` basic-auth branch **with** a database header | yes - unchanged behaviour, plus the refusal now names the database | yes - `...presentHeaderStillAuthenticatesAgainstThatDatabase`, `...refusalNamesTheDatabaseThatWasChecked`, `...wrongPasswordIsStillRefused`, and end-to-end `Issue7320ScopedUserGrpcIT.userGrantedAnotherDatabaseIsRefusedAndTheRefusalNamesIt` |
+| `GrpcAuthInterceptor` bearer-token branch | **argued** - verified by reading `getValidSession(token, database)` in full: `database` appears in exactly three `Level.FINE` log messages and nowhere else, so no grant check ever ran on this path and the fallback value was never load-bearing | n/a - the existing `GrpcAuthInterceptorTest` token cases stay green (9/9) |
 
-No blank rows, so no follow-up issue was filed from this sweep.
+No blank rows.
 
 ### Reachability
 
 - `RemoteGrpcServer.newBlockingStub` / `newAsyncStub` are called from `RemoteGrpcDatabase`'s
-  constructor (lines 156-157), which every gRPC client path goes through - not behind a flag.
+  constructor (lines 181-182), which every gRPC client path goes through - not behind a flag. Both
+  stub fields are `final` and every one of the class's RPC call sites uses one of them.
+- The only in-tree subclass, `RemoteGrpcDatabaseWithCompression`, overrides neither factory. Both
+  stay `protected`, so an out-of-tree subclass that does override them keeps compiling.
 - `GrpcAuthInterceptor` is installed by `GrpcServerPlugin` on the live server; the changed line is on
   the basic-auth path every data-plane RPC takes when security is enabled.
-- Both halves are exercised against a real server by `Issue7320ScopedUserGrpcIT`, which fails on the
-  pre-fix tree.
+- Both halves are exercised against a real server by `Issue7320ScopedUserGrpcIT`.
+
+### Proof the tests fail without the fix
+
+The three production files were restored to their pre-fix content (`git show HEAD~1:<path>`) and the
+suites re-run:
+
+```
+grpcw unit tests, pre-fix:
+[ERROR] Issue7320GrpcAuthInterceptorDatabaseHeaderTest.absentHeaderAuthenticatesAtServerLevel:108
+[ERROR] Issue7320GrpcAuthInterceptorDatabaseHeaderTest.emptyHeaderAuthenticatesAtServerLevel:123
+[ERROR] Issue7320GrpcAuthInterceptorDatabaseHeaderTest.refusalNamesTheDatabaseThatWasChecked:159
+[ERROR] Issue7320GrpcAuthInterceptorDatabaseHeaderTest.wrongPasswordIsStillRefused:177
+[ERROR] Tests run: 221, Failures: 4, Errors: 0, Skipped: 0
+
+Issue7320ScopedUserGrpcIT, pre-fix:
+[ERROR] Tests run: 3, Failures: 1, Errors: 2
+com.arcadedb.remote.RemoteException: gRPC error: Invalid credentials
+Caused by: io.grpc.StatusRuntimeException: UNAUTHENTICATED: Invalid credentials
+```
+
+The IT fails with the exact symptom the issue reports. The fifth interceptor case,
+`presentHeaderStillAuthenticatesAgainstThatDatabase`, passes before and after by design: it is the
+unchanged-behaviour guard, and a test that changed colour there would mean the fix had moved
+something it should not.
+
+### Test results (with the fix)
+
+```
+grpcw  unit:   Tests run: 221, Failures: 0, Errors: 0, Skipped: 0
+grpc-client unit: Tests run: 154, Failures: 0, Errors: 0, Skipped: 0
+Issue7320ScopedUserGrpcIT:  Tests run: 3, Failures: 0, Errors: 0
+Authorization regression ITs (Issue4794GrpcPerDbAuthorizationIT, Issue5039GrpcAdminAuthorizationIT,
+  Issue5040GrpcTransactionHijackIT, Issue7304GrpcControlPlaneAuthorizationIT,
+  GrpcTransactionScriptingAuthorizationIT, Issue4793GrpcGetDatabaseSecurityIT):
+  Tests run: 70, Failures: 0, Errors: 0
+```
+
+One caveat on how that last line was reached: the gRPC server port is a fixed 50051 with no range,
+so two agents running gRPC ITs on this machine collide, and the collision reads as
+`ServerException: Error starting plugin: GrpcServerPlugin` / `IOException: Failed to bind to address
+0.0.0.0/0.0.0.0:50051`, not as a port message in the summary. Thirteen errors in the first run were
+all that, confirmed with `lsof -nP -iTCP:50051` (another JVM held it) and cleared by re-running once
+the port was free. Nothing was loosened to get there.
 
 ## Residual risk
 
@@ -177,30 +258,52 @@ No blank rows, so no follow-up issue was filed from this sweep.
   that obtains a stub from `RemoteGrpcServer.newBlockingStub(timeout)` directly (the no-database
   overload, kept for source compatibility) still sends no header - and is then authenticated at
   server level by the server half rather than refused. That is the intended pairing, not a gap.
+  `RemoteDatabase.databaseName` is assigned once in the constructor and has no setter, so a stub
+  cannot go stale against a re-pointed database.
 - Per-database authorization is unchanged: it is enforced in
   `ArcadeDbGrpcService.validateCredentials(credentials, databaseName)` against the **request-body**
-  database (`getDatabase` chokepoint, line 4644), which is what `Issue4794GrpcPerDbAuthorizationIT`
-  pins. Dropping the `"default"` fallback removes a check that was never the authorization gate.
+  database, which is what `Issue4794GrpcPerDbAuthorizationIT` pins.
+- The refusal now repeats the message `ServerSecurity` produced. Reading `ServerSecurity.authenticate`,
+  the three it can produce are `"User/Password not valid"` (one message for both a missing user and a
+  wrong password, so no user enumeration), `"User has not access to database 'X'"` (X is the name the
+  caller itself sent) and the lockout message. HTTP already reports the same strings, so this is
+  parity, not new disclosure.
+- **#7374** - a `RemoteGrpcDatabase` built with a different user than its `RemoteGrpcServer` sends the
+  server's user on the metadata and its own in the request body. Pre-existing and independent: wrong
+  the same way before and after this fix. Filed, not fixed here.
+- **#7375** - `Issue7305TimeSeriesGrpcAclIT` still grants its scoped user `"*"` databases, with a
+  comment pointing at this issue. The workaround is now unnecessary, but narrowing it means editing
+  an existing test, which this workflow does not do. Filed, not fixed here.
 
 ## Adversarial pass
 
-The orchestrator's Phase 1.5 spawns an isolated subagent to write the follow-up issue it would file
-against this patch. No `Task` tool was available in this session, so the pass was run by the author
-against the diff instead - weaker, because it was already convinced. Recorded here so the gap is
-visible rather than silently skipped.
+Phase 1.5 asks for an isolated subagent that has not been convinced by the author's reasoning. **No
+`Task` tool was available in this session**, so no such subagent could be spawned, and the pass was
+run by the author against the diff instead. That is weaker, and is recorded here rather than
+silently skipped. Each objection below was checked with a command, not from memory.
 
 | Objection | Verdict | Evidence |
 |---|---|---|
-| "Dropping the `"default"` grant check widens who reaches the service layer." | Real but not a defect - see *Does dropping the `"default"` check widen access?* above. Every one of the 14 data-plane RPCs authorizes the request-body database via `getDatabase` or `authorizeTransactionAccess`, and the removed check only ever admitted `"*"` principals. | audit above |
-| "`insertBidirectional` never calls the authorization gate." | Not real. It reaches it through `new InsertContext(opts)` -> `getDatabase(opts.getDatabase(), opts.getCredentials())` (line 4410), 1000 lines from the RPC. | `grep -n "InsertContext(InsertOptions opts)" -A 5` |
-| "The header is captured once at stub construction, so a `RemoteGrpcDatabase` re-pointed at another database would send a stale name." | Not real. `RemoteDatabase.databaseName` is assigned once in the constructor (`network/.../RemoteDatabase.java:100`) and there is no setter; `RemoteGrpcDatabase.databaseName` is `final`. | `grep -rn "setDatabase\b\|databaseName =" network/.../RemoteDatabase.java` |
-| "`e.getMessage()` can be null, and a null failure reads as success." | Real, and fixed in this branch before the PR opened: `authenticationFailure` falls back to `"Invalid credentials"` on a null or blank message rather than returning null. | `GrpcAuthInterceptor.authenticationFailure` |
-| "The end-to-end IT passes with only the server half applied, so it does not prove the client sends anything." | Real, and answered by construction: `Issue7320GrpcDatabaseHeaderTest` reads the metadata back off the very stub `RemoteGrpcDatabase` builds, so the client half has its own assertion independent of the IT. | `Issue7320GrpcDatabaseHeaderTest` |
-
-Nothing survived as an out-of-scope defect, so no follow-up issue was filed.
+| "Dropping the `"default"` grant check widens who reaches the service layer." | Real question, not a defect. All 22 data-plane RPCs reach `validateCredentials(credentials, databaseName)`, whose both branches enforce the grant; the removed check only ever admitted `"*"` principals. | scripted RPC-gate audit + `validateCredentials` body, above; `Issue4794GrpcPerDbAuthorizationIT` 4/4 |
+| "The audit was written before #7305/#7306 landed, so the eight RPCs they added are unaudited." | Real, and fixed: the branch was rebased onto current `main` and the audit re-run over all 22 RPCs, including `timeSeries*`, `vectorSearch`, `hybridSearch`, `fullTextSearch`. | table above |
+| "The bearer-token branch loses a grant check when `database` becomes null." | Not real. `getValidSession(token, database)` uses `database` in three `Level.FINE` log messages and nowhere else - read in full, not grepped. | `sed -n '/getValidSession/,/^  }/p'` |
+| "The end-to-end IT passes with only the server half applied, so it does not prove the client sends anything." | Real, and answered by construction: `Issue7320GrpcDatabaseHeaderTest` reads the metadata back off the very stub `RemoteGrpcDatabase` builds, so the client half has an assertion that does not depend on the IT. | `Issue7320GrpcDatabaseHeaderTest` |
+| "`e.getMessage()` can be null, and a null failure reads as success." | Real, fixed in this branch: `authenticationFailure` falls back to `"Invalid credentials"` on a null or blank message rather than returning null. | `GrpcAuthInterceptor.authenticationFailure` |
+| "Echoing the security message to an unauthenticated caller leaks whether a user exists." | Not real. `ServerSecurity.authenticate` answers a missing user and a wrong password with the same `"User/Password not valid"`. | `ServerSecurity.authenticate` lines 226-231 |
+| "The IT hardcodes port 2480, so whatever already listens there answers it." | Real, fixed before the PR: the IT now derives the HTTP port from `getServer(0).getHttpServer().getPort()` and creates its users through `POST /api/v1/server/users`, the way `Issue7305TimeSeriesGrpcAclIT` does. gRPC's own port stays 50051 because the plugin has no range. | rewritten `Issue7320ScopedUserGrpcIT` |
+| "The user the caller passes to `RemoteGrpcDatabase` is never the one on the wire." | Real, out of scope. Filed as **#7374**. | `RemoteGrpcDatabase.buildCredentials` vs `RemoteGrpcServer.createCredentials` |
+| "A test that works around this bug still carries the workaround and a comment saying the bug is open." | Real, out of scope (editing an existing test). Filed as **#7375**. | `Issue7305TimeSeriesGrpcAclIT:182-194` |
 
 ## Drive-by
 
 `RemoteGrpcServer.createCredentials()` carried a commented-out `curl`-style example containing a
 password-shaped literal (`x-arcade-password: oY9uU2uJ8nD8iY7t`). The comment described the very header
 this issue is about, and the replacement code names the key explicitly, so the comment went with it.
+
+## Note on provenance
+
+An earlier session left this worktree with the fix and its tests uncommitted, unrebased (cut before
+#7305/#7306 merged) and unverified - no commit, no branch on `origin`, no PR. This run adopted that
+work rather than discarding it, then rebased it onto `main`, re-ran the completeness sweep over the
+grown RPC surface, rewrote the IT off the hardcoded port, proved the tests fail without the fix, and
+filed the two follow-ups. Nothing here is inherited on trust.

--- a/docs/7320-grpc-client-database-header.md
+++ b/docs/7320-grpc-client-database-header.md
@@ -307,3 +307,37 @@ An earlier session left this worktree with the fix and its tests uncommitted, un
 work rather than discarding it, then rebased it onto `main`, re-ran the completeness sweep over the
 grown RPC surface, rewrote the IT off the hardcoded port, proved the tests fail without the fix, and
 filed the two follow-ups. Nothing here is inherited on trust.
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/7377
+
+## Review cycles
+
+- **cycle 1 - `432716f5`** - `claude` reviewed the diff and re-derived the doc's claims against the
+  source rather than taking them: it re-read `ServerSecurity.authenticate` and confirmed the bounded
+  set of three messages (so echoing `e.getMessage()` adds no user-enumeration vector), confirmed the
+  blank-vs-absent normalization is symmetric on both sides of the wire, confirmed
+  `userName`/`userPassword` are `Objects.requireNonNull`'d in the `RemoteGrpcServer` constructor so
+  the unconditional `headers.put` cannot NPE, and confirmed `RemoteGrpcDatabase.databaseName` is
+  `final`. Verdict: **no bugs, no blocking issues**, security a net narrowing. No code changes were
+  applied, so no second cycle was needed. Two non-blocking observations, both declined with reasons:
+
+  1. *"`Issue7320ScopedUserGrpcIT.createUser` duplicates the `HttpURLConnection` POST helper from
+     `Issue7305TimeSeriesGrpcAclIT` almost verbatim - worth lifting into a shared helper if a third
+     gRPC IT needs it."* Declined here, and the reviewer's own condition says why: there are two
+     copies, not three. Extracting a shared helper means editing `Issue7305TimeSeriesGrpcAclIT`, an
+     existing test this workflow does not modify, and #7375 is already queued to touch that file -
+     which is the right moment to extract it, with a third caller in sight or not.
+  2. *"The bearer-token branch's `database` parameter is effectively dead (used only in `FINE` log
+     messages); consider wiring it into a real check or dropping it."* Declined: the parameter is not
+     dead, it is diagnostic - it is what tells an operator reading FINE logs which database a
+     rejected token was aimed at. Wiring it into a real grant check would be a behaviour change to
+     the token path, which is not what this issue reports and would want its own review. Worth
+     knowing: after this fix those three log lines print `database: null` for a header-less call,
+     which is honest (no database was named) but reads oddly. Left alone rather than churning a PR
+     the reviewer passed.
+
+## Final state
+
+`clean-approval` - one cycle, no review-driven code changes, no deferred items.

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
@@ -184,14 +184,22 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
   }
 
   /**
-   * Override this method to customize blocking stub creation
+   * Override this method to customize blocking stub creation.
+   * <p>
+   * The stub names this database on every call, so the server's auth interceptor authenticates the
+   * caller against the database the calls actually target. Before #7320 no database travelled with the
+   * call and the server fell back to the literal name {@code "default"}, which refused every principal
+   * whose grants named real databases.
    */
   protected ArcadeDbServiceGrpc.ArcadeDbServiceBlockingV2Stub createBlockingStub() {
-    return this.remoteGrpcServer.newBlockingStub(getTimeout());
+    return this.remoteGrpcServer.newBlockingStub(getTimeout(), databaseName);
   }
 
+  /**
+   * @see #createBlockingStub()
+   */
   protected ArcadeDbServiceGrpc.ArcadeDbServiceStub createAsyncStub() {
-    return this.remoteGrpcServer.newAsyncStub(getTimeout());
+    return this.remoteGrpcServer.newAsyncStub(getTimeout(), databaseName);
   }
 
   @Override

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
@@ -102,6 +102,22 @@ import java.util.concurrent.TimeUnit;
  */
 public class RemoteGrpcServer implements AutoCloseable {
 
+  // Hoisted out of the credential-attach path: Metadata.Key.of() validates and lower-cases the name on every
+  // call, and these four (five, with a database) are attached to EVERY RPC.
+  private static final Metadata.Key<String> USERNAME_KEY         =
+      Metadata.Key.of("username", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_KEY         =
+      Metadata.Key.of("password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> ARCADE_USER_KEY      =
+      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> ARCADE_PASSWORD_KEY  =
+      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  /**
+   * The key {@code GrpcAuthInterceptor} reads to decide which database to authenticate the call against.
+   */
+  private static final Metadata.Key<String> ARCADE_DATABASE_KEY  =
+      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
   private final String host;
   private final int    port;
   private final String userName;
@@ -219,18 +235,47 @@ public class RemoteGrpcServer implements AutoCloseable {
     return interceptors.isEmpty() ? current : ClientInterceptors.intercept(current, interceptors);
   }
 
-  public ArcadeDbServiceGrpc.ArcadeDbServiceBlockingV2Stub newBlockingStub(int timeout) {
+  /**
+   * A data-plane stub that names no database. The server then authenticates the credentials at server
+   * level; per-database authorization still happens against the database named in each request body.
+   * Prefer {@link #newBlockingStub(int, String)} when the target database is known.
+   */
+  public ArcadeDbServiceGrpc.ArcadeDbServiceBlockingV2Stub newBlockingStub(final int timeout) {
+    return newBlockingStub(timeout, null);
+  }
+
+  /**
+   * A data-plane stub whose every call carries {@code database} on the {@code x-arcade-database}
+   * metadata the server's auth interceptor reads.
+   * <p>
+   * Issue #7320: without that key the interceptor fell back to the literal name {@code "default"} and
+   * authenticated the caller against a database it had never named, so any principal not granted
+   * {@code "*"} was refused on its first RPC.
+   *
+   * @param database the database the calls target, or {@code null}/blank to send no database at all
+   */
+  public ArcadeDbServiceGrpc.ArcadeDbServiceBlockingV2Stub newBlockingStub(final int timeout, final String database) {
 
     return ArcadeDbServiceGrpc.newBlockingV2Stub(channel())
-        .withCallCredentials(createCredentials())
+        .withCallCredentials(createCredentials(database))
         .withDeadlineAfter(timeout, TimeUnit.MILLISECONDS)
         .withCompression("gzip");
   }
 
-  public ArcadeDbServiceGrpc.ArcadeDbServiceStub newAsyncStub(int timeout) {
+  /**
+   * @see #newBlockingStub(int)
+   */
+  public ArcadeDbServiceGrpc.ArcadeDbServiceStub newAsyncStub(final int timeout) {
+    return newAsyncStub(timeout, null);
+  }
+
+  /**
+   * @see #newBlockingStub(int, String)
+   */
+  public ArcadeDbServiceGrpc.ArcadeDbServiceStub newAsyncStub(final int timeout, final String database) {
 
     return ArcadeDbServiceGrpc.newStub(channel())
-        .withCallCredentials(createCredentials())
+        .withCallCredentials(createCredentials(database))
         .withDeadlineAfter(timeout, TimeUnit.MILLISECONDS)
         .withCompression("gzip");
   }
@@ -582,43 +627,49 @@ public class RemoteGrpcServer implements AutoCloseable {
   }
 
   /**
-   * Creates call credentials for authentication
+   * Creates call credentials for authentication, naming no database. Used by the admin plane, whose
+   * RPCs authenticate from the request body and never read the database metadata.
    */
-  protected CallCredentials createCallCredentials(String userName, String userPassword) {
-    ensureCredentialsAllowedOverChannel();
-    return new CallCredentials() {
-      @Override
-      public void applyRequestMetadata(RequestInfo requestInfo, Executor appExecutor, MetadataApplier applier) {
-        Metadata headers = new Metadata();
-        headers.put(Metadata.Key.of("username", Metadata.ASCII_STRING_MARSHALLER), userName);
-        headers.put(Metadata.Key.of("password", Metadata.ASCII_STRING_MARSHALLER), userPassword);
-        headers.put(Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER), userName);
-        headers.put(Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER), userPassword);
-        applier.apply(headers);
-      }
-
-      @Override
-      public void thisUsesUnstableApi() {
-        // Required by the interface
-      }
-    };
+  protected CallCredentials createCallCredentials(final String userName, final String userPassword) {
+    return credentials(userName, userPassword, null);
   }
 
+  /**
+   * @see #createCredentials(String)
+   */
   protected CallCredentials createCredentials() {
+    return createCredentials(null);
+  }
+
+  /**
+   * Credentials for this server's user, naming the database the calls target so the server's auth
+   * interceptor authenticates against that database rather than against a name nobody sent (#7320).
+   *
+   * @param database the target database, or {@code null}/blank to omit the key entirely
+   */
+  protected CallCredentials createCredentials(final String database) {
+    return credentials(userName, userPassword, database);
+  }
+
+  private CallCredentials credentials(final String user, final String password, final String database) {
     ensureCredentialsAllowedOverChannel();
+    // Blank is the same as absent: an empty header would only make the server special-case it.
+    final String targetDatabase = database == null || database.isBlank() ? null : database;
+
     return new CallCredentials() {
       @Override
-      public void applyRequestMetadata(RequestInfo requestInfo, Executor appExecutor, MetadataApplier applier) {
-        Metadata headers = new Metadata();
-        headers.put(Metadata.Key.of("username", Metadata.ASCII_STRING_MARSHALLER), userName);
-        headers.put(Metadata.Key.of("password", Metadata.ASCII_STRING_MARSHALLER), userPassword);
-        headers.put(Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER), userName);
-        headers.put(Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER), userPassword);
+      public void applyRequestMetadata(final RequestInfo requestInfo, final Executor appExecutor,
+          final MetadataApplier applier) {
+        final Metadata headers = new Metadata();
+        headers.put(USERNAME_KEY, user);
+        headers.put(PASSWORD_KEY, password);
+        headers.put(ARCADE_USER_KEY, user);
+        headers.put(ARCADE_PASSWORD_KEY, password);
+        if (targetDatabase != null)
+          headers.put(ARCADE_DATABASE_KEY, targetDatabase);
         applier.apply(headers);
       }
 
-      // x-arcade-user: root" -H "x-arcade-password: oY9uU2uJ8nD8iY7t" -H
-      // "x-arcade-database: local_shakeiq_curonix_poc-app"
       @Override
       public void thisUsesUnstableApi() {
         // Required by the interface

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue7320GrpcDatabaseHeaderTest.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue7320GrpcDatabaseHeaderTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote.grpc;
+
+import io.grpc.CallCredentials;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7320: {@code GrpcAuthInterceptor} authenticates a data-plane call against the database named
+ * in the {@code x-arcade-database} metadata, and the shipped client never sent that key - so every
+ * call was authenticated against the literal name {@code "default"}.
+ * <p>
+ * These cases read the credentials back off the stub that {@link RemoteGrpcServer} actually hands to
+ * {@link RemoteGrpcDatabase}, rather than off a factory method, so the assertion covers the wiring and
+ * not only the header-building code. No RPC is issued, so no server has to be listening: a gRPC
+ * channel connects lazily.
+ */
+class Issue7320GrpcDatabaseHeaderTest {
+
+  private static final Metadata.Key<String> DATABASE_HEADER =
+      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> USER_HEADER     =
+      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER =
+      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+
+  private static final String DATABASE = "graph7320";
+
+  private RemoteGrpcServer server() {
+    return new RemoteGrpcServer("localhost", 50051, "root", "secret", true, List.of());
+  }
+
+  /**
+   * Runs the credentials the way gRPC runs them on every call and returns the metadata they produced.
+   */
+  private static Metadata requestMetadata(final CallCredentials credentials) {
+    assertThat(credentials).as("the stub carries call credentials").isNotNull();
+
+    final AtomicReference<Metadata> captured = new AtomicReference<>();
+    credentials.applyRequestMetadata(null, Runnable::run, new CallCredentials.MetadataApplier() {
+      @Override
+      public void apply(final Metadata headers) {
+        captured.set(headers);
+      }
+
+      @Override
+      public void fail(final Status status) {
+        throw new AssertionError("credentials refused to apply: " + status);
+      }
+    });
+
+    final Metadata headers = captured.get();
+    assertThat(headers).as("credentials applied request metadata").isNotNull();
+    return headers;
+  }
+
+  @Test
+  void blockingStubCredentialsCarryTheTargetDatabase() {
+    try (final RemoteGrpcServer server = server()) {
+      final Metadata headers = requestMetadata(
+          server.newBlockingStub(1_000, DATABASE).getCallOptions().getCredentials());
+
+      assertThat(headers.get(DATABASE_HEADER)).isEqualTo(DATABASE);
+      assertThat(headers.get(USER_HEADER)).isEqualTo("root");
+      assertThat(headers.get(PASSWORD_HEADER)).isEqualTo("secret");
+    }
+  }
+
+  @Test
+  void asyncStubCredentialsCarryTheTargetDatabase() {
+    try (final RemoteGrpcServer server = server()) {
+      final Metadata headers = requestMetadata(
+          server.newAsyncStub(1_000, DATABASE).getCallOptions().getCredentials());
+
+      assertThat(headers.get(DATABASE_HEADER)).isEqualTo(DATABASE);
+      assertThat(headers.get(USER_HEADER)).isEqualTo("root");
+    }
+  }
+
+  /**
+   * A database-less stub is still reachable through the pre-#7320 overloads. It sends no database key
+   * rather than an empty or invented one, which is what lets the server authenticate it at server
+   * level instead of against a name nobody asked for.
+   */
+  @Test
+  void databaseLessStubSendsNoDatabaseKeyAtAll() {
+    try (final RemoteGrpcServer server = server()) {
+      assertThat(requestMetadata(server.newBlockingStub(1_000).getCallOptions().getCredentials())
+          .containsKey(DATABASE_HEADER)).isFalse();
+      assertThat(requestMetadata(server.newAsyncStub(1_000).getCallOptions().getCredentials())
+          .containsKey(DATABASE_HEADER)).isFalse();
+    }
+  }
+
+  /**
+   * A blank database name is treated as no name at all, so the client cannot send an empty header that
+   * the interceptor would have to special-case.
+   */
+  @Test
+  void blankDatabaseNameSendsNoDatabaseKey() {
+    try (final RemoteGrpcServer server = server()) {
+      assertThat(requestMetadata(server.newBlockingStub(1_000, "  ").getCallOptions().getCredentials())
+          .containsKey(DATABASE_HEADER)).isFalse();
+    }
+  }
+}

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue7320ScopedUserGrpcIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue7320ScopedUserGrpcIT.java
@@ -29,15 +29,20 @@ import com.arcadedb.server.grpc.InsertOptions.TransactionMode;
 import com.arcadedb.server.grpc.InsertSummary;
 import com.arcadedb.server.security.ServerSecurity;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Issue #7320: a principal whose grants name real databases could not use gRPC at all. The client sent
@@ -45,16 +50,21 @@ import static org.assertj.core.api.Assertions.assertThat;
  * name {@code "default"} - a database this user is not granted - and refused the first RPC with
  * {@code UNAUTHENTICATED: Invalid credentials}. Only a principal granted {@code "*"} could connect.
  * <p>
- * The user here is granted the test database and nothing else, which is the shape the issue reports.
- * The test drives both stubs {@link RemoteGrpcDatabase} builds: the blocking one (query and command)
- * and the async one (bidirectional ingestion), because each takes its credentials from its own
- * {@code CallCredentials} instance.
+ * The users here are granted ONE named database each, which is the shape the issue reports. The test
+ * drives both stubs {@link RemoteGrpcDatabase} builds - the blocking one (query and command) and the
+ * async one (bidirectional ingestion) - because each takes its credentials from its own
+ * {@code CallCredentials} instance, and it drives the refusal path too: a user granted some OTHER
+ * database must still be refused, and the refusal must name the database rather than blame the
+ * password.
  */
 class Issue7320ScopedUserGrpcIT extends BaseGraphServerTest {
 
-  private static final String SCOPED_USER = "scoped7320";
-  private static final String SCOPED_PASS = "scoped7320password";
-  private static final String TYPE        = "Scoped7320";
+  private static final int    GRPC_PORT    = 50051;
+  private static final String SCOPED_USER  = "scoped7320";
+  private static final String SCOPED_PWD   = "scoped7320password";
+  private static final String FOREIGN_USER = "foreign7320";
+  private static final String FOREIGN_PWD  = "foreign7320password";
+  private static final String TYPE         = "Scoped7320";
 
   private RemoteGrpcServer   grpcServer;
   private RemoteGrpcDatabase database;
@@ -62,28 +72,12 @@ class Issue7320ScopedUserGrpcIT extends BaseGraphServerTest {
   @Override
   public void setTestConfiguration() {
     super.setTestConfiguration();
-    GlobalConfiguration.SERVER_PLUGINS.setValue("GRPC:com.arcadedb.server.grpc.GrpcServerPlugin");
-  }
-
-  @BeforeEach
-  void createScopedUserAndConnect() {
-    final ServerSecurity security = getServer(0).getSecurity();
-    if (!security.existsUser(SCOPED_USER)) {
-      final JSONObject config = new JSONObject();
-      config.put("name", SCOPED_USER);
-      config.put("password", security.encodePassword(SCOPED_PASS));
-      // Granted the test database ONLY: no "*" wildcard, which is what made gRPC work before the fix.
-      config.put("databases", new JSONObject().put(getDatabaseName(), new JSONArray().put("admin")));
-      security.createUser(config);
-    }
-
-    grpcServer = new RemoteGrpcServer("localhost", 50051, SCOPED_USER, SCOPED_PASS, true, List.of());
-    database = new RemoteGrpcDatabase(grpcServer, "localhost", 50051, 2480, getDatabaseName(), SCOPED_USER,
-        SCOPED_PASS);
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
   }
 
   @AfterEach
-  void disconnectAndDropScopedUser() {
+  @Override
+  public void endTest() {
     if (database != null) {
       database.close();
       database = null;
@@ -92,28 +86,41 @@ class Issue7320ScopedUserGrpcIT extends BaseGraphServerTest {
       grpcServer.close();
       grpcServer = null;
     }
-    final ServerSecurity security = getServer(0).getSecurity();
-    if (security.existsUser(SCOPED_USER))
-      security.dropUser(SCOPED_USER);
     GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
   }
 
+  /**
+   * The blocking stub: a user granted only this database can query it over gRPC. Before the fix this
+   * failed on the first RPC with {@code UNAUTHENTICATED: Invalid credentials}, because the server
+   * checked the grant against the name {@code "default"}.
+   */
   @Test
-  void scopedUserCanQueryOverGrpc() {
-    database.command("sql", "CREATE VERTEX TYPE `" + TYPE + "` IF NOT EXISTS");
-    database.command("sql", "INSERT INTO `" + TYPE + "` SET id = 1");
+  void scopedUserCanQueryOverGrpc() throws Exception {
+    command(0, "CREATE VERTEX TYPE `" + TYPE + "` IF NOT EXISTS");
+    command(0, "INSERT INTO `" + TYPE + "` SET id = 'seed'");
+    createUser(SCOPED_USER, SCOPED_PWD, getDatabaseName());
 
-    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS c FROM `" + TYPE + "`")) {
+    final RemoteGrpcDatabase scoped = connect(SCOPED_USER, SCOPED_PWD);
+
+    try (final ResultSet rs = scoped.query("sql", "SELECT count(*) AS c FROM `" + TYPE + "`")) {
       assertThat(rs.hasNext()).isTrue();
       assertThat(((Number) rs.next().getProperty("c")).longValue()).isEqualTo(1L);
     }
   }
 
+  /**
+   * The async stub, which carries its own {@code CallCredentials} instance and would keep sending no
+   * database if only the blocking one had been fixed.
+   */
   @Test
   void scopedUserCanIngestOverTheAsyncStub() throws Exception {
-    database.command("sql", "CREATE VERTEX TYPE `" + TYPE + "` IF NOT EXISTS");
-    database.command("sql", "CREATE PROPERTY `" + TYPE + "`.id IF NOT EXISTS STRING");
-    database.command("sql", "CREATE INDEX IF NOT EXISTS ON `" + TYPE + "` (id) UNIQUE");
+    command(0, "CREATE VERTEX TYPE `" + TYPE + "` IF NOT EXISTS");
+    command(0, "CREATE PROPERTY `" + TYPE + "`.id IF NOT EXISTS STRING");
+    command(0, "CREATE INDEX IF NOT EXISTS ON `" + TYPE + "` (id) UNIQUE");
+    createUser(SCOPED_USER, SCOPED_PWD, getDatabaseName());
+
+    final RemoteGrpcDatabase scoped = connect(SCOPED_USER, SCOPED_PWD);
 
     final List<Map<String, Object>> rows = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
@@ -129,11 +136,74 @@ class Issue7320ScopedUserGrpcIT extends BaseGraphServerTest {
         .setConflictMode(ConflictMode.CONFLICT_ERROR)
         .setTransactionMode(TransactionMode.PER_BATCH)
         .setServerBatchSize(10)
-        .setCredentials(database.buildCredentials())
+        .setCredentials(scoped.buildCredentials())
         .build();
 
-    final InsertSummary summary = database.ingestBidi(options, rows, 5, 5, 60_000);
+    final InsertSummary summary = scoped.ingestBidi(options, rows, 5, 5, 60_000);
 
     assertThat(summary.getInserted()).isEqualTo(10);
+  }
+
+  /**
+   * The header is a grant check, not decoration: a user granted some other database is still refused
+   * when it targets this one, and the refusal now says which database was checked instead of blaming
+   * the password - the second half of the issue's complaint.
+   */
+  @Test
+  void userGrantedAnotherDatabaseIsRefusedAndTheRefusalNamesIt() throws Exception {
+    command(0, "CREATE VERTEX TYPE `" + TYPE + "` IF NOT EXISTS");
+    createUser(FOREIGN_USER, FOREIGN_PWD, "someotherdatabase7320");
+
+    final RemoteGrpcDatabase foreign = connect(FOREIGN_USER, FOREIGN_PWD);
+
+    assertThatThrownBy(() -> foreign.query("sql", "SELECT FROM `" + TYPE + "`"))
+        .as("a user with no grant on this database must not reach it over gRPC")
+        .hasMessageContaining(getDatabaseName());
+  }
+
+  private RemoteGrpcDatabase connect(final String user, final String password) {
+    grpcServer = new RemoteGrpcServer("localhost", GRPC_PORT, user, password, true, List.of());
+    // The port the test server actually bound: the configured range starts at 2480, but a server already
+    // listening there pushes this one up.
+    database = new RemoteGrpcDatabase(grpcServer, "localhost", GRPC_PORT,
+        getServer(0).getHttpServer().getPort(), getDatabaseName(), user, password);
+    return database;
+  }
+
+  /**
+   * Creates a principal granted {@code database} and nothing else - no {@code "*"} wildcard, which is
+   * what every gRPC test needed before this fix. The group is {@code admin}, which the default group
+   * configuration defines under the {@code "*"} database, so no group has to be added here.
+   * <p>
+   * The user goes in through the server's own {@code POST /api/v1/server/users} endpoint rather than
+   * through {@code ServerSecurity.createUser}, because the handler is what encodes the password into
+   * the form the authentication path expects. Same approach as {@code Issue7305TimeSeriesGrpcAclIT}.
+   */
+  private void createUser(final String name, final String password, final String database) throws Exception {
+    final ServerSecurity security = getServer(0).getSecurity();
+    if (security.existsUser(name))
+      security.dropUser(name);
+
+    final JSONObject payload = new JSONObject()
+        .put("name", name)
+        .put("password", password)
+        .put("databases", new JSONObject().put(database, new JSONArray().put("admin")));
+
+    final HttpURLConnection connection = (HttpURLConnection) URI.create(
+            "http://127.0.0.1:" + getServer(0).getHttpServer().getPort() + "/api/v1/server/users").toURL()
+        .openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization", "Basic " + Base64.getEncoder()
+        .encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes(StandardCharsets.UTF_8)));
+    connection.setRequestProperty("Content-Type", "application/json");
+    connection.setDoOutput(true);
+    try (final OutputStream out = connection.getOutputStream()) {
+      out.write(payload.toString().getBytes(StandardCharsets.UTF_8));
+    }
+    try {
+      assertThat(connection.getResponseCode()).isEqualTo(201);
+    } finally {
+      connection.disconnect();
+    }
   }
 }

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue7320ScopedUserGrpcIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue7320ScopedUserGrpcIT.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.grpc.InsertOptions;
+import com.arcadedb.server.grpc.InsertOptions.ConflictMode;
+import com.arcadedb.server.grpc.InsertOptions.TransactionMode;
+import com.arcadedb.server.grpc.InsertSummary;
+import com.arcadedb.server.security.ServerSecurity;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7320: a principal whose grants name real databases could not use gRPC at all. The client sent
+ * no {@code x-arcade-database} metadata, so the server authenticated every call against the literal
+ * name {@code "default"} - a database this user is not granted - and refused the first RPC with
+ * {@code UNAUTHENTICATED: Invalid credentials}. Only a principal granted {@code "*"} could connect.
+ * <p>
+ * The user here is granted the test database and nothing else, which is the shape the issue reports.
+ * The test drives both stubs {@link RemoteGrpcDatabase} builds: the blocking one (query and command)
+ * and the async one (bidirectional ingestion), because each takes its credentials from its own
+ * {@code CallCredentials} instance.
+ */
+class Issue7320ScopedUserGrpcIT extends BaseGraphServerTest {
+
+  private static final String SCOPED_USER = "scoped7320";
+  private static final String SCOPED_PASS = "scoped7320password";
+  private static final String TYPE        = "Scoped7320";
+
+  private RemoteGrpcServer   grpcServer;
+  private RemoteGrpcDatabase database;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GRPC:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void createScopedUserAndConnect() {
+    final ServerSecurity security = getServer(0).getSecurity();
+    if (!security.existsUser(SCOPED_USER)) {
+      final JSONObject config = new JSONObject();
+      config.put("name", SCOPED_USER);
+      config.put("password", security.encodePassword(SCOPED_PASS));
+      // Granted the test database ONLY: no "*" wildcard, which is what made gRPC work before the fix.
+      config.put("databases", new JSONObject().put(getDatabaseName(), new JSONArray().put("admin")));
+      security.createUser(config);
+    }
+
+    grpcServer = new RemoteGrpcServer("localhost", 50051, SCOPED_USER, SCOPED_PASS, true, List.of());
+    database = new RemoteGrpcDatabase(grpcServer, "localhost", 50051, 2480, getDatabaseName(), SCOPED_USER,
+        SCOPED_PASS);
+  }
+
+  @AfterEach
+  void disconnectAndDropScopedUser() {
+    if (database != null) {
+      database.close();
+      database = null;
+    }
+    if (grpcServer != null) {
+      grpcServer.close();
+      grpcServer = null;
+    }
+    final ServerSecurity security = getServer(0).getSecurity();
+    if (security.existsUser(SCOPED_USER))
+      security.dropUser(SCOPED_USER);
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+  }
+
+  @Test
+  void scopedUserCanQueryOverGrpc() {
+    database.command("sql", "CREATE VERTEX TYPE `" + TYPE + "` IF NOT EXISTS");
+    database.command("sql", "INSERT INTO `" + TYPE + "` SET id = 1");
+
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS c FROM `" + TYPE + "`")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(((Number) rs.next().getProperty("c")).longValue()).isEqualTo(1L);
+    }
+  }
+
+  @Test
+  void scopedUserCanIngestOverTheAsyncStub() throws Exception {
+    database.command("sql", "CREATE VERTEX TYPE `" + TYPE + "` IF NOT EXISTS");
+    database.command("sql", "CREATE PROPERTY `" + TYPE + "`.id IF NOT EXISTS STRING");
+    database.command("sql", "CREATE INDEX IF NOT EXISTS ON `" + TYPE + "` (id) UNIQUE");
+
+    final List<Map<String, Object>> rows = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      final Map<String, Object> row = new HashMap<>();
+      row.put("id", "row-" + i);
+      rows.add(row);
+    }
+
+    final InsertOptions options = InsertOptions.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setTargetClass(TYPE)
+        .addKeyColumns("id")
+        .setConflictMode(ConflictMode.CONFLICT_ERROR)
+        .setTransactionMode(TransactionMode.PER_BATCH)
+        .setServerBatchSize(10)
+        .setCredentials(database.buildCredentials())
+        .build();
+
+    final InsertSummary summary = database.ingestBidi(options, rows, 5, 5, 60_000);
+
+    assertThat(summary.getInserted()).isEqualTo(10);
+  }
+}

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java
@@ -22,6 +22,7 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.server.http.HttpAuthSession;
 import com.arcadedb.server.http.HttpAuthSessionManager;
 import com.arcadedb.server.security.ServerSecurity;
+import com.arcadedb.server.security.ServerSecurityException;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
 import io.grpc.Context;
@@ -150,11 +151,14 @@ class GrpcAuthInterceptor implements ServerInterceptor {
     }
 
     try {
-      // Get database name from header (required for authentication)
-      String database = headers.get(DATABASE_HEADER);
-      if (database == null || database.isEmpty()) {
-        database = "default"; // Use default database if not specified
-      }
+      // The database the caller named, or null when it named none. An absent header used to resolve to
+      // the literal name "default", which ServerSecurity.authenticate treats as a real grant check: a
+      // principal configured with "databases": { "graph": [...] } was refused on its first RPC because
+      // it holds no grant on a database called "default" (issue #7320). Authenticating a header-less
+      // call at server level instead grants nothing extra - per-database authorization is enforced
+      // downstream in ArcadeDbGrpcService.validateCredentials against the database named in the REQUEST
+      // BODY, which is the gate Issue4794GrpcPerDbAuthorizationIT pins.
+      final String database = normalizeDatabase(headers.get(DATABASE_HEADER));
 
       // Try Bearer token authentication first
       final String authorization = headers.get(AUTHORIZATION_HEADER);
@@ -180,9 +184,11 @@ class GrpcAuthInterceptor implements ServerInterceptor {
           return new ServerCall.Listener<ReqT>() {
           };
         } else {
-          // Validate credentials
-          if (!validateCredentials(username, password, database)) {
-            call.close(Status.UNAUTHENTICATED.withDescription("Invalid credentials"), new Metadata());
+          // Validate credentials. The refusal repeats the reason security gave, so a missing grant does
+          // not read as a mistyped password - the complaint in issue #7320.
+          final String failure = authenticationFailure(username, password, database);
+          if (failure != null) {
+            call.close(Status.UNAUTHENTICATED.withDescription(failure), new Metadata());
             return new ServerCall.Listener<ReqT>() {
             };
           }
@@ -262,19 +268,42 @@ class GrpcAuthInterceptor implements ServerInterceptor {
     return session;
   }
 
-  private boolean validateCredentials(String username, String password, String database) {
-    if (security == null) {
-      return true; // No security configured
-    }
+  /**
+   * Treats a blank database name as no database at all, so an empty header is never handed to the grant
+   * check as the database {@code ""}.
+   */
+  private static String normalizeDatabase(final String database) {
+    return database == null || database.isBlank() ? null : database;
+  }
+
+  private boolean validateCredentials(final String username, final String password, final String database) {
+    return authenticationFailure(username, password, database) == null;
+  }
+
+  /**
+   * Authenticates {@code username}/{@code password}, additionally requiring a grant on {@code database}
+   * when one is named. Returns {@code null} when the caller is authenticated, otherwise the reason to
+   * report - the message {@link ServerSecurity} itself produced, so "user has no access to database X"
+   * is not reported as a bad password (issue #7320).
+   */
+  private String authenticationFailure(final String username, final String password, final String database) {
+    if (security == null)
+      return null; // No security configured
 
     try {
-      // ArcadeDB's authenticate method requires database name as well
-      // Returns a SecurityUser object if authentication succeeds, null otherwise
-      Object authenticatedUser = security.authenticate(username, password, database);
-      return authenticatedUser != null;
-    } catch (Exception e) {
+      // ArcadeDB's authenticate method takes the database name as well, and enforces the grant only when
+      // it is non-null.
+      return security.authenticate(username, password, database) != null ? null : "Invalid credentials";
+    } catch (final ServerSecurityException e) {
+      // Expected refusal (bad password, missing grant, lockout): FINE, not SEVERE, and the caller is told
+      // which of them it was. A blank message would read as SUCCESS to the caller of this method, so it
+      // falls back to the generic wording rather than to null.
+      LogManager.instance().log(this, Level.FINE, "Failed to authenticate user: %s for database: %s", username, database);
+      final String reason = e.getMessage();
+      return reason == null || reason.isBlank() ? "Invalid credentials" : reason;
+    } catch (final Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "Failed to authenticate user: %s for database: %s", e, username, database);
-      return false;
+      return "Invalid credentials";
     }
   }
 

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7320GrpcAuthInterceptorDatabaseHeaderTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7320GrpcAuthInterceptorDatabaseHeaderTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.server.security.ServerSecurity;
+import com.arcadedb.server.security.ServerSecurityException;
+import com.arcadedb.server.security.ServerSecurityUser;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.Status;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #7320: a data-plane call that carries no {@code x-arcade-database} metadata was authenticated
+ * against the literal database name {@code "default"}, which {@code ServerSecurity.authenticate}
+ * treats as a real grant check. Every principal whose grants name actual databases was therefore
+ * refused on its first RPC, and the refusal blamed the password.
+ * <p>
+ * The interceptor now authenticates a header-less call at server level - no database, so no grant
+ * check - and leaves per-database authorization where it already was: at
+ * {@code ArcadeDbGrpcService.validateCredentials}, against the database named in the request body
+ * (pinned by {@code Issue4794GrpcPerDbAuthorizationIT}).
+ */
+class Issue7320GrpcAuthInterceptorDatabaseHeaderTest {
+
+  private static final Metadata.Key<String> USER_HEADER     =
+      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER =
+      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER =
+      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private ServerSecurity                    security;
+  private ServerSecurityUser                scopedUser;
+  private GrpcAuthInterceptor               interceptor;
+  private ServerCall<Object, Object>        call;
+  private ServerCallHandler<Object, Object> handler;
+
+  @BeforeEach
+  @SuppressWarnings("unchecked")
+  void setUp() {
+    security = mock(ServerSecurity.class);
+    scopedUser = mock(ServerSecurityUser.class);
+    call = mock(ServerCall.class);
+    handler = mock(ServerCallHandler.class);
+
+    final MethodDescriptor<Object, Object> method = mock(MethodDescriptor.class);
+    when(call.getMethodDescriptor()).thenReturn(method);
+    when(method.getFullMethodName()).thenReturn("com.arcadedb.grpc.ArcadeDbService/ExecuteQuery");
+
+    // Security is enabled: at least one principal is configured.
+    when(security.getUsers()).thenReturn(Collections.singleton("scoped"));
+
+    interceptor = new GrpcAuthInterceptor(security);
+  }
+
+  private Metadata basicAuthHeaders(final String database) {
+    final Metadata headers = new Metadata();
+    headers.put(USER_HEADER, "scoped");
+    headers.put(PASSWORD_HEADER, "scopedpassword");
+    if (database != null)
+      headers.put(DATABASE_HEADER, database);
+    return headers;
+  }
+
+  /**
+   * The mock authenticates only at server level, exactly like a principal granted {@code graph7320}
+   * and nothing else: any grant check against another name throws. Before the fix the interceptor
+   * asked for {@code "default"} and the call was closed.
+   */
+  @Test
+  void absentHeaderAuthenticatesAtServerLevel() {
+    when(security.authenticate("scoped", "scopedpassword", null)).thenReturn(scopedUser);
+    when(security.authenticate("scoped", "scopedpassword", "default"))
+        .thenThrow(new ServerSecurityException("User has not access to database 'default'"));
+
+    interceptor.interceptCall(call, basicAuthHeaders(null), handler);
+
+    verify(security).authenticate("scoped", "scopedpassword", null);
+    verify(handler).startCall(any(), any());
+    verify(call, never()).close(any(), any());
+  }
+
+  /**
+   * An empty header value is the same as no header: it names no database, so it must not be handed to
+   * the grant check as an empty string either.
+   */
+  @Test
+  void emptyHeaderAuthenticatesAtServerLevel() {
+    when(security.authenticate("scoped", "scopedpassword", null)).thenReturn(scopedUser);
+
+    interceptor.interceptCall(call, basicAuthHeaders(""), handler);
+
+    verify(security).authenticate("scoped", "scopedpassword", null);
+    verify(handler).startCall(any(), any());
+    verify(call, never()).close(any(), any());
+  }
+
+  /**
+   * A client that does name its database keeps being authenticated against that database, so the fix
+   * does not turn the header into decoration.
+   */
+  @Test
+  void presentHeaderStillAuthenticatesAgainstThatDatabase() {
+    when(security.authenticate("scoped", "scopedpassword", "graph7320")).thenReturn(scopedUser);
+
+    interceptor.interceptCall(call, basicAuthHeaders("graph7320"), handler);
+
+    verify(security).authenticate("scoped", "scopedpassword", "graph7320");
+    verify(handler).startCall(any(), any());
+    verify(call, never()).close(any(), any());
+  }
+
+  /**
+   * "Invalid credentials" pointed at the password when the real cause was a missing grant. The
+   * refusal now carries the reason security gave, so the operator sees which database was checked.
+   */
+  @Test
+  void refusalNamesTheDatabaseThatWasChecked() {
+    when(security.authenticate("scoped", "scopedpassword", "forbidden7320"))
+        .thenThrow(new ServerSecurityException("User has not access to database 'forbidden7320'"));
+
+    interceptor.interceptCall(call, basicAuthHeaders("forbidden7320"), handler);
+
+    final ArgumentCaptor<Status> status = ArgumentCaptor.forClass(Status.class);
+    verify(call).close(status.capture(), any());
+    verify(handler, never()).startCall(any(), any());
+
+    assertThat(status.getValue().getCode()).isEqualTo(Status.Code.UNAUTHENTICATED);
+    assertThat(status.getValue().getDescription()).contains("forbidden7320");
+  }
+
+  /**
+   * A wrong password is still refused, and still says so.
+   */
+  @Test
+  void wrongPasswordIsStillRefused() {
+    when(security.authenticate("scoped", "scopedpassword", null))
+        .thenThrow(new ServerSecurityException("User/Password not valid"));
+
+    interceptor.interceptCall(call, basicAuthHeaders(null), handler);
+
+    final ArgumentCaptor<Status> status = ArgumentCaptor.forClass(Status.class);
+    verify(call).close(status.capture(), any());
+    verify(handler, never()).startCall(any(), any());
+
+    assertThat(status.getValue().getCode()).isEqualTo(Status.Code.UNAUTHENTICATED);
+    assertThat(status.getValue().getDescription()).contains("User/Password not valid");
+  }
+}


### PR DESCRIPTION
Closes #7320

## Summary

`GrpcAuthInterceptor` authenticates every data-plane call against the database named in the
`x-arcade-database` request metadata, and `RemoteGrpcServer` never sent that key - so the interceptor
fell back to the literal name `"default"` and authenticated every call against a database the caller
had never named. `ServerSecurity.authenticate` treats that as a real grant check, so a principal
configured with `"databases": { "graph": [...] }` was refused on its first RPC with
`UNAUTHENTICATED: Invalid credentials` - a message pointing at the password rather than at the
missing grant. Only a principal granted `"*"` could use gRPC at all. This fixes both halves: the
client stubs now carry the database each `RemoteGrpcDatabase` targets, and a call that names no
database is authenticated at server level (`database == null`) instead of against `"default"`, with
the refusal repeating the reason security actually gave. Per-database authorization is untouched -
it is enforced downstream in `ArcadeDbGrpcService.validateCredentials` against the database in the
request body, and all 22 data-plane RPCs reach it.

## Test plan

- [ ] `mvn -pl grpcw -am test` - `Issue7320GrpcAuthInterceptorDatabaseHeaderTest` covers the server
      half: absent header, empty header, present header, the refusal naming the database, and a
      wrong password still being refused as one.
- [ ] `mvn -pl grpc-client -am test` - `Issue7320GrpcDatabaseHeaderTest` reads the metadata back off
      the very stub `RemoteGrpcDatabase` builds, for both the blocking and the async stub, and pins
      that a database-less or blank-named stub sends no key at all rather than an empty one.
- [ ] `mvn -pl grpc-client -DskipITs=false -Dit.test=Issue7320ScopedUserGrpcIT verify` - end to end
      against a real server, with users granted **one named database each**: query over the blocking
      stub, bidirectional ingest over the async stub, and a user granted another database still
      refused with a message that names the database. All three fail on the pre-fix tree with the
      exact `UNAUTHENTICATED: Invalid credentials` the issue reports.
- [ ] Authorization regression set stays green: `Issue4794GrpcPerDbAuthorizationIT`,
      `Issue5039GrpcAdminAuthorizationIT`, `Issue5040GrpcTransactionHijackIT`,
      `Issue7304GrpcControlPlaneAuthorizationIT`, `GrpcTransactionScriptingAuthorizationIT`,
      `Issue4793GrpcGetDatabaseSecurityIT` (70 tests).
- [ ] Note when running gRPC ITs locally: the plugin's port is a fixed 50051 with no range, so a
      second agent running gRPC ITs collides and the failure reads as
      `Error starting plugin: GrpcServerPlugin`. Check `lsof -nP -iTCP:50051` before believing it.

## Coverage

Entry points this fix covers, each with a test that drives it through that path:

| Entry point | Status |
|---|---|
| `RemoteGrpcServer.newBlockingStub` -> `createCredentials` (data-plane blocking stub) | fixed, tested |
| `RemoteGrpcServer.newAsyncStub` -> `createCredentials` (data-plane async/streaming stub) | fixed, tested |
| `GrpcAuthInterceptor` basic-auth branch, **no** database header (any third-party client) | fixed, tested |
| `GrpcAuthInterceptor` basic-auth branch, **with** a database header | unchanged behaviour, now tested |
| `RemoteGrpcServer.adminServiceBlockingV2Stub` (admin plane) | argued: admin RPCs return from `interceptCall` before the header is read and authenticate from the request body, already database-less |
| `GrpcAuthInterceptor` bearer-token branch | argued: `getValidSession(token, database)` uses `database` in three `Level.FINE` log messages and nowhere else, so no grant check ever ran there |

Does removing the `"default"` check widen access? No: all 22 data-plane RPCs reach
`validateCredentials(credentials, databaseName)` through `getDatabase` or
`authorizeTransactionAccess`, and both of its branches enforce the per-database grant. The removed
check only ever admitted `"*"` principals, who are authorized everywhere anyway. The audit is
scripted in the tracking doc rather than eyeballed, because #7305 and #7306 added eight RPCs after
this branch was cut.

**Known gaps**

- **#7374** - a `RemoteGrpcDatabase` built with a different user than its `RemoteGrpcServer` sends
  the server's user on the call metadata and its own in the request body. Pre-existing and
  independent of the database header: wrong the same way before and after this fix.
- **#7375** - `Issue7305TimeSeriesGrpcAclIT` still grants its scoped user `"*"` databases with a
  comment pointing at this issue. The workaround is now unnecessary, but narrowing it means editing
  an existing test, which this branch does not do. The behaviour is covered here by
  `Issue7320ScopedUserGrpcIT` instead.

Full sweep, the pre-fix failure output, and the adversarial pass are in
`docs/7320-grpc-client-database-header.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwTsBYjyoDn2vKXQGmt5bK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * gRPC requests now consistently target and authenticate against the selected database.
  * Database-scoped users can access permitted databases while unauthorized database access is rejected with clearer messages.
  * Calls without a database selection now authenticate at the server level instead of incorrectly targeting a default database.

* **Tests**
  * Added coverage for database metadata, blocking and asynchronous requests, scoped-user access, and authentication failures.

* **Documentation**
  * Added design and analysis documentation for the database-header and authentication improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->