### PR TITLE
feat(#7309): groups, API tokens and user update on the gRPC control plane

### DIFF
--- a/docs/7309-grpc-groups-api-tokens-user-update.md
+++ b/docs/7309-grpc-groups-api-tokens-user-update.md
@@ -269,3 +269,64 @@ against the issue with the same three questions. Findings:
 | `GrpcTransportSecurityInterceptor` might not run before the handler, leaving the gate to fail closed on every call and disabling the mint outright | **Not real.** `createApiTokenReturnsTheMaterialOnceAndListsTheTokenWithout` mints successfully over a real channel. Since the gate refuses when the key is absent, a successful mint is proof the interceptor ran and published a verdict - the positive control doubles as the registration and ordering test |
 | The token listing might carry the plaintext by copying the stored document | **Not real**, and now prevented by construction: `listApiTokens` names each field it copies rather than removing one from a copy. `createApiTokenReturnsTheMaterialOnceAndListsTheTokenWithout` asserts `etl.toString()` does not contain the minted token |
 | `PutUserHandler` could have changed which of "user not found" and "password too short" wins | **Not real.** Both old handler and `ServerControlPlane.updateUser` look the user up first and validate the password second; `updateUserAnswersNotFoundForAnAbsentUser` pins the order from the gRPC side and `UserManagementIT` from the HTTP side |
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/7383
+
+### Review cycles
+
+**Cycle 1 - `2461063f`.** The `claude` reviewer traced each HTTP handler's old inline logic against
+the new `ServerControlPlane` method and confirmed the status codes match, calling out specifically
+that `PostApiTokenHandler`'s 409-vs-400 split survives as `AlreadyExistsException` vs
+`IllegalArgumentException`. It found one issue:
+
+- **Dangling `{@link Issue7309ApiTokenSecrecyTest}`** in the IT's class javadoc - a class that does
+  not exist, left over from an earlier plan to split these tests across two files. Fixed: the javadoc
+  now names `createApiTokenMintsOnlyOverAProtectedTransport` and
+  `GrpcTransportSecurityInterceptorTest`, which are where the refusal side actually lives.
+
+Codacy reported one minor CodeStyle issue on the same commit. Two changes went in for it:
+
+- `parseDocument` caught `RuntimeException` where `JSONObject(String)` raises exactly
+  `JSONException`. Narrowed - the broad catch would have reported a bug in that method as "your JSON
+  is malformed", sending the caller after a document that is fine.
+- `RemoteGrpcServer` imported `ListBackupsResponse` and never used it. Dead already on `main`;
+  re-sorting the import block to add this change's imports is what pulled it into the diff.
+
+**Cycle 2 - `3f4f90a8`.** The three fixes above. `grpcw` 223/223, the new IT 17/17, before pushing.
+Codacy still reported one minor CodeStyle issue on this commit, so neither of the two guesses made
+for cycle 1 was the one it meant.
+
+**Cycle 3 - the fully-qualified names, and the loopback assumption.** Two items, one from Codacy and
+one from the cycle-2 review, which independently named the same FQN problem.
+
+The cycle-2 `claude` review raised:
+
+- **The FQN nit** - `Issue7309GrpcSecurityControlPlaneIT` used fully-qualified names where an import
+  works. Already fixed locally when the review landed, from the same reasoning (below).
+- **The loopback trust assumption** - `isLoopbackPeer` cannot distinguish a genuinely local client
+  from a TLS-terminating reverse proxy forwarding a remote caller to cleartext 127.0.0.1, and the
+  reviewer asked for that to be stated where a future reader will find it. Fixed: it is now a
+  paragraph in `GrpcTransportSecurityInterceptor`'s class doc rather than only in this document's
+  residual-risk section.
+
+Everything else in that review was confirmation of choices already made, with no action.
+
+Codacy does not expose which line it flagged through the GitHub API, so the diff was re-read against
+the project's own rule instead - CLAUDE.md: "don't use fully qualified names if possible, always
+import the class and just use the name". Four violations, all in the two new test files:
+
+```
+Issue7309GrpcSecurityControlPlaneIT.java:423,501,502,505   com.arcadedb.log.Logger
+Issue7309GrpcSecurityControlPlaneIT.java:558              java.util.stream.IntStream
+GrpcTransportSecurityInterceptorTest.java:138             java.security.NoSuchAlgorithmException
+```
+
+All replaced with imports. Whether or not this is the line Codacy meant, it is a real violation of a
+rule this repository states, so it is worth fixing either way - and that is the honest reason for the
+change, not a claim to have identified the finding.
+
+### Deferred items
+
+None. Both reviews produced only actionable, clear comments, and every one was applied.

--- a/docs/7309-grpc-groups-api-tokens-user-update.md
+++ b/docs/7309-grpc-groups-api-tokens-user-update.md
@@ -1,0 +1,271 @@
+# #7309 - gRPC control plane: groups, API tokens and user update
+
+Follow-up to #7304, which put `ListUsers`/`CreateUser`/`DeleteUser` on `ArcadeDbAdminService` and
+left the remaining rows of the `/server/*` security table HTTP-only.
+
+## Finding ledger
+
+Read from the issue body; one row per HTTP route it names.
+
+- [x] 1. `PUT /server/users` (`PutUserHandler`) - update password and/or per-database groups
+- [x] 2. `GET /server/groups` (`GetGroupsHandler`) - read the group/permission document
+- [x] 3. `POST /server/groups` (`PostGroupHandler`) - create/replace a group
+- [x] 4. `DELETE /server/groups` (`DeleteGroupHandler`) - drop a group
+- [x] 5. `GET /server/api-tokens` (`GetApiTokensHandler`) - list issued tokens
+- [x] 6. `POST /server/api-tokens` (`PostApiTokenHandler`) - mint a token, **returns secret material**
+- [x] 7. `DELETE /server/api-tokens` (`DeleteApiTokenHandler`) - revoke a token
+
+The issue attaches two security questions to row 6, tracked as sub-items:
+
+- [x] 6a. Nothing refuses to *receive* a minted token over a plaintext channel to a non-loopback
+  host, though `RemoteGrpcServer` refuses to *send* credentials over one.
+- [x] 6b. `GrpcLoggingInterceptor` and `GrpcMetricsInterceptor` see every message; a token-bearing
+  response must be proved not to reach a log sink.
+
+## Completeness
+
+### 1. The invariant
+
+Two, because rows 1-5 and 7 are adapters and row 6 is not:
+
+> **Parity.** Every `checkRootUser`-gated route under `/server/*` is reachable as a
+> `requireServerAdmin`-gated RPC on `ArcadeDbAdminService`, and both transports run one
+> implementation of the operation rather than two that can drift.
+
+> **Secrecy.** Plaintext API-token material minted by the server leaves the process only towards a
+> peer whose transport protects it, and reaches no log sink or metric tag on the way out.
+
+### 2. Every way to violate it - found by command, not by memory
+
+**The `/server/*` security surface is exactly nine routes** - so the issue's seven-row table plus
+#7304's three is the whole of it, with `GET /server/users` counted in #7304:
+
+```
+$ grep -rnE "UserHandler|GroupHandler|GroupsHandler|ApiToken" \
+    server/src/main/java/com/arcadedb/server/http/HttpServer.java
+249:        .get("/server/api-tokens", new GetApiTokensHandler(this))
+250:        .post("/server/api-tokens", new PostApiTokenHandler(this))
+251:        .delete("/server/api-tokens", new DeleteApiTokenHandler(this))
+253:        .post("/server/users", new PostUserHandler(this))
+254:        .put("/server/users", new PutUserHandler(this))
+255:        .delete("/server/users", new DeleteUserHandler(this))
+256:        .get("/server/groups", new GetGroupsHandler(this))
+257:        .post("/server/groups", new PostGroupHandler(this))
+258:        .delete("/server/groups", new DeleteGroupHandler(this))
+```
+
+(`.get("/server/users", new GetUsersHandler(this))` is line 252, covered by #7304.)
+
+**Writers and readers of the group document - the HTTP handlers are the only non-test callers**, so
+moving the body into `ServerControlPlane` cannot orphan a second caller:
+
+```
+$ grep -rnE "\.saveGroup\(|\.deleteGroup\(|\.groupsToJSON\(" --include="*.java" . \
+    | grep -v /target/ | grep -v /src/test/
+server/.../handler/DeleteGroupHandler.java:55:    final boolean deleted = security.deleteGroup(database, name);
+server/.../handler/GetGroupsHandler.java:40:    final JSONObject groups = ...getSecurity().groupsToJSON();
+server/.../handler/PostGroupHandler.java:62:    security.saveGroup(database, name, groupConfig);
+```
+
+**Writers and readers of the token store - same, three HTTP handlers and the store itself:**
+
+```
+$ grep -rnE "createToken\(|deleteToken\(|listTokens\(|getApiTokenConfiguration\(" --include="*.java" . \
+    | grep -v /target/ | grep -v /src/test/
+server/.../security/ServerSecurity.java:1112          (the accessor)
+server/.../security/ApiTokenConfiguration.java:132,162,188   (the store)
+server/.../handler/PostApiTokenHandler.java:57,60
+server/.../handler/GetApiTokensHandler.java:41,42
+server/.../handler/DeleteApiTokenHandler.java:47,48
+```
+
+**Writer of a user update - one HTTP handler:**
+
+```
+$ grep -rnE "updateUserClusterWide\(" --include="*.java" . | grep -v /target/ | grep -v /src/test/
+server/.../security/ServerSecurity.java:431   (the definition)
+server/.../security/ServerSecurity.java:568   (internal re-entry)
+server/.../handler/PutUserHandler.java:72
+```
+
+**Sibling of the same shape - what else returns secret material in a response body?** Only the
+token mint:
+
+```
+$ grep -rn "put(\"token\"" --include="*.java" server/src/main/java | grep -v /target/
+server/.../security/ApiTokenConfiguration.java:  response.put("token", tokenValue);
+```
+
+**Is the group/token state replicated on HA, as user state is?** No - and this is a
+*pre-existing* asymmetry, not one this change introduces:
+
+```
+$ grep -rnE "saveGroup|deleteGroup|groupRepository|ApiToken" --include="*.java" \
+    server/src/main/java/com/arcadedb/server/ha/
+(no matches)
+$ grep -rnE "replicateSecurityUsers" --include="*.java" server/src/main/java/ | head -4
+HAServerPlugin.java:262:  default void replicateSecurityUsers(...)
+ServerSecurity.java:422,448,475     (createUserClusterWide / updateUserClusterWide / dropUserClusterWide)
+```
+
+`ServerSecurity.saveGroup`/`deleteGroup` write through `groupRepository` to a local file; nothing
+submits a Raft entry. Same for `ApiTokenConfiguration`, which owns `server-api-tokens.json`.
+
+**Do the interceptors touch message content?** Read both:
+
+- `GrpcLoggingInterceptor` logs `methodName`, elapsed millis, the two compression header values and,
+  on failure, `status`. It never holds a reference to a request or response message - it overrides
+  `sendHeaders` and `close`, not `sendMessage`.
+- `GrpcMetricsInterceptor` overrides `sendMessage`, but only to test
+  `message instanceof ExecuteCommandResponse response && !response.getSuccess()`. It never
+  stringifies the message; the meters carry `method` and `status` tags only.
+
+So 6b holds on today's tree. It is an invariant nothing enforces, which is what the regression test
+added here is for.
+
+**Does the client already refuse a plaintext non-loopback channel?** Yes, for every admin RPC,
+because the admin stub attaches call credentials:
+
+```
+RemoteGrpcServer.adminServiceBlockingV2Stub()
+  -> createCallCredentials(userName, userPassword)
+     -> ensureCredentialsAllowedOverChannel()   // throws SecurityException
+```
+
+That covers 6a on ArcadeDB's own Java client, but only there: `allowInsecureCredentials=true` opts
+out of it, and a grpcurl or Python caller never runs it at all. The gate that actually holds the
+invariant has to be server-side, at the point the secret leaves the process.
+
+### 3. Coverage table
+
+| # | Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|---|
+| 1 | `UpdateUser` RPC -> `ServerControlPlane.updateUser` | yes | yes |
+| 1b | `PUT /server/users` -> same `ServerControlPlane.updateUser` | yes (refactored onto it) | yes |
+| 2 | `ListGroups` RPC -> `ServerControlPlane.listGroups` | yes | yes |
+| 2b | `GET /server/groups` -> same | yes (refactored) | yes |
+| 3 | `SaveGroup` RPC -> `ServerControlPlane.saveGroup` | yes | yes |
+| 3b | `POST /server/groups` -> same | yes (refactored) | yes |
+| 4 | `DeleteGroup` RPC -> `ServerControlPlane.deleteGroup` | yes | yes |
+| 4b | `DELETE /server/groups` -> same | yes (refactored) | yes |
+| 5 | `ListApiTokens` RPC -> `ServerControlPlane.listApiTokens` | yes | yes |
+| 5b | `GET /server/api-tokens` -> same | yes (refactored) | yes |
+| 6 | `CreateApiToken` RPC -> `ServerControlPlane.createApiToken` | yes | yes |
+| 6b | `POST /server/api-tokens` -> same | yes (refactored) | yes |
+| 6a | secret material over an unprotected transport | yes - server-side gate | yes |
+| 6b' | secret material into a log sink / metric tag | yes - regression test pins it | yes |
+| 7 | `DeleteApiToken` RPC -> `ServerControlPlane.deleteApiToken` | yes | yes |
+| 7b | `DELETE /server/api-tokens` -> same | yes (refactored) | yes |
+| C1 | `RemoteGrpcServer` client methods for rows 1-7 | yes | yes |
+| C2 | `RemoteServer` (HTTP Java client) methods for rows 1-7 | **filed as #7372** | no |
+| C3 | groups + API tokens are node-local on an HA cluster | **filed as #7373** | no |
+
+Rows C2 and C3 are the two the sweep found that the issue does not name. Neither is a regression
+introduced here; both are recorded as follow-up issues before this PR opens.
+
+### 5. Reachability
+
+- `ArcadeDbGrpcAdminService` is constructed by `GrpcServerPlugin.configureServer`, which both
+  `startStandardServer` and `startXdsServer` call - so the new RPCs are live on either builder.
+- The new `GrpcTransportSecurityInterceptor` is registered unconditionally in the same method,
+  beside the logging and metrics interceptors. `CreateApiToken` **fails closed** when its context
+  key is absent, so a future refactor that drops the registration turns the mint off rather than
+  turning the gate off silently.
+- The refactored HTTP handlers are the ones `HttpServer` registers at lines 249-258, unchanged.
+
+### 7. Residual risk
+
+- **A token minted over gRPC still lands in a node-local file** (row C3). On an HA cluster the token
+  authenticates only against the node that minted it. That was already true over HTTP; this change
+  makes it reachable from one more transport, which is why it is filed rather than left implicit.
+- **The secrecy gate reads the transport, not the operator's intent.** A TLS-terminating proxy in
+  front of a plaintext gRPC port on a loopback interface is indistinguishable, from inside the
+  process, from a local client - and is allowed. That is the same assumption
+  `RemoteGrpcServer.isLoopbackHost` already makes on the client side.
+- **`permissions` travels as a JSON string** in `CreateApiTokenRequest`/`ApiTokenInfo`, not as proto
+  fields, for the reason `GetBackupConfigResponse.config_json` gives: it is the same free-form
+  document the HTTP body carries, and a second declaration of its shape here would be one more thing
+  to keep in step with it.
+- Nothing else. The coverage table above is the evidence: every row is fixed here or filed.
+
+## What was built
+
+**One implementation per operation, two transports.** Seven methods moved into
+`ServerControlPlane` - `updateUser`, `listGroups`, `saveGroup`, `deleteGroup`, `listApiTokens`,
+`createApiToken`, `deleteApiToken` - and the six HTTP handlers were rewritten onto them. What moved
+is not only the happy path: the group-permission cache refresh, the admin-group refusal, the
+permission-document validation and the plaintext-token refusal all moved too, because each is a rule
+a second transport would otherwise have silently lacked.
+
+Two exception types carry the outcomes both transports need to tell apart:
+`ServerControlPlane.NotFoundException` (HTTP 404 / gRPC `NOT_FOUND`) and `AlreadyExistsException`
+(HTTP 409 / gRPC `ALREADY_EXISTS`).
+
+**The mint's transport gate.** `GrpcTransportSecurityInterceptor` publishes, per call, whether the
+transport protects the response - TLS session present, or loopback peer - and `CreateApiToken`
+refuses with `FAILED_PRECONDITION` unless it does. It fails closed on an absent key, so removing the
+interceptor stops tokens being minted rather than stops them being protected.
+
+## Test results
+
+| Suite | Result |
+|---|---|
+| `Issue7309GrpcSecurityControlPlaneIT` (new, 17 tests) | 17/17 |
+| `GrpcTransportSecurityInterceptorTest` (new, 7 tests) | 7/7 |
+| `grpcw` full surefire suite | 223/223 |
+| `GroupManagementIT` + `ApiTokenAuthenticationIT` + `UserManagementIT` (HTTP regression) | 27/27 |
+| adjacent security ITs (`Issue6806`, `SchemaMutationAuthorization`, `CrossDatabaseAccess`, `Issue6808`, `Issue5269`, `OpenApiSpecGeneration`) | 35/35 |
+
+### The secrecy test was wrong first, and that is worth recording
+
+`aMintedTokenReachesNoLogSinkAndNoMetricTag` was written first against a `java.util.logging` handler
+attached to the root logger. A deliberate leak injected into `GrpcLoggingInterceptor.sendMessage` -
+logging the whole response message at INFO - **did not fail it**. The engine logs through its own
+pluggable `com.arcadedb.log.Logger`, so a JUL handler sees only what that implementation forwards, at
+whatever level it is configured for.
+
+Rewritten to capture at `LogManager.setLogger`, the engine's own seam, the same injected leak fails
+the test. Only then was the mutation reverted and the test confirmed green. The captured text on a
+clean run is the evidence for 6b:
+
+```
+gRPC call started: %s (request compression: %s, client accepts: %s) null
+  com.arcadedb.grpc.ArcadeDbAdminService/CreateApiToken none gzip null null ...
+gRPC call completed: %s (%sms, req-compression: %s, resp-compression: %s) null
+  com.arcadedb.grpc.ArcadeDbAdminService/CreateApiToken 1 none none null ...
+```
+
+Method name, compression, elapsed millis. No payload.
+
+### Unrelated red seen while testing
+
+The `server` module's full surefire run showed failures in `AutoCommitParameterTest`,
+`Issue6220TruncateHttpDefaultTest`, `QueryEndpointReadOnlyTest` and `ClusterInternalAuthTest`. None
+of them touch anything this branch changes, and the cause is the one `CLAUDE.md` documents:
+
+- `ClusterInternalAuthTest` targets `http://localhost:2480`. On this machine a Homebrew ArcadeDB has
+  held `*:2480` for six days (`lsof -nP -iTCP:2480 -sTCP:LISTEN` -> pid 93797, `ELAPSED 06-04:13`),
+  `localhost` resolves to `::1`, and that stranger answers the cluster token with 401. The assertion
+  reads `Expecting actual: 401 not to be equal to: 401`, which looks like an auth bug and is a port
+  conflict.
+- The other three target `127.0.0.1:2480`, reach the test's own server, and **passed when re-run in
+  isolation** - they fail only in a full run sharing the machine with another agent's `server` build.
+
+Neither is this branch's, and neither is filed here: the first is a local environment condition, the
+second is the known cost of concurrent builds.
+
+## Adversarial pass
+
+The orchestrator's Phase 1.5 spawns a subagent that has not seen the author's reasoning and asks it
+to write the follow-up issue it would file against the patch. **No `Task` tool was available in this
+session**, so no such subagent could be spawned. Per the skill's error table that is not a hard gate;
+it is recorded here rather than passed off as done, and the pass was run by re-reading the diff
+against the issue with the same three questions. Findings:
+
+| Finding | Disposition |
+|---|---|
+| The three REST `/server/users` routes reach `*ClusterWide` on a follower with no leader gate, while the `POST /server` command path forwards to the leader - so gRPC's `requireLeader` on `UpdateUser` is stricter than the HTTP route it mirrors | Real, out of scope - **filed as #7380** |
+| `POST /server/api-tokens` with an explicitly empty `"database"` used to store a token scoped to the database named `""`; it now normalizes to `"*"` | Real, in scope - behaviour change, deliberate, documented on `ServerControlPlane.createApiToken`. A token scoped to `""` matched no database and could never be used |
+| `GrpcTransportSecurityInterceptor` might not run before the handler, leaving the gate to fail closed on every call and disabling the mint outright | **Not real.** `createApiTokenReturnsTheMaterialOnceAndListsTheTokenWithout` mints successfully over a real channel. Since the gate refuses when the key is absent, a successful mint is proof the interceptor ran and published a verdict - the positive control doubles as the registration and ordering test |
+| The token listing might carry the plaintext by copying the stored document | **Not real**, and now prevented by construction: `listApiTokens` names each field it copies rather than removing one from a copy. `createApiTokenReturnsTheMaterialOnceAndListsTheTokenWithout` asserts `etl.toString()` does not contain the minted token |
+| `PutUserHandler` could have changed which of "user not found" and "password too short" wins | **Not real.** Both old handler and `ServerControlPlane.updateUser` look the user up first and validate the password second; `updateUserAnswersNotFoundForAnAbsentUser` pins the order from the gRPC side and `UserManagementIT` from the HTTP side |

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
@@ -44,7 +44,6 @@ import com.arcadedb.server.grpc.GetServerEventsResponse;
 import com.arcadedb.server.grpc.HealthRequest;
 import com.arcadedb.server.grpc.ListApiTokensRequest;
 import com.arcadedb.server.grpc.ListBackupsRequest;
-import com.arcadedb.server.grpc.ListBackupsResponse;
 import com.arcadedb.server.grpc.ListDatabasesRequest;
 import com.arcadedb.server.grpc.ListDatabasesResponse;
 import com.arcadedb.server.grpc.ListGroupsRequest;

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
@@ -21,14 +21,19 @@ package com.arcadedb.remote.grpc;
 import com.arcadedb.remote.RemoteException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.grpc.AlignDatabaseRequest;
+import com.arcadedb.server.grpc.ApiTokenInfo;
 import com.arcadedb.server.grpc.ArcadeDbAdminServiceGrpc;
 import com.arcadedb.server.grpc.ArcadeDbServiceGrpc;
 import com.arcadedb.server.grpc.BackupInfo;
 import com.arcadedb.server.grpc.CloseDatabaseRequest;
+import com.arcadedb.server.grpc.CreateApiTokenRequest;
+import com.arcadedb.server.grpc.CreateApiTokenResponse;
 import com.arcadedb.server.grpc.CreateDatabaseRequest;
 import com.arcadedb.server.grpc.CreateUserRequest;
 import com.arcadedb.server.grpc.DatabaseCredentials;
+import com.arcadedb.server.grpc.DeleteApiTokenRequest;
 import com.arcadedb.server.grpc.DeleteBackupRequest;
+import com.arcadedb.server.grpc.DeleteGroupRequest;
 import com.arcadedb.server.grpc.DeleteUserRequest;
 import com.arcadedb.server.grpc.DisconnectClusterRequest;
 import com.arcadedb.server.grpc.DropDatabaseRequest;
@@ -37,27 +42,32 @@ import com.arcadedb.server.grpc.GetBackupConfigResponse;
 import com.arcadedb.server.grpc.GetServerEventsRequest;
 import com.arcadedb.server.grpc.GetServerEventsResponse;
 import com.arcadedb.server.grpc.HealthRequest;
+import com.arcadedb.server.grpc.ListApiTokensRequest;
 import com.arcadedb.server.grpc.ListBackupsRequest;
 import com.arcadedb.server.grpc.ListBackupsResponse;
 import com.arcadedb.server.grpc.ListDatabasesRequest;
 import com.arcadedb.server.grpc.ListDatabasesResponse;
+import com.arcadedb.server.grpc.ListGroupsRequest;
 import com.arcadedb.server.grpc.ListUsersRequest;
 import com.arcadedb.server.grpc.OpenDatabaseRequest;
 import com.arcadedb.server.grpc.ProfilerDocumentResponse;
 import com.arcadedb.server.grpc.ProfilerListRequest;
 import com.arcadedb.server.grpc.ProfilerLoadRequest;
 import com.arcadedb.server.grpc.ProfilerResetRequest;
-import com.arcadedb.server.grpc.ProfilerRunInfo;
 import com.arcadedb.server.grpc.ProfilerResultsRequest;
+import com.arcadedb.server.grpc.ProfilerRunInfo;
 import com.arcadedb.server.grpc.ProfilerStartRequest;
 import com.arcadedb.server.grpc.ProfilerStopRequest;
 import com.arcadedb.server.grpc.ReadyRequest;
 import com.arcadedb.server.grpc.ReadyResponse;
+import com.arcadedb.server.grpc.SaveGroupRequest;
 import com.arcadedb.server.grpc.SetBackupConfigRequest;
 import com.arcadedb.server.grpc.SetDatabaseSettingRequest;
 import com.arcadedb.server.grpc.SetServerSettingRequest;
 import com.arcadedb.server.grpc.ShutdownRequest;
 import com.arcadedb.server.grpc.TriggerBackupRequest;
+import com.arcadedb.server.grpc.UpdateUserRequest;
+import com.arcadedb.server.grpc.UserDatabases;
 import com.arcadedb.server.grpc.UserGroups;
 import com.arcadedb.server.grpc.UserInfo;
 import io.grpc.CallCredentials;
@@ -412,6 +422,107 @@ public class RemoteGrpcServer implements AutoCloseable {
   public List<UserInfo> listUsers() {
     return call("list users", stub -> stub.listUsers(
         ListUsersRequest.newBuilder().setCredentials(buildCredentials()).build())).getUsersList();
+  }
+
+  /**
+   * Updates an existing user. Both arguments are independently optional: a null leaves that part of
+   * the user alone, so changing a password does not clear the user's grants and vice versa. Passing
+   * an empty (non-null) map DOES clear them - that is the caller saying so.
+   */
+  public void updateUser(final String user, final String password, final Map<String, List<String>> databases) {
+    final UpdateUserRequest.Builder request = UpdateUserRequest.newBuilder().setCredentials(buildCredentials())
+        .setUser(user);
+    if (password != null)
+      request.setPassword(password);
+    if (databases != null) {
+      final UserDatabases.Builder grants = UserDatabases.newBuilder();
+      databases.forEach((database, groups) -> grants.putDatabases(database,
+          UserGroups.newBuilder().addAllGroups(groups).build()));
+      request.setDatabases(grants.build());
+    }
+
+    call("update user", stub -> stub.updateUser(request.build()));
+  }
+
+  /**
+   * Changes only a user's password, leaving its per-database grants as they are.
+   */
+  public void updateUserPassword(final String user, final String password) {
+    updateUser(user, password, null);
+  }
+
+  /**
+   * Replaces only a user's per-database grants, leaving its password as it is.
+   */
+  public void updateUserGrants(final String user, final Map<String, List<String>> databases) {
+    updateUser(user, null, Objects.requireNonNull(databases, "databases"));
+  }
+
+  /**
+   * The whole group/permission document, as {@code GET /server/groups} returns it.
+   */
+  public JSONObject listGroups() {
+    return new JSONObject(call("list groups", stub -> stub.listGroups(
+        ListGroupsRequest.newBuilder().setCredentials(buildCredentials()).build())).getGroupsJson());
+  }
+
+  /**
+   * Creates or replaces one group on {@code database} ({@code "*"} for every database), and refreshes
+   * the permissions of the open databases it applies to. Replaces: the definition becomes exactly
+   * {@code groupConfig}, it is not merged into an existing group of the same name.
+   */
+  public void saveGroup(final String database, final String name, final JSONObject groupConfig) {
+    call("save group", stub -> stub.saveGroup(SaveGroupRequest.newBuilder().setCredentials(buildCredentials())
+        .setDatabase(database).setName(name).setGroupJson(groupConfig.toString()).build()));
+  }
+
+  public void deleteGroup(final String database, final String name) {
+    call("delete group", stub -> stub.deleteGroup(DeleteGroupRequest.newBuilder().setCredentials(buildCredentials())
+        .setDatabase(database).setName(name).build()));
+  }
+
+  /**
+   * The issued API tokens: metadata plus each token's hash, which is the handle
+   * {@link #deleteApiToken(String)} takes. Never the token material - the server does not keep it.
+   */
+  public List<ApiTokenInfo> listApiTokens() {
+    return call("list api tokens", stub -> stub.listApiTokens(
+        ListApiTokensRequest.newBuilder().setCredentials(buildCredentials()).build())).getTokensList();
+  }
+
+  /**
+   * Mints an API token. <b>The returned {@code token} field is the only copy of the token that will
+   * ever exist</b>: the server keeps its SHA-256 and cannot produce the plaintext again.
+   * <p>
+   * Two refusals guard it, and they are independent. Client-side, this call cannot even be attempted
+   * over a plaintext channel to a non-loopback host, because every admin RPC attaches call credentials
+   * and {@code createCallCredentials} refuses that combination. Server-side, the mint is refused with
+   * {@code FAILED_PRECONDITION} unless the connection is TLS or loopback - which is the one that also
+   * holds for a caller that opted out with {@code allowInsecureCredentials}, or that is not this
+   * client at all.
+   *
+   * @param expiresAt   epoch millis at which the token stops working; 0 for a token that does not expire
+   * @param permissions the permission document, or null for none
+   */
+  public CreateApiTokenResponse createApiToken(final String name, final String database, final long expiresAt,
+      final JSONObject permissions) {
+    final CreateApiTokenRequest.Builder request = CreateApiTokenRequest.newBuilder()
+        .setCredentials(buildCredentials()).setName(name).setDatabase(database == null ? "" : database)
+        .setExpiresAt(expiresAt);
+    if (permissions != null)
+      request.setPermissionsJson(permissions.toString());
+
+    return call("create api token", stub -> stub.createApiToken(request.build()));
+  }
+
+  /**
+   * Revokes a token by its hash - the {@code tokenHash} of a {@link #listApiTokens()} entry, or of a
+   * {@link #createApiToken} response's {@code info}. The plaintext token is deliberately not accepted
+   * by the server.
+   */
+  public void deleteApiToken(final String tokenHash) {
+    call("delete api token", stub -> stub.deleteApiToken(DeleteApiTokenRequest.newBuilder()
+        .setCredentials(buildCredentials()).setTokenHash(tokenHash).build()));
   }
 
   public GetBackupConfigResponse getBackupConfig() {

--- a/grpc/src/main/proto/arcadedb-server.proto
+++ b/grpc/src/main/proto/arcadedb-server.proto
@@ -964,8 +964,20 @@ service ArcadeDbAdminService {
   rpc GetDatabaseInfo (GetDatabaseInfoRequest) returns (GetDatabaseInfoResponse);
 
   rpc CreateUser     (CreateUserRequest)     returns (CreateUserResponse);
+  rpc UpdateUser     (UpdateUserRequest)     returns (UpdateUserResponse);
   rpc DeleteUser     (DeleteUserRequest)     returns (DeleteUserResponse);
   rpc ListUsers      (ListUsersRequest)      returns (ListUsersResponse);
+
+  // groups - the per-database permission documents users hold through the 'databases' map above
+  rpc ListGroups  (ListGroupsRequest)  returns (ListGroupsResponse);
+  rpc SaveGroup   (SaveGroupRequest)   returns (SaveGroupResponse);
+  rpc DeleteGroup (DeleteGroupRequest) returns (DeleteGroupResponse);
+
+  // API tokens. CreateApiToken returns secret material and is gated on transport security; see the
+  // comment on CreateApiTokenResponse.
+  rpc ListApiTokens  (ListApiTokensRequest)  returns (ListApiTokensResponse);
+  rpc CreateApiToken (CreateApiTokenRequest) returns (CreateApiTokenResponse);
+  rpc DeleteApiToken (DeleteApiTokenRequest) returns (DeleteApiTokenResponse);
 
   // settings
   rpc SetServerSetting   (SetServerSettingRequest)   returns (SetServerSettingResponse);
@@ -1154,6 +1166,141 @@ message ListUsersRequest {
 }
 message ListUsersResponse {
   repeated UserInfo users = 1;
+}
+
+// The per-database grants of one user, wrapped in a message so the field can carry PRESENCE. A bare
+// map field cannot: proto3 gives no way to tell "the caller said nothing about grants" from "the
+// caller cleared every grant", and PUT /server/users draws exactly that distinction - a body without
+// a "databases" key leaves the existing grants alone.
+message UserDatabases {
+  map<string, UserGroups> databases = 1;
+}
+
+// Updates an existing user, as PUT /server/users?name=<user> does. Both mutable fields are optional
+// and independent: an absent one leaves that part of the user untouched, so changing a password does
+// not silently drop the user's grants. A request that sets neither is a no-op, not an error - the
+// same answer the HTTP route gives an empty body.
+message UpdateUserRequest {
+  DatabaseCredentials credentials = 1;
+  string user = 2;
+  // The new plaintext password, hashed server-side. Subject to the same length policy as every other
+  // password the server accepts.
+  optional string password = 3;
+  // The complete new grants map, replacing whatever the user held. Present-and-empty clears them.
+  optional UserDatabases databases = 4;
+}
+message UpdateUserResponse {
+  bool success = 1;
+  string message = 2;
+}
+
+// -----------------------------------------------------------------------------
+// Control plane: groups
+// -----------------------------------------------------------------------------
+
+message ListGroupsRequest {
+  DatabaseCredentials credentials = 1;
+}
+message ListGroupsResponse {
+  // The whole group document, as GET /server/groups returns it under "result". Carried as JSON for
+  // the reason GetBackupConfigResponse.config_json is: it is a free-form document with a version
+  // field and per-database group maps, and declaring its shape a second time here would be one more
+  // thing to keep in step with the file on disk.
+  string groups_json = 1;
+}
+
+// Creates or replaces one group, as POST /server/groups does. Replaces: the named group's definition
+// becomes exactly what this request carries, it is not merged into the existing one.
+message SaveGroupRequest {
+  DatabaseCredentials credentials = 1;
+  // The database the group applies to, or "*" for every database.
+  string database = 2;
+  string name     = 3;
+  // The group definition: resultSetLimit, readTimeout, access and types, as the HTTP body carries
+  // them. An absent key takes the same default the HTTP handler applies (-1 for the two limits, empty
+  // for the two collections).
+  string group_json = 4;
+}
+message SaveGroupResponse {
+  bool success = 1;
+  string message = 2;
+}
+
+message DeleteGroupRequest {
+  DatabaseCredentials credentials = 1;
+  string database = 2;
+  string name     = 3;
+}
+message DeleteGroupResponse {
+  bool success = 1;
+  string message = 2;
+}
+
+// -----------------------------------------------------------------------------
+// Control plane: API tokens
+// -----------------------------------------------------------------------------
+
+// One issued token as the control plane REPORTS it: the hash that identifies it for revocation and
+// the last four characters of the token, never the token itself. This is the projection
+// GET /server/api-tokens returns.
+message ApiTokenInfo {
+  string name         = 1;
+  string database     = 2;
+  int64  expires_at   = 3; // epoch millis; 0 means no expiry
+  int64  created_at   = 4; // epoch millis
+  // The permission document, as JSON - the same free-form shape SaveGroupRequest.group_json carries.
+  string permissions_json = 5;
+  // SHA-256 of the token. This is the handle DeleteApiToken takes.
+  string token_hash   = 6;
+  // The token's last four characters, so an operator can tell two tokens apart in a list.
+  string token_suffix = 7;
+}
+
+message ListApiTokensRequest {
+  DatabaseCredentials credentials = 1;
+}
+message ListApiTokensResponse {
+  repeated ApiTokenInfo tokens = 1;
+}
+
+message CreateApiTokenRequest {
+  DatabaseCredentials credentials = 1;
+  // Must be unique across issued tokens; a duplicate is refused with ALREADY_EXISTS.
+  string name     = 2;
+  // The database the token is scoped to. Empty means "*", every database, as the HTTP default does.
+  string database = 3;
+  int64  expires_at = 4; // epoch millis; 0 or absent means the token does not expire
+  string permissions_json = 5;
+}
+
+// THE ONLY MESSAGE IN THIS FILE THAT CARRIES SECRET MATERIAL.
+//
+// 'token' is the plaintext token, returned exactly once - the server keeps only its SHA-256 and can
+// never produce it again. Two consequences the rest of the control plane does not have:
+//
+//   1. The server refuses this RPC unless the call's transport protects the response: TLS, or a
+//      loopback peer. Over a cleartext channel to a remote host the mint is refused with
+//      FAILED_PRECONDITION rather than answered, because RemoteGrpcServer's refusal to SEND
+//      credentials over such a channel has no counterpart on the receive direction and a non-Java
+//      client never runs it at all.
+//   2. Nothing on the server's own paths may copy this field anywhere durable. The two interceptors
+//      that see every message read only the method name, the status and, for one specific response
+//      type, a boolean - never the payload.
+message CreateApiTokenResponse {
+  string token = 1;
+  // Everything about the token that is safe to keep, including the hash needed to revoke it.
+  ApiTokenInfo info = 2;
+}
+
+// Revokes a token by its HASH. The plaintext token is deliberately not accepted: it would then
+// appear in whatever logged the request, which is the exposure revoking it is meant to end.
+message DeleteApiTokenRequest {
+  DatabaseCredentials credentials = 1;
+  string token_hash = 2;
+}
+message DeleteApiTokenResponse {
+  bool success = 1;
+  string message = 2;
 }
 
 // -----------------------------------------------------------------------------

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
@@ -27,6 +27,7 @@ import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.VertexType;
 import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
 import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.HAServerPlugin;
@@ -472,7 +473,10 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
       return new JSONObject();
     try {
       return new JSONObject(json);
-    } catch (final RuntimeException e) {
+    } catch (final JSONException e) {
+      // Narrow deliberately: JSONObject(String) wraps a parse failure in exactly this type, and a
+      // broader catch here would also turn a bug in this method into a 'your JSON is malformed'
+      // answer, sending the caller after a document that is fine.
       throw new IllegalArgumentException("'" + fieldName + "' is not a valid JSON document: " + e.getMessage());
     }
   }

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
@@ -317,6 +317,181 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
     });
   }
 
+  /**
+   * Updates an existing user, as {@code PUT /server/users} does. Both mutable fields carry explicit
+   * presence in the proto, so "change the password and leave the grants alone" is expressible - which
+   * is the whole reason this is a separate RPC rather than a re-run of {@code CreateUser}.
+   * <p>
+   * Leader-gated for the same reason {@code CreateUser} is: the update goes through
+   * {@code updateUserClusterWide}, which on an HA cluster submits a Raft entry.
+   */
+  @Override
+  public void updateUser(final UpdateUserRequest req, final StreamObserver<UpdateUserResponse> resp) {
+    respond(resp, "updateUser", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+      requireLeader("UpdateUser");
+
+      JSONObject databases = null;
+      if (req.hasDatabases()) {
+        databases = new JSONObject();
+        for (final var entry : req.getDatabases().getDatabasesMap().entrySet())
+          databases.put(entry.getKey(), new JSONArray(entry.getValue().getGroupsList()));
+      }
+
+      controlPlane.updateUser(req.getUser(), req.hasPassword() ? req.getPassword() : null, databases);
+
+      return UpdateUserResponse.newBuilder().setSuccess(true)
+          .setMessage("User '" + req.getUser() + "' updated").build();
+    });
+  }
+
+  // ------------------------------------------------------------------------------------
+  // Groups
+  // ------------------------------------------------------------------------------------
+
+  /**
+   * The group document. Not leader-gated: {@code ServerSecurity} writes groups to a node-local file
+   * and submits no Raft entry, so there is no leader for this state to have - a divergence from the
+   * user document that is tracked as issue #7373, not compensated for here.
+   */
+  @Override
+  public void listGroups(final ListGroupsRequest req, final StreamObserver<ListGroupsResponse> resp) {
+    respond(resp, "listGroups", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      return ListGroupsResponse.newBuilder().setGroupsJson(controlPlane.listGroups().toString()).build();
+    });
+  }
+
+  @Override
+  public void saveGroup(final SaveGroupRequest req, final StreamObserver<SaveGroupResponse> resp) {
+    respond(resp, "saveGroup", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      controlPlane.saveGroup(req.getDatabase(), req.getName(), parseDocument(req.getGroupJson(), "group_json"));
+
+      return SaveGroupResponse.newBuilder().setSuccess(true)
+          .setMessage("Group '" + req.getName() + "' saved for database '" + req.getDatabase() + "'").build();
+    });
+  }
+
+  @Override
+  public void deleteGroup(final DeleteGroupRequest req, final StreamObserver<DeleteGroupResponse> resp) {
+    respond(resp, "deleteGroup", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      controlPlane.deleteGroup(req.getDatabase(), req.getName());
+
+      return DeleteGroupResponse.newBuilder().setSuccess(true)
+          .setMessage("Group '" + req.getName() + "' deleted from database '" + req.getDatabase() + "'").build();
+    });
+  }
+
+  // ------------------------------------------------------------------------------------
+  // API tokens
+  // ------------------------------------------------------------------------------------
+
+  @Override
+  public void listApiTokens(final ListApiTokensRequest req, final StreamObserver<ListApiTokensResponse> resp) {
+    respond(resp, "listApiTokens", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      final ListApiTokensResponse.Builder builder = ListApiTokensResponse.newBuilder();
+      final JSONArray tokens = controlPlane.listApiTokens();
+      for (int i = 0; i < tokens.length(); i++)
+        builder.addTokens(toApiTokenInfo(tokens.getJSONObject(i)));
+
+      return builder.build();
+    });
+  }
+
+  /**
+   * Mints an API token. The one RPC on this service whose response carries secret material, and the
+   * only one with a transport precondition on top of the usual authentication and authorization: the
+   * plaintext token is written back only over TLS or to a loopback peer.
+   * <p>
+   * The refusal is {@code FAILED_PRECONDITION} rather than {@code PERMISSION_DENIED} because the
+   * caller is not the problem - a root credential is exactly right, and the same call over a TLS
+   * channel succeeds. What is wrong is the connection it arrived on, which is the caller's to fix by
+   * reconnecting, not an authorization decision to appeal.
+   */
+  @Override
+  public void createApiToken(final CreateApiTokenRequest req, final StreamObserver<CreateApiTokenResponse> resp) {
+    respond(resp, "createApiToken", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+      requireTransportSafeForSecrets();
+
+      final JSONObject token = controlPlane.createApiToken(req.getName(), req.getDatabase(), req.getExpiresAt(),
+          parseDocument(req.getPermissionsJson(), "permissions_json"));
+
+      // getString with no default would raise on an absent key; the plaintext token is the one field
+      // createToken always sets, and reading it defensively would hide its absence rather than report
+      // it, so it is read strictly.
+      return CreateApiTokenResponse.newBuilder()
+          .setToken(token.getString("token"))
+          .setInfo(toApiTokenInfo(token))
+          .build();
+    });
+  }
+
+  @Override
+  public void deleteApiToken(final DeleteApiTokenRequest req, final StreamObserver<DeleteApiTokenResponse> resp) {
+    respond(resp, "deleteApiToken", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      controlPlane.deleteApiToken(req.getTokenHash());
+
+      return DeleteApiTokenResponse.newBuilder().setSuccess(true).setMessage("Token deleted").build();
+    });
+  }
+
+  /**
+   * Projects one stored token document onto the wire message. It names every field it copies, so a
+   * field later added to the stored document - the plaintext token is already one such field on the
+   * document {@code createApiToken} returns - is not carried out here by accident.
+   */
+  private static ApiTokenInfo toApiTokenInfo(final JSONObject token) {
+    return ApiTokenInfo.newBuilder()
+        .setName(token.getString("name", ""))
+        .setDatabase(token.getString("database", ""))
+        .setExpiresAt(token.getLong("expiresAt", 0L))
+        .setCreatedAt(token.getLong("createdAt", 0L))
+        .setPermissionsJson(token.getJSONObject("permissions", new JSONObject()).toString())
+        .setTokenHash(token.getString("tokenHash", ""))
+        .setTokenSuffix(token.getString("tokenSuffix", ""))
+        .build();
+  }
+
+  /**
+   * Reads a free-form JSON field of a request. An absent field is an empty document, which is what an
+   * unset proto string looks like and what the HTTP body means by omitting the key; a present but
+   * unparseable one is the caller's error and must not surface as an INTERNAL fault.
+   */
+  private static JSONObject parseDocument(final String json, final String fieldName) {
+    if (json == null || json.isBlank())
+      return new JSONObject();
+    try {
+      return new JSONObject(json);
+    } catch (final RuntimeException e) {
+      throw new IllegalArgumentException("'" + fieldName + "' is not a valid JSON document: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Refuses to write secret material back over a transport that does not protect it.
+   * <p>
+   * Fails closed when {@link GrpcTransportSecurityInterceptor} did not run: an absent key is not
+   * "unknown, carry on" but "nothing vouched for this connection". That way removing the interceptor
+   * stops tokens being minted rather than stopping them being protected.
+   */
+  private void requireTransportSafeForSecrets() throws StatusException {
+    if (!Boolean.TRUE.equals(GrpcTransportSecurityInterceptor.SECRET_SAFE_TRANSPORT_KEY.get()))
+      throw Status.FAILED_PRECONDITION.withDescription(
+              "Refusing to return API token material over an unprotected transport. Enable gRPC TLS "
+                  + "(arcadedb.grpc.tls.enabled), or issue the token from a client on the loopback interface.")
+          .asException();
+  }
+
   // ------------------------------------------------------------------------------------
   // Database lifecycle beyond create/drop
   // ------------------------------------------------------------------------------------
@@ -641,6 +816,14 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
     // exception types alike), and PERMISSION_DENIED is the status that says the same thing.
     if (e instanceof ServerSecurityException)
       return Status.PERMISSION_DENIED.withDescription(e.getMessage()).asException();
+    // The operation named a user, group or token that does not exist. HTTP answers these 404, and
+    // NOT_FOUND is the status that says the same thing (issue #7309).
+    if (e instanceof ServerControlPlane.NotFoundException)
+      return Status.NOT_FOUND.withDescription(e.getMessage()).asException();
+    // A token name already issued: HTTP's 409 on this transport, and distinct from INVALID_ARGUMENT
+    // because the request is well formed - it is the identity that is taken.
+    if (e instanceof ServerControlPlane.AlreadyExistsException)
+      return Status.ALREADY_EXISTS.withDescription(e.getMessage()).asException();
     // A backup already running for the same database is HTTP's 409 on the other transport: the request
     // is well formed and authorized, and retrying once the other run finishes is the fix.
     if (e instanceof ServerControlPlane.BackupInProgressException)

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcServerPlugin.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcServerPlugin.java
@@ -305,6 +305,11 @@ public class GrpcServerPlugin implements ServerPlugin {
 
     // Add interceptors for logging, metrics, auth, etc.
     serverBuilder.intercept(new GrpcLoggingInterceptor());
+    // Records whether each call's transport can carry secret material back to the caller. Registered
+    // unconditionally, and on this shared path so both the standard and the xDS builder get it:
+    // CreateApiToken refuses to mint when its context key is absent, so dropping this line disables
+    // the minting of API tokens rather than silently disabling the check (issue #7309).
+    serverBuilder.intercept(new GrpcTransportSecurityInterceptor());
     // Publish gRPC metrics into the server's shared JVM-wide registry so the same exporters that
     // scrape the rest of the server (Prometheus, OTLP, JMX, Studio) also see gRPC telemetry.
     serverBuilder.intercept(new GrpcMetricsInterceptor(Metrics.globalRegistry));

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcTransportSecurityInterceptor.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcTransportSecurityInterceptor.java
@@ -48,6 +48,15 @@ import java.net.SocketAddress;
  * connection here rather than from configuration, so a TLS setting that did not actually take effect
  * cannot vouch for a plaintext socket.
  * <p>
+ * <b>What "loopback" assumes.</b> That the peer on the other end of a loopback socket is the client
+ * itself, and not a TLS-terminating reverse proxy forwarding a remote caller to cleartext 127.0.0.1.
+ * From inside this process the two are indistinguishable - a proxied remote caller presents exactly
+ * the same address - so such a deployment gets the token minted for it. That is the same trust model
+ * "trust loopback" HTTP setups already run on, and it is stated here rather than left to be
+ * rediscovered, because this class exists precisely to close a transport-trust gap: an operator who
+ * fronts the gRPC port with a proxy has moved the trust boundary to the proxy and needs to protect it
+ * there.
+ * <p>
  * <b>What it deliberately does not do</b> is refuse the call. It records a fact; the handler decides.
  * An interceptor that closed the call would have to know which methods carry secrets, putting that
  * list one refactor away from disagreeing with the service that defines them.

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcTransportSecurityInterceptor.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcTransportSecurityInterceptor.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import io.grpc.Context;
+import io.grpc.Contexts;
+import io.grpc.Grpc;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+/**
+ * Publishes, for the duration of each call, whether the call's transport is fit to carry secret
+ * material back to the caller (issue #7309).
+ * <p>
+ * Only one RPC needs this: {@code CreateApiToken} returns a plaintext API token, the single response
+ * field in this service that the server can never reproduce and that authenticates its holder.
+ * {@code RemoteGrpcServer} already refuses to <i>send</i> credentials over a cleartext channel to a
+ * non-loopback host, but that guard runs in ArcadeDB's own Java client, can be opted out of with
+ * {@code allowInsecureCredentials}, and is not running at all when the caller is grpcurl or a Python
+ * stub. The guard that actually holds has to sit where the secret leaves the process.
+ * <p>
+ * <b>What counts as fit.</b> Either the transport is encrypted - gRPC exposes an
+ * {@link Grpc#TRANSPORT_ATTR_SSL_SESSION} for TLS connections and nothing for cleartext ones - or the
+ * peer is on the loopback interface, where the bytes never reach a network. That is the same pair of
+ * conditions {@code RemoteGrpcServer.isLoopbackHost} applies from the other end, read from the live
+ * connection here rather than from configuration, so a TLS setting that did not actually take effect
+ * cannot vouch for a plaintext socket.
+ * <p>
+ * <b>What it deliberately does not do</b> is refuse the call. It records a fact; the handler decides.
+ * An interceptor that closed the call would have to know which methods carry secrets, putting that
+ * list one refactor away from disagreeing with the service that defines them.
+ */
+public class GrpcTransportSecurityInterceptor implements ServerInterceptor {
+
+  /**
+   * True when the current call arrived over a transport that protects the response body.
+   * <p>
+   * Read it with {@code SECRET_SAFE_TRANSPORT_KEY.get()}, which returns {@code null} when this
+   * interceptor did not run. A null is NOT "unknown, carry on": a caller handling secret material must
+   * treat it as unfit, so that removing this interceptor turns the minting of tokens off rather than
+   * turning the gate off.
+   */
+  public static final Context.Key<Boolean> SECRET_SAFE_TRANSPORT_KEY = Context.key("secret-safe-transport");
+
+  @Override
+  public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(final ServerCall<ReqT, RespT> call,
+      final Metadata headers, final ServerCallHandler<ReqT, RespT> next) {
+
+    final boolean encrypted = call.getAttributes().get(Grpc.TRANSPORT_ATTR_SSL_SESSION) != null;
+    final boolean safe = encrypted || isLoopbackPeer(call.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR));
+
+    return Contexts.interceptCall(Context.current().withValue(SECRET_SAFE_TRANSPORT_KEY, safe), call, headers, next);
+  }
+
+  /**
+   * Whether the peer is on this machine's loopback interface. Fails closed on anything it cannot read
+   * as an IP socket - an in-process or unix-domain transport reports an address type this does not
+   * recognise, and answering "safe" for an address whose shape is unknown is the wrong direction to
+   * guess in.
+   */
+  private static boolean isLoopbackPeer(final SocketAddress remoteAddress) {
+    if (!(remoteAddress instanceof final InetSocketAddress inetAddress))
+      return false;
+
+    // Already-resolved is the normal case for an accepted connection; getAddress() returning null
+    // means the address is unresolved, and an unresolved peer is not a peer known to be local.
+    final InetAddress address = inetAddress.getAddress();
+    return address != null && address.isLoopbackAddress();
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcTransportSecurityInterceptorTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcTransportSecurityInterceptorTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSession;
 import java.net.InetSocketAddress;
+import java.security.NoSuchAlgorithmException;
 import java.net.SocketAddress;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -135,7 +136,7 @@ class GrpcTransportSecurityInterceptorTest {
   private static SSLSession unhandshakenSslSession() {
     try {
       return SSLContext.getDefault().createSSLEngine().getSession();
-    } catch (final java.security.NoSuchAlgorithmException e) {
+    } catch (final NoSuchAlgorithmException e) {
       throw new IllegalStateException("the platform must provide a default SSLContext", e);
     }
   }

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcTransportSecurityInterceptorTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcTransportSecurityInterceptorTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import io.grpc.Attributes;
+import io.grpc.Context;
+import io.grpc.Grpc;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.Status;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7309: what {@link GrpcTransportSecurityInterceptor} decides, per connection.
+ * <p>
+ * The decision is the whole of the server-side guard on {@code CreateApiToken}, and it is made from
+ * two transport attributes that no integration test can vary - every in-process test connects over
+ * loopback. So it is driven here directly, one case per combination that matters, including the two
+ * that must fail closed: an address shape the code does not recognise, and an unresolved address.
+ */
+class GrpcTransportSecurityInterceptorTest {
+
+  @Test
+  void aLoopbackPeerOverCleartextIsSafe() {
+    assertThat(decisionFor(new InetSocketAddress("127.0.0.1", 51000), false)).isTrue();
+  }
+
+  @Test
+  void anIpv6LoopbackPeerIsSafe() {
+    assertThat(decisionFor(new InetSocketAddress("::1", 51000), false)).isTrue();
+  }
+
+  /**
+   * The case the guard exists for: a remote peer on a cleartext connection. Minting a token towards
+   * this one would put the token on the wire in the clear.
+   */
+  @Test
+  void aRemotePeerOverCleartextIsNotSafe() {
+    assertThat(decisionFor(new InetSocketAddress("203.0.113.7", 51000), false)).isFalse();
+  }
+
+  /**
+   * TLS makes a remote peer safe - that is the configuration the refusal is telling the operator to
+   * move to, so it has to actually be accepted, or the message would be advice that does not work.
+   */
+  @Test
+  void aRemotePeerOverTlsIsSafe() {
+    assertThat(decisionFor(new InetSocketAddress("203.0.113.7", 51000), true)).isTrue();
+  }
+
+  /**
+   * Fail closed on an address the code cannot read as an IP socket - an in-process or unix-domain
+   * transport reports one of these. "Unknown" must not resolve to "local".
+   */
+  @Test
+  void anUnrecognisedAddressShapeIsNotSafe() {
+    assertThat(decisionFor(new SocketAddress() {
+    }, false)).isFalse();
+  }
+
+  /**
+   * Fail closed on an unresolved address: {@code InetSocketAddress.getAddress()} is null there, and a
+   * peer whose address was never resolved is not a peer known to be local.
+   */
+  @Test
+  void anUnresolvedAddressIsNotSafe() {
+    assertThat(decisionFor(InetSocketAddress.createUnresolved("localhost", 51000), false)).isFalse();
+  }
+
+  @Test
+  void noAddressAtAllIsNotSafe() {
+    assertThat(decisionFor(null, false)).isFalse();
+  }
+
+  /**
+   * Runs one call through the interceptor and reports the value it published, which is the only thing
+   * the interceptor produces.
+   */
+  private static boolean decisionFor(final SocketAddress remoteAddress, final boolean tls) {
+    final Attributes.Builder attributes = Attributes.newBuilder();
+    if (remoteAddress != null)
+      attributes.set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, remoteAddress);
+    if (tls)
+      attributes.set(Grpc.TRANSPORT_ATTR_SSL_SESSION, unhandshakenSslSession());
+
+    final AtomicReference<Boolean> published = new AtomicReference<>();
+
+    new GrpcTransportSecurityInterceptor().interceptCall(
+        new AttributesOnlyServerCall(attributes.build()),
+        new Metadata(),
+        (call, headers) -> {
+          published.set(GrpcTransportSecurityInterceptor.SECRET_SAFE_TRANSPORT_KEY.get());
+          return new ServerCall.Listener<>() {
+          };
+        });
+
+    assertThat(published.get()).as("the interceptor must publish a decision on every call").isNotNull();
+    // Outside the call, the key is unset again - the guard must not leak a permissive value into
+    // whatever runs next on this thread.
+    assertThat(GrpcTransportSecurityInterceptor.SECRET_SAFE_TRANSPORT_KEY.get(Context.current())).isNull();
+    return published.get();
+  }
+
+  /**
+   * A real {@link SSLSession}, taken from a fresh {@code SSLEngine} that has not handshaken. The
+   * interceptor tests this attribute for PRESENCE only - gRPC sets it exactly when the transport is
+   * TLS - so an un-handshaken session is the honest stand-in and needs no stubbing at all.
+   */
+  private static SSLSession unhandshakenSslSession() {
+    try {
+      return SSLContext.getDefault().createSSLEngine().getSession();
+    } catch (final java.security.NoSuchAlgorithmException e) {
+      throw new IllegalStateException("the platform must provide a default SSLContext", e);
+    }
+  }
+
+  /**
+   * A {@link ServerCall} that answers only what the interceptor asks of it. Hand written rather than
+   * mocked so the test states exactly which parts of the call the interceptor is allowed to depend on:
+   * if it ever starts reading something else, this fails loudly instead of returning a mock default.
+   */
+  private static final class AttributesOnlyServerCall extends ServerCall<Object, Object> {
+    private final Attributes attributes;
+
+    private AttributesOnlyServerCall(final Attributes attributes) {
+      this.attributes = attributes;
+    }
+
+    @Override
+    public Attributes getAttributes() {
+      return attributes;
+    }
+
+    @Override
+    public void request(final int numMessages) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void sendHeaders(final Metadata headers) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void sendMessage(final Object message) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close(final Status status, final Metadata trailers) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isCancelled() {
+      return false;
+    }
+
+    @Override
+    public MethodDescriptor<Object, Object> getMethodDescriptor() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7309GrpcSecurityControlPlaneIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7309GrpcSecurityControlPlaneIT.java
@@ -1,0 +1,562 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.security.ApiTokenConfiguration;
+import io.grpc.Context;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import io.micrometer.core.instrument.Metrics;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+/**
+ * Issue #7309: the rows of the {@code /server/*} security table that #7304 left HTTP-only - updating
+ * a user, the three group routes and the three API-token routes - reachable over gRPC.
+ * <p>
+ * One test per RPC, each driving it against a real server and then reading the result back through a
+ * DIFFERENT surface than the one that wrote it wherever possible: a group written by {@code SaveGroup}
+ * is read through {@code ListGroups}, a token minted by {@code CreateApiToken} is looked for in
+ * {@code ListApiTokens}, and a user updated by {@code UpdateUser} is checked against
+ * {@code ServerSecurity} itself. A test that asserted only on the RPC's own response would pass
+ * against a handler that built a convincing answer and wrote nothing.
+ * <p>
+ * The channel is loopback, so {@code CreateApiToken}'s transport gate permits the mint here. The
+ * refusal side of that gate is {@link Issue7309ApiTokenSecrecyTest}'s subject.
+ */
+class Issue7309GrpcSecurityControlPlaneIT extends BaseGraphServerTest {
+
+  private static final int GRPC_PORT = 51181;
+
+  private ManagedChannel                                              channel;
+  private ArcadeDbAdminServiceGrpc.ArcadeDbAdminServiceBlockingStub   admin;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+    GlobalConfiguration.GRPC_PORT.setValue(GRPC_PORT);
+  }
+
+  @BeforeEach
+  void openChannel() {
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    admin = ArcadeDbAdminServiceGrpc.newBlockingStub(channel).withDeadlineAfter(30, TimeUnit.SECONDS);
+  }
+
+  @AfterEach
+  void closeChannel() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+      channel = null;
+    }
+  }
+
+  private static DatabaseCredentials root() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Row 1 - PUT /server/users
+  // -------------------------------------------------------------------------------------------
+
+  /**
+   * The distinction that makes UpdateUser a separate RPC rather than a re-run of CreateUser: each
+   * mutable field carries presence, so an update naming only one of them leaves the other alone. A
+   * handler that rebuilt the user from the request would pass a password-only assertion and silently
+   * drop the grants, so both halves are asserted after each of the two updates.
+   */
+  @Test
+  void updateUserChangesOnlyTheFieldsTheRequestCarries() {
+    admin.createUser(CreateUserRequest.newBuilder().setCredentials(root())
+        .setUser("elena").setPassword("initialPassword1")
+        .putDatabases("*", UserGroups.newBuilder().addGroups("admin").build()).build());
+
+    // Password only: the grants must survive it.
+    admin.updateUser(UpdateUserRequest.newBuilder().setCredentials(root())
+        .setUser("elena").setPassword("replacedPassword1").build());
+
+    assertThat(grantsOf("elena")).containsExactly("admin");
+    assertThat(getServer(0).getSecurity().authenticate("elena", "replacedPassword1", null)).isNotNull();
+
+    // Grants only: the password must survive it.
+    admin.updateUser(UpdateUserRequest.newBuilder().setCredentials(root())
+        .setUser("elena")
+        .setDatabases(UserDatabases.newBuilder()
+            .putDatabases("*", UserGroups.newBuilder().addGroups("reader").build()).build())
+        .build());
+
+    assertThat(grantsOf("elena")).containsExactly("reader");
+    assertThat(getServer(0).getSecurity().authenticate("elena", "replacedPassword1", null)).isNotNull();
+  }
+
+  @Test
+  void updateUserRejectsAPasswordShorterThanThePolicy() {
+    admin.createUser(CreateUserRequest.newBuilder().setCredentials(root())
+        .setUser("shortpw").setPassword("longEnoughPassword").build());
+
+    final StatusRuntimeException failure = catchThrowableOfType(StatusRuntimeException.class,
+        () -> admin.updateUser(UpdateUserRequest.newBuilder().setCredentials(root())
+            .setUser("shortpw").setPassword("short").build()));
+
+    assertThat(failure.getStatus().getCode()).isEqualTo(Status.Code.INVALID_ARGUMENT);
+    assertThat(failure.getStatus().getDescription()).contains("at least 8 characters");
+  }
+
+  @Test
+  void updateUserAnswersNotFoundForAnAbsentUser() {
+    final StatusRuntimeException failure = catchThrowableOfType(StatusRuntimeException.class,
+        () -> admin.updateUser(UpdateUserRequest.newBuilder().setCredentials(root())
+            .setUser("nobody").setPassword("longEnoughPassword").build()));
+
+    assertThat(failure.getStatus().getCode()).isEqualTo(Status.Code.NOT_FOUND);
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Rows 2-4 - the group routes
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  void listGroupsReturnsTheGroupDocument() {
+    final JSONObject groups = new JSONObject(admin.listGroups(
+        ListGroupsRequest.newBuilder().setCredentials(root()).build()).getGroupsJson());
+
+    assertThat(groups.getJSONObject("databases").getJSONObject("*").getJSONObject("groups").has("admin")).isTrue();
+  }
+
+  /**
+   * A group saved over gRPC has to be readable as a group, not merely stored: the assertion reads the
+   * normalized defaults back, which is the part the HTTP handler used to apply and the shared
+   * implementation now applies for both transports.
+   */
+  @Test
+  void saveGroupWritesAGroupReadableThroughListGroups() {
+    admin.saveGroup(SaveGroupRequest.newBuilder().setCredentials(root())
+        .setDatabase("*").setName("analyst")
+        .setGroupJson(new JSONObject().put("resultSetLimit", 250L)
+            .put("types", new JSONObject().put("*", new JSONObject()
+                .put("access", new JSONArray().put("readRecord"))))
+            .toString())
+        .build());
+
+    final JSONObject analyst = wildcardGroups().getJSONObject("analyst");
+    assertThat(analyst.getLong("resultSetLimit")).isEqualTo(250L);
+    // Not supplied by the caller, so it must carry the shared default rather than being absent.
+    assertThat(analyst.getLong("readTimeout")).isEqualTo(-1L);
+    assertThat(analyst.getJSONObject("types").getJSONObject("*").getJSONArray("access").getString(0))
+        .isEqualTo("readRecord");
+  }
+
+  @Test
+  void deleteGroupRemovesIt() {
+    admin.saveGroup(SaveGroupRequest.newBuilder().setCredentials(root())
+        .setDatabase("*").setName("temporary").setGroupJson("{}").build());
+    assertThat(wildcardGroups().has("temporary")).isTrue();
+
+    admin.deleteGroup(DeleteGroupRequest.newBuilder().setCredentials(root())
+        .setDatabase("*").setName("temporary").build());
+
+    assertThat(wildcardGroups().has("temporary")).isFalse();
+  }
+
+  @Test
+  void deleteGroupAnswersNotFoundForAnAbsentGroup() {
+    final StatusRuntimeException failure = catchThrowableOfType(StatusRuntimeException.class,
+        () -> admin.deleteGroup(DeleteGroupRequest.newBuilder().setCredentials(root())
+            .setDatabase("*").setName("neverExisted").build()));
+
+    assertThat(failure.getStatus().getCode()).isEqualTo(Status.Code.NOT_FOUND);
+  }
+
+  /**
+   * The refusal that keeps a deployment from locking itself out. It lives in the shared
+   * implementation, so proving gRPC inherits it is proving it was not left behind in the HTTP handler.
+   */
+  @Test
+  void deleteGroupRefusesTheAdminGroupOfTheDefaultDatabase() {
+    final StatusRuntimeException failure = catchThrowableOfType(StatusRuntimeException.class,
+        () -> admin.deleteGroup(DeleteGroupRequest.newBuilder().setCredentials(root())
+            .setDatabase("*").setName("admin").build()));
+
+    assertThat(failure.getStatus().getCode()).isEqualTo(Status.Code.INVALID_ARGUMENT);
+    assertThat(failure.getStatus().getDescription()).contains("admin group");
+    assertThat(wildcardGroups().has("admin")).isTrue();
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Rows 5-7 - the API-token routes
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  void createApiTokenReturnsTheMaterialOnceAndListsTheTokenWithout() {
+    final CreateApiTokenResponse minted = admin.createApiToken(CreateApiTokenRequest.newBuilder()
+        .setCredentials(root()).setName("etl").setDatabase("graph").setExpiresAt(0)
+        .setPermissionsJson(new JSONObject()
+            .put("types", new JSONObject().put("*", new JSONObject()
+                .put("access", new JSONArray().put("readRecord")))).toString())
+        .build());
+
+    assertThat(minted.getToken()).startsWith("at-");
+    assertThat(minted.getInfo().getName()).isEqualTo("etl");
+    assertThat(minted.getInfo().getDatabase()).isEqualTo("graph");
+    assertThat(minted.getInfo().getTokenHash()).isNotEmpty();
+    // The listing carries the hash needed to revoke the token and never the token itself - the
+    // property that makes the mint's one-time answer meaningful.
+    final List<ApiTokenInfo> listed = admin.listApiTokens(
+        ListApiTokensRequest.newBuilder().setCredentials(root()).build()).getTokensList();
+
+    final ApiTokenInfo etl = listed.stream().filter(t -> "etl".equals(t.getName())).findFirst().orElseThrow();
+    assertThat(etl.getTokenHash()).isEqualTo(minted.getInfo().getTokenHash());
+    assertThat(etl.getTokenSuffix()).isEqualTo(minted.getToken().substring(minted.getToken().length() - 4));
+    assertThat(etl.toString()).doesNotContain(minted.getToken());
+    assertThat(new JSONObject(etl.getPermissionsJson()).getJSONObject("types").getJSONObject("*")
+        .getJSONArray("access").getString(0)).isEqualTo("readRecord");
+  }
+
+  @Test
+  void createApiTokenRefusesADuplicateNameWithAlreadyExists() {
+    admin.createApiToken(CreateApiTokenRequest.newBuilder().setCredentials(root()).setName("unique").build());
+
+    final StatusRuntimeException failure = catchThrowableOfType(StatusRuntimeException.class,
+        () -> admin.createApiToken(CreateApiTokenRequest.newBuilder().setCredentials(root())
+            .setName("unique").build()));
+
+    assertThat(failure.getStatus().getCode()).isEqualTo(Status.Code.ALREADY_EXISTS);
+  }
+
+  /**
+   * The permission-document check that used to be private to {@code PostApiTokenHandler}. An access
+   * verb the engine does not define would grant nothing at all, so it is refused rather than stored.
+   */
+  @Test
+  void createApiTokenRefusesAnUnknownAccessVerb() {
+    final StatusRuntimeException failure = catchThrowableOfType(StatusRuntimeException.class,
+        () -> admin.createApiToken(CreateApiTokenRequest.newBuilder().setCredentials(root())
+            .setName("bogus")
+            .setPermissionsJson(new JSONObject().put("types", new JSONObject().put("*", new JSONObject()
+                .put("access", new JSONArray().put("readAllTheThings")))).toString())
+            .build()));
+
+    assertThat(failure.getStatus().getCode()).isEqualTo(Status.Code.INVALID_ARGUMENT);
+    assertThat(failure.getStatus().getDescription()).contains("readAllTheThings");
+  }
+
+  @Test
+  void deleteApiTokenRevokesByHash() {
+    final CreateApiTokenResponse minted = admin.createApiToken(CreateApiTokenRequest.newBuilder()
+        .setCredentials(root()).setName("revokeMe").build());
+
+    admin.deleteApiToken(DeleteApiTokenRequest.newBuilder().setCredentials(root())
+        .setTokenHash(minted.getInfo().getTokenHash()).build());
+
+    assertThat(admin.listApiTokens(ListApiTokensRequest.newBuilder().setCredentials(root()).build())
+        .getTokensList()).noneMatch(t -> "revokeMe".equals(t.getName()));
+  }
+
+  /**
+   * Revocation by plaintext token is refused for the reason revocation exists: the token would then
+   * appear in whatever recorded the request.
+   */
+  @Test
+  void deleteApiTokenRefusesAPlaintextToken() {
+    final CreateApiTokenResponse minted = admin.createApiToken(CreateApiTokenRequest.newBuilder()
+        .setCredentials(root()).setName("plaintextRevoke").build());
+
+    final StatusRuntimeException failure = catchThrowableOfType(StatusRuntimeException.class,
+        () -> admin.deleteApiToken(DeleteApiTokenRequest.newBuilder().setCredentials(root())
+            .setTokenHash(minted.getToken()).build()));
+
+    assertThat(failure.getStatus().getCode()).isEqualTo(Status.Code.INVALID_ARGUMENT);
+    // Still live: a refused revocation must not half-happen.
+    assertThat(admin.listApiTokens(ListApiTokensRequest.newBuilder().setCredentials(root()).build())
+        .getTokensList()).anyMatch(t -> "plaintextRevoke".equals(t.getName()));
+  }
+
+  @Test
+  void deleteApiTokenAnswersNotFoundForAnUnknownHash() {
+    final StatusRuntimeException failure = catchThrowableOfType(StatusRuntimeException.class,
+        () -> admin.deleteApiToken(DeleteApiTokenRequest.newBuilder().setCredentials(root())
+            .setTokenHash("0".repeat(64)).build()));
+
+    assertThat(failure.getStatus().getCode()).isEqualTo(Status.Code.NOT_FOUND);
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Authorization - the gate every one of these RPCs shares
+  // -------------------------------------------------------------------------------------------
+
+  /**
+   * Every route in this group is {@code checkRootUser}-gated on HTTP, so every RPC has to be
+   * {@code requireServerAdmin}-gated here. Driven once per RPC rather than once overall: the gate is a
+   * line in each handler, and a handler that forgot it would still pass a test that only checked its
+   * neighbours.
+   */
+  @Test
+  void everyNewRpcRefusesANonRootAccount() {
+    admin.createUser(CreateUserRequest.newBuilder().setCredentials(root())
+        .setUser("plainuser").setPassword("plainPassword1").build());
+
+    final DatabaseCredentials plain = DatabaseCredentials.newBuilder()
+        .setUsername("plainuser").setPassword("plainPassword1").build();
+
+    assertPermissionDenied(() -> admin.updateUser(
+        UpdateUserRequest.newBuilder().setCredentials(plain).setUser("plainuser").build()));
+    assertPermissionDenied(() -> admin.listGroups(
+        ListGroupsRequest.newBuilder().setCredentials(plain).build()));
+    assertPermissionDenied(() -> admin.saveGroup(
+        SaveGroupRequest.newBuilder().setCredentials(plain).setDatabase("*").setName("x").build()));
+    assertPermissionDenied(() -> admin.deleteGroup(
+        DeleteGroupRequest.newBuilder().setCredentials(plain).setDatabase("*").setName("x").build()));
+    assertPermissionDenied(() -> admin.listApiTokens(
+        ListApiTokensRequest.newBuilder().setCredentials(plain).build()));
+    assertPermissionDenied(() -> admin.createApiToken(
+        CreateApiTokenRequest.newBuilder().setCredentials(plain).setName("x").build()));
+    assertPermissionDenied(() -> admin.deleteApiToken(
+        DeleteApiTokenRequest.newBuilder().setCredentials(plain).setTokenHash("0".repeat(64)).build()));
+  }
+
+  private static void assertPermissionDenied(final Runnable call) {
+    final StatusRuntimeException failure = catchThrowableOfType(StatusRuntimeException.class, call::run);
+    assertThat(failure.getStatus().getCode()).isEqualTo(Status.Code.PERMISSION_DENIED);
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // The two questions the issue attaches to the mint
+  // -------------------------------------------------------------------------------------------
+
+  /**
+   * 6a - the mint is refused unless the call's transport protects the answer.
+   * <p>
+   * Every channel an in-process test can open is loopback, so the three transport verdicts are driven
+   * into the handler through the context key that {@link GrpcTransportSecurityInterceptor} publishes,
+   * against the real service and the real server. The <b>absent</b> case is the one that matters most:
+   * it is what a future refactor that drops the interceptor registration produces, and it must read as
+   * "nothing vouched for this connection", not as "no objection".
+   * <p>
+   * The permitted case is the positive control. Without it, a handler that refused unconditionally
+   * would pass the two refusal assertions.
+   */
+  @Test
+  void createApiTokenMintsOnlyOverAProtectedTransport() {
+    final ArcadeDbGrpcAdminService service = new ArcadeDbGrpcAdminService(getServer(0),
+        getServer(0).getSecurity().getCredentialsValidator());
+
+    final CreateApiTokenRequest request = CreateApiTokenRequest.newBuilder()
+        .setCredentials(root()).setName("gated").build();
+
+    assertThat(mintUnder(service, request, null))
+        .as("no interceptor ran, so nothing vouched for the transport")
+        .isEqualTo(Status.Code.FAILED_PRECONDITION);
+
+    assertThat(mintUnder(service, request, false))
+        .as("the interceptor read the transport as unprotected")
+        .isEqualTo(Status.Code.FAILED_PRECONDITION);
+
+    // Nothing was minted by either refusal.
+    assertThat(admin.listApiTokens(ListApiTokensRequest.newBuilder().setCredentials(root()).build())
+        .getTokensList()).noneMatch(t -> "gated".equals(t.getName()));
+
+    // Positive control: the same call over a transport the interceptor vouched for succeeds.
+    final CapturingObserver<CreateApiTokenResponse> permitted = new CapturingObserver<>();
+    contextWith(true).run(() -> service.createApiToken(request, permitted));
+    assertThat(permitted.error).isNull();
+    assertThat(permitted.value.getToken()).startsWith("at-");
+  }
+
+  /**
+   * 6b - a minted token reaches no log sink and no metric tag.
+   * <p>
+   * The two interceptors that see every message read the method name, the status and, for one specific
+   * response type, a boolean; neither stringifies a payload. That is a property of today's code that
+   * nothing enforces, which is what this test is for: it mints a real token over the real server with
+   * every engine log call captured, and searches the captured text - and every meter the gRPC
+   * interceptors registered - for the token material.
+   * <p>
+   * The capture is installed through {@link LogManager#setLogger}, the engine's own logging seam,
+   * rather than by attaching a {@code java.util.logging} handler to the root logger. That distinction
+   * decides whether this test works at all: the engine logs through its pluggable
+   * {@link com.arcadedb.log.Logger}, so a JUL handler sees whatever that implementation chooses to
+   * forward and at whatever level it is configured for - which was verified to miss an INFO-level leak
+   * deliberately injected into {@code GrpcLoggingInterceptor.sendMessage}. Capturing at the seam sees
+   * every call the engine makes, before any level or handler filtering.
+   */
+  @Test
+  void aMintedTokenReachesNoLogSinkAndNoMetricTag() {
+    final LogManager logManager = LogManager.instance();
+    final com.arcadedb.log.Logger previousLogger = logManager.getLogger();
+    final CapturingLogger captured = new CapturingLogger(previousLogger);
+
+    final String token;
+    try {
+      logManager.setLogger(captured);
+      token = admin.createApiToken(CreateApiTokenRequest.newBuilder().setCredentials(root())
+          .setName("loggingProbe").build()).getToken();
+      // Emitted while the capture is still installed, obviously - but stated explicitly because
+      // getting this wrong is silent: a canary logged after the restore proves nothing, and the
+      // assertion below would then fail for a reason that has nothing to do with token material.
+      logManager.log(this, Level.FINE, "canary %s", "value");
+    } finally {
+      logManager.setLogger(previousLogger);
+    }
+
+    assertThat(token).startsWith("at-");
+    // The capture has to have seen SOMETHING, or this test would pass however loudly the token leaked.
+    // The gRPC interceptors' own FINE lines would satisfy that, so the canary is explicit rather than
+    // inherited from them - it also pins that arguments, not just format strings, are captured.
+    assertThat(captured.text()).contains("canary").contains("value");
+
+    assertThat(captured.text()).doesNotContain(token);
+    // The suffix is four characters and could collide with anything; the hash could not, and it is the
+    // value an over-helpful log line would most plausibly carry.
+    assertThat(captured.text()).doesNotContain(ApiTokenConfiguration.hashToken(token));
+
+    final String meters = Metrics.globalRegistry.getMeters().stream()
+        .map(meter -> meter.getId().toString())
+        .collect(Collectors.joining(" "));
+    assertThat(meters).doesNotContain(token);
+  }
+
+  /**
+   * Calls {@code createApiToken} with the transport verdict set to {@code safe} - or, when it is null,
+   * with the key never set at all - and returns the failure.
+   */
+  private static Status.Code mintUnder(final ArcadeDbGrpcAdminService service,
+      final CreateApiTokenRequest request, final Boolean safe) {
+    final CapturingObserver<CreateApiTokenResponse> observer = new CapturingObserver<>();
+    contextWith(safe).run(() -> service.createApiToken(request, observer));
+
+    assertThat(observer.error).as("the call must have failed").isNotNull();
+    // Called directly rather than over a channel, so the service's own StatusException arrives here -
+    // a channel would have re-thrown it to the caller as the StatusRuntimeException the other tests
+    // in this class catch. Reading the status off either shape keeps the assertion about the status.
+    return Status.fromThrowable(observer.error).getCode();
+  }
+
+  private static Context contextWith(final Boolean safe) {
+    return safe == null ? Context.current()
+        : Context.current().withValue(GrpcTransportSecurityInterceptor.SECRET_SAFE_TRANSPORT_KEY, safe);
+  }
+
+  /** Records what the service wrote back, so a unary call can be driven without a channel. */
+  private static final class CapturingObserver<T> implements StreamObserver<T> {
+    private T         value;
+    private Throwable error;
+
+    @Override
+    public void onNext(final T value) {
+      this.value = value;
+    }
+
+    @Override
+    public void onError(final Throwable error) {
+      this.error = error;
+    }
+
+    @Override
+    public void onCompleted() {
+    }
+  }
+
+  /**
+   * Records every engine log call, message and arguments alike, and forwards it to the logger it
+   * replaced so a failing run still shows its normal output.
+   */
+  private static final class CapturingLogger implements com.arcadedb.log.Logger {
+    private final com.arcadedb.log.Logger delegate;
+    private final StringBuilder           text = new StringBuilder();
+
+    private CapturingLogger(final com.arcadedb.log.Logger delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object arg1, final Object arg2, final Object arg3, final Object arg4,
+        final Object arg5, final Object arg6, final Object arg7, final Object arg8, final Object arg9,
+        final Object arg10, final Object arg11, final Object arg12, final Object arg13, final Object arg14,
+        final Object arg15, final Object arg16, final Object arg17) {
+      record(message, exception, context, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11,
+          arg12, arg13, arg14, arg15, arg16, arg17);
+      delegate.log(requester, level, message, exception, context, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8,
+          arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17);
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object... args) {
+      record(message, exception, context, args);
+      delegate.log(requester, level, message, exception, context, args);
+    }
+
+    @Override
+    public void flush() {
+      delegate.flush();
+    }
+
+    private void record(final String message, final Throwable exception, final String context, final Object... values) {
+      synchronized (text) {
+        text.append(message).append(' ').append(context).append(' ');
+        if (exception != null)
+          text.append(exception).append(' ');
+        for (final Object value : values)
+          text.append(value).append(' ');
+      }
+    }
+
+    private String text() {
+      synchronized (text) {
+        return text.toString();
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------------------------
+
+  /** The groups {@code userName} holds on the wildcard database, read from the server's own security. */
+  private List<String> grantsOf(final String userName) {
+    final JSONObject databases = getServer(0).getSecurity().getUser(userName).toJSON().getJSONObject("databases");
+    final JSONArray groups = databases.getJSONArray("*");
+    return java.util.stream.IntStream.range(0, groups.length()).mapToObj(groups::getString).toList();
+  }
+
+  private JSONObject wildcardGroups() {
+    return new JSONObject(admin.listGroups(ListGroupsRequest.newBuilder().setCredentials(root()).build())
+        .getGroupsJson()).getJSONObject("databases").getJSONObject("*").getJSONObject("groups");
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7309GrpcSecurityControlPlaneIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7309GrpcSecurityControlPlaneIT.java
@@ -54,8 +54,11 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
  * {@code ServerSecurity} itself. A test that asserted only on the RPC's own response would pass
  * against a handler that built a convincing answer and wrote nothing.
  * <p>
- * The channel is loopback, so {@code CreateApiToken}'s transport gate permits the mint here. The
- * refusal side of that gate is {@link Issue7309ApiTokenSecrecyTest}'s subject.
+ * The channel is loopback, so {@code CreateApiToken}'s transport gate permits the mint here - which
+ * makes the successful mint a positive control for the gate as well as for the RPC. The refusal side
+ * is {@link #createApiTokenMintsOnlyOverAProtectedTransport}, which drives the verdict into the
+ * handler directly because every channel an in-process test can open is loopback, and
+ * {@link GrpcTransportSecurityInterceptorTest}, which covers how that verdict is reached.
  */
 class Issue7309GrpcSecurityControlPlaneIT extends BaseGraphServerTest {
 

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7309GrpcSecurityControlPlaneIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7309GrpcSecurityControlPlaneIT.java
@@ -20,6 +20,7 @@ package com.arcadedb.server.grpc;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.log.Logger;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.BaseGraphServerTest;
@@ -38,6 +39,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
+import java.util.stream.IntStream;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -412,7 +414,7 @@ class Issue7309GrpcSecurityControlPlaneIT extends BaseGraphServerTest {
    * The capture is installed through {@link LogManager#setLogger}, the engine's own logging seam,
    * rather than by attaching a {@code java.util.logging} handler to the root logger. That distinction
    * decides whether this test works at all: the engine logs through its pluggable
-   * {@link com.arcadedb.log.Logger}, so a JUL handler sees whatever that implementation chooses to
+   * {@link Logger}, so a JUL handler sees whatever that implementation chooses to
    * forward and at whatever level it is configured for - which was verified to miss an INFO-level leak
    * deliberately injected into {@code GrpcLoggingInterceptor.sendMessage}. Capturing at the seam sees
    * every call the engine makes, before any level or handler filtering.
@@ -420,7 +422,7 @@ class Issue7309GrpcSecurityControlPlaneIT extends BaseGraphServerTest {
   @Test
   void aMintedTokenReachesNoLogSinkAndNoMetricTag() {
     final LogManager logManager = LogManager.instance();
-    final com.arcadedb.log.Logger previousLogger = logManager.getLogger();
+    final Logger previousLogger = logManager.getLogger();
     final CapturingLogger captured = new CapturingLogger(previousLogger);
 
     final String token;
@@ -498,11 +500,11 @@ class Issue7309GrpcSecurityControlPlaneIT extends BaseGraphServerTest {
    * Records every engine log call, message and arguments alike, and forwards it to the logger it
    * replaced so a failing run still shows its normal output.
    */
-  private static final class CapturingLogger implements com.arcadedb.log.Logger {
-    private final com.arcadedb.log.Logger delegate;
+  private static final class CapturingLogger implements Logger {
+    private final Logger delegate;
     private final StringBuilder           text = new StringBuilder();
 
-    private CapturingLogger(final com.arcadedb.log.Logger delegate) {
+    private CapturingLogger(final Logger delegate) {
       this.delegate = delegate;
     }
 
@@ -555,7 +557,7 @@ class Issue7309GrpcSecurityControlPlaneIT extends BaseGraphServerTest {
   private List<String> grantsOf(final String userName) {
     final JSONObject databases = getServer(0).getSecurity().getUser(userName).toJSON().getJSONObject("databases");
     final JSONArray groups = databases.getJSONArray("*");
-    return java.util.stream.IntStream.range(0, groups.length()).mapToObj(groups::getString).toList();
+    return IntStream.range(0, groups.length()).mapToObj(groups::getString).toList();
   }
 
   private JSONObject wildcardGroups() {

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -30,6 +30,7 @@ import com.arcadedb.server.backup.AutoBackupSchedulerPlugin;
 import com.arcadedb.server.backup.BackupCoordinator;
 import com.arcadedb.server.backup.BackupRetentionManager;
 import com.arcadedb.server.monitor.ServerQueryProfiler;
+import com.arcadedb.server.security.ApiTokenConfiguration;
 import com.arcadedb.server.security.ServerSecurity;
 import com.arcadedb.server.security.ServerSecurityUser;
 import com.arcadedb.utility.FileUtils;
@@ -351,6 +352,290 @@ public class ServerControlPlane {
 
     if (!server.getSecurity().dropUserClusterWide(userName))
       throw new IllegalArgumentException("User '" + userName + "' not found on server");
+  }
+
+  /**
+   * Applies a partial update to an existing user, the operation {@code PUT /server/users} performs.
+   * <p>
+   * {@code newPassword} and {@code newDatabases} are independent and each may be null, meaning "leave
+   * this part of the user alone". That is the distinction the HTTP body draws by omitting a key, and
+   * it matters: an update that always rewrote both would let a password change silently drop the
+   * user's grants. A non-null-but-empty {@code newDatabases} does clear them - that is a caller
+   * saying so, not a caller staying silent.
+   * <p>
+   * The update is composed onto a <b>copy</b> of the stored user, so a failure part way through
+   * leaves the live object untouched, and is applied through
+   * {@link ServerSecurity#updateUserClusterWide} so an HA cluster converges on it (issue #6808).
+   *
+   * @throws NotFoundException        when no user by that name exists
+   * @throws IllegalArgumentException when the new password violates the length policy
+   */
+  public void updateUser(final String userName, final String newPassword, final JSONObject newDatabases) {
+    if (userName == null || userName.isBlank())
+      throw new IllegalArgumentException("User name was missing");
+
+    final ServerSecurity security = server.getSecurity();
+
+    final ServerSecurityUser existingUser = security.getUser(userName);
+    if (existingUser == null)
+      throw new NotFoundException("User '" + userName + "' not found");
+
+    final JSONObject updatedConfig = existingUser.toJSON().copy();
+
+    if (newPassword != null) {
+      validatePasswordLength(newPassword);
+      updatedConfig.put("password", security.encodePassword(newPassword));
+    }
+
+    if (newDatabases != null)
+      updatedConfig.put("databases", newDatabases);
+
+    security.updateUserClusterWide(updatedConfig);
+  }
+
+  /**
+   * The password policy {@code PUT /server/users} has always applied to an update. It is deliberately
+   * NOT {@code CredentialsValidator}, which {@link #createUser} uses: the validator also checks the
+   * password against the user name, and this method is reached with the name of a user that already
+   * exists, so routing an update through it would start refusing passwords that creation accepted.
+   * Changing that is a policy decision, not a refactor, so the bound stays where it was.
+   */
+  private static void validatePasswordLength(final String password) {
+    if (password.length() < 8)
+      throw new IllegalArgumentException("User password must be at least 8 characters");
+    if (password.length() > 256)
+      throw new IllegalArgumentException("User password cannot be longer than 256 characters");
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Security: groups
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * The whole group document, as {@code GET /server/groups} returns it. It carries no secret: a group
+   * is a set of permissions, and the users holding it are named in the user documents, not here.
+   */
+  public JSONObject listGroups() {
+    return server.getSecurity().groupsToJSON();
+  }
+
+  /**
+   * Creates or replaces one group and refreshes the permissions of every open database it applies to.
+   * <p>
+   * The refresh is the half that is easy to leave out and impossible to notice from the response: the
+   * group document on disk is the durable state, but each open {@code DatabaseInternal} caches the
+   * permissions derived from it, so without {@link ServerSecurity#updateSchema} a saved group takes
+   * effect only for databases opened afterwards. It lives here rather than in the HTTP handler for
+   * exactly that reason - a second transport calling only {@code saveGroup} would have written the
+   * file and changed nothing.
+   *
+   * @param groupConfig the group definition, replacing any existing one of the same name. Missing
+   *                    keys are defaulted the way the HTTP body defaults them.
+   */
+  public void saveGroup(final String database, final String name, final JSONObject groupConfig) {
+    if (database == null || database.isBlank())
+      throw new IllegalArgumentException("Database name is required");
+    if (name == null || name.isBlank())
+      throw new IllegalArgumentException("Group name is required");
+
+    final JSONObject normalized = new JSONObject();
+    normalized.put("resultSetLimit", groupConfig.getLong("resultSetLimit", -1L));
+    normalized.put("readTimeout", groupConfig.getLong("readTimeout", -1L));
+    normalized.put("access", groupConfig.has("access") ? groupConfig.getJSONArray("access") : new JSONArray());
+    normalized.put("types", groupConfig.has("types") ? groupConfig.getJSONObject("types") : new JSONObject());
+
+    server.getSecurity().saveGroup(database, name, normalized);
+    refreshPermissionsOf(database);
+  }
+
+  /**
+   * Drops a group and refreshes the permissions of every open database it applied to.
+   *
+   * @throws IllegalArgumentException when asked for the {@code admin} group of the default
+   *                                  {@code "*"} database, which every deployment relies on
+   * @throws NotFoundException        when no such group exists on that database
+   */
+  public void deleteGroup(final String database, final String name) {
+    if (database == null || database.isBlank())
+      throw new IllegalArgumentException("Database parameter is required");
+    if (name == null || name.isBlank())
+      throw new IllegalArgumentException("Group name parameter is required");
+
+    if ("admin".equals(name) && "*".equals(database))
+      throw new IllegalArgumentException("Cannot delete the admin group from the default (*) database");
+
+    if (!server.getSecurity().deleteGroup(database, name))
+      throw new NotFoundException("Group '" + name + "' not found in database '" + database + "'");
+
+    refreshPermissionsOf(database);
+  }
+
+  /**
+   * Re-derives the cached permissions of every open database the group change applies to - all of
+   * them when the change was made against {@code "*"}.
+   */
+  private void refreshPermissionsOf(final String database) {
+    final ServerSecurity security = server.getSecurity();
+    for (final String databaseName : server.getDatabaseNames()) {
+      if ("*".equals(database) || databaseName.equals(database))
+        security.updateSchema((DatabaseInternal) server.getDatabase(databaseName));
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Security: API tokens
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * The issued tokens, in the projection {@code GET /server/api-tokens} returns: each token's
+   * metadata, its SHA-256 hash - the handle needed to revoke it - and its last four characters.
+   * <p>
+   * The projection is explicit, field by field, rather than a copy of the stored document with the
+   * secret removed. The stored document happens to hold no plaintext today, but a listing built by
+   * subtraction is one added field away from disclosing one, and this list is the thing an operator
+   * reads.
+   */
+  public JSONArray listApiTokens() {
+    final JSONArray result = new JSONArray();
+    for (final JSONObject token : server.getSecurity().getApiTokenConfiguration().listTokens()) {
+      final JSONObject entry = new JSONObject();
+      entry.put("name", token.getString("name"));
+      entry.put("database", token.getString("database"));
+      entry.put("expiresAt", token.getLong("expiresAt", 0));
+      entry.put("createdAt", token.getLong("createdAt", 0));
+      entry.put("permissions", token.getJSONObject("permissions"));
+      entry.put("tokenHash", token.getString("tokenHash"));
+      entry.put("tokenSuffix", token.getString("tokenSuffix", ""));
+      result.put(entry);
+    }
+    return result;
+  }
+
+  /**
+   * Mints an API token and returns it <b>including the plaintext token under {@code "token"}</b>. The
+   * server keeps only the hash, so this is the one and only time that value exists outside the
+   * caller's hands.
+   * <p>
+   * <b>This method performs no transport check.</b> It cannot: it does not know how the caller
+   * arrived. Deciding whether the answer may be written back is the transport's job. gRPC does it,
+   * through {@code GrpcTransportSecurityInterceptor}: the mint is refused unless the call arrived
+   * over TLS or from a loopback peer. <b>HTTP does not</b> - {@code POST /server/api-tokens} mints a
+   * token over a cleartext listener to any host, as it always has - which is filed as issue #7372
+   * rather than changed here, because tightening a route that already behaves this way is a
+   * compatibility decision and not part of adding a second transport.
+   *
+   * A blank {@code database} means {@code "*"}, every database. That is what an omitted key has always
+   * meant over HTTP; it now also covers an explicitly empty one, which previously stored a token scoped
+   * to the database named "" - a scope no database can match, so the token could never have been used.
+   * gRPC needs the same normalization for a different reason: an unset proto3 string is "" and cannot
+   * be told from an omitted one.
+   *
+   * @throws IllegalArgumentException when the name is missing or the permission document is malformed
+   * @throws AlreadyExistsException   when a token of that name has already been issued
+   */
+  public JSONObject createApiToken(final String name, final String database, final long expiresAt,
+      final JSONObject permissions) {
+    if (name == null || name.isBlank())
+      throw new IllegalArgumentException("Token name is required");
+
+    final JSONObject effectivePermissions = permissions != null ? permissions : new JSONObject();
+
+    final String validationError = validateTokenPermissions(effectivePermissions);
+    if (validationError != null)
+      throw new IllegalArgumentException(validationError);
+
+    final String effectiveDatabase = database == null || database.isBlank() ? "*" : database;
+
+    try {
+      return server.getSecurity().getApiTokenConfiguration()
+          .createToken(name, effectiveDatabase, expiresAt, effectivePermissions);
+    } catch (final IllegalArgumentException e) {
+      // ApiTokenConfiguration.createToken raises this for exactly one reason - a duplicate name - and
+      // that is a conflict (409 / ALREADY_EXISTS), not a malformed request. Re-typing it here keeps
+      // both transports from having to tell the two apart by matching on the message text.
+      throw new AlreadyExistsException(e.getMessage());
+    }
+  }
+
+  /**
+   * Revokes a token by its SHA-256 hash.
+   *
+   * @throws IllegalArgumentException when handed a plaintext token instead of a hash. Accepting one
+   *                                  would put live token material into whatever logged the call,
+   *                                  which is the exposure the revocation is trying to end.
+   * @throws NotFoundException        when no token has that hash
+   */
+  public void deleteApiToken(final String tokenHash) {
+    if (tokenHash == null || tokenHash.isBlank())
+      throw new IllegalArgumentException("Token hash parameter is required");
+
+    if (ApiTokenConfiguration.isApiToken(tokenHash))
+      throw new IllegalArgumentException("Use token hash (from list endpoint) instead of plaintext token for deletion");
+
+    if (!server.getSecurity().getApiTokenConfiguration().deleteToken(tokenHash))
+      throw new NotFoundException("Token not found");
+  }
+
+  private static final Set<String> VALID_TOKEN_ACCESS_VALUES = Set.of(
+      "createRecord", "readRecord", "updateRecord", "deleteRecord");
+
+  /**
+   * Checks the shape of a token's permission document, returning the complaint or null. It is a
+   * shape check, not a semantic one: an unknown type name is allowed - the type may be created later -
+   * while an access verb outside the four the engine defines is not, because it would silently grant
+   * nothing.
+   */
+  private static String validateTokenPermissions(final JSONObject permissions) {
+    if (permissions.has("types")) {
+      if (!(permissions.get("types") instanceof final JSONObject types))
+        return "'permissions.types' must be a JSON object";
+
+      for (final String typeName : types.keySet()) {
+        if (!(types.get(typeName) instanceof final JSONObject typeObj))
+          return "'permissions.types." + typeName + "' must be a JSON object";
+
+        if (typeObj.has("access")) {
+          if (!(typeObj.get("access") instanceof final JSONArray access))
+            return "'permissions.types." + typeName + ".access' must be a JSON array";
+
+          for (int i = 0; i < access.length(); i++) {
+            final String value = access.getString(i);
+            if (!VALID_TOKEN_ACCESS_VALUES.contains(value))
+              return "Invalid access value '" + value + "' in permissions.types." + typeName
+                  + ". Valid values: " + VALID_TOKEN_ACCESS_VALUES;
+          }
+        }
+      }
+    }
+
+    if (permissions.has("database") && !(permissions.get("database") instanceof JSONArray))
+      return "'permissions.database' must be a JSON array";
+
+    return null;
+  }
+
+  /**
+   * Raised when the operation names something that does not exist - a user, a group, a token. HTTP
+   * answers it 404 and gRPC {@code NOT_FOUND}; both carry this message verbatim.
+   * <p>
+   * It is a distinct type rather than an {@link IllegalArgumentException} because the two mean
+   * different things to a caller: a malformed argument is worth fixing and retrying, an absent target
+   * is not.
+   */
+  public static class NotFoundException extends RuntimeException {
+    public NotFoundException(final String message) {
+      super(message);
+    }
+  }
+
+  /**
+   * Raised when the operation would create something whose identity is already taken. HTTP answers it
+   * 409 and gRPC {@code ALREADY_EXISTS}.
+   */
+  public static class AlreadyExistsException extends RuntimeException {
+    public AlreadyExistsException(final String message) {
+      super(message);
+    }
   }
 
   // ---------------------------------------------------------------------------------------------

--- a/server/src/main/java/com/arcadedb/server/http/handler/DeleteApiTokenHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/DeleteApiTokenHandler.java
@@ -19,15 +19,23 @@
 package com.arcadedb.server.http.handler;
 
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ServerControlPlane;
 import com.arcadedb.server.http.HttpServer;
-import com.arcadedb.server.security.ApiTokenConfiguration;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.server.HttpServerExchange;
 
+/**
+ * {@code DELETE /server/api-tokens?token=<hash>}: revokes a token by its hash. The refusal to accept
+ * a plaintext token here - it would land in whatever logged the request, which is the exposure the
+ * revocation is ending - lives in {@link ServerControlPlane#deleteApiToken} so the gRPC
+ * {@code DeleteApiToken} RPC refuses it too (issue #7309).
+ */
 public class DeleteApiTokenHandler extends AbstractServerHttpHandler {
+  private final ServerControlPlane controlPlane;
 
   public DeleteApiTokenHandler(final HttpServer httpServer) {
     super(httpServer);
+    this.controlPlane = new ServerControlPlane(httpServer.getServer());
   }
 
   @Override
@@ -35,20 +43,14 @@ public class DeleteApiTokenHandler extends AbstractServerHttpHandler {
       final JSONObject payload) {
     checkRootUser(user);
 
-    final String tokenHash = getQueryParameter(exchange, "token");
-    if (tokenHash == null || tokenHash.isBlank())
-      return new ExecutionResponse(400, new JSONObject().put("error", "Token hash parameter is required").toString());
+    try {
+      controlPlane.deleteApiToken(getQueryParameter(exchange, "token"));
+    } catch (final ServerControlPlane.NotFoundException e) {
+      return new ExecutionResponse(404, new JSONObject().put("result", "Token not found").toString());
+    } catch (final IllegalArgumentException e) {
+      return new ExecutionResponse(400, new JSONObject().put("error", e.getMessage()).toString());
+    }
 
-    // Only accept token hashes, not plaintext tokens — plaintext tokens in query parameters could leak in server logs and URL history
-    if (ApiTokenConfiguration.isApiToken(tokenHash))
-      return new ExecutionResponse(400,
-          new JSONObject().put("error", "Use token hash (from list endpoint) instead of plaintext token for deletion").toString());
-
-    final ApiTokenConfiguration tokenConfig = httpServer.getServer().getSecurity().getApiTokenConfiguration();
-    final boolean deleted = tokenConfig.deleteToken(tokenHash);
-
-    final JSONObject response = new JSONObject();
-    response.put("result", deleted ? "Token deleted" : "Token not found");
-    return new ExecutionResponse(deleted ? 200 : 404, response.toString());
+    return new ExecutionResponse(200, new JSONObject().put("result", "Token deleted").toString());
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/DeleteGroupHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/DeleteGroupHandler.java
@@ -18,20 +18,24 @@
  */
 package com.arcadedb.server.http.handler;
 
-import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ServerControlPlane;
 import com.arcadedb.server.http.HttpServer;
-import com.arcadedb.server.security.ServerSecurity;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.server.HttpServerExchange;
 
 /**
- * @author Luca Garulli (l.garulli@arcadedata.com)
+ * {@code DELETE /server/groups?database=<db>&name=<group>}: drops one group. Delegates to
+ * {@link ServerControlPlane#deleteGroup}, which also refuses to drop the {@code admin} group of the
+ * default database and refreshes the permissions of every open database the group applied to, so the
+ * gRPC {@code DeleteGroup} RPC gets both (issue #7309).
  */
 public class DeleteGroupHandler extends AbstractServerHttpHandler {
+  private final ServerControlPlane controlPlane;
 
   public DeleteGroupHandler(final HttpServer httpServer) {
     super(httpServer);
+    this.controlPlane = new ServerControlPlane(httpServer.getServer());
   }
 
   @Override
@@ -40,32 +44,14 @@ public class DeleteGroupHandler extends AbstractServerHttpHandler {
     checkRootUser(user);
 
     final String database = getQueryParameter(exchange, "database");
-    if (database == null || database.isBlank())
-      return new ExecutionResponse(400, new JSONObject().put("error", "Database parameter is required").toString());
-
     final String name = getQueryParameter(exchange, "name");
-    if (name == null || name.isBlank())
-      return new ExecutionResponse(400, new JSONObject().put("error", "Group name parameter is required").toString());
 
-    if ("admin".equals(name) && "*".equals(database))
-      return new ExecutionResponse(400,
-          new JSONObject().put("error", "Cannot delete the admin group from the default (*) database").toString());
-
-    final ServerSecurity security = httpServer.getServer().getSecurity();
-    final boolean deleted = security.deleteGroup(database, name);
-
-    if (!deleted) {
-      final JSONObject response = new JSONObject();
-      response.put("error", "Group '" + name + "' not found in database '" + database + "'");
-      return new ExecutionResponse(404, response.toString());
-    }
-
-    // Refresh permissions on affected open databases
-    for (final String dbName : httpServer.getServer().getDatabaseNames()) {
-      if ("*".equals(database) || dbName.equals(database)) {
-        final DatabaseInternal db = (DatabaseInternal) httpServer.getServer().getDatabase(dbName);
-        security.updateSchema(db);
-      }
+    try {
+      controlPlane.deleteGroup(database, name);
+    } catch (final ServerControlPlane.NotFoundException e) {
+      return new ExecutionResponse(404, new JSONObject().put("error", e.getMessage()).toString());
+    } catch (final IllegalArgumentException e) {
+      return new ExecutionResponse(400, new JSONObject().put("error", e.getMessage()).toString());
     }
 
     final JSONObject response = new JSONObject();

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetApiTokensHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetApiTokensHandler.java
@@ -20,17 +20,23 @@ package com.arcadedb.server.http.handler;
 
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ServerControlPlane;
 import com.arcadedb.server.http.HttpServer;
-import com.arcadedb.server.security.ApiTokenConfiguration;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.server.HttpServerExchange;
 
-import java.util.List;
-
+/**
+ * {@code GET /server/api-tokens}: the issued tokens, as metadata plus the hash needed to revoke each
+ * one. The projection - which never includes token material - lives in
+ * {@link ServerControlPlane#listApiTokens} so the gRPC {@code ListApiTokens} RPC returns exactly the
+ * same fields (issue #7309).
+ */
 public class GetApiTokensHandler extends AbstractServerHttpHandler {
+  private final ServerControlPlane controlPlane;
 
   public GetApiTokensHandler(final HttpServer httpServer) {
     super(httpServer);
+    this.controlPlane = new ServerControlPlane(httpServer.getServer());
   }
 
   @Override
@@ -38,25 +44,11 @@ public class GetApiTokensHandler extends AbstractServerHttpHandler {
       final JSONObject payload) {
     checkRootUser(user);
 
-    final ApiTokenConfiguration tokenConfig = httpServer.getServer().getSecurity().getApiTokenConfiguration();
-    final List<JSONObject> tokens = tokenConfig.listTokens();
-
-    final JSONArray result = new JSONArray();
-    for (final JSONObject token : tokens) {
-      final JSONObject entry = new JSONObject();
-      entry.put("name", token.getString("name"));
-      entry.put("database", token.getString("database"));
-      entry.put("expiresAt", token.getLong("expiresAt", 0));
-      entry.put("createdAt", token.getLong("createdAt", 0));
-      entry.put("permissions", token.getJSONObject("permissions"));
-      entry.put("tokenHash", token.getString("tokenHash"));
-      entry.put("tokenSuffix", token.getString("tokenSuffix", ""));
-      result.put(entry);
-    }
+    final JSONArray tokens = controlPlane.listApiTokens();
 
     final JSONObject response = new JSONObject();
-    response.put("result", result);
-    response.put("count", tokens.size());
+    response.put("result", tokens);
+    response.put("count", tokens.length());
     return new ExecutionResponse(200, response.toString());
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetGroupsHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetGroupsHandler.java
@@ -19,17 +19,22 @@
 package com.arcadedb.server.http.handler;
 
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ServerControlPlane;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.server.HttpServerExchange;
 
 /**
- * @author Luca Garulli (l.garulli@arcadedata.com)
+ * {@code GET /server/groups}: the whole group/permission document. Reads through
+ * {@link ServerControlPlane#listGroups} so the gRPC {@code ListGroups} RPC returns the same document
+ * (issue #7309).
  */
 public class GetGroupsHandler extends AbstractServerHttpHandler {
+  private final ServerControlPlane controlPlane;
 
   public GetGroupsHandler(final HttpServer httpServer) {
     super(httpServer);
+    this.controlPlane = new ServerControlPlane(httpServer.getServer());
   }
 
   @Override
@@ -37,10 +42,8 @@ public class GetGroupsHandler extends AbstractServerHttpHandler {
       final JSONObject payload) {
     checkRootUser(user);
 
-    final JSONObject groups = httpServer.getServer().getSecurity().groupsToJSON();
-
     final JSONObject response = new JSONObject();
-    response.put("result", groups);
+    response.put("result", controlPlane.listGroups());
     return new ExecutionResponse(200, response.toString());
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostApiTokenHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostApiTokenHandler.java
@@ -18,19 +18,27 @@
  */
 package com.arcadedb.server.http.handler;
 
-import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ServerControlPlane;
 import com.arcadedb.server.http.HttpServer;
-import com.arcadedb.server.security.ApiTokenConfiguration;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.server.HttpServerExchange;
 
-import java.util.Set;
-
+/**
+ * {@code POST /server/api-tokens}: mints a token and returns it, plaintext, exactly once. Minting and
+ * the validation of the permission document live in {@link ServerControlPlane#createApiToken} so the
+ * gRPC {@code CreateApiToken} RPC applies the same rules (issue #7309).
+ * <p>
+ * This route applies no transport check: it mints over whichever listener the request arrived on. The
+ * gRPC RPC does apply one, because it was added with the gate rather than inheriting years of
+ * behaviour. Bringing the two into line is issue #7372.
+ */
 public class PostApiTokenHandler extends AbstractServerHttpHandler {
+  private final ServerControlPlane controlPlane;
 
   public PostApiTokenHandler(final HttpServer httpServer) {
     super(httpServer);
+    this.controlPlane = new ServerControlPlane(httpServer.getServer());
   }
 
   @Override
@@ -41,25 +49,17 @@ public class PostApiTokenHandler extends AbstractServerHttpHandler {
     if (payload == null)
       return new ExecutionResponse(400, new JSONObject().put("error", "Request body is required").toString());
 
-    final String name = payload.getString("name", "");
-    if (name.isBlank())
-      return new ExecutionResponse(400, new JSONObject().put("error", "Token name is required").toString());
-
-    final String database = payload.getString("database", "*");
-    final long expiresAt = payload.getLong("expiresAt", 0);
-    final JSONObject permissions = payload.getJSONObject("permissions", new JSONObject());
-
-    // Validate permissions structure
-    final String validationError = validatePermissions(permissions);
-    if (validationError != null)
-      return new ExecutionResponse(400, new JSONObject().put("error", validationError).toString());
-
-    final ApiTokenConfiguration tokenConfig = httpServer.getServer().getSecurity().getApiTokenConfiguration();
     final JSONObject tokenJson;
     try {
-      tokenJson = tokenConfig.createToken(name, database, expiresAt, permissions);
-    } catch (final IllegalArgumentException e) {
+      tokenJson = controlPlane.createApiToken(
+          payload.getString("name", ""),
+          payload.getString("database", "*"),
+          payload.getLong("expiresAt", 0),
+          payload.getJSONObject("permissions", new JSONObject()));
+    } catch (final ServerControlPlane.AlreadyExistsException e) {
       return new ExecutionResponse(409, new JSONObject().put("error", e.getMessage()).toString());
+    } catch (final IllegalArgumentException e) {
+      return new ExecutionResponse(400, new JSONObject().put("error", e.getMessage()).toString());
     }
 
     final JSONObject response = new JSONObject();
@@ -70,46 +70,5 @@ public class PostApiTokenHandler extends AbstractServerHttpHandler {
   @Override
   protected boolean mustExecuteOnWorkerThread() {
     return true;
-  }
-
-  private static final Set<String> VALID_ACCESS_VALUES = Set.of(
-      "createRecord", "readRecord", "updateRecord", "deleteRecord");
-
-  private static String validatePermissions(final JSONObject permissions) {
-    if (permissions.has("types")) {
-      final Object typesObj = permissions.get("types");
-      if (!(typesObj instanceof JSONObject))
-        return "'permissions.types' must be a JSON object";
-
-      final JSONObject types = (JSONObject) typesObj;
-      for (final String typeName : types.keySet()) {
-        final Object typeDef = types.get(typeName);
-        if (!(typeDef instanceof JSONObject))
-          return "'permissions.types." + typeName + "' must be a JSON object";
-
-        final JSONObject typeObj = (JSONObject) typeDef;
-        if (typeObj.has("access")) {
-          final Object accessObj = typeObj.get("access");
-          if (!(accessObj instanceof JSONArray))
-            return "'permissions.types." + typeName + ".access' must be a JSON array";
-
-          final JSONArray access = (JSONArray) accessObj;
-          for (int i = 0; i < access.length(); i++) {
-            final String value = access.getString(i);
-            if (!VALID_ACCESS_VALUES.contains(value))
-              return "Invalid access value '" + value + "' in permissions.types." + typeName
-                  + ". Valid values: " + VALID_ACCESS_VALUES;
-          }
-        }
-      }
-    }
-
-    if (permissions.has("database")) {
-      final Object dbObj = permissions.get("database");
-      if (!(dbObj instanceof JSONArray))
-        return "'permissions.database' must be a JSON array";
-    }
-
-    return null;
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostGroupHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostGroupHandler.java
@@ -18,21 +18,24 @@
  */
 package com.arcadedb.server.http.handler;
 
-import com.arcadedb.database.DatabaseInternal;
-import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ServerControlPlane;
 import com.arcadedb.server.http.HttpServer;
-import com.arcadedb.server.security.ServerSecurity;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.server.HttpServerExchange;
 
 /**
- * @author Luca Garulli (l.garulli@arcadedata.com)
+ * {@code POST /server/groups}: creates or replaces one group. The operation - normalizing the group
+ * document and refreshing the permissions cached by every open database it applies to - lives in
+ * {@link ServerControlPlane#saveGroup} so the gRPC {@code SaveGroup} RPC does both halves too
+ * (issue #7309).
  */
 public class PostGroupHandler extends AbstractServerHttpHandler {
+  private final ServerControlPlane controlPlane;
 
   public PostGroupHandler(final HttpServer httpServer) {
     super(httpServer);
+    this.controlPlane = new ServerControlPlane(httpServer.getServer());
   }
 
   @Override
@@ -44,29 +47,12 @@ public class PostGroupHandler extends AbstractServerHttpHandler {
       return new ExecutionResponse(400, new JSONObject().put("error", "Request body is required").toString());
 
     final String database = payload.getString("database", "");
-    if (database.isBlank())
-      return new ExecutionResponse(400, new JSONObject().put("error", "Database name is required").toString());
-
     final String name = payload.getString("name", "");
-    if (name.isBlank())
-      return new ExecutionResponse(400, new JSONObject().put("error", "Group name is required").toString());
 
-    // Build group config
-    final JSONObject groupConfig = new JSONObject();
-    groupConfig.put("resultSetLimit", payload.getLong("resultSetLimit", -1L));
-    groupConfig.put("readTimeout", payload.getLong("readTimeout", -1L));
-    groupConfig.put("access", payload.has("access") ? payload.getJSONArray("access") : new JSONArray());
-    groupConfig.put("types", payload.has("types") ? payload.getJSONObject("types") : new JSONObject());
-
-    final ServerSecurity security = httpServer.getServer().getSecurity();
-    security.saveGroup(database, name, groupConfig);
-
-    // Refresh permissions on affected open databases
-    for (final String dbName : httpServer.getServer().getDatabaseNames()) {
-      if ("*".equals(database) || dbName.equals(database)) {
-        final DatabaseInternal db = (DatabaseInternal) httpServer.getServer().getDatabase(dbName);
-        security.updateSchema(db);
-      }
+    try {
+      controlPlane.saveGroup(database, name, payload);
+    } catch (final IllegalArgumentException e) {
+      return new ExecutionResponse(400, new JSONObject().put("error", e.getMessage()).toString());
     }
 
     final JSONObject response = new JSONObject();

--- a/server/src/main/java/com/arcadedb/server/http/handler/PutUserHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PutUserHandler.java
@@ -19,18 +19,23 @@
 package com.arcadedb.server.http.handler;
 
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ServerControlPlane;
 import com.arcadedb.server.http.HttpServer;
-import com.arcadedb.server.security.ServerSecurity;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.server.HttpServerExchange;
 
 /**
- * @author Luca Garulli (l.garulli@arcadedata.com)
+ * {@code PUT /server/users?name=<user>}: updates an existing user's password, per-database groups, or
+ * both. The operation itself lives in {@link ServerControlPlane#updateUser} so the gRPC
+ * {@code UpdateUser} RPC runs this exact code rather than a second copy of it (issue #7309); what is
+ * left here is reading the request and choosing the status code.
  */
 public class PutUserHandler extends AbstractServerHttpHandler {
+  private final ServerControlPlane controlPlane;
 
   public PutUserHandler(final HttpServer httpServer) {
     super(httpServer);
+    this.controlPlane = new ServerControlPlane(httpServer.getServer());
   }
 
   @Override
@@ -45,31 +50,18 @@ public class PutUserHandler extends AbstractServerHttpHandler {
     if (name == null || name.isBlank())
       return new ExecutionResponse(400, new JSONObject().put("error", "Query parameter 'name' is required").toString());
 
-    final ServerSecurity security = httpServer.getServer().getSecurity();
+    // Absent means "leave this part of the user alone", which is why both are read as nullable rather
+    // than defaulted: a PUT carrying only a password must not clear the user's grants.
+    final String password = payload.has("password") ? payload.getString("password") : null;
+    final JSONObject databases = payload.has("databases") ? payload.getJSONObject("databases") : null;
 
-    final ServerSecurityUser existingUser = security.getUser(name);
-    if (existingUser == null)
-      return new ExecutionResponse(404, new JSONObject().put("error", "User '" + name + "' not found").toString());
-
-    // Build updated config from a copy to avoid mutating the live user object
-    final JSONObject updatedConfig = existingUser.toJSON().copy();
-
-    if (payload.has("password")) {
-      final String password = payload.getString("password");
-      if (password.length() < 8)
-        return new ExecutionResponse(400, new JSONObject().put("error", "User password must be at least 8 characters").toString());
-      if (password.length() > 256)
-        return new ExecutionResponse(400, new JSONObject().put("error", "User password cannot be longer than 256 characters").toString());
-      updatedConfig.put("password", security.encodePassword(password));
+    try {
+      controlPlane.updateUser(name, password, databases);
+    } catch (final ServerControlPlane.NotFoundException e) {
+      return new ExecutionResponse(404, new JSONObject().put("error", e.getMessage()).toString());
+    } catch (final IllegalArgumentException e) {
+      return new ExecutionResponse(400, new JSONObject().put("error", e.getMessage()).toString());
     }
-
-    if (payload.has("databases"))
-      updatedConfig.put("databases", payload.getJSONObject("databases"));
-
-    // Cluster-aware: on an HA cluster this replicates as a Raft entry so every peer applies the change.
-    // Calling security.updateUser() directly applied it only on the node that served the request, silently
-    // diverging the cluster's security state (issue #6808).
-    security.updateUserClusterWide(updatedConfig);
 
     final JSONObject response = new JSONObject();
     response.put("result", "User '" + name + "' updated");


### PR DESCRIPTION
Closes #7309

Completes the `/server/*` security table on gRPC, which #7304 left three rows short. Seven
operations moved into `ServerControlPlane` and the six HTTP handlers were rewritten onto them, so
both transports run one implementation rather than two that can drift - and what moved is not only
the happy path, but the group-permission cache refresh, the admin-group refusal, the token
permission-document validation and the plaintext-token refusal, each of which is a rule a second
transport would otherwise have silently lacked. `CreateApiToken` is the one RPC that returns secret
material, so it carries a precondition the others do not: a new `GrpcTransportSecurityInterceptor`
records whether each call's transport protects the response (TLS session present, or loopback peer)
and the mint is refused with `FAILED_PRECONDITION` otherwise, failing closed when the context key is
absent so that removing the interceptor stops tokens being minted rather than stops them being
protected.

## The two security questions the issue raised

**"Nothing refuses to *receive* a minted token over a plaintext channel."** Now something does, and
it is server-side, which is where it has to be: `RemoteGrpcServer`'s existing refusal runs in
ArcadeDB's own Java client, can be opted out of with `allowInsecureCredentials`, and is not running
at all when the caller is grpcurl or a Python stub. `GrpcTransportSecurityInterceptor` reads the live
connection - not configuration - so a TLS setting that did not take effect cannot vouch for a
plaintext socket.

**"A token-bearing response must be proved not to reach a log sink."** It is proved, and the proof
was wrong the first time. The test was written against a `java.util.logging` handler on the root
logger; a leak deliberately injected into `GrpcLoggingInterceptor.sendMessage` **did not fail it**,
because the engine logs through its own pluggable `com.arcadedb.log.Logger`. Rewritten to capture at
`LogManager.setLogger`, the same injected leak fails the test - only then was the mutation reverted
and the test confirmed green. On a clean run the captured text is method name, compression and
elapsed millis, with no payload.

## Test plan

- [ ] `mvn -pl grpcw -DskipTests=true -DskipITs=false -Dit.test=Issue7309GrpcSecurityControlPlaneIT verify` - 17 tests, one per RPC plus the two security properties
- [ ] `mvn -pl grpcw test` - 223/223, including the new 7-case `GrpcTransportSecurityInterceptorTest`
- [ ] `mvn -pl server -DskipTests=true -DskipITs=false -Dit.test=GroupManagementIT,ApiTokenAuthenticationIT,UserManagementIT verify` - 27/27, the HTTP regression net for the refactor
- [ ] `mvn -pl server -DskipTests=true -DskipITs=false -Dit.test=Issue6806GroupPermissionRefreshIT,SchemaMutationAuthorizationIT,CrossDatabaseAccessIT,Issue6808LoginTokenRevocationIT,OpenApiSpecGenerationIT,Issue5269FileAccessRefreshIT verify` - 35/35
- [ ] To see the transport gate refuse rather than permit, connect from another host over a plaintext channel: the mint answers `FAILED_PRECONDITION`, every other admin RPC still works

**Note for reviewers running the `server` suite locally:** a stray ArcadeDB listening on 2480 makes
`ClusterInternalAuthTest` fail with `Expecting actual: 401 not to be equal to: 401` - it targets
`http://localhost:2480`, `localhost` resolves to `::1`, and the stranger answers. Check
`lsof -nP -iTCP:2480 -sTCP:LISTEN` before reading that as an auth bug.

## Coverage

Entry points covered, each with a test driving it through that path:

| Entry point | Test |
|---|---|
| `UpdateUser` RPC | `updateUserChangesOnlyTheFieldsTheRequestCarries`, plus the two refusals |
| `PUT /server/users` (refactored onto the same code) | `UserManagementIT` |
| `ListGroups` / `SaveGroup` / `DeleteGroup` RPCs | `listGroupsReturnsTheGroupDocument`, `saveGroupWritesAGroupReadableThroughListGroups`, `deleteGroupRemovesIt` + not-found + admin-group refusal |
| `GET`/`POST`/`DELETE /server/groups` (refactored) | `GroupManagementIT` |
| `ListApiTokens` / `CreateApiToken` / `DeleteApiToken` RPCs | `createApiTokenReturnsTheMaterialOnceAndListsTheTokenWithout`, duplicate-name, bad-verb, revoke-by-hash, plaintext refusal, unknown-hash |
| `GET`/`POST`/`DELETE /server/api-tokens` (refactored) | `ApiTokenAuthenticationIT` |
| `requireServerAdmin` on all seven RPCs | `everyNewRpcRefusesANonRootAccount`, driven once per RPC |
| Secret material over an unprotected transport | `createApiTokenMintsOnlyOverAProtectedTransport` (absent key, false, and a permitted positive control) + `GrpcTransportSecurityInterceptorTest` |
| Secret material into a log sink or metric tag | `aMintedTokenReachesNoLogSinkAndNoMetricTag` |
| `RemoteGrpcServer` client methods | exercised through the proto surface the IT drives |

### Known gaps

Three, each filed before this PR opened:

- **#7372** - `RemoteServer`, the HTTP Java client, still has no methods for any of these nine routes.
  gRPC's client now covers all of them and HTTP's covers three.
- **#7373** - groups and API tokens are node-local while users are Raft-replicated. A token minted on
  one node authenticates only there, and revoking one applies to one node. Pre-existing on HTTP; this
  PR makes it reachable from a second transport, which is why it is filed rather than left implicit.
- **#7380** - found by the adversarial pass: the three REST `/server/users` routes reach
  `*ClusterWide` on a follower with no leader gate, while the `POST /server` command path forwards to
  the leader. gRPC gates all three, so the REST routes are now the only ungated way in.

One deliberate behaviour change: `POST /server/api-tokens` with an explicitly empty `"database"` used
to store a token scoped to the database named `""` - a scope no database can match, so the token
could never be used. It now normalizes to `"*"`, as an omitted key always has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwTsBYjyoDn2vKXQGmt5bK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added administration support for updating users, managing groups, and creating, listing, and revoking API tokens through gRPC and HTTP interfaces.
  - API-token creation is restricted to protected connections or local access, and newly generated secrets are returned only once.
  - Added consistent validation and error handling, including password policies, permission checks, duplicate detection, and missing-resource responses.
  - Group and user changes now apply consistently across supported administration interfaces.

- **Documentation**
  - Added design and implementation documentation covering the administration API and security guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->