### PR TITLE
feat(#7311): per-chunk acknowledgements for HTTP batch inserts

### DIFF
--- a/docs/7311-http-streaming-batch-insert.md
+++ b/docs/7311-http-streaming-batch-insert.md
@@ -233,6 +233,29 @@ could tell anyone at that point.
 
 Deferred: none. Disagreed: none.
 
+### Cycle 4 - `188e328f76`
+
+Found by widening the regression run to the whole `com.arcadedb.remote` IT package rather than the classes
+this branch touches - which is the only reason it was found at all, and it is a defect this branch
+introduced, not a review comment.
+
+**`Issue7031RemoteClientIT` broke, 3 of 4 tests.** `RemoteGraphBatch.flush()` had been changed to call the new
+`sendBatch(content, queryParams, onProgress)` overload, and the two-argument `sendBatch(content, queryParams)`
+was left delegating to it. But the two-argument method is an **overridable extension point**: that test
+subclasses `RemoteDatabase` and overrides it to record every payload and to simulate a failed request. With
+the delegation pointing that way, every flush went to the sibling the subclass had not overridden, so the stub
+never fired and three tests that exercise #7031's "a failed flush is not re-sent" contract silently stopped
+exercising anything. Nothing in the compiler or in the classes this branch changed says so.
+
+The delegation is inverted: the two-argument method holds the buffered implementation again, and the overload
+returns `sendBatch(content, queryParams)` when there is no listener. `RemoteGraphBatchProgressIT.
+aFlushWithNoListenerStillGoesThroughTheOverridableSend` pins the direction with its own recording subclass, and
+both it and the three `Issue7031RemoteClientIT` tests were confirmed to fail against the inverted form.
+
+This is the "dual-path trap" shape: a new overload beside an existing overridable method is a second path, and
+the callers have to be moved deliberately rather than by whichever signature is most convenient at the call
+site.
+
 Other reviewers on this PR: CodeRabbit reached its free-tier review limit and produced no findings. Codacy
 reported "4 new issues (1 high ErrorProne, 3 minor CodeStyle)" and **its findings are not retrievable from
 here** - neither `gh pr view --json comments` nor the check-run summary carries them, only the Codacy
@@ -290,3 +313,26 @@ promise held for one shape of failure and not the other.
 3. **Cosmetic:** the double blank lines introduced around the new blocks are collapsed.
 
 Deferred: none. Disagreed: none.
+
+### Cycle 4 - `188e328f76`
+
+Found by widening the regression run to the whole `com.arcadedb.remote` IT package rather than the classes
+this branch touches - which is the only reason it was found at all, and it is a defect this branch
+introduced, not a review comment.
+
+**`Issue7031RemoteClientIT` broke, 3 of 4 tests.** `RemoteGraphBatch.flush()` had been changed to call the new
+`sendBatch(content, queryParams, onProgress)` overload, and the two-argument `sendBatch(content, queryParams)`
+was left delegating to it. But the two-argument method is an **overridable extension point**: that test
+subclasses `RemoteDatabase` and overrides it to record every payload and to simulate a failed request. With
+the delegation pointing that way, every flush went to the sibling the subclass had not overridden, so the stub
+never fired and three tests that exercise #7031's "a failed flush is not re-sent" contract silently stopped
+exercising anything. Nothing in the compiler or in the classes this branch changed says so.
+
+The delegation is inverted: the two-argument method holds the buffered implementation again, and the overload
+returns `sendBatch(content, queryParams)` when there is no listener. `RemoteGraphBatchProgressIT.
+aFlushWithNoListenerStillGoesThroughTheOverridableSend` pins the direction with its own recording subclass, and
+both it and the three `Issue7031RemoteClientIT` tests were confirmed to fail against the inverted form.
+
+This is the "dual-path trap" shape: a new overload beside an existing overridable method is a second path, and
+the callers have to be moved deliberately rather than by whichever signature is most convenient at the call
+site.

--- a/docs/7311-http-streaming-batch-insert.md
+++ b/docs/7311-http-streaming-batch-insert.md
@@ -86,6 +86,8 @@ the old signature delegates to it. No existing test is touched.
 | OpenAPI document | yes | yes - `PostBatchStreamingOpenApiTest` |
 | `RemoteDatabase` / `RemoteGraphBatch` (Java driver) | yes - `sendBatch(..., onProgress)` + `withProgressListener` | yes - `RemoteGraphBatchProgressIT` |
 | Idempotency key of the BUFFERED `/batch` encoding not covering the payload | **no** - filed as #7381 (pre-existing, found by this sweep) | n/a |
+| A streamed response has no bound, so a very large load can block the worker mid-write | **no** - filed as #7388 (raised in review) | n/a |
+| `commitIndex` on a FAILED load, relayed by a follower | yes | yes - `RaftBatchStreamingForwardIT.aRelayedStreamThatFailsMidLoadStillCarriesTheBookmark` |
 | gRPC `InsertBidirectional` control frames (`Start` / `Commit`) over HTTP | **no** - argued: needs a duplex channel, belongs to `/ws` (#7382) | n/a |
 | `/ws` streaming batch surface (`Start`/`Commit` control frames) | **no** - filed as #7382 | n/a |
 
@@ -96,10 +98,15 @@ the old signature delegates to it. No existing test is touched.
   edges are buffered by `GraphBatch` and written at `close()`, so an edge-phase progress line reports records
   *accepted*, not records committed. This is stated in the javadoc, in the OpenAPI description and in the
   handler.
-- Writing the response while reading the request is full duplex over one socket. A client that never reads
-  its response and whose socket buffers fill would deadlock, in principle. The response is orders of magnitude
-  smaller than the request it describes (one ~200-byte line per `vertexBatchSize` records, default 10,000), so
-  the response cannot fill a socket buffer before the request drains it. No timeout was added for it.
+- Writing the response while reading the request is full duplex over one socket, and the cost of that is NOT
+  flat, which the first version of this section got wrong by comparing one progress line to the whole upload.
+  The lines accumulate with the size of the load - roughly one ~200-byte line per `vertexBatchSize` records,
+  10,000 by default - so a load of millions of records writes hundreds of KB of response. A client that reads
+  nothing until its upload has finished (a plain `HttpURLConnection` that writes its whole body and only then
+  calls `getResponseCode()` is exactly that shape) can fill the socket buffers, at which point the server
+  blocks inside a response `write()` and stops reading the request too. The read side is watched
+  (`httpStreamingReadTimeout`); the write side is not. An ordinary client that reads while it writes never
+  meets it, and a small load cannot reach it at all. Bounding it is **#7388**.
 - Once a 200 is on the wire the status code cannot be taken back, so a failure raised after the first line is
   reported in band with its intended status in the `error` object's `status` field. The distinction a client
   keys on (400 client input vs 408 truncation vs 500) survives; the HTTP status line does not.
@@ -186,3 +193,38 @@ Considered and left alone, with the reason:
 - Writing the response while reading the request can deadlock in principle if a client never reads. See
   **Residual risk**: the response is smaller than the request by orders of magnitude, so it cannot fill a
   socket buffer before the request drains it.
+
+## Review cycles
+
+### Cycle 1 - `11f9393113`
+
+The `claude` reviewer raised five items and blocked on none of them. All five were acted on:
+
+1. **Fully-qualified names in `PostBatchStreamingIT`** (`java.util.Map`, `java.util.ArrayDeque`,
+   `java.io.InputStream`), against CLAUDE.md's "always import the class and just use the name". Fixed:
+   imported.
+2. **The OpenAPI document declared `commitIndex` only on the `summary` line**, while the handler puts it on
+   `terminal` before the `summary`/`error` branch - so it is on both - and `RemoteDatabase.readStreamedBatch`
+   already reads it off `error`. Verified, and the reviewer is right that this matters most on a failure: a
+   batch is not atomic, so a load that failed mid-stream still committed the chunks a READ_YOUR_WRITES client
+   has to read back. `commitIndex` added to the `error` schema, and `BatchStreamingApiSpecTest` now asserts
+   both keys.
+3. **No test pinned `commitIndex` on an in-band `error` line.** Real gap, and it pinned behaviour the driver
+   depends on. `RaftBatchStreamingForwardIT.aRelayedStreamThatFailsMidLoadStillCarriesTheBookmark` fails a
+   relayed load on an unknown edge endpoint and asserts `status`, `partialCommit` and `commitIndex`.
+4. **The residual-risk write-up undersold the full-duplex hazard.** Accepted: comparing ONE progress line to
+   the whole upload was the wrong comparison, because the lines accumulate with the size of the load. The
+   javadoc, this document and the OpenAPI description now say the risk scales with load size, and **#7388** is
+   filed for bounding it. Not fixed in this PR because every candidate bound - a rate floor, a line cap, a
+   write-side watchdog - changes what a client observes and needs its own decision; the issue lays the three
+   out, including which existing tests each one would invalidate.
+5. **`BatchProgressSink#chunk` still declared `throws IOException`,** which the only implementation already
+   catches. Dropped - and the javadoc now says why it must stay dropped: not being able to throw an
+   `IOException` is what stops the next implementation from having one caught by `streamRecords` and answered
+   as a truncated request body.
+
+Deferred: none. Disagreed: none.
+
+While re-running, `RaftBatchStreamingForwardIT` failed once with a 403 because it addressed nodes by the
+`248n` literal the older HA ITs use, and the follower index happened to land on the node whose port a foreign
+server was holding. It now reads `getServer(i).getHttpServer().getPort()`, like the other new ITs.

--- a/docs/7311-http-streaming-batch-insert.md
+++ b/docs/7311-http-streaming-batch-insert.md
@@ -76,7 +76,9 @@ the old signature delegates to it. No existing test is touched.
 | Same, terminal `summary` line == the unary 200 body | yes | yes - `theSummaryLineCarriesTheSameObjectTheUnaryEncodingWouldHaveSent` |
 | Same, client-input failure after the stream started (400 body) | yes | yes - `aClientInputFailureAfterTheStreamStartedIsReportedInBand` |
 | Same, truncated upload after the stream started (408 body) | yes | yes - `aTruncatedUploadAfterTheStreamStartedIsReportedInBand` |
-| Same, failure **before** the stream started | yes (rethrown, standard status mapping) | yes - `aFailureBeforeTheStreamStartedKeepsItsRealStatusCode` |
+| Same, failure **before** the stream started, THROWN out of `streamRecords` | yes (rethrown, standard status mapping) | yes - `aFailureBeforeTheStreamStartedKeepsItsRealStatusCode` |
+| Same, failure **before** the stream started, RETURNED by `streamRecords` (400 / 408) | yes (the buffered answer is returned unchanged) | yes - `aMalformedFirstRecordKeepsItsRealStatusCode`, `aTruncatedUploadBeforeTheFirstFlushKeepsItsRealStatusCode` |
+| Engine failure raised **after** the first acknowledgement | yes - counters, `partialCommit` and `commitIndex` in band; `statusMapped:false` says the status is not the mapped one (#7396) | yes - `anEngineFailureAfterTheFirstAcknowledgementCarriesTheCountersInBand` |
 | `POST /batch` with no `Accept`, or any other type | unchanged | yes - `theUnaryEncodingIsByteIdenticalWhenTheStreamIsNotNegotiated` |
 | `Accept: application/x-ndjson;q=0` | unchanged (the q=0 rule) | yes - `PostBatchStreamingNegotiationTest` |
 | `X-ArcadeDB-Commit-Index` read-your-writes bookmark (#5862) | yes - moved in band | yes - `theCommitIndexBookmarkTravelsInTheTerminalLine` (HA), unit-covered by `commitIndexIsOmittedOnAStandaloneDatabase` |
@@ -87,6 +89,7 @@ the old signature delegates to it. No existing test is touched.
 | `RemoteDatabase` / `RemoteGraphBatch` (Java driver) | yes - `sendBatch(..., onProgress)` + `withProgressListener` | yes - `RemoteGraphBatchProgressIT` |
 | Idempotency key of the BUFFERED `/batch` encoding not covering the payload | **no** - filed as #7381 (pre-existing, found by this sweep) | n/a |
 | A streamed response has no bound, so a very large load can block the worker mid-write | **no** - filed as #7388 (raised in review) | n/a |
+| The in-band status of a post-start engine failure is the unclassified 500, not the mapped one | **no** - filed as #7396 (needs the classifier extracted from `sendMappedErrorResponse`; a second copy of that chain is the mistake its own javadoc records six bugs for) | n/a |
 | `commitIndex` on a FAILED load, relayed by a follower | yes | yes - `RaftBatchStreamingForwardIT.aRelayedStreamThatFailsMidLoadStillCarriesTheBookmark` |
 | gRPC `InsertBidirectional` control frames (`Start` / `Commit`) over HTTP | **no** - argued: needs a duplex channel, belongs to `/ws` (#7382) | n/a |
 | `/ws` streaming batch surface (`Start`/`Commit` control frames) | **no** - filed as #7382 | n/a |
@@ -231,13 +234,59 @@ could tell anyone at that point.
 Deferred: none. Disagreed: none.
 
 Other reviewers on this PR: CodeRabbit reached its free-tier review limit and produced no findings. Codacy
-reported "4 new issues (1 high ErrorProne, 3 minor CodeStyle)" against the first commit; the three CodeStyle
-ones are the fully-qualified names item 1 fixed, and the individual findings are not retrievable through the
-GitHub API or the check-run summary, only through the Codacy dashboard. The one plausible ErrorProne-high in
-this diff is `catch (final Throwable t)` in `streamRecordsAsNdJson`, which is deliberate and is the same thing
-`AbstractServerHttpHandler.handleRequest` does one class away: once bytes are on the wire nothing may escape
-without the client being told, so narrowing it would reintroduce the `UT000002` this design exists to avoid.
+reported "4 new issues (1 high ErrorProne, 3 minor CodeStyle)" and **its findings are not retrievable from
+here** - neither `gh pr view --json comments` nor the check-run summary carries them, only the Codacy
+dashboard, which the developer can open and this agent cannot.
+
+Two things are known about them rather than guessed. `.codacy.yml` excludes `**/src/test/**`, `**/*Test.java`
+and `**/*IT.java`, so all four are in the production sources of this branch, and none of them is the
+fully-qualified-name item the reviewer raised - that was in a test file. The one construct in the changed
+production code that a PMD "ErrorProne" ruleset would most plausibly rank high is `catch (final Throwable t)`
+in `streamRecordsAsNdJson`, or `NdJsonBatchResponse` being an `AutoCloseable` created outside a
+try-with-resources. Both are deliberate: catching `Throwable` is what
+`AbstractServerHttpHandler.handleRequest` does one class away, and once bytes are on the wire nothing may
+escape without the client being told; and the response cannot be a try-with-resources precisely because it must
+still be open in the `catch` that writes the in-band failure. That is a hypothesis about what the tool said,
+not a reading of it. **The developer should open the Codacy dashboard before merging** - it is the one review
+surface this branch could not read.
 
 While re-running, `RaftBatchStreamingForwardIT` failed once with a 403 because it addressed nodes by the
 `248n` literal the older HA ITs use, and the follower index happened to land on the node whose port a foreign
 server was holding. It now reads `getServer(i).getHttpServer().getPort()`, like the other new ITs.
+
+### Cycle 2 - `599ee35fd8`
+
+The reviewer's run for this commit completed without posting a comment. Nothing to act on. A close-guard
+found while re-reading `streamRecordsAsNdJson` was pushed as `229fa3df0c`.
+
+### Cycle 3 - `229fa3df0c`
+
+Two findings, and the first is the kind this branch was supposed to be proof against - the "lazy start"
+promise held for one shape of failure and not the other.
+
+1. **The promise did not cover a failure `streamRecords` REPORTS BY RETURNING.** A malformed first record, an
+   unknown temporary id, a body that ends before the first flush - all of those are caught inside
+   `streamRecords` and returned as a `400`/`408` `ExecutionResponse`, so they reach the terminal-line branch
+   rather than the `catch`. That branch called `response.open()` unconditionally, which sets 200. So the most
+   ordinary failure of all - bad input on line 1 - was answered `200` with the real status buried in the body,
+   contradicting the method's own javadoc, the coverage-table row, and the `400`/`408` the OpenAPI document
+   declares for this endpoint. Verified and fixed: when nothing has been acknowledged, the buffered answer is
+   returned unchanged and the bookmark goes back to being a header. Two tests, both confirmed to fail against
+   the unfixed branch.
+   The existing `aFailureBeforeTheStreamStartedKeepsItsRealStatusCode` did not catch it because both cases it
+   drives - a duplicated key on the first flush, an invalid `refMode` - THROW, and the throw path already
+   checked `hasStarted()`. That is the test-writing mistake, not just the code one: one shape of the failure
+   was tested and the sibling shape was assumed.
+2. **A post-start engine failure lost the counters and the bookmark.** The in-band error line was built from
+   scratch with only a message, a class and a hardcoded 500. The buffered encoding still delivers the bookmark
+   for that same failure (the `finally` in `execute` emits it even when the exception propagates), so dropping
+   it was a genuine regression against the encoding this one extends. Fixed: the counters as of the last
+   acknowledgement, `partialCommit`, and `commitIndex` now travel.
+   The hardcoded 500 is **not** fixed here, and the reason is on the record: the fine-grained mapping lives in
+   `sendMappedErrorResponse`, whose javadoc documents that hand-written mirrors of its chain produced six
+   separate bugs. A seventh mirror is worse than an honest 500, so the line now carries `statusMapped: false`
+   and names the exception class as the discriminator, and **#7396** is filed to extract the classifier so
+   there is still exactly one.
+3. **Cosmetic:** the double blank lines introduced around the new blocks are collapsed.
+
+Deferred: none. Disagreed: none.

--- a/docs/7311-http-streaming-batch-insert.md
+++ b/docs/7311-http-streaming-batch-insert.md
@@ -223,7 +223,20 @@ The `claude` reviewer raised five items and blocked on none of them. All five we
    `IOException` is what stops the next implementation from having one caught by `streamRecords` and answered
    as a truncated request body.
 
+Also hardened while re-reading the method: `response.close()` in the `finally` could itself throw on a broken
+connection, which would have replaced the answer just written - or, on the rethrow branch, the exception that
+still had a status code to be answered with. It is logged and swallowed now; there is nothing a close failure
+could tell anyone at that point.
+
 Deferred: none. Disagreed: none.
+
+Other reviewers on this PR: CodeRabbit reached its free-tier review limit and produced no findings. Codacy
+reported "4 new issues (1 high ErrorProne, 3 minor CodeStyle)" against the first commit; the three CodeStyle
+ones are the fully-qualified names item 1 fixed, and the individual findings are not retrievable through the
+GitHub API or the check-run summary, only through the Codacy dashboard. The one plausible ErrorProne-high in
+this diff is `catch (final Throwable t)` in `streamRecordsAsNdJson`, which is deliberate and is the same thing
+`AbstractServerHttpHandler.handleRequest` does one class away: once bytes are on the wire nothing may escape
+without the client being told, so narrowing it would reintroduce the `UT000002` this design exists to avoid.
 
 While re-running, `RaftBatchStreamingForwardIT` failed once with a 403 because it addressed nodes by the
 `248n` literal the older HA ITs use, and the follower index happened to land on the node whose port a foreign

--- a/docs/7311-http-streaming-batch-insert.md
+++ b/docs/7311-http-streaming-batch-insert.md
@@ -1,0 +1,188 @@
+# #7311 - HTTP has no counterpart for the gRPC client-streaming insert RPCs
+
+Split out of #7306. gRPC exposes `InsertStream`, `InsertBidirectional` and `GraphBatchLoad`;
+`POST /api/v1/batch/{database}` already reads an `application/x-ndjson` request body incrementally, so the
+*ingress* half of client-streaming exists over HTTP. What has no counterpart is the **per-chunk response**: a
+`/batch` caller learns nothing until the whole body has been consumed and the single summary object is written.
+
+## The two decisions the issue asked to settle first
+
+1. **Does the bidirectional shape belong on HTTP at all, or on `/ws`?**
+   The half of `InsertBidirectional` that carries information is `BatchAck`: the outcome of chunk *n* reaching the
+   client while chunk *n+1* is still being sent. HTTP/1.1 expresses exactly that - a server may begin its response
+   before the request body is complete - and Undertow's blocking exchange lets one worker thread read the request
+   stream and write the response stream in turn. So the *acknowledgement* half is expressible here and is what
+   this issue implements.
+   What is **not** expressible is the other half: `Start`/`Commit` control frames that let the client change the
+   shape of the session mid-stream, and a server that pushes an unsolicited message. Those need a real duplex
+   channel and stay on `/ws`, which is why OpenAPI 3.0 cannot describe them and why `/ws` is deliberately absent
+   from the generated document. This PR does not add them.
+
+2. **Is an incremental `/batch` response additive?**
+   Only if negotiated. Today's response is one JSON object; turning it into a stream unconditionally is a
+   breaking change. So it is selected with `Accept: application/x-ndjson`, exactly the way #7306 negotiated the
+   streaming query, and a request that does not ask for it receives the byte-identical body it received before.
+
+## Invariant
+
+> A `POST /api/v1/batch/{database}` that sends `Accept: application/x-ndjson` receives a newline-delimited JSON
+> body whose `progress` lines are flushed to the client while the request body is still being read, terminated
+> by exactly one `summary` or `error` line carrying the same object the unary encoding would have sent; a
+> request that does not negotiate that encoding receives the same status and the same bytes it did before.
+
+## Completeness
+
+### Every path that produces a `/batch` response
+
+```
+$ grep -n "new ExecutionResponse\|return null" server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
+212:    return null;                                    # parseRequestPayload, not a response
+221:    return new ExecutionResponse(400, ...)           # missing database parameter
+426:    return new ExecutionResponse(400, error.toString())      # client-input failure, streamRecords
+485:    return new ExecutionResponse(200, result.toString())     # success, streamRecords
+664:    return new ExecutionResponse(status, error.toString())   # partialPayloadResponse: 408 / 400 / 500
+1135..1195: forwardBatchToLeader                       # follower relay: 400/401/503 + leader's own answer
+```
+
+### Every consumer of the `Accept` negotiation added by #7306
+
+```
+$ grep -rn "isNdJsonRequested" --include="*.java" . | grep -v /target/
+server/.../GetQueryHandler.java:69     server/.../GetQueryHandler.java:160
+server/.../PostCommandHandler.java:176
+server/.../AbstractQueryHandler.java:283   (the definition)
+```
+
+`isNdJsonRequested` lived on `AbstractQueryHandler`, which `PostBatchHandler` does not extend. It is moved
+verbatim to `AbstractServerHttpHandler` (with `isRejectedByQValue`, the two `Accept` patterns and
+`X-Accel-Buffering`) so both hierarchies negotiate identically rather than through a second copy of the parser.
+
+### Callers of the forwarding builder, which must keep compiling unchanged
+
+```
+$ grep -rn "buildForwardRequest" --include="*.java" . | grep -v /target/
+server/src/test/java/.../PostBatchHandlerForwardRequestTest.java:53,66,79,95,113
+server/src/main/java/.../PostBatchHandler.java:1175,1222
+```
+
+Five existing tests pin the 6-argument signature, so the `Accept` header is added through an **overload** and
+the old signature delegates to it. No existing test is touched.
+
+### Coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| `POST /batch` on a standalone/leader node, `Accept: application/x-ndjson` | yes | yes - `PostBatchStreamingIT.progressReachesTheClientBeforeTheBodyHasBeenFullySent` |
+| Same, terminal `summary` line == the unary 200 body | yes | yes - `theSummaryLineCarriesTheSameObjectTheUnaryEncodingWouldHaveSent` |
+| Same, client-input failure after the stream started (400 body) | yes | yes - `aClientInputFailureAfterTheStreamStartedIsReportedInBand` |
+| Same, truncated upload after the stream started (408 body) | yes | yes - `aTruncatedUploadAfterTheStreamStartedIsReportedInBand` |
+| Same, failure **before** the stream started | yes (rethrown, standard status mapping) | yes - `aFailureBeforeTheStreamStartedKeepsItsRealStatusCode` |
+| `POST /batch` with no `Accept`, or any other type | unchanged | yes - `theUnaryEncodingIsByteIdenticalWhenTheStreamIsNotNegotiated` |
+| `Accept: application/x-ndjson;q=0` | unchanged (the q=0 rule) | yes - `PostBatchStreamingNegotiationTest` |
+| `X-ArcadeDB-Commit-Index` read-your-writes bookmark (#5862) | yes - moved in band | yes - `theCommitIndexBookmarkTravelsInTheTerminalLine` (HA), unit-covered by `commitIndexIsOmittedOnAStandaloneDatabase` |
+| Idempotency replay (`X-Request-Id`) handing a buffered body to a streaming caller | yes - streaming requests do not participate | yes - `AbstractServerHttpHandlerNdJsonIdempotencyTest` |
+| `POST /batch` on an HA **follower** (relayed to the leader) | yes - `Accept` forwarded, leader's stream relayed | yes - `RaftBatchStreamingForwardIT` |
+| CSV request body (`text/csv`) with `Accept: application/x-ndjson` | yes - same code path, format only affects the parser | yes - `aCsvPayloadStreamsProgressToo` |
+| OpenAPI document | yes | yes - `PostBatchStreamingOpenApiTest` |
+| `RemoteDatabase` / `RemoteGraphBatch` (Java driver) | yes - `sendBatch(..., onProgress)` + `withProgressListener` | yes - `RemoteGraphBatchProgressIT` |
+| Idempotency key of the BUFFERED `/batch` encoding not covering the payload | **no** - filed as #7381 (pre-existing, found by this sweep) | n/a |
+| gRPC `InsertBidirectional` control frames (`Start` / `Commit`) over HTTP | **no** - argued: needs a duplex channel, belongs to `/ws` (#7382) | n/a |
+| `/ws` streaming batch surface (`Start`/`Commit` control frames) | **no** - filed as #7382 | n/a |
+
+## Residual risk
+
+- A progress line is an **upper bound on what is durable**, exactly like the `verticesCreated` /
+  `edgesCreated` counters the existing 400/408 bodies carry: vertices are committed at every vertex flush, but
+  edges are buffered by `GraphBatch` and written at `close()`, so an edge-phase progress line reports records
+  *accepted*, not records committed. This is stated in the javadoc, in the OpenAPI description and in the
+  handler.
+- Writing the response while reading the request is full duplex over one socket. A client that never reads
+  its response and whose socket buffers fill would deadlock, in principle. The response is orders of magnitude
+  smaller than the request it describes (one ~200-byte line per `vertexBatchSize` records, default 10,000), so
+  the response cannot fill a socket buffer before the request drains it. No timeout was added for it.
+- Once a 200 is on the wire the status code cannot be taken back, so a failure raised after the first line is
+  reported in band with its intended status in the `error` object's `status` field. The distinction a client
+  keys on (400 client input vs 408 truncation vs 500) survives; the HTTP status line does not.
+
+## Changes
+
+| File | What |
+|---|---|
+| `server/.../AbstractServerHttpHandler.java` | `isNdJsonRequested`, `isRejectedByQValue`, the two `Accept` patterns and `X-Accel-Buffering` moved up from `AbstractQueryHandler` so both hierarchies negotiate through one parser. A request that negotiated the stream no longer takes part in the idempotency replay cache |
+| `server/.../AbstractQueryHandler.java` | the same members removed; behaviour identical, they are inherited now |
+| `server/.../NdJsonResultStream.java` | `writeEvent(kind, body, forceFlush)` and `hasStarted()`, so a second surface can use the same writer and flush discipline instead of a second copy of it |
+| `server/.../PostBatchHandler.java` | `Accept: application/x-ndjson` selects a streamed answer: `BatchProgressSink` at every commit boundary, `NdJsonBatchResponse` opening the response lazily so a failure that happens first keeps its real status, the terminal line built from the very `ExecutionResponse` the buffered encoding returns, and the follower relay passing the leader's stream through |
+| `server/.../openapi/CoreApiSpec.java` | the `Accept` parameter, the second 200 content type and the `NdJsonBatchEvent` schema |
+| `network/.../RemoteDatabase.java` | `sendBatch(content, params, onProgress)` negotiates the encoding, dispatches the `progress` lines and returns the `summary`; a failure line becomes a `DatabaseOperationException` carrying the in-band status |
+| `network/.../RemoteGraphBatch.java` | `Builder.withProgressListener(...)` |
+
+## Test results
+
+```
+PostBatchStreamingIT                    10/10   (server)
+BatchStreamingApiSpecTest                4/4    (server, unit)
+RemoteGraphBatchProgressIT               3/3    (server)
+RaftBatchStreamingForwardIT              1/1    (ha-raft, @Tag("slow"))
+NdJsonResultStreamTest                   7/7    regression
+CoreApiSpecTest                         23/23   regression
+PostBatchHandlerIT                      26/26   regression *
+Issue5470BatchErrorDeliveryIT           12/12   regression
+Issue5618BatchLineAccountingIT           6/6    regression
+RemoteGraphBatchIT                      15/15   regression
+Issue7306HttpStreamingQueryIT           18/18   regression
+Issue7306RemoteDatabaseStreamingAndVectorIT 9/9 regression
+network module (surefire)              478/478 regression
+```
+
+`*` On this developer machine a foreign ArcadeDB server (6 days old, different credentials) was listening on
+port 2480 for the whole session, which the older ITs address by hard-coded literal. Three `PostBatchHandlerIT`
+methods and both `Issue5023IdempotencyKeyReplayTest` methods answered 403/503 from that server when run
+together with others; every one of them passes when re-run on its own, and none of them touches the code this
+branch changes. The new ITs read the port the server actually bound
+(`getServer(0).getHttpServer().getPort()`) and are immune to it.
+
+### Proof the tests can fail
+
+Mutating `PostBatchHandler.execute`'s `streaming` flag to `false`: 9 of the 10 `PostBatchStreamingIT` methods
+fail, `progressReachesTheClientBeforeTheBodyHasBeenFullySent` with a read timeout - the server waiting for the
+whole body, which is the defect. The tenth,
+`theUnaryEncodingIsUnchangedWhenTheStreamIsNotNegotiated`, keeps passing, which is what it is for.
+
+Mutating the relayed `Accept` to `null`: `RaftBatchStreamingForwardIT` fails on "a follower must not answer a
+negotiated stream with the buffered encoding".
+
+## Adversarial pass
+
+The orchestrator's Phase 1.5 wants a subagent that has not been convinced by the author's reasoning. No
+subagent-spawning tool was available in this environment, so the pass was run by the author against the staged
+diff instead - which is weaker, and is recorded as such. Four findings, all fixed in this branch before the PR
+opened:
+
+1. **A failed RESPONSE write was reported as a truncated REQUEST body.** `streamRecords` catches `IOException`
+   and answers it with `truncatedBody(...)` - "only N of the M announced bytes were received", with the counts
+   a client resumes from. The progress sink writes to the response from inside that `try`, so a client that
+   stopped reading would have been told, precisely and machine-parsably, that its upload was cut short. A
+   write failure now travels as `BatchResponseWriteException`, which that catch cannot see.
+2. **`close()` on a response that opened but never wrote would have committed an empty 200.** The catch that
+   rethrows a pre-stream failure - so it keeps its real status - ran with a `finally` that closed the output
+   stream, which is what commits the response. `NdJsonBatchResponse.close()` is now a no-op until a line has
+   actually been written, and the rethrow branch says why.
+3. **The idempotency skip was keyed on the header alone.** `Accept: application/x-ndjson` on a route that
+   cannot stream - `POST /api/v1/user`, `POST /api/v1/server` - would have dropped that route's replay
+   protection while giving nothing back, since it answers the same buffered body either way. The skip is now
+   gated on `supportsNdJsonEncoding()`, which only `PostBatchHandler` and `PostCommandHandler` override.
+4. **A cross-flush edge with a progress listener was untested.** `RemoteGraphBatch` resolves an edge against a
+   vertex sent in an earlier request through the temporary-id mapping that request returned, which on this
+   encoding rides in the terminal line. A driver that read the progress lines and stopped there would drop
+   every cross-flush edge, silently.
+   `RemoteGraphBatchProgressIT.anEdgeAcrossTwoFlushesStillResolvesWithAListener` now pins it.
+
+Considered and left alone, with the reason:
+
+- `RemoteDatabase.readStreamedBatch`'s buffered fallback raises a `DatabaseOperationException` carrying the raw
+  body rather than going through `manageException`, which the negotiated-buffered path uses. It is reachable
+  only against a server too old to know the encoding, and the body is the same text `manageException` would
+  have parsed. Not worth a second code path on a compatibility branch.
+- Writing the response while reading the request can deadlock in principle if a client never reads. See
+  **Residual risk**: the response is smaller than the request by orders of magnitude, so it cannot fill a
+  socket buffer before the request drains it.

--- a/docs/7311-http-streaming-batch-insert.md
+++ b/docs/7311-http-streaming-batch-insert.md
@@ -30,6 +30,14 @@ Split out of #7306. gRPC exposes `InsertStream`, `InsertBidirectional` and `Grap
 > by exactly one `summary` or `error` line carrying the same object the unary encoding would have sent; a
 > request that does not negotiate that encoding receives the same status and the same bytes it did before.
 
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/7386
+
+Follow-ups filed while working on it: **#7381** (the buffered `/batch` idempotency key does not cover the
+payload), **#7382** (the `Start`/`Commit` control frames belong on `/ws`), **#7388** (a streamed response is
+unbounded), **#7396** (extract the error classifier so an in-band status can be exact).
+
 ## Completeness
 
 ### Every path that produces a `/batch` response
@@ -336,3 +344,34 @@ both it and the three `Issue7031RemoteClientIT` tests were confirmed to fail aga
 This is the "dual-path trap" shape: a new overload beside an existing overridable method is a second path, and
 the callers have to be moved deliberately rather than by whichever signature is most convenient at the call
 site.
+
+### Cycle 4 review - `59bf4a9659`
+
+The reviewer traced all four branches of the lazy-open state machine, confirmed the `sendBatch` delegation
+direction against what `Issue7031RemoteClientIT` needs, and closed with "nothing above blocks merging as far as
+I can tell". Three non-blocking notes, two of which were claims **this branch had written and got wrong**, so
+they were fixed rather than deferred:
+
+1. **`supportsNdJsonEncoding()`'s javadoc said "overridden by the three that stream"; only two override it.**
+   `grep -rn 'protected boolean supportsNdJsonEncoding' server/src/main` returns `PostCommandHandler`,
+   `PostBatchHandler` and the base declaration - `GetQueryHandler` streams but does not override, and does not
+   need to, because the only caller is the POST-only idempotency gate. The javadoc now says that, with the
+   command that establishes it.
+2. **`readStreamedBatch`'s buffered fallback is a second error-formatting path** next to `manageException`.
+   Kept, and now says why in the code: it is compat-only, `manageException` wants an `HttpResponse<String>`
+   this path does not have, and building one would add a conversion to a branch whose only job is to surface a
+   server too old to stream. Its message now names the HTTP status and the reason as well as the body.
+3. **No test for the #7388 backpressure scenario** (a client that never reads while uploading a large
+   payload). Correct, and deliberate: #7388 carries that scenario in its own Verification section, because the
+   test only becomes writable once a bound is chosen - every candidate bound implies a different assertion.
+
+The reviewer also asked that the Codacy dashboard be checked before merging, which the PR description already
+flags as the one review surface this branch could not read.
+
+## Final state
+
+`max-cycles-reached` - four review cycles ran, and the fourth came back non-blocking. Not `clean-approval` only
+because that fourth review still produced the two comment corrections above, which were applied without a fifth
+review. Nothing is deferred and nothing was disagreed with.
+
+**Merging is the developer's decision. This branch does not merge PRs.**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftBatchStreamingForwardIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftBatchStreamingForwardIT.java
@@ -53,6 +53,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class RaftBatchStreamingForwardIT extends BaseRaftHATest {
 
   private static final String VERTEX_TYPE = "StreamNode";
+  private static final String EDGE_TYPE   = "StreamEdge";
   private static final String NDJSON      = "application/x-ndjson";
 
   @Override
@@ -106,9 +107,52 @@ class RaftBatchStreamingForwardIT extends BaseRaftHATest {
           .isEqualTo(vertices);
   }
 
+  /**
+   * The bookmark has to travel on a FAILED load too, and that is not a detail: a batch is not atomic, so a load
+   * that failed mid-stream still committed the chunks before the failure, and a READ_YOUR_WRITES client has to
+   * be able to read exactly those back. The buffered encoding says so by emitting {@code X-ArcadeDB-Commit-Index}
+   * on its 400/408 answers (issue #5862); here it is a field of the terminal {@code error} line, which is what
+   * {@code RemoteDatabase.readStreamedBatch} reads and what the OpenAPI document declares.
+   */
+  @Test
+  void aRelayedStreamThatFailsMidLoadStillCarriesTheBookmark() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+    final int followerIndex = (leaderIndex + 1) % getServerCount();
+
+    httpCommand(leaderIndex, "CREATE VERTEX TYPE " + VERTEX_TYPE + " IF NOT EXISTS");
+    httpCommand(leaderIndex, "CREATE PROPERTY " + VERTEX_TYPE + ".node_id IF NOT EXISTS STRING");
+    httpCommand(leaderIndex, "CREATE EDGE TYPE " + EDGE_TYPE + " IF NOT EXISTS");
+    waitForAllServers();
+    waitForReplicationIsCompleted(followerIndex);
+
+    final StringBuilder body = new StringBuilder();
+    for (int i = 0; i < 6; i++)
+      body.append("{\"@type\":\"vertex\",\"@class\":\"").append(VERTEX_TYPE).append("\",\"@id\":\"f")
+          .append(i).append("\",\"node_id\":\"f").append(i).append("\"}\n");
+    // An endpoint no vertex of this payload declares: the load fails with vertices already committed, and with
+    // the 200 of the stream already on the wire.
+    body.append("{\"@type\":\"edge\",\"@class\":\"").append(EDGE_TYPE)
+        .append("\",\"@from\":\"f0\",\"@to\":\"no-such-vertex\"}\n");
+
+    final List<JSONObject> events = postStreamedBatch(followerIndex, body.toString(), "vertexBatchSize=2");
+
+    final JSONObject last = events.getLast();
+    assertThat(last.has("error")).as("expected a terminal error line, got " + last).isTrue();
+
+    final JSONObject error = last.getJSONObject("error");
+    assertThat(error.getInt("status")).isEqualTo(400);
+    assertThat(error.getBoolean("partialCommit"))
+        .as("the vertices committed before the failure are durable")
+        .isTrue();
+    assertThat(error.has("commitIndex"))
+        .as("a READ_YOUR_WRITES client must be able to read back exactly the chunks that did commit")
+        .isTrue();
+  }
+
   private List<JSONObject> postStreamedBatch(final int serverIndex, final String body, final String queryString)
       throws Exception {
-    String url = "http://127.0.0.1:248" + serverIndex + "/api/v1/batch/" + getDatabaseName();
+    String url = "http://127.0.0.1:" + httpPort(serverIndex) + "/api/v1/batch/" + getDatabaseName();
     if (queryString != null && !queryString.isEmpty())
       url += "?" + queryString;
 
@@ -146,7 +190,7 @@ class RaftBatchStreamingForwardIT extends BaseRaftHATest {
 
   private String httpCommand(final int serverIndex, final String sql) throws Exception {
     final HttpURLConnection conn = (HttpURLConnection) new URI(
-        "http://127.0.0.1:248" + serverIndex + "/api/v1/command/" + getDatabaseName())
+        "http://127.0.0.1:" + httpPort(serverIndex) + "/api/v1/command/" + getDatabaseName())
         .toURL().openConnection();
     try {
       conn.setRequestMethod("POST");
@@ -165,6 +209,16 @@ class RaftBatchStreamingForwardIT extends BaseRaftHATest {
     } finally {
       conn.disconnect();
     }
+  }
+
+  /**
+   * The port a node actually bound, never the 248n it was asked for. Anything already listening there - an
+   * IDE-left server, another agent's run - would otherwise take these requests and answer them as a different
+   * build, which surfaces as an authentication failure rather than as a port conflict, and only for whichever
+   * node the follower index happened to land on.
+   */
+  private int httpPort(final int serverIndex) {
+    return getServer(serverIndex).getHttpServer().getPort();
   }
 
   private static String basicAuth() {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftBatchStreamingForwardIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftBatchStreamingForwardIT.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7311: a batch that lands on a FOLLOWER is relayed to the leader over a second HTTP request, so the
+ * streaming encoding the client negotiated has to travel with it. Without that a client asking a follower for
+ * per-chunk acknowledgements would receive the leader's buffered object under {@code application/json} - a
+ * silent downgrade of the one thing it asked for, and a body its NDJSON reader cannot parse.
+ * <p>
+ * The read-your-writes bookmark of issue #5862 is checked on the same request: on this encoding it cannot be a
+ * response header (the response has started by the time its value is known), so the relayed answer has to carry
+ * the leader's {@code commitIndex} inside the terminal line or a READ_YOUR_WRITES client loses it at the hop.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+@Tag("slow")
+class RaftBatchStreamingForwardIT extends BaseRaftHATest {
+
+  private static final String VERTEX_TYPE = "StreamNode";
+  private static final String NDJSON      = "application/x-ndjson";
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    config.setValue(GlobalConfiguration.HA_QUORUM, "majority");
+  }
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Test
+  void aStreamedBatchPostedToAFollowerIsRelayedAsAStream() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+    final int followerIndex = (leaderIndex + 1) % getServerCount();
+
+    httpCommand(leaderIndex, "CREATE VERTEX TYPE " + VERTEX_TYPE + " IF NOT EXISTS");
+    httpCommand(leaderIndex, "CREATE PROPERTY " + VERTEX_TYPE + ".node_id IF NOT EXISTS STRING");
+    waitForAllServers();
+    waitForReplicationIsCompleted(followerIndex);
+
+    final int vertices = 40;
+    final StringBuilder body = new StringBuilder();
+    for (int i = 0; i < vertices; i++)
+      body.append("{\"@type\":\"vertex\",\"@class\":\"").append(VERTEX_TYPE).append("\",\"@id\":\"s")
+          .append(i).append("\",\"node_id\":\"s").append(i).append("\"}\n");
+
+    final List<JSONObject> events = postStreamedBatch(followerIndex, body.toString(), "vertexBatchSize=5");
+
+    assertThat(events.stream().filter(e -> e.has("progress")).count())
+        .as("the leader's chunk acknowledgements must reach the client through the follower, not be swallowed "
+            + "by it and replaced with a single object")
+        .isGreaterThan(1);
+
+    final JSONObject last = events.getLast();
+    assertThat(last.has("summary")).as("a relayed stream still ends with its terminal line, got " + last).isTrue();
+
+    final JSONObject summary = last.getJSONObject("summary");
+    assertThat(summary.getLong("verticesCreated")).isEqualTo(vertices);
+    assertThat(summary.has("commitIndex"))
+        .as("the read-your-writes bookmark travels in the terminal line on this encoding, and must survive the hop")
+        .isTrue();
+
+    assertClusterConsistency();
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(getServerDatabase(i, getDatabaseName()).countType(VERTEX_TYPE, true))
+          .as("Server %d must hold every relayed vertex", i)
+          .isEqualTo(vertices);
+  }
+
+  private List<JSONObject> postStreamedBatch(final int serverIndex, final String body, final String queryString)
+      throws Exception {
+    String url = "http://127.0.0.1:248" + serverIndex + "/api/v1/batch/" + getDatabaseName();
+    if (queryString != null && !queryString.isEmpty())
+      url += "?" + queryString;
+
+    final HttpURLConnection conn = (HttpURLConnection) new URI(url).toURL().openConnection();
+    try {
+      conn.setRequestMethod("POST");
+      conn.setRequestProperty("Authorization", basicAuth());
+      conn.setRequestProperty("Content-Type", NDJSON);
+      conn.setRequestProperty("Accept", NDJSON);
+      conn.setDoOutput(true);
+
+      final byte[] data = body.getBytes(StandardCharsets.UTF_8);
+      conn.setFixedLengthStreamingMode(data.length);
+      try (final DataOutputStream out = new DataOutputStream(conn.getOutputStream())) {
+        out.write(data);
+      }
+
+      assertThat(conn.getResponseCode()).isEqualTo(200);
+      assertThat(conn.getContentType())
+          .as("a follower must not answer a negotiated stream with the buffered encoding")
+          .contains(NDJSON);
+
+      final List<JSONObject> events = new ArrayList<>();
+      try (final BufferedReader in = new BufferedReader(
+          new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
+        for (String line = in.readLine(); line != null; line = in.readLine())
+          if (!line.isBlank())
+            events.add(new JSONObject(line));
+      }
+      return events;
+    } finally {
+      conn.disconnect();
+    }
+  }
+
+  private String httpCommand(final int serverIndex, final String sql) throws Exception {
+    final HttpURLConnection conn = (HttpURLConnection) new URI(
+        "http://127.0.0.1:248" + serverIndex + "/api/v1/command/" + getDatabaseName())
+        .toURL().openConnection();
+    try {
+      conn.setRequestMethod("POST");
+      conn.setRequestProperty("Authorization", basicAuth());
+      conn.setRequestProperty("Content-Type", "application/json");
+      conn.setDoOutput(true);
+
+      final JSONObject payload = new JSONObject();
+      payload.put("language", "sql");
+      payload.put("command", sql);
+      try (final DataOutputStream out = new DataOutputStream(conn.getOutputStream())) {
+        out.write(payload.toString().getBytes(StandardCharsets.UTF_8));
+      }
+      conn.connect();
+      return readResponse(conn);
+    } finally {
+      conn.disconnect();
+    }
+  }
+
+  private static String basicAuth() {
+    return "Basic " + Base64.getEncoder().encodeToString(
+        ("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
@@ -72,6 +72,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 import java.util.logging.Level;
 
 import static com.arcadedb.schema.Property.CAT_PROPERTY;
@@ -1254,6 +1255,24 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
   }
 
   JSONObject sendBatch(final String content, final Map<String, String> queryParams) {
+    return sendBatch(content, queryParams, null);
+  }
+
+  /**
+   * Sends one bulk-load payload to {@code POST /api/v1/batch} and returns the load's summary object.
+   * <p>
+   * With a {@code onProgress} listener the request negotiates the streaming encoding of issue #7311
+   * ({@code Accept: application/x-ndjson}) and the listener is handed every {@code progress} line as it arrives,
+   * so a caller learns what the server has committed while the rest of its payload is still being read. The
+   * object returned is the terminal {@code summary} line, which carries exactly the fields the buffered
+   * encoding returns - so nothing downstream of this method has to know which encoding was used.
+   * <p>
+   * With a {@code null} listener nothing is negotiated and the buffered request goes out exactly as before.
+   *
+   * @param onProgress notified once per chunk acknowledgement, or {@code null} to send an unnegotiated request
+   */
+  JSONObject sendBatch(final String content, final Map<String, String> queryParams,
+      final Consumer<JSONObject> onProgress) {
     checkDatabaseIsOpen();
 
     final StringBuilder urlBuilder = new StringBuilder(getUrl("batch", databaseName));
@@ -1269,10 +1288,15 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
     }
 
     try {
-      final HttpRequest request = createRequestBuilder("POST", urlBuilder.toString())
+      final HttpRequest.Builder builder = createRequestBuilder("POST", urlBuilder.toString())
           .POST(HttpRequest.BodyPublishers.ofString(content))
-          .header("Content-Type", "application/x-ndjson")
-          .build();
+          .header("Content-Type", NDJSON_CONTENT_TYPE);
+      if (onProgress != null)
+        builder.header("Accept", NDJSON_CONTENT_TYPE);
+      final HttpRequest request = builder.build();
+
+      if (onProgress != null)
+        return readStreamedBatch(httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream()), onProgress);
 
       final HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
@@ -1293,6 +1317,67 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
     } catch (final Exception e) {
       throw new DatabaseOperationException("Error on batch import", e);
     }
+  }
+
+  /**
+   * Consumes the streaming answer of a bulk load: dispatches every {@code progress} line to the listener and
+   * returns the terminal {@code summary} (issue #7311).
+   * <p>
+   * A server that answered with the buffered encoding after being asked for the stream is an older node, and is
+   * read as the single object it is rather than fed to the line reader - the same fallback check
+   * {@code query()} makes for the streaming query, and for the same reason: without it the driver would fail
+   * somewhere in the middle of a body that is perfectly valid.
+   * <p>
+   * A stream that ends with neither {@code summary} nor {@code error} did not arrive whole - a dropped
+   * connection, a proxy that cut it - and is raised as a failure rather than returned as a load with no
+   * counters, which would look to the caller exactly like a load of an empty payload.
+   */
+  private JSONObject readStreamedBatch(final HttpResponse<InputStream> response,
+      final Consumer<JSONObject> onProgress) throws IOException {
+
+    final String contentType = response.headers().firstValue("Content-Type").orElse("");
+    if (!contentType.toLowerCase(Locale.ROOT).contains(NDJSON_CONTENT_TYPE)) {
+      try (final InputStream in = response.body()) {
+        final String body = new String(in.readAllBytes(), DatabaseFactory.getDefaultCharset());
+        if (response.statusCode() != 200)
+          throw new DatabaseOperationException("Error on batch import: " + body);
+        return new JSONObject(body);
+      }
+    }
+
+    try (final BufferedReader reader = new BufferedReader(
+        new InputStreamReader(response.body(), DatabaseFactory.getDefaultCharset()))) {
+      for (String line = reader.readLine(); line != null; line = reader.readLine()) {
+        if (line.isBlank())
+          continue;
+        final JSONObject event = new JSONObject(line);
+        if (event.has("progress")) {
+          onProgress.accept(event.getJSONObject("progress"));
+          continue;
+        }
+        if (event.has("summary")) {
+          final JSONObject summary = event.getJSONObject("summary");
+          // The bookmark of issue #5862 rides in the terminal line on this encoding, because the response has
+          // already started by the time the server knows it and a header set then would be dropped in silence.
+          if (summary.has("commitIndex"))
+            updateLastCommitIndex(summary.getLong("commitIndex"));
+          return summary;
+        }
+        if (event.has("error")) {
+          final JSONObject error = event.getJSONObject("error");
+          if (error.has("commitIndex"))
+            updateLastCommitIndex(error.getLong("commitIndex"));
+          throw new DatabaseOperationException("Error on batch import (status " + error.getInt("status", 0) + "): "
+              + error.getString("error", "no message") + ". The load is not atomic: "
+              + error.getLong("verticesCreated", 0) + " vertices and " + error.getLong("edgesCreated", 0)
+              + " were attempted before it failed");
+        }
+      }
+    }
+
+    throw new DatabaseOperationException(
+        "The streamed batch answer ended without a summary or an error line, so the load did not complete and how "
+            + "much of it was committed is unknown");
   }
 
   protected ResultSet createResultSet(final JSONObject response) {

--- a/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
@@ -1370,7 +1370,8 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
           throw new DatabaseOperationException("Error on batch import (status " + error.getInt("status", 0) + "): "
               + error.getString("error", "no message") + ". The load is not atomic: "
               + error.getLong("verticesCreated", 0) + " vertices and " + error.getLong("edgesCreated", 0)
-              + " were attempted before it failed");
+              + " edges were attempted before it failed, and the chunks before the failure are durable - "
+              + "re-sending the whole payload would duplicate them");
         }
       }
     }

--- a/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
@@ -1255,48 +1255,13 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
   }
 
   JSONObject sendBatch(final String content, final Map<String, String> queryParams) {
-    return sendBatch(content, queryParams, null);
-  }
-
-  /**
-   * Sends one bulk-load payload to {@code POST /api/v1/batch} and returns the load's summary object.
-   * <p>
-   * With a {@code onProgress} listener the request negotiates the streaming encoding of issue #7311
-   * ({@code Accept: application/x-ndjson}) and the listener is handed every {@code progress} line as it arrives,
-   * so a caller learns what the server has committed while the rest of its payload is still being read. The
-   * object returned is the terminal {@code summary} line, which carries exactly the fields the buffered
-   * encoding returns - so nothing downstream of this method has to know which encoding was used.
-   * <p>
-   * With a {@code null} listener nothing is negotiated and the buffered request goes out exactly as before.
-   *
-   * @param onProgress notified once per chunk acknowledgement, or {@code null} to send an unnegotiated request
-   */
-  JSONObject sendBatch(final String content, final Map<String, String> queryParams,
-      final Consumer<JSONObject> onProgress) {
     checkDatabaseIsOpen();
 
-    final StringBuilder urlBuilder = new StringBuilder(getUrl("batch", databaseName));
-    if (queryParams != null && !queryParams.isEmpty()) {
-      urlBuilder.append('?');
-      boolean first = true;
-      for (final Map.Entry<String, String> entry : queryParams.entrySet()) {
-        if (!first)
-          urlBuilder.append('&');
-        urlBuilder.append(entry.getKey()).append('=').append(entry.getValue());
-        first = false;
-      }
-    }
-
     try {
-      final HttpRequest.Builder builder = createRequestBuilder("POST", urlBuilder.toString())
+      final HttpRequest request = createRequestBuilder("POST", batchUrl(queryParams))
           .POST(HttpRequest.BodyPublishers.ofString(content))
-          .header("Content-Type", NDJSON_CONTENT_TYPE);
-      if (onProgress != null)
-        builder.header("Accept", NDJSON_CONTENT_TYPE);
-      final HttpRequest request = builder.build();
-
-      if (onProgress != null)
-        return readStreamedBatch(httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream()), onProgress);
+          .header("Content-Type", NDJSON_CONTENT_TYPE)
+          .build();
 
       final HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
@@ -1317,6 +1282,64 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
     } catch (final Exception e) {
       throw new DatabaseOperationException("Error on batch import", e);
     }
+  }
+
+  /**
+   * Sends one bulk-load payload to {@code POST /api/v1/batch} and returns the load's summary object.
+   * <p>
+   * With a {@code onProgress} listener the request negotiates the streaming encoding of issue #7311
+   * ({@code Accept: application/x-ndjson}) and the listener is handed every {@code progress} line as it arrives,
+   * so a caller learns what the server has committed while the rest of its payload is still being read. The
+   * object returned is the terminal {@code summary} line, which carries exactly the fields the buffered
+   * encoding returns - so nothing downstream of this method has to know which encoding was used.
+   * <p>
+   * With a {@code null} listener this delegates to {@link #sendBatch(String, Map)}, so a subclass that overrode
+   * that method to intercept every flush still sees it. A subclass that wants to intercept a load WITH a
+   * listener has to override this method too - there is no third place the two paths meet.
+   *
+   * @param onProgress notified once per chunk acknowledgement, or {@code null} to send an unnegotiated request
+   */
+  JSONObject sendBatch(final String content, final Map<String, String> queryParams,
+      final Consumer<JSONObject> onProgress) {
+    // Delegates rather than duplicates, and in this direction on purpose: sendBatch(content, queryParams) is an
+    // overridable extension point that a subclass replaces to intercept every flush - Issue7031RemoteClientIT
+    // does exactly that to simulate a failed request. Routing the no-listener case through the new overload
+    // instead would have walked straight past those overrides, silently, since the compiler is perfectly happy
+    // to call the sibling method nobody overrode.
+    if (onProgress == null)
+      return sendBatch(content, queryParams);
+
+    checkDatabaseIsOpen();
+
+    try {
+      final HttpRequest request = createRequestBuilder("POST", batchUrl(queryParams))
+          .POST(HttpRequest.BodyPublishers.ofString(content))
+          .header("Content-Type", NDJSON_CONTENT_TYPE)
+          .header("Accept", NDJSON_CONTENT_TYPE)
+          .build();
+
+      return readStreamedBatch(httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream()), onProgress);
+    } catch (final DatabaseOperationException e) {
+      throw e;
+    } catch (final Exception e) {
+      throw new DatabaseOperationException("Error on batch import", e);
+    }
+  }
+
+  /** The {@code POST /api/v1/batch} URL with the caller's options rendered as its query string. */
+  private String batchUrl(final Map<String, String> queryParams) {
+    final StringBuilder urlBuilder = new StringBuilder(getUrl("batch", databaseName));
+    if (queryParams != null && !queryParams.isEmpty()) {
+      urlBuilder.append('?');
+      boolean first = true;
+      for (final Map.Entry<String, String> entry : queryParams.entrySet()) {
+        if (!first)
+          urlBuilder.append('&');
+        urlBuilder.append(entry.getKey()).append('=').append(entry.getValue());
+        first = false;
+      }
+    }
+    return urlBuilder.toString();
   }
 
   /**

--- a/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
@@ -1360,10 +1360,16 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
 
     final String contentType = response.headers().firstValue("Content-Type").orElse("");
     if (!contentType.toLowerCase(Locale.ROOT).contains(NDJSON_CONTENT_TYPE)) {
+      // Compatibility only: reachable against a server that predates issue #7311 and ignored the Accept header.
+      // Deliberately not routed through manageException, which wants an HttpResponse<String> this path does not
+      // have - and building one to reuse it would add a conversion to a branch whose only job is to surface a
+      // server too old to stream, on its way to being unreachable.
       try (final InputStream in = response.body()) {
         final String body = new String(in.readAllBytes(), DatabaseFactory.getDefaultCharset());
         if (response.statusCode() != 200)
-          throw new DatabaseOperationException("Error on batch import: " + body);
+          throw new DatabaseOperationException(
+              "Error on batch import (server did not honour the streaming encoding, HTTP " + response.statusCode()
+                  + "): " + body);
         return new JSONObject(body);
       }
     }

--- a/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * Client-side batch graph importer that buffers vertices and edges as JSONL,
@@ -71,6 +72,11 @@ public class RemoteGraphBatch implements AutoCloseable {
   private final   RemoteDatabase      database;
   private final   Map<String, String> queryParams;
   private final   int                 flushEvery;
+  /**
+   * Notified once per server-side chunk acknowledgement while a flush is still uploading, or {@code null} when
+   * the caller did not ask for progress and the flush uses the buffered request it always used (issue #7311).
+   */
+  private final   Consumer<JSONObject> progressListener;
   private final   StringBuilder       buffer;
   protected       int                 vertexCounter;
   /** Position of the first vertex of the buffer being filled, i.e. what the server has to number this payload from. */
@@ -96,6 +102,12 @@ public class RemoteGraphBatch implements AutoCloseable {
   private int    resolvedCount; // number of vertices whose RIDs have been resolved
 
   RemoteGraphBatch(final RemoteDatabase database, final Map<String, String> queryParams, final int flushEvery) {
+    this(database, queryParams, flushEvery, null);
+  }
+
+  RemoteGraphBatch(final RemoteDatabase database, final Map<String, String> queryParams, final int flushEvery,
+      final Consumer<JSONObject> progressListener) {
+    this.progressListener = progressListener;
     this.database = database;
     this.queryParams = queryParams;
     // Edges buffered in a later flush reference vertices created by an earlier one, so this client cannot work
@@ -123,6 +135,7 @@ public class RemoteGraphBatch implements AutoCloseable {
    */
   protected RemoteGraphBatch(final RemoteDatabase database) {
     this.database = database;
+    this.progressListener = null;
     this.queryParams = null;
     this.flushEvery = Integer.MAX_VALUE;
     this.buffer = null;
@@ -231,7 +244,7 @@ public class RemoteGraphBatch implements AutoCloseable {
 
     queryParams.put("ordinalBase", Integer.toString(bufferOrdinalBase));
 
-    final JSONObject response = database.sendBatch(buffer.toString(), queryParams);
+    final JSONObject response = database.sendBatch(buffer.toString(), queryParams, progressListener);
 
     totalVerticesCreated += response.getLong("verticesCreated");
     totalEdgesCreated += response.getLong("edgesCreated");
@@ -571,6 +584,7 @@ public class RemoteGraphBatch implements AutoCloseable {
     protected Boolean parallelFlush;
     protected Integer commitRetries;
     protected Long    commitRetryDelayMs;
+    protected Consumer<JSONObject> progressListener;
 
     /** Not for direct use: a builder comes from {@link RemoteDatabase#batch()}, which picks the right one for its transport. */
     protected Builder(final RemoteDatabase database) {
@@ -706,10 +720,32 @@ public class RemoteGraphBatch implements AutoCloseable {
         queryParams.put(name, value.toString());
     }
 
+    /**
+     * Asks the server to acknowledge each chunk while a flush is still being uploaded, and hands every
+     * acknowledgement to {@code listener} (issue #7311).
+     * <p>
+     * Without this the answer to a flush arrives only once the server has consumed the whole payload, so a
+     * flush of 50,000 records reports nothing for its entire duration. With it the request negotiates the
+     * streaming encoding and the listener sees a {@code progress} object - {@code phase},
+     * {@code verticesCreated}, {@code edgesCreated} and the line accounting - at every server-side commit
+     * boundary. The counters are records ATTEMPTED, the same upper bound the partial-commit counters of a
+     * failed load carry.
+     * <p>
+     * The listener runs on the thread calling {@link RemoteGraphBatch#flush()}, in line with reading the
+     * response, so anything slow in it delays the load it is reporting on.
+     * <p>
+     * A server too old to understand the encoding answers with the buffered object as it always did and the
+     * listener is simply never called; the load itself is unaffected either way.
+     */
+    public Builder withProgressListener(final Consumer<JSONObject> listener) {
+      this.progressListener = listener;
+      return this;
+    }
+
     /** Creates the {@link RemoteGraphBatch} ready for buffering vertices and edges. */
     public RemoteGraphBatch build() {
       final int effectiveFlushEvery = flushEvery == 0 ? Integer.MAX_VALUE : flushEvery;
-      return new RemoteGraphBatch(database, toQueryParams(), effectiveFlushEvery);
+      return new RemoteGraphBatch(database, toQueryParams(), effectiveFlushEvery, progressListener);
     }
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
@@ -39,14 +39,11 @@ import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.HttpServer;
 import io.undertow.server.HttpServerExchange;
-import io.undertow.util.HeaderValues;
 import io.undertow.util.Headers;
-import io.undertow.util.HttpString;
 
 import java.io.IOException;
 import java.util.*;
 import java.util.logging.Level;
-import java.util.regex.Pattern;
 
 import static com.arcadedb.schema.Property.RID_PROPERTY;
 
@@ -79,16 +76,6 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
    * the log: the leading characters are what identifies the query for an operator.
    */
   private static final int MAX_LOGGED_COMMAND_CHARS = 120;
-
-  /**
-   * Tells a buffering reverse proxy to pass the streamed bytes through instead of accumulating them, which would
-   * silently undo the encoding. Same header the SSE endpoints already set.
-   */
-  private static final HttpString X_ACCEL_BUFFERING = new HttpString("X-Accel-Buffering");
-
-  /** Precompiled rather than {@code String.split}, which recompiles the pattern on every request. */
-  private static final Pattern ACCEPT_ENTRY     = Pattern.compile(",");
-  private static final Pattern ACCEPT_PARAMETER = Pattern.compile(";");
 
   /**
    * Outcome of serializing a {@link ResultSet} into an HTTP response: how many rows reached the response and
@@ -270,55 +257,6 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
     if (limit != statedLimit && outcome.truncated())
       throw resultSetTooLarge(maxResultRows);
     return outcome;
-  }
-
-  /**
-   * True when the caller selected the streaming encoding by sending {@code Accept: application/x-ndjson}.
-   * <p>
-   * Negotiated rather than routed on purpose (issue #7306): the buffered {@code application/json} body is what
-   * every existing client - the Studio webapp included - parses, so streaming had to be reachable without
-   * changing what a request that does not ask for it receives. A caller that sends no {@code Accept}, or one
-   * that names any other type, gets exactly the response it got before.
-   */
-  protected static boolean isNdJsonRequested(final HttpServerExchange exchange) {
-    final HeaderValues accept = exchange.getRequestHeaders().get(Headers.ACCEPT);
-    if (accept == null)
-      return false;
-    for (final String header : accept) {
-      if (header == null)
-        continue;
-      // One Accept header can list several types, each with its own parameters. Splitting them matters for
-      // 'q': 'application/json, application/x-ndjson;q=0' is the standard spelling of "anything but that one",
-      // and a bare contains() over the whole header would read it as a request for the stream.
-      for (final String entry : ACCEPT_ENTRY.split(header)) {
-        final String[] parts = ACCEPT_PARAMETER.split(entry.trim());
-        if (parts[0].trim().equalsIgnoreCase(NdJsonResultStream.CONTENT_TYPE))
-          return !isRejectedByQValue(parts);
-      }
-    }
-    return false;
-  }
-
-  /**
-   * True when an {@code Accept} entry carries {@code q=0}, which RFC 9110 defines as "not acceptable" rather
-   * than as a weak preference. An unparseable q is treated as absent, the same as any other malformed
-   * parameter: the type was still named.
-   */
-  private static boolean isRejectedByQValue(final String[] parts) {
-    for (int i = 1; i < parts.length; i++) {
-      final String parameter = parts[i].trim();
-      if (!parameter.regionMatches(true, 0, "q=", 0, 2))
-        continue;
-      try {
-        // Compared with a tolerance rather than against 0 exactly: q is a decimal with at most three digits,
-        // so anything this small is the "not acceptable" the sender meant, and an exact float comparison on a
-        // parsed decimal is the kind of thing that works until it does not.
-        return Double.parseDouble(parameter.substring(2).trim()) < 0.0001d;
-      } catch (final NumberFormatException ignored) {
-        return false;
-      }
-    }
-    return false;
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -1391,10 +1391,15 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
 
   /**
    * Whether this handler can answer in the {@code application/x-ndjson} streaming encoding when the caller
-   * negotiates it. False for every route that always writes the same buffered body; overridden by the three
-   * that stream - the query handlers of issue #7306 and {@link PostBatchHandler} of issue #7311.
+   * negotiates it. False for every route that always writes the same buffered body.
    * <p>
-   * It exists for the idempotency gate above: whether a streamed answer can be replayed from the cache is a
+   * Overridden by {@code PostCommandHandler} (issue #7306) and {@link PostBatchHandler} (issue #7311) - and by
+   * those two only, verified with
+   * {@code grep -rn 'protected boolean supportsNdJsonEncoding' server/src/main}. {@code GetQueryHandler}
+   * streams as well but does not override it, and does not need to: the only caller is the idempotency gate,
+   * which applies to POST requests alone.
+   * <p>
+   * That gate is the whole reason this exists: whether a streamed answer can be replayed from the cache is a
    * property of the handler, and reading it off the request header alone would change the behaviour of routes
    * that do not stream at all.
    */

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -71,6 +71,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
 import java.util.logging.Level;
 
 public abstract class AbstractServerHttpHandler implements HttpHandler {
@@ -500,7 +501,19 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
       final String rawRequestId = exchange.getRequestHeaders().getFirst(IdempotencyCache.HEADER_REQUEST_ID);
       final boolean idempotentPost = "POST".equalsIgnoreCase(exchange.getRequestMethod().toString())
           && rawRequestId != null && !rawRequestId.isBlank()
-          && exchange.getRequestHeaders().getFirst(SESSION_ID_HEADER) == null;
+          && exchange.getRequestHeaders().getFirst(SESSION_ID_HEADER) == null
+          // A request that negotiated the streaming encoding stays out of the replay cache entirely. The cache
+          // key is built from method, path, database and body - never from the Accept header - so a hit
+          // recorded by an earlier buffered request would be replayed to this caller as one application/json
+          // object, which is not the encoding it asked for and not a shape its NDJSON reader can parse. It
+          // could not populate the cache either: a streamed handler writes its own response and returns null,
+          // which aborts the reservation. Not reserving says that outright instead of leaving it implicit
+          // (issue #7311).
+          //
+          // Gated on the handler, not on the header alone: a route that cannot stream answers the same body
+          // whatever Accept says, so dropping ITS replay protection because a client sent a header it ignores
+          // would take away a guarantee and give nothing back.
+          && !(supportsNdJsonEncoding() && isNdJsonRequested(exchange));
 
       if (idempotentPost) {
         // Bind the key to method/path/database/body so a reused correlation id cannot replay a different
@@ -1240,6 +1253,69 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     return ServerControlPlane.filterAuthorizedDatabases(user, databaseNames);
   }
 
+
+  /**
+   * Tells a buffering reverse proxy to pass the streamed bytes through instead of accumulating them, which would
+   * silently undo the encoding. Same header the SSE endpoints already set.
+   */
+  protected static final HttpString X_ACCEL_BUFFERING = new HttpString("X-Accel-Buffering");
+
+  /** Precompiled rather than {@code String.split}, which recompiles the pattern on every request. */
+  private static final Pattern ACCEPT_ENTRY     = Pattern.compile(",");
+  private static final Pattern ACCEPT_PARAMETER = Pattern.compile(";");
+
+  /**
+   * True when the caller selected the streaming encoding by sending {@code Accept: application/x-ndjson}.
+   * <p>
+   * Negotiated rather than routed on purpose (issue #7306): the buffered {@code application/json} body is what
+   * every existing client - the Studio webapp included - parses, so streaming had to be reachable without
+   * changing what a request that does not ask for it receives. A caller that sends no {@code Accept}, or one
+   * that names any other type, gets exactly the response it got before.
+   * <p>
+   * Lives here rather than on {@code AbstractQueryHandler}, where #7306 first wrote it, because
+   * {@link PostBatchHandler} negotiates the same encoding for its streaming insert response (issue #7311) and
+   * does not extend that hierarchy. One parser, so the two surfaces cannot drift on what {@code q=0} means.
+   */
+  protected static boolean isNdJsonRequested(final HttpServerExchange exchange) {
+    final HeaderValues accept = exchange.getRequestHeaders().get(Headers.ACCEPT);
+    if (accept == null)
+      return false;
+    for (final String header : accept) {
+      if (header == null)
+        continue;
+      // One Accept header can list several types, each with its own parameters. Splitting them matters for
+      // 'q': 'application/json, application/x-ndjson;q=0' is the standard spelling of "anything but that one",
+      // and a bare contains() over the whole header would read it as a request for the stream.
+      for (final String entry : ACCEPT_ENTRY.split(header)) {
+        final String[] parts = ACCEPT_PARAMETER.split(entry.trim());
+        if (parts[0].trim().equalsIgnoreCase(NdJsonResultStream.CONTENT_TYPE))
+          return !isRejectedByQValue(parts);
+      }
+    }
+    return false;
+  }
+
+  /**
+   * True when an {@code Accept} entry carries {@code q=0}, which RFC 9110 defines as "not acceptable" rather
+   * than as a weak preference. An unparseable q is treated as absent, the same as any other malformed
+   * parameter: the type was still named.
+   */
+  private static boolean isRejectedByQValue(final String[] parts) {
+    for (int i = 1; i < parts.length; i++) {
+      final String parameter = parts[i].trim();
+      if (!parameter.regionMatches(true, 0, "q=", 0, 2))
+        continue;
+      try {
+        // Compared with a tolerance rather than against 0 exactly: q is a decimal with at most three digits,
+        // so anything this small is the "not acceptable" the sender meant, and an exact float comparison on a
+        // parsed decimal is the kind of thing that works until it does not.
+        return Double.parseDouble(parameter.substring(2).trim()) < 0.0001d;
+      } catch (final NumberFormatException ignored) {
+        return false;
+      }
+    }
+    return false;
+  }
   /**
    * Resolves the {@link HAReplicatedDatabase} backing {@code database}, either directly or through
    * {@link DatabaseInternal#getWrappedDatabaseInstance()}, or {@code null} on a standalone (non-HA)
@@ -1311,6 +1387,19 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
    */
   protected boolean mustExecuteOnWorkerThread(final HttpServerExchange exchange) {
     return mustExecuteOnWorkerThread();
+  }
+
+  /**
+   * Whether this handler can answer in the {@code application/x-ndjson} streaming encoding when the caller
+   * negotiates it. False for every route that always writes the same buffered body; overridden by the three
+   * that stream - the query handlers of issue #7306 and {@link PostBatchHandler} of issue #7311.
+   * <p>
+   * It exists for the idempotency gate above: whether a streamed answer can be replayed from the cache is a
+   * property of the handler, and reading it off the request header alone would change the behaviour of routes
+   * that do not stream at all.
+   */
+  protected boolean supportsNdJsonEncoding() {
+    return false;
   }
 
   protected boolean requiresJsonPayload() {

--- a/server/src/main/java/com/arcadedb/server/http/handler/NdJsonResultStream.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/NdJsonResultStream.java
@@ -25,8 +25,8 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
 /**
- * Writes a query result to a client as newline-delimited JSON, one line per event, without ever holding more
- * than one row in memory (issue #7306).
+ * Writes a response to a client as newline-delimited JSON, one line per event, without ever holding more
+ * than one event in memory (issue #7306).
  * <p>
  * <b>Wire format.</b> Every line is a JSON object carrying exactly one key, which names the kind of event:
  * <ul>
@@ -48,7 +48,11 @@ import java.nio.charset.StandardCharsets;
  * latency on a slow one, instead of trading one away for the other. The trailer and the error line always
  * flush.
  * <p>
- * Not thread-safe, and does not need to be: one query is serialized by the one worker thread serving it.
+ * <b>Other event kinds.</b> {@link #writeEvent} takes the envelope key, so a second surface can define its own
+ * vocabulary on the same discipline instead of a second writer. {@code POST /api/v1/batch} does, with
+ * {@code progress} / {@code summary} / {@code error} (issue #7311).
+ * <p>
+ * Not thread-safe, and does not need to be: one request is serialized by the one worker thread serving it.
  */
 public final class NdJsonResultStream implements AutoCloseable {
   /**
@@ -110,6 +114,25 @@ public final class NdJsonResultStream implements AutoCloseable {
    */
   public void writeError(final String message) throws IOException {
     writeLine(new JSONObject().put("error", new JSONObject().put("message", message)), true);
+  }
+
+  /**
+   * Emits one event under an arbitrary envelope key, for a surface whose vocabulary is not the query one. The
+   * caller decides whether the line is flushed at once: an event a consumer is waiting on - a batch progress
+   * line, a trailer - has to be, while a high-rate event leaves the decision to the size/interval policy above.
+   */
+  public void writeEvent(final String kind, final JSONObject body, final boolean forceFlush) throws IOException {
+    writeLine(new JSONObject().put(kind, body), forceFlush);
+  }
+
+  /**
+   * Whether anything has been written yet, which for this stream means whether the response has been committed:
+   * the first line is always flushed. A caller that has written nothing can still let an exception travel to the
+   * standard error mapping and receive a real status code, instead of reporting it in band under a 200 that was
+   * never sent (issue #7311).
+   */
+  public boolean hasStarted() {
+    return started;
   }
 
   private void writeLine(final JSONObject event, final boolean forceFlush) throws IOException {

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
@@ -40,19 +40,25 @@ import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.ServerConnection;
 import io.undertow.util.HeaderValues;
+import io.undertow.util.Headers;
 import io.undertow.util.HttpString;
 import org.xnio.Options;
 
+import java.io.BufferedReader;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.logging.Level;
@@ -83,6 +89,28 @@ import java.util.logging.Level;
  * Response: {@code verticesCreated}, {@code edgesCreated}, {@code elapsedMs}, {@code bytesRead} and, when temporary
  * ids were used, {@code idMapping} - replaced by {@code idMappingOmitted} / {@code idMappingSize} past
  * {@link #MAX_ID_MAPPING_IN_RESPONSE} entries, unless {@code idMapping=true} demands it.
+ * <p>
+ * Streaming response ({@code Accept: application/x-ndjson}): the answer above is a single object written after the
+ * whole body has been consumed, so a caller learns nothing about chunk <i>n</i> until chunk <i>n+1</i> and every
+ * chunk after it has been sent. That is the one half of the gRPC {@code InsertBidirectional} shape HTTP had no
+ * counterpart for (issue #7311). A caller that sends {@code Accept: application/x-ndjson} instead receives a
+ * newline-delimited stream, written while its own upload is still being read:
+ * <ul>
+ * <li>{@code {"progress": {...}}} - emitted at every vertex commit and every {@code commitEvery} edges, carrying
+ *     the same counters the final answer carries, plus {@code phase} ({@code vertices} or {@code edges});</li>
+ * <li>{@code {"summary": {...}}} - the last line of a successful load. Byte-for-byte the object the buffered
+ *     encoding would have sent, produced by the same code, plus {@code commitIndex} on a replicated database;</li>
+ * <li>{@code {"error": {...}}} - the last line of a failed one: the object the buffered encoding would have sent,
+ *     plus the {@code status} it would have sent it under. A 200 is already on the wire by then and cannot be
+ *     taken back, so the status travels in band and the line is the only terminator a consumer gets - a stream
+ *     that ends with neither {@code summary} nor {@code error} did not arrive whole.</li>
+ * </ul>
+ * A progress line is an upper bound on what is durable, exactly like the partial-commit counters below: vertices
+ * are committed at each flush, but {@code GraphBatch} buffers edges and writes them at close, so an edge-phase
+ * line counts records ACCEPTED. A request that does not negotiate the encoding - no {@code Accept}, another type,
+ * or {@code application/x-ndjson;q=0} - receives the same bytes under the same status as before. The
+ * {@code X-ArcadeDB-Commit-Index} bookmark (issue #5862) cannot be a header on this encoding because the response
+ * has already started when the value becomes known, so it is carried inside the terminal line instead.
  * <p>
  * Line accounting: every answer, successful or not, also carries {@code linesRead} and {@code linesSkipped} (blank
  * lines, plus CSV headers and {@code ---} separators), so {@code linesRead - linesSkipped} is the number of records
@@ -162,6 +190,10 @@ import java.util.logging.Level;
 public class PostBatchHandler extends AbstractServerHttpHandler {
 
   private static final int        VERTEX_BATCH_SIZE     = 10_000;
+  /** Value of the {@code phase} field of a progress line while vertices are being committed. */
+  private static final String     VERTEX_PHASE          = "vertices";
+  /** Value of the {@code phase} field of a progress line while edges are being accepted. */
+  private static final String     EDGE_PHASE            = "edges";
   /**
    * Above this many temporary ids the mapping is not echoed back. The response would otherwise hold a second full
    * copy of the map, as JSON, in one string: a bulk load of millions of vertices turns the last step of a successful
@@ -204,6 +236,11 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
   }
 
   @Override
+  protected boolean supportsNdJsonEncoding() {
+    return true;
+  }
+
+  @Override
   protected String parseRequestPayload(final HttpServerExchange e) {
     // Do NOT load full body. We'll stream from the InputStream in execute().
     // Just ensure blocking mode is started.
@@ -233,6 +270,10 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
         ? contentTypeHeader.getFirst().toLowerCase()
         : "application/x-ndjson";
 
+    // Response encoding, negotiated exactly the way #7306 negotiated the streaming query. Read before any work
+    // starts because it decides how EVERY answer below is written, the leader-forwarding one included.
+    final boolean streaming = isNdJsonRequested(exchange);
+
     // Start streaming input. The stream must be created BEFORE relaxing the connection watchdog below:
     // UndertowInputStream captures the read timeout in effect at construction time and uses it to bound
     // every blocking read, so a client that stops sending is still cut off after
@@ -253,7 +294,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
       // the user thread (issue #4122).
       final HAServerPlugin ha = httpServer.getServer().getHA();
       if (ha != null && !ha.isLeader())
-        return forwardBatchToLeader(exchange, ha, databaseName, user, contentType, inputStream);
+        return forwardBatchToLeader(exchange, ha, databaseName, user, contentType, inputStream, streaming);
 
       final DatabaseInternal database = httpServer.getServer().getDatabase(databaseName, false, false);
       final boolean isCsv = contentType.contains("text/csv");
@@ -267,9 +308,21 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
       // (408/400): whatever chunk got through is already durable, and a client must be able to read it
       // back regardless of how the request itself was answered (issue #5862).
       final HAReplicatedDatabase haDb = resolveHAReplicatedDatabase(database);
+
+      // Every query parameter is parsed BEFORE the streaming encoding writes anything, so a request that names
+      // an invalid refMode or a negative vertexBatchSize is still refused with the 400 the buffered encoding
+      // gives it. Once a line is on the wire the status code can no longer be chosen (issue #7311).
+      final VertexRefResolver vertexRefs = newVertexRefResolver(exchange);
+      final int vertexBatchSize = parseVertexBatchSize(exchange);
+      final long expectedRecords = parseExpectedRecords(exchange);
+
+      if (streaming)
+        return streamRecordsAsNdJson(exchange, databaseName, isCsv, builder, inputStream, vertexRefs,
+            vertexBatchSize, expectedRecords, haDb);
+
       try {
-        return streamRecords(exchange, databaseName, isCsv, builder, inputStream, newVertexRefResolver(exchange),
-            System.currentTimeMillis(), parseVertexBatchSize(exchange), parseExpectedRecords(exchange));
+        return streamRecords(exchange, databaseName, isCsv, builder, inputStream, vertexRefs,
+            System.currentTimeMillis(), vertexBatchSize, expectedRecords, BatchProgressSink.NONE);
       } finally {
         emitCommitIndexBookmark(exchange, haDb);
       }
@@ -281,11 +334,17 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
   /**
    * Consumes the streaming request body and feeds it to a {@link GraphBatch}. Extracted from
    * {@link #execute} so the caller can restore the connection read timeout in a {@code finally} block.
+   *
+   * @param progress notified at every commit boundary, so the NDJSON encoding can acknowledge a chunk while the
+   *                 client is still uploading the next one (issue #7311).
+   *                 {@link BatchProgressSink#NONE} on the buffered encoding, which is what keeps that answer
+   *                 byte-identical: the same code produces it, and nothing else in this method knows the
+   *                 difference
    */
   private ExecutionResponse streamRecords(final HttpServerExchange exchange, final String databaseName,
       final boolean isCsv, final GraphBatch.Builder builder, final CountingInputStream inputStream,
       final VertexRefResolver vertexRefs, final long startTime, final int vertexBatchSize,
-      final long expectedRecords) throws Exception {
+      final long expectedRecords, final BatchProgressSink progress) throws Exception {
 
     long verticesCreated = 0;
     long edgesCreated = 0;
@@ -327,6 +386,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
           if (!vertexPropsBatch.isEmpty()) {
             verticesCreated += flushVertexBatch(batch, currentTypeName, vertexPropsBatch, vertexTempIds, vertexRefs,
                 verticesCreated);
+            progress.chunk(VERTEX_PHASE, verticesCreated, edgesCreated, stream, vertexRefs, inputStream);
           }
 
           // Process this first edge record
@@ -343,6 +403,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
         if (currentTypeName != null && !currentTypeName.equals(rec.typeName)) {
           verticesCreated += flushVertexBatch(batch, currentTypeName, vertexPropsBatch, vertexTempIds, vertexRefs,
               verticesCreated);
+          progress.chunk(VERTEX_PHASE, verticesCreated, edgesCreated, stream, vertexRefs, inputStream);
         }
         currentTypeName = rec.typeName;
         vertexPropsBatch.add(rec.copyProperties());
@@ -351,13 +412,25 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
         if (vertexPropsBatch.size() >= vertexBatchSize) {
           verticesCreated += flushVertexBatch(batch, currentTypeName, vertexPropsBatch, vertexTempIds, vertexRefs,
               verticesCreated);
+          progress.chunk(VERTEX_PHASE, verticesCreated, edgesCreated, stream, vertexRefs, inputStream);
         }
       }
 
       // Flush remaining vertices (e.g., vertex-only import or last batch before EOF)
-      if (!vertexPropsBatch.isEmpty())
+      if (!vertexPropsBatch.isEmpty()) {
         verticesCreated += flushVertexBatch(batch, currentTypeName, vertexPropsBatch, vertexTempIds, vertexRefs,
             verticesCreated);
+        progress.chunk(VERTEX_PHASE, verticesCreated, edgesCreated, stream, vertexRefs, inputStream);
+      }
+
+      // Edge-phase cadence for the progress stream. commitEvery is what GraphBatch writes per transaction during
+      // an edge flush, so it is the closest thing the edge phase has to the vertex phase's commit boundary; when
+      // it is 0 the whole flush commits at once and there is no boundary at all, so the vertex cadence is reused
+      // rather than emitting nothing for the entire edge phase (issue #7311).
+      final int progressEveryEdges = batch.getCommitEvery() > 0 ? batch.getCommitEvery() : vertexBatchSize;
+      // Seeded with the edge the vertex loop already consumed on its way out, so the first cadence window is a
+      // full one rather than one record short.
+      long edgesSinceProgress = edgesCreated;
 
       // Phase 2: Remaining edges
       while (stream.hasNext()) {
@@ -367,6 +440,10 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
               + ". All vertices must appear before edges");
         processEdge(batch, rec, vertexRefs, stream.getLineNumber());
         edgesCreated++;
+        if (++edgesSinceProgress >= progressEveryEdges) {
+          progress.chunk(EDGE_PHASE, verticesCreated, edgesCreated, stream, vertexRefs, inputStream);
+          edgesSinceProgress = 0;
+        }
       }
 
       // batch.close() is called by try-with-resources: flushes edges, connects incoming edges
@@ -483,6 +560,183 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     }
 
     return new ExecutionResponse(200, result.toString());
+  }
+
+
+  /**
+   * Notified at every commit boundary of a load, so a response encoding that can say something before the end
+   * of the request has something to say (issue #7311). {@link #NONE} on the buffered encoding, which is how the
+   * answer that encoding produces stays byte-identical: one code path, one set of counters, and the only
+   * difference is whether anybody is listening.
+   */
+  @FunctionalInterface
+  interface BatchProgressSink {
+    /** Ignores every boundary. The buffered encoding, and every path that predates the streaming one. */
+    BatchProgressSink NONE = (phase, verticesCreated, edgesCreated, stream, vertexRefs, inputStream) -> {
+    };
+
+    void chunk(String phase, long verticesCreated, long edgesCreated, BatchRecordStream stream,
+        VertexRefResolver vertexRefs, CountingInputStream inputStream) throws IOException;
+  }
+
+  /**
+   * Runs a load and answers it as newline-delimited JSON, writing progress lines to the client while its upload
+   * is still being read - the acknowledgement half of the gRPC {@code InsertBidirectional} shape, which HTTP had
+   * no counterpart for (issue #7311).
+   * <p>
+   * The load itself is {@link #streamRecords}, unchanged and shared with the buffered encoding: it still returns
+   * the one {@link ExecutionResponse} it always returned, and this method turns that into the terminal line
+   * rather than into a status line and a body. So the two encodings cannot disagree about what a load did - the
+   * object is produced once, by the same code, and only the envelope around it differs.
+   * <p>
+   * <b>Why the response is started lazily.</b> Nothing is written until the first progress line, so a load that
+   * fails before it commits anything - an engine error on the very first flush, a security failure, a
+   * {@code DuplicatedKeyException} - still travels to {@link AbstractServerHttpHandler}'s error mapping and is
+   * answered with the status that mapping chose. Only once a line is on the wire is the status unrecoverable,
+   * and only then is a failure reported in band. That is the difference between a client seeing 409 "do not
+   * retry" and seeing a 200 whose body it has to parse to discover the same thing.
+   * <p>
+   * <b>Full duplex on one socket.</b> This writes the response while {@link #streamRecords} reads the request.
+   * HTTP/1.1 permits it and Undertow's blocking exchange supports it, but it does mean a client that never
+   * reads could in principle fill its receive buffer and deadlock against a server that is not reading either.
+   * It cannot happen at these volumes: one ~200-byte line per {@code vertexBatchSize} records (10,000 by
+   * default) against a request body measured in megabytes, so the response drains many orders of magnitude
+   * faster than it is produced.
+   *
+   * @return always {@code null} - the response is written here, which {@link AbstractServerHttpHandler#handleRequest}
+   *         reads as "the handler sent it itself", the same contract the SSE paths use
+   */
+  private ExecutionResponse streamRecordsAsNdJson(final HttpServerExchange exchange, final String databaseName,
+      final boolean isCsv, final GraphBatch.Builder builder, final CountingInputStream inputStream,
+      final VertexRefResolver vertexRefs, final int vertexBatchSize, final long expectedRecords,
+      final HAReplicatedDatabase haDb) throws Exception {
+
+    final NdJsonBatchResponse response = new NdJsonBatchResponse(exchange);
+    try {
+      final ExecutionResponse unary = streamRecords(exchange, databaseName, isCsv, builder, inputStream, vertexRefs,
+          System.currentTimeMillis(), vertexBatchSize, expectedRecords,
+          (phase, verticesCreated, edgesCreated, stream, refs, in) -> {
+            final JSONObject event = new JSONObject();
+            event.put("phase", phase);
+            event.put("verticesCreated", verticesCreated);
+            event.put("edgesCreated", edgesCreated);
+            addLineAccounting(event, stream, refs, in);
+            try {
+              // Forced, unlike a query row: a progress line exists to be read now, and there are few enough of
+              // them that the syscall the size/interval policy is there to save does not matter here.
+              response.open().writeEvent("progress", event, true);
+            } catch (final IOException e) {
+              // NOT allowed to surface as an IOException. streamRecords catches that and answers "the request
+              // body was truncated" with the counts to resume from, which would be a precise, machine-parsable
+              // and completely wrong diagnosis: the body arrived, it is the RESPONSE that could not be written.
+              throw new BatchResponseWriteException(e);
+            }
+          });
+
+      final JSONObject terminal = new JSONObject(unary.getResponse());
+      // The bookmark of issue #5862 cannot be a header on this encoding: by the time the commit index is known
+      // the response has usually started, and a header set then is dropped without a word. It carries the same
+      // meaning in band, on the same line as the counters a READ_YOUR_WRITES client is reconciling against.
+      if (haDb != null) {
+        final long lastApplied = haDb.getLastAppliedIndex();
+        if (lastApplied >= 0)
+          terminal.put("commitIndex", lastApplied);
+      }
+
+      if (unary.getCode() == 200)
+        response.open().writeEvent("summary", terminal, true);
+      else
+        // The status the buffered encoding would have sent, in band because a 200 is already on the wire. Every
+        // other field is what that encoding would have carried, so a client applies one piece of logic to both.
+        response.open().writeEvent("error", terminal.put("status", unary.getCode()), true);
+    } catch (final Throwable t) {
+      if (!response.hasStarted())
+        // Nothing has been sent: the exception can still be answered with a real status code, so let the
+        // standard mapping in AbstractServerHttpHandler do exactly what it does for the buffered encoding.
+        // response.close() below is a no-op in that state, deliberately - closing the output stream would
+        // commit the very 200 this branch exists to avoid sending.
+        throw t;
+
+      final Throwable reported = t instanceof BatchResponseWriteException ? t.getCause() : t;
+      LogManager.instance().log(this, Level.WARNING,
+          "Streaming batch load on database '%s' failed after the response had already started", reported,
+          databaseName);
+      try {
+        response.open().writeEvent("error", new JSONObject()
+            .put("error", reported.getMessage() != null ? reported.getMessage() : reported.toString())
+            .put("exception", reported.getClass().getName())
+            .put("status", 500), true);
+      } catch (final IOException writeFailed) {
+        // The connection that could not carry the load cannot carry the explanation either. Nothing is left to
+        // tell the client with; the stream simply ends without a terminal line, which is exactly how a consumer
+        // recognises an answer that did not arrive whole.
+        LogManager.instance().log(this, Level.FINE,
+            "Could not write the in-band failure of a streaming batch load on database '%s': %s", null, databaseName,
+            writeFailed.getMessage());
+      }
+    } finally {
+      response.close();
+    }
+    return null;
+  }
+
+  /**
+   * A failure writing the streamed RESPONSE, kept distinct from a failure reading the request body. Unchecked and
+   * of its own type on purpose: {@link #streamRecords} catches {@link IOException} and answers it as a truncated
+   * upload, with the counts a client needs to resume from - a diagnosis that would be precise, machine-parsable
+   * and about the wrong end of the connection.
+   */
+  private static final class BatchResponseWriteException extends RuntimeException {
+    private BatchResponseWriteException(final IOException cause) {
+      super(cause);
+    }
+  }
+
+  /**
+   * The NDJSON response of a batch load, which does not exist until it has something to say.
+   * <p>
+   * Undertow commits the status line and headers on the first flushed byte, so deferring the whole set-up until
+   * the first line is what keeps the standard error mapping available to a load that fails before it produces
+   * one. {@link #close()} is a no-op on a response that never opened, for the same reason: closing the output
+   * stream would send the 200 this class exists to avoid sending prematurely.
+   */
+  private static final class NdJsonBatchResponse implements AutoCloseable {
+    private final HttpServerExchange   exchange;
+    private       NdJsonResultStream   stream;
+
+    private NdJsonBatchResponse(final HttpServerExchange exchange) {
+      this.exchange = exchange;
+    }
+
+    private NdJsonResultStream open() {
+      if (stream == null) {
+        exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, NdJsonResultStream.CONTENT_TYPE);
+        // A buffering reverse proxy would accumulate the stream and defeat the encoding without saying so. Same
+        // pair of headers the streaming query and the SSE endpoints set.
+        exchange.getResponseHeaders().put(Headers.CACHE_CONTROL, "no-cache");
+        exchange.getResponseHeaders().put(X_ACCEL_BUFFERING, "no");
+        exchange.setStatusCode(200);
+        if (!exchange.isBlocking())
+          exchange.startBlocking();
+        stream = new NdJsonResultStream(exchange.getOutputStream());
+      }
+      return stream;
+    }
+
+    private boolean hasStarted() {
+      return stream != null && stream.hasStarted();
+    }
+
+    /**
+     * Ends the response, and only a response that exists. Closing the output stream of a load that opened this
+     * and then failed before writing anything would commit an empty 200 and take away the status code that
+     * failure was still entitled to.
+     */
+    @Override
+    public void close() throws IOException {
+      if (hasStarted())
+        stream.close();
+    }
   }
 
   /**
@@ -1114,10 +1368,19 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
    * a follower: the bulk-load path mutates shared state (schema dictionary, type metadata)
    * that only the leader can safely serialize. Mirrors the engine-level forwarding already used
    * by {@code RaftReplicatedDatabase.command()} for SQL writes.
+   * <p>
+   * The negotiated encoding travels with the payload (issue #7311). Without it a client that asked a follower
+   * for the streaming answer would be handed the leader's buffered one under an {@code application/json}
+   * content type - a silent downgrade of the very thing it negotiated, and a body its NDJSON reader cannot
+   * parse. With it the leader streams, and {@link #relayNdJsonFromLeader} passes those lines straight through
+   * as they arrive, so the acknowledgements keep reaching the client while the follower is still relaying the
+   * upload.
+   *
+   * @param streaming whether the client negotiated {@code Accept: application/x-ndjson}
    */
   private ExecutionResponse forwardBatchToLeader(final HttpServerExchange exchange, final HAServerPlugin ha,
       final String databaseName, final ServerSecurityUser user, final String contentType,
-      final CountingInputStream body) throws Exception {
+      final CountingInputStream body, final boolean streaming) throws Exception {
 
     // A peer already relayed this load to what it believed was the leader and it landed here, on a node that
     // is not the leader either. Relaying it on would send it round the cycle that wrong address created, one
@@ -1173,9 +1436,16 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     // The body travels through the same guarded stream the leader-side load would use, so a cut upload cannot
     // relay a replay of its own bytes on to the leader either (issue #6180).
     final HttpRequest request = buildForwardRequest(url, contentType, clusterToken, user.getName(),
-        exchange.getRequestContentLength(), body);
+        exchange.getRequestContentLength(), body, streaming ? NdJsonResultStream.CONTENT_TYPE : null);
 
     try {
+      if (streaming)
+        // send() returns as soon as the leader's response HEADERS arrive, which on the streaming encoding is at
+        // the leader's first progress line - while the JDK client's own executor thread is still publishing the
+        // relayed upload. That is what keeps the acknowledgements incremental across the hop.
+        return relayNdJsonFromLeader(exchange, databaseName,
+            HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofInputStream()));
+
       final HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
 
       // ExecutionResponse carries only status + body, so the leader's X-ArcadeDB-Commit-Index bookmark
@@ -1221,6 +1491,18 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
    */
   static HttpRequest buildForwardRequest(final String url, final String contentType, final String clusterToken,
       final String userName, final long contentLength, final InputStream body) {
+    return buildForwardRequest(url, contentType, clusterToken, userName, contentLength, body, null);
+  }
+
+  /**
+   * As above, and additionally relays the response encoding the client negotiated (issue #7311). A {@code null}
+   * {@code accept} sends no header at all, which is what makes the leader answer a forwarded request exactly as
+   * it did before this parameter existed.
+   *
+   * @param accept the {@code Accept} header to relay, or {@code null} for none
+   */
+  static HttpRequest buildForwardRequest(final String url, final String contentType, final String clusterToken,
+      final String userName, final long contentLength, final InputStream body, final String accept) {
 
     final AtomicBoolean bodyTaken = new AtomicBoolean(false);
     final Supplier<InputStream> oneShotBody = () -> {
@@ -1235,7 +1517,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     if (contentLength >= 0)
       publisher = HttpRequest.BodyPublishers.fromPublisher(publisher, contentLength);
 
-    return HttpRequest.newBuilder()
+    final HttpRequest.Builder forward = HttpRequest.newBuilder()
         .uri(URI.create(url))
         .version(HttpClient.Version.HTTP_1_1)
         .header("Content-Type", contentType)
@@ -1244,7 +1526,64 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
         // One hop only: a node that receives this and is not the leader refuses it rather than resolving the
         // same leader address - which may name nobody - and relaying it again (issue #6191).
         .header(LeaderForwardContext.FORWARDED_TO_LEADER_HEADER, "true")
-        .POST(publisher)
-        .build();
+        .POST(publisher);
+
+    if (accept != null)
+      forward.header("Accept", accept);
+
+    return forward.build();
+  }
+
+  /**
+   * Passes the leader's NDJSON answer through to the client, line by line, as it arrives (issue #7311).
+   * <p>
+   * Copied rather than parsed: a line the leader emitted is already the line this client asked for, so relaying
+   * the bytes is both the cheapest thing to do and the only one that cannot make the two nodes disagree about
+   * the wire format. Each line is flushed on its own, because a relay that batched them would reintroduce
+   * exactly the latency the encoding exists to remove.
+   * <p>
+   * A leader that answered with anything other than the streaming encoding - an older node, or a refusal issued
+   * before the load started, which is a normal status-carrying error response - is relayed as the buffered
+   * answer it is, so the follower never invents a stream the leader did not send.
+   */
+  private ExecutionResponse relayNdJsonFromLeader(final HttpServerExchange exchange, final String databaseName,
+      final HttpResponse<InputStream> response) throws IOException {
+
+    final String leaderContentType = response.headers().firstValue("Content-Type").orElse("");
+    if (response.statusCode() != 200
+        || !leaderContentType.toLowerCase(Locale.ROOT).contains(NdJsonResultStream.CONTENT_TYPE)) {
+      // Not a stream: read it whole and answer it the way every other forwarded response is answered.
+      try (final InputStream in = response.body()) {
+        response.headers().firstValue("X-ArcadeDB-Commit-Index")
+            .ifPresent(val -> exchange.getResponseHeaders().put(new HttpString("X-ArcadeDB-Commit-Index"), val));
+        return new ExecutionResponse(response.statusCode(),
+            new String(in.readAllBytes(), StandardCharsets.UTF_8));
+      }
+    }
+
+    exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, NdJsonResultStream.CONTENT_TYPE);
+    exchange.getResponseHeaders().put(Headers.CACHE_CONTROL, "no-cache");
+    exchange.getResponseHeaders().put(X_ACCEL_BUFFERING, "no");
+    exchange.setStatusCode(200);
+    if (!exchange.isBlocking())
+      exchange.startBlocking();
+
+    try (final BufferedReader in = new BufferedReader(
+        new InputStreamReader(response.body(), StandardCharsets.UTF_8));
+        final OutputStream out = exchange.getOutputStream()) {
+      for (String line = in.readLine(); line != null; line = in.readLine()) {
+        out.write(line.getBytes(StandardCharsets.UTF_8));
+        out.write('\n');
+        out.flush();
+      }
+    } catch (final IOException e) {
+      LogManager.instance().log(this, Level.WARNING,
+          "Error relaying the streamed batch answer of database '%s' from the leader: %s", null, databaseName,
+          e.getMessage());
+      // The 200 and part of the stream are already on the wire, so there is no status left to change and no
+      // terminal line to trust: a consumer that saw neither 'summary' nor 'error' knows it did not get
+      // everything, which is the contract the encoding is built on.
+    }
+    return null;
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
@@ -107,7 +107,14 @@ import java.util.logging.Level;
  * </ul>
  * A progress line is an upper bound on what is durable, exactly like the partial-commit counters below: vertices
  * are committed at each flush, but {@code GraphBatch} buffers edges and writes them at close, so an edge-phase
- * line counts records ACCEPTED. A request that does not negotiate the encoding - no {@code Accept}, another type,
+ * line counts records ACCEPTED. Writing the response while the request is still being read is full duplex over
+ * one connection, and the cost of that is not flat: the lines accumulate with the size of the load - roughly one
+ * ~200-byte line per {@code vertexBatchSize} records - so a client that uploads millions of records without
+ * reading anything until it has finished can eventually fill the response socket buffer and block the worker
+ * thread mid-write, which stops it reading the upload too. An ordinary client that reads while it writes never
+ * meets this, and a small load cannot reach it at all; bounding it for the large ones is issue #7388.
+ * <p>
+ * A request that does not negotiate the encoding - no {@code Accept}, another type,
  * or {@code application/x-ndjson;q=0} - receives the same bytes under the same status as before. The
  * {@code X-ArcadeDB-Commit-Index} bookmark (issue #5862) cannot be a header on this encoding because the response
  * has already started when the value becomes known, so it is carried inside the terminal line instead.
@@ -575,8 +582,14 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     BatchProgressSink NONE = (phase, verticesCreated, edgesCreated, stream, vertexRefs, inputStream) -> {
     };
 
+    /**
+     * Deliberately declares no checked exception. {@link #streamRecords} answers an {@link IOException} as a
+     * truncated REQUEST body, with the counts a client resumes from, so an implementation that let one escape
+     * from writing the RESPONSE would produce a precise and completely wrong diagnosis. Not being able to throw
+     * one is what stops the next implementation from reintroducing that.
+     */
     void chunk(String phase, long verticesCreated, long edgesCreated, BatchRecordStream stream,
-        VertexRefResolver vertexRefs, CountingInputStream inputStream) throws IOException;
+        VertexRefResolver vertexRefs, CountingInputStream inputStream);
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
@@ -103,7 +103,11 @@ import java.util.logging.Level;
  * <li>{@code {"error": {...}}} - the last line of a failed one: the object the buffered encoding would have sent,
  *     plus the {@code status} it would have sent it under. A 200 is already on the wire by then and cannot be
  *     taken back, so the status travels in band and the line is the only terminator a consumer gets - a stream
- *     that ends with neither {@code summary} nor {@code error} did not arrive whole.</li>
+ *     that ends with neither {@code summary} nor {@code error} did not arrive whole. An engine failure raised
+ *     after the stream started adds {@code statusMapped: false}, because the fine-grained status the buffered
+ *     encoding would have chosen is decided by a classifier this path cannot reach without copying it
+ *     (issue #7396); the {@code exception} class is the discriminator there, and the counters and the bookmark
+ *     travel as they do on every other failure.</li>
  * </ul>
  * A progress line is an upper bound on what is durable, exactly like the partial-commit counters below: vertices
  * are committed at each flush, but {@code GraphBatch} buffers edges and writes them at close, so an edge-phase
@@ -569,7 +573,6 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     return new ExecutionResponse(200, result.toString());
   }
 
-
   /**
    * Notified at every commit boundary of a load, so a response encoding that can say something before the end
    * of the request has something to say (issue #7311). {@link #NONE} on the buffered encoding, which is how the
@@ -603,11 +606,14 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
    * object is produced once, by the same code, and only the envelope around it differs.
    * <p>
    * <b>Why the response is started lazily.</b> Nothing is written until the first progress line, so a load that
-   * fails before it commits anything - an engine error on the very first flush, a security failure, a
-   * {@code DuplicatedKeyException} - still travels to {@link AbstractServerHttpHandler}'s error mapping and is
-   * answered with the status that mapping chose. Only once a line is on the wire is the status unrecoverable,
-   * and only then is a failure reported in band. That is the difference between a client seeing 409 "do not
-   * retry" and seeing a 200 whose body it has to parse to discover the same thing.
+   * fails before it commits anything is still answered with a real status code. That covers both shapes of
+   * failure, which is the part that is easy to get wrong: an exception that PROPAGATES - a security failure, a
+   * {@code DuplicatedKeyException} on the very first flush - is rethrown here and travels to
+   * {@link AbstractServerHttpHandler}'s error mapping, and a failure {@link #streamRecords} REPORTS BY
+   * RETURNING - a malformed record, an unknown temporary id, a body that ended early - is returned unchanged so
+   * the pipeline sends it under the 400 or 408 it always carried. Only once a line is on the wire is the status
+   * unrecoverable, and only then is a failure reported in band. That is the difference between a client seeing
+   * 409 "do not retry" and seeing a 200 whose body it has to parse to discover the same thing.
    * <p>
    * <b>Full duplex on one socket.</b> This writes the response while {@link #streamRecords} reads the request.
    * HTTP/1.1 permits it and Undertow's blocking exchange supports it, but it does mean a client that never
@@ -625,6 +631,9 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
       final HAReplicatedDatabase haDb) throws Exception {
 
     final NdJsonBatchResponse response = new NdJsonBatchResponse(exchange);
+    // Counters as of the last acknowledgement, so a failure that cannot reach streamRecords' own counters -
+    // an engine exception raised after the stream started - still has something honest to report.
+    final long[] lastProgress = new long[2];
     try {
       final ExecutionResponse unary = streamRecords(exchange, databaseName, isCsv, builder, inputStream, vertexRefs,
           System.currentTimeMillis(), vertexBatchSize, expectedRecords,
@@ -634,6 +643,8 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
             event.put("verticesCreated", verticesCreated);
             event.put("edgesCreated", edgesCreated);
             addLineAccounting(event, stream, refs, in);
+            lastProgress[0] = verticesCreated;
+            lastProgress[1] = edgesCreated;
             try {
               // Forced, unlike a query row: a progress line exists to be read now, and there are few enough of
               // them that the syscall the size/interval policy is there to save does not matter here.
@@ -645,6 +656,18 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
               throw new BatchResponseWriteException(e);
             }
           });
+
+      if (unary.getCode() != 200 && !response.hasStarted()) {
+        // A failure streamRecords REPORTS BY RETURNING - a malformed record, an unknown temporary id, a
+        // truncated body - reaches this branch rather than the catch below, and when it happens before a single
+        // acknowledgement has been written the status line is still ours to choose. Choosing 200 there would
+        // contradict this method's own promise, the 400 and 408 the OpenAPI document declares for this
+        // endpoint, and every client that keys on the status rather than parsing the body. So the buffered
+        // answer is sent as-is, which also makes it byte-identical, and the bookmark goes back to being the
+        // header it can still be (issue #7311, cycle 3 review).
+        emitCommitIndexBookmark(exchange, haDb);
+        return unary;
+      }
 
       final JSONObject terminal = new JSONObject(unary.getResponse());
       // The bookmark of issue #5862 cannot be a header on this encoding: by the time the commit index is known
@@ -675,10 +698,31 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
           "Streaming batch load on database '%s' failed after the response had already started", reported,
           databaseName);
       try {
-        response.open().writeEvent("error", new JSONObject()
+        final JSONObject error = new JSONObject()
             .put("error", reported.getMessage() != null ? reported.getMessage() : reported.toString())
             .put("exception", reported.getClass().getName())
-            .put("status", 500), true);
+            // 500 is the unclassified fallback, NOT a classification. The fine-grained mapping - 409 for a
+            // duplicated key, 503 for a retryable conflict, 403, 404 - lives in
+            // AbstractServerHttpHandler.sendMappedErrorResponse, whose javadoc records that hand-written
+            // mirrors of it produced six separate bugs, so a second copy is not made here. The flag says so
+            // outright and the exception class is the discriminator a client keys on instead. Making the
+            // in-band status exact means extracting that classifier so there is still exactly one: issue #7396.
+            .put("status", 500)
+            .put("statusMapped", false);
+        // What a client reconciles with, and what the buffered encoding still delivers for this same failure:
+        // its counters travel in the error body, and its bookmark is emitted by the finally in execute(). Both
+        // were dropped here, which is the one place this encoding was worse than the one it extends
+        // (cycle 3 review). The counters are as of the last acknowledgement, which is the same upper bound on
+        // what is durable that every other count on this endpoint carries.
+        error.put("verticesCreated", lastProgress[0]);
+        error.put("edgesCreated", lastProgress[1]);
+        error.put("partialCommit", lastProgress[0] > 0 || lastProgress[1] > 0);
+        if (haDb != null) {
+          final long lastApplied = haDb.getLastAppliedIndex();
+          if (lastApplied >= 0)
+            error.put("commitIndex", lastApplied);
+        }
+        response.open().writeEvent("error", error, true);
       } catch (final IOException writeFailed) {
         // The connection that could not carry the load cannot carry the explanation either. Nothing is left to
         // tell the client with; the stream simply ends without a terminal line, which is exactly how a consumer

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
@@ -688,7 +688,16 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
             writeFailed.getMessage());
       }
     } finally {
-      response.close();
+      try {
+        response.close();
+      } catch (final IOException e) {
+        // Nothing is left that this could tell anyone. The terminal line is either on the wire or it is not,
+        // and letting a close failure out here would replace the answer just written - or, on the rethrow
+        // branch above, the exception that still had a status code to be answered with.
+        LogManager.instance().log(this, Level.FINE,
+            "Could not close the streamed answer of a batch load on database '%s': %s", null, databaseName,
+            e.getMessage());
+      }
     }
     return null;
   }

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
@@ -133,6 +133,12 @@ public class PostCommandHandler extends AbstractQueryHandler {
     return true;
   }
 
+  /** Answers {@code Accept: application/x-ndjson} with a streamed result set (issue #7306). */
+  @Override
+  protected boolean supportsNdJsonEncoding() {
+    return true;
+  }
+
   @Override
   public ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user, final Database database,
       final JSONObject json)

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -99,6 +99,7 @@ public class CoreApiSpec implements OpenApiContributor {
     openAPI.getComponents().addSchemas("BatchResponse", createBatchResponseSchema());
     openAPI.getComponents().addSchemas("BatchError", createBatchErrorSchema());
     openAPI.getComponents().addSchemas("ProgressResponse", createProgressResponseSchema());
+    openAPI.getComponents().addSchemas("NdJsonBatchEvent", createNdJsonBatchEventSchema());
   }
 
   private PathItem createServerPath() {
@@ -326,9 +327,18 @@ public class CoreApiSpec implements OpenApiContributor {
 
             A body that ends before its announced length answers 408 with the same partial-commit \
             counts, never a 200 with a truncated count. Compare the returned 'bytesRead' against the \
-            bytes sent to verify a chunked upload arrived whole.""");
+            bytes sent to verify a chunked upload arrived whole.
+
+            Send 'Accept: application/x-ndjson' to be acknowledged while you are still uploading. The \
+            answer is then a newline-delimited stream: a 'progress' line at every vertex commit and \
+            every 'commitEvery' edges, then exactly one 'summary' or 'error' line carrying the same \
+            object this endpoint would otherwise have returned. That is the HTTP counterpart of the \
+            per-chunk acknowledgement of the gRPC InsertBidirectional RPC. A progress line counts \
+            records attempted, the same upper bound the partial-commit counters carry. Anything else \
+            in Accept, including an absent header, returns the buffered object unchanged.""");
 
     post.addParametersItem(SpecBuilders.pathParam("database", "Database name"));
+    post.addParametersItem(batchNdJsonAcceptParam());
     post.addParametersItem(SpecBuilders.queryParam("batchSize",
         "Records buffered per GraphBatch flush. Default 100000.", false, "integer"));
     post.addParametersItem(SpecBuilders.queryParam("lightEdges",
@@ -419,6 +429,11 @@ public class CoreApiSpec implements OpenApiContributor {
     // retrying. Every other failure keeps the base handler's standard error shape.
     final ApiResponses responses = new ApiResponses();
     responses.addApiResponse("200", SpecBuilders.jsonResponse("Load completed", "BatchResponse"));
+    // The streaming encoding answers 200 for a FAILED load too: by the time the verdict is reached the status
+    // line is already sent, so the failure is the terminal 'error' line and its 'status' field instead.
+    final MediaType ndjsonBatch = new MediaType();
+    ndjsonBatch.setSchema(SpecBuilders.ref("NdJsonBatchEvent"));
+    responses.get("200").getContent().addMediaType(NDJSON, ndjsonBatch);
     responses.addApiResponse("400", SpecBuilders.jsonResponse(
         "Client-input failure, with the counts attempted before it", "BatchError"));
     responses.addApiResponse("408", SpecBuilders.jsonResponse(
@@ -740,6 +755,57 @@ public class CoreApiSpec implements OpenApiContributor {
         "True when the mapping was too large to return"));
     schema.addProperty("idMappingSize", SpecBuilders.integer(
         "Number of entries in the omitted mapping"));
+    return schema;
+  }
+
+  /**
+   * The {@code Accept} header that selects the streaming batch encoding (issue #7311). Declared as an explicit
+   * parameter as well as a response content type because a generated client otherwise has no way to ask for it.
+   */
+  private static Parameter batchNdJsonAcceptParam() {
+    final Parameter accept = SpecBuilders.headerParam("Accept", """
+        Send 'application/x-ndjson' to receive per-chunk acknowledgements while the request body is still being \
+        uploaded, instead of one object after the whole load. Anything else - including an absent header - \
+        returns the buffered application/json body unchanged.""", false);
+    accept.getSchema().setEnum(List.of(SpecBuilders.JSON, NDJSON));
+    return accept;
+  }
+
+  /**
+   * One line of the streaming batch encoding (issue #7311). Same self-delimiting discipline as the streaming
+   * query: exactly one key per line naming the event, and a stream that ends with neither {@code summary} nor
+   * {@code error} is one that did not arrive whole.
+   */
+  private Schema<?> createNdJsonBatchEventSchema() {
+    final Schema<Object> schema = SpecBuilders.object("""
+        One line of a streamed bulk load. Exactly one of 'progress', 'summary' or 'error' is present.""");
+
+    final Schema<Object> progress = SpecBuilders.object("""
+        A chunk acknowledgement, written while the request body is still being read. Emitted at every vertex \
+        commit and every 'commitEvery' edges. The counters are records ATTEMPTED, the same upper bound on what \
+        is durable that the partial-commit counters carry: vertices are committed at each flush, while edges are \
+        buffered and written when the load ends.""");
+    progress.addProperty("phase", SpecBuilders.string("'vertices' or 'edges'"));
+    progress.addProperty("verticesCreated", SpecBuilders.integer("Vertices attempted so far"));
+    progress.addProperty("edgesCreated", SpecBuilders.integer("Edges attempted so far"));
+    addLoadAccounting(progress);
+    schema.addProperty("progress", progress);
+
+    final Schema<Object> summary = SpecBuilders.object("""
+        Terminal line of a successful load: the same object the buffered application/json response carries, \
+        plus 'commitIndex' on a replicated database - the read-your-writes bookmark, which cannot be a response \
+        header here because the response has already started when its value becomes known.""");
+    summary.addProperty("commitIndex", SpecBuilders.integer(
+        "Last applied Raft index, the value the X-ArcadeDB-Commit-Index header carries on the buffered encoding"));
+    schema.addProperty("summary", summary);
+
+    final Schema<Object> error = SpecBuilders.object("""
+        Terminal line of a failed load: the same object the buffered encoding carries, plus the 'status' it \
+        would have been sent under. The status line cannot be taken back once the stream has started, so the \
+        status travels in band.""");
+    error.addProperty("status", SpecBuilders.integer(
+        "HTTP status the buffered encoding would have used: 400, 408 or 500"));
+    schema.addProperty("error", error);
     return schema;
   }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -805,6 +805,14 @@ public class CoreApiSpec implements OpenApiContributor {
         status travels in band.""");
     error.addProperty("status", SpecBuilders.integer(
         "HTTP status the buffered encoding would have used: 400, 408 or 500"));
+    // Carried on a FAILED load too, and not by accident: a batch is not atomic, so a load that failed
+    // mid-stream still committed the chunks before the failure, and a READ_YOUR_WRITES client has to be able
+    // to read them back. That is the same rule the buffered encoding follows by emitting the header on its
+    // 400/408 answers (issue #5862), and a client generated from a document that declared the bookmark only
+    // on 'summary' would not know to look for it where it matters most.
+    error.addProperty("commitIndex", SpecBuilders.integer(
+        "Last applied Raft index, present on a replicated database. On a failed load it bookmarks the chunks "
+            + "that were committed before the failure"));
     schema.addProperty("error", error);
     return schema;
   }

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -335,7 +335,12 @@ public class CoreApiSpec implements OpenApiContributor {
             object this endpoint would otherwise have returned. That is the HTTP counterpart of the \
             per-chunk acknowledgement of the gRPC InsertBidirectional RPC. A progress line counts \
             records attempted, the same upper bound the partial-commit counters carry. Anything else \
-            in Accept, including an absent header, returns the buffered object unchanged.""");
+            in Accept, including an absent header, returns the buffered object unchanged.
+
+            A load that fails before it has acknowledged anything still answers with its real status \
+            code and the buffered error body, because the status line has not been sent yet: the 400 \
+            and 408 below apply to a streaming request too. Only a failure raised after the first \
+            progress line is reported in band under a 200.""");
 
     post.addParametersItem(SpecBuilders.pathParam("database", "Database name"));
     post.addParametersItem(batchNdJsonAcceptParam());
@@ -805,6 +810,10 @@ public class CoreApiSpec implements OpenApiContributor {
         status travels in band.""");
     error.addProperty("status", SpecBuilders.integer(
         "HTTP status the buffered encoding would have used: 400, 408 or 500"));
+    error.addProperty("statusMapped", SpecBuilders.bool("""
+        Present and false when 'status' is the unclassified 500 fallback rather than the status the buffered \
+        encoding would have chosen - the case of an engine failure raised after the stream had already \
+        started. Key on 'exception' there, not on 'status'. Absent whenever 'status' is exact."""));
     // Carried on a FAILED load too, and not by accident: a batch is not atomic, so a load that failed
     // mid-stream still committed the chunks before the failure, and a READ_YOUR_WRITES client has to be able
     // to read them back. That is the same rule the buffered encoding follows by emitting the header on its

--- a/server/src/test/java/com/arcadedb/remote/RemoteGraphBatchProgressIT.java
+++ b/server/src/test/java/com/arcadedb/remote/RemoteGraphBatchProgressIT.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote;
+
+import com.arcadedb.exception.DatabaseOperationException;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7311: the Java driver can be acknowledged per chunk instead of only at the end of a flush. Without a
+ * listener the flush sends the request it always sent, so the server-side encoding is opt-in from here too.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class RemoteGraphBatchProgressIT extends BaseGraphServerTest {
+  private static final String DATABASE_NAME = "remote-batch-progress";
+
+  @Override
+  protected boolean isCreateDatabases() {
+    return false;
+  }
+
+  @BeforeEach
+  public void beginTest() {
+    super.beginTest();
+    final RemoteServer server = remoteServer();
+    if (!server.exists(DATABASE_NAME))
+      server.create(DATABASE_NAME);
+  }
+
+  @AfterEach
+  public void endTest() {
+    final RemoteServer server = remoteServer();
+    if (server.exists(DATABASE_NAME))
+      server.drop(DATABASE_NAME);
+    super.endTest();
+  }
+
+  @Test
+  @Timeout(120)
+  void aProgressListenerIsCalledOncePerServerSideChunk() {
+    final RemoteDatabase database = remoteDatabase();
+    database.command("sql", "CREATE VERTEX TYPE Person");
+
+    final List<JSONObject> progress = new ArrayList<>();
+    try (final RemoteGraphBatch batch = database.batch()
+        .withVertexBatchSize(2)
+        .withProgressListener(progress::add)
+        .build()) {
+      for (int i = 0; i < 8; i++)
+        batch.createVertex("Person", "name", "p" + i);
+    }
+
+    assertThat(progress)
+        .as("a flush of eight vertices committed two at a time must report more than once")
+        .hasSizeGreaterThan(1);
+    assertThat(progress.getFirst().getString("phase")).isEqualTo("vertices");
+    assertThat(progress.getFirst().getLong("verticesCreated")).isEqualTo(2);
+    assertThat(progress.getLast().getLong("verticesCreated"))
+        .as("the acknowledgements are cumulative, so the last one is not smaller than the first")
+        .isGreaterThanOrEqualTo(progress.getFirst().getLong("verticesCreated"));
+
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) as cnt FROM Person")) {
+      final Result r = rs.nextIfAvailable();
+      assertThat(((Number) r.getProperty("cnt")).longValue()).isEqualTo(8);
+    }
+  }
+
+  /**
+   * The load still has to work the same way, and a flush still has to hand back the summary the caller reads its
+   * totals from - the listener is an addition to the answer, not a replacement for it.
+   */
+  @Test
+  @Timeout(120)
+  void theTotalsAreTheSameWithAndWithoutAListener() {
+    final RemoteDatabase database = remoteDatabase();
+    database.command("sql", "CREATE VERTEX TYPE Person");
+    database.command("sql", "CREATE EDGE TYPE KNOWS");
+
+    final RemoteGraphBatch batch = database.batch().withVertexBatchSize(2)
+        .withProgressListener(event -> {
+        }).build();
+    final String a = batch.createVertex("Person", "name", "Alice");
+    final String b = batch.createVertex("Person", "name", "Bob");
+    batch.createEdge("KNOWS", a, b, "since", 2020);
+    batch.close();
+
+    assertThat(batch.getResult().getVerticesCreated()).isEqualTo(2);
+    assertThat(batch.getResult().getEdgesCreated()).isEqualTo(1);
+  }
+
+  /**
+   * A failed load still fails, and the message still carries how much was attempted: on this encoding the
+   * failure is a line under a 200, so a driver that only looked at the status code would report success.
+   */
+  @Test
+  @Timeout(120)
+  void aFailedLoadStillFailsWhenItArrivesAsALineRatherThanAStatus() {
+    final RemoteDatabase database = remoteDatabase();
+    database.command("sql", "CREATE VERTEX TYPE Person");
+    database.command("sql", "CREATE EDGE TYPE KNOWS");
+
+    final RemoteGraphBatch batch = database.batch().withVertexBatchSize(1)
+        .withProgressListener(event -> {
+        }).build();
+    batch.createVertex("Person", "name", "Alice");
+    // An endpoint no vertex of this payload declares: the server rejects the edge mid-load, with a 200 already
+    // on the wire.
+    batch.createEdge("KNOWS", "v0", "v999999");
+
+    assertThatThrownBy(batch::flush)
+        .isInstanceOf(DatabaseOperationException.class)
+        .hasMessageContaining("status 400")
+        .hasMessageContaining("attempted before it failed");
+  }
+
+  /**
+   * A listener must not change what the flush does with the server's answer. The temporary-id mapping a batch
+   * needs to resolve an edge against a vertex sent in an EARLIER request travels in the terminal line on this
+   * encoding, and a driver that read the progress lines and stopped there would drop every cross-flush edge -
+   * silently, since nothing else in the load would fail.
+   */
+  @Test
+  @Timeout(120)
+  void anEdgeAcrossTwoFlushesStillResolvesWithAListener() {
+    final RemoteDatabase database = remoteDatabase();
+    database.command("sql", "CREATE VERTEX TYPE Person");
+    database.command("sql", "CREATE EDGE TYPE KNOWS");
+
+    final List<JSONObject> progress = new ArrayList<>();
+    final List<String> ids = new ArrayList<>();
+    try (final RemoteGraphBatch batch = database.batch()
+        .withFlushEvery(4)
+        .withVertexBatchSize(2)
+        .withProgressListener(progress::add)
+        .build()) {
+      for (int i = 0; i < 10; i++)
+        ids.add(batch.createVertex("Person", "name", "p" + i));
+      // The first of these was created in a request that has already been answered, so it can only be resolved
+      // through the mapping that request returned.
+      batch.createEdge("KNOWS", ids.getFirst(), ids.getLast());
+    }
+
+    assertThat(progress).isNotEmpty();
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) as cnt FROM KNOWS")) {
+      assertThat(((Number) rs.nextIfAvailable().getProperty("cnt")).longValue())
+          .as("the edge spanning two flushes must exist")
+          .isEqualTo(1);
+    }
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) as cnt FROM Person")) {
+      assertThat(((Number) rs.nextIfAvailable().getProperty("cnt")).longValue()).isEqualTo(10);
+    }
+  }
+
+  private RemoteServer remoteServer() {
+    return new RemoteServer("127.0.0.1", httpPort(), "root", BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
+  }
+
+  private RemoteDatabase remoteDatabase() {
+    return new RemoteDatabase("127.0.0.1", httpPort(), DATABASE_NAME, "root",
+        BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
+  }
+
+  private int httpPort() {
+    return getServer(0).getHttpServer().getPort();
+  }
+}

--- a/server/src/test/java/com/arcadedb/remote/RemoteGraphBatchProgressIT.java
+++ b/server/src/test/java/com/arcadedb/remote/RemoteGraphBatchProgressIT.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -177,6 +178,39 @@ class RemoteGraphBatchProgressIT extends BaseGraphServerTest {
     }
     try (final ResultSet rs = database.query("sql", "SELECT count(*) as cnt FROM Person")) {
       assertThat(((Number) rs.nextIfAvailable().getProperty("cnt")).longValue()).isEqualTo(10);
+    }
+  }
+
+  /**
+   * The progress listener is an overload, and an overload is a second path: a flush that asks for no progress
+   * has to keep going through {@code sendBatch(content, queryParams)}, which is the method a subclass replaces
+   * to intercept every request this client makes. Routing it through the new three-argument sibling instead
+   * walks past those overrides in silence - the compiler is perfectly happy to call the method nobody
+   * overrode - and the only symptom is a stub that never fires, which reads as a test that stopped reproducing
+   * its own bug rather than as a broken client.
+   */
+  @Test
+  @Timeout(120)
+  void aFlushWithNoListenerStillGoesThroughTheOverridableSend() {
+    final List<String> intercepted = new ArrayList<>();
+    try (final RemoteDatabase database = new RemoteDatabase("127.0.0.1", httpPort(), DATABASE_NAME, "root",
+        BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS) {
+      @Override
+      JSONObject sendBatch(final String content, final Map<String, String> queryParams) {
+        intercepted.add(content);
+        return super.sendBatch(content, queryParams);
+      }
+    }) {
+      database.command("sql", "CREATE VERTEX TYPE Person");
+
+      try (final RemoteGraphBatch batch = database.batch().build()) {
+        batch.createVertex("Person", "name", "Alice");
+      }
+
+      assertThat(intercepted)
+          .as("a flush without a progress listener must still reach the method subclasses override")
+          .hasSize(1);
+      assertThat(intercepted.getFirst()).contains("Alice");
     }
   }
 

--- a/server/src/test/java/com/arcadedb/server/PostBatchStreamingIT.java
+++ b/server/src/test/java/com/arcadedb/server/PostBatchStreamingIT.java
@@ -250,6 +250,98 @@ class PostBatchStreamingIT extends BaseGraphServerTest {
     }
   }
 
+  /**
+   * The other half of the same rule, and the one the first version of this branch got wrong: a failure
+   * {@code streamRecords} REPORTS BY RETURNING - a malformed record, an unknown temporary id, a truncated body -
+   * is not a thrown exception, and it reaches the terminal-line branch rather than the catch. When it happens
+   * before a single acknowledgement has been written the status is still ours to choose, so it has to be the
+   * real one: a client that keys on the status code, and the OpenAPI document that still declares 400 and 408
+   * for this endpoint, would otherwise read a rejected payload as a successful load.
+   */
+  @Test
+  @Timeout(60)
+  void aMalformedFirstRecordKeepsItsRealStatusCode() throws Exception {
+    final HttpURLConnection conn = open("", NDJSON, NDJSON);
+    writeBody(conn, "this is not json at all\n".getBytes(StandardCharsets.UTF_8));
+    try {
+      assertThat(conn.getResponseCode())
+          .as("nothing had been written, so the buffered encoding's 400 was still available and must be used")
+          .isEqualTo(400);
+      assertThat(conn.getContentType()).contains("application/json");
+      final JSONObject error = new JSONObject(readAll(conn.getErrorStream()));
+      assertThat(error.getBoolean("partialCommit")).isFalse();
+      assertThat(error.getLong("verticesCreated")).isZero();
+    } finally {
+      conn.disconnect();
+    }
+  }
+
+  /**
+   * Same rule for a body that stops before the first flush: at the default {@code vertexBatchSize} nothing has
+   * been acknowledged yet, so the truncation keeps the 408 the buffered encoding gives it rather than becoming a
+   * 200 whose body has to be parsed to discover the load failed.
+   */
+  @Test
+  @Timeout(60)
+  void aTruncatedUploadBeforeTheFirstFlushKeepsItsRealStatusCode() throws Exception {
+    final byte[] sent = ndjsonVertices(1_000_000, 3);
+
+    try (final Socket socket = new Socket("127.0.0.1", httpPort())) {
+      socket.setSoTimeout(30_000);
+      final OutputStream out = socket.getOutputStream();
+      // No vertexBatchSize: the default is 10,000, so three vertices never reach a flush and never acknowledge.
+      out.write(requestHead("", NDJSON, 1_000_000));
+      out.write(sent);
+      out.flush();
+      socket.shutdownOutput();
+
+      final BufferedReader raw = new BufferedReader(
+          new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+      assertThat(readStatusLine(raw))
+          .as("a truncation nothing has been acknowledged before keeps its real status")
+          .contains("408");
+    }
+  }
+
+  /**
+   * A failure the engine raises AFTER the first acknowledgement cannot have its status back - a 200 is on the
+   * wire - so everything a client needs to reconcile has to be in the line instead. It must not be answered
+   * with a bare message: the counters, the partial-commit flag and, on a replicated database, the bookmark are
+   * exactly what the buffered encoding still delivers for the same failure.
+   */
+  @Test
+  @Timeout(60)
+  void anEngineFailureAfterTheFirstAcknowledgementCarriesTheCountersInBand() throws Exception {
+    // V1.id is unique, so this id is already taken when the payload below reaches its second batch.
+    postStreamed(ndjsonVertices(1_100_010, 1), "?vertexBatchSize=1", NDJSON);
+
+    final StringBuilder body = new StringBuilder();
+    for (int i = 0; i < 2; i++)
+      body.append("{\"@type\":\"vertex\",\"@class\":\"V1\",\"@id\":\"d").append(i).append("\",\"id\":")
+          .append(1_100_000 + i).append("}\n");
+    // Second batch, and a duplicate: the load fails with the first two vertices acknowledged and committed.
+    body.append("{\"@type\":\"vertex\",\"@class\":\"V1\",\"@id\":\"d9\",\"id\":1100010}\n");
+
+    final List<JSONObject> events = postStreamed(body.toString().getBytes(StandardCharsets.UTF_8),
+        "?vertexBatchSize=2", NDJSON);
+
+    assertThat(countEvents(events, "progress"))
+        .as("the failure has to come after an acknowledgement, or this test proves nothing")
+        .isGreaterThan(0);
+
+    final JSONObject error = terminal(events, "error");
+    assertThat(error.getString("exception"))
+        .as("the exception class is the discriminator once the status line can no longer carry one")
+        .contains("DuplicatedKeyException");
+    assertThat(error.getBoolean("statusMapped"))
+        .as("the in-band status is not the fine-grained one the buffered encoding would have mapped")
+        .isFalse();
+    assertThat(error.getLong("verticesCreated"))
+        .as("the counters a client reconciles with must survive a failure of this shape too")
+        .isEqualTo(2);
+    assertThat(error.getBoolean("partialCommit")).isTrue();
+  }
+
   /** The edge phase is acknowledged too, on the {@code commitEvery} boundary GraphBatch writes edges at. */
   @Test
   @Timeout(60)

--- a/server/src/test/java/com/arcadedb/server/PostBatchStreamingIT.java
+++ b/server/src/test/java/com/arcadedb/server/PostBatchStreamingIT.java
@@ -24,15 +24,19 @@ import org.junit.jupiter.api.Timeout;
 
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.Socket;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -75,7 +79,7 @@ class PostBatchStreamingIT extends BaseGraphServerTest {
       final BufferedReader raw = new BufferedReader(
           new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
       assertThat(readStatusLine(raw)).as("the streaming encoding always answers 200").contains("200");
-      final java.util.Map<String, String> headers = readHeaders(raw);
+      final Map<String, String> headers = readHeaders(raw);
       assertThat(headers).containsEntry("content-type", NDJSON);
       final NdJsonBodyReader in = new NdJsonBodyReader(raw, headers);
 
@@ -403,7 +407,7 @@ class PostBatchStreamingIT extends BaseGraphServerTest {
     }
   }
 
-  private static String readAll(final java.io.InputStream in) throws Exception {
+  private static String readAll(final InputStream in) throws Exception {
     try (in) {
       return new String(in.readAllBytes(), StandardCharsets.UTF_8);
     }
@@ -446,8 +450,8 @@ class PostBatchStreamingIT extends BaseGraphServerTest {
     return in.readLine();
   }
 
-  private static java.util.Map<String, String> readHeaders(final BufferedReader in) throws Exception {
-    final java.util.Map<String, String> headers = new java.util.HashMap<>();
+  private static Map<String, String> readHeaders(final BufferedReader in) throws Exception {
+    final Map<String, String> headers = new HashMap<>();
     for (String line = in.readLine(); line != null && !line.isEmpty(); line = in.readLine()) {
       final int colon = line.indexOf(':');
       if (colon > 0)
@@ -467,9 +471,9 @@ class PostBatchStreamingIT extends BaseGraphServerTest {
   private static final class NdJsonBodyReader {
     private final BufferedReader        in;
     private final boolean               chunked;
-    private final java.util.ArrayDeque<String> pending = new java.util.ArrayDeque<>();
+    private final ArrayDeque<String>     pending = new ArrayDeque<>();
 
-    private NdJsonBodyReader(final BufferedReader in, final java.util.Map<String, String> headers) {
+    private NdJsonBodyReader(final BufferedReader in, final Map<String, String> headers) {
       this.in = in;
       this.chunked = "chunked".equalsIgnoreCase(headers.getOrDefault("transfer-encoding", ""));
     }

--- a/server/src/test/java/com/arcadedb/server/PostBatchStreamingIT.java
+++ b/server/src/test/java/com/arcadedb/server/PostBatchStreamingIT.java
@@ -1,0 +1,513 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.Socket;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7311: {@code POST /api/v1/batch/{database}} answers a client that sends
+ * {@code Accept: application/x-ndjson} with per-chunk acknowledgements written while its upload is still being
+ * read - the acknowledgement half of the gRPC {@code InsertBidirectional} shape, which HTTP had no counterpart
+ * for. A client that does not negotiate the encoding gets exactly what it got before.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class PostBatchStreamingIT extends BaseGraphServerTest {
+
+  private static final String NDJSON = "application/x-ndjson";
+
+  /**
+   * The point of the whole issue: a progress line has to reach the client BEFORE the request body has been fully
+   * sent, or the encoding is only a differently-shaped version of the answer that already existed.
+   * <p>
+   * The proof is not the ordering of statements in this method - that would only show that the client read
+   * before it finished writing - but the {@code bytesRead} the server puts on the line it sent: strictly fewer
+   * than the {@code Content-Length} it was promised. A server that answered only at the end of the body could
+   * not produce that number.
+   */
+  @Test
+  @Timeout(60)
+  void progressReachesTheClientBeforeTheBodyHasBeenFullySent() throws Exception {
+    final byte[] head = ndjsonVertices(100_000, 4);
+    final byte[] tail = ndjsonVertices(100_010, 4);
+    final int announced = head.length + tail.length;
+
+    try (final Socket socket = new Socket("127.0.0.1", httpPort())) {
+      socket.setSoTimeout(30_000);
+      final OutputStream out = socket.getOutputStream();
+      out.write(requestHead("?vertexBatchSize=2", NDJSON, announced));
+      // Only the first half. The rest is deliberately withheld until a line has come back.
+      out.write(head);
+      out.flush();
+
+      final BufferedReader raw = new BufferedReader(
+          new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+      assertThat(readStatusLine(raw)).as("the streaming encoding always answers 200").contains("200");
+      final java.util.Map<String, String> headers = readHeaders(raw);
+      assertThat(headers).containsEntry("content-type", NDJSON);
+      final NdJsonBodyReader in = new NdJsonBodyReader(raw, headers);
+
+      final JSONObject first = new JSONObject(in.nextLine());
+      assertThat(first.has("progress"))
+          .as("the first line of a load still uploading must be a chunk acknowledgement, not the summary")
+          .isTrue();
+
+      final JSONObject progress = first.getJSONObject("progress");
+      assertThat(progress.getString("phase")).isEqualTo("vertices");
+      assertThat(progress.getLong("verticesCreated")).isEqualTo(2);
+      assertThat(progress.getLong("bytesRead"))
+          .as("the acknowledgement was written having read less than the announced body, which is what makes it "
+              + "an acknowledgement and not a summary")
+          .isLessThan(announced);
+
+      // Only now does the rest of the payload go out.
+      out.write(tail);
+      out.flush();
+
+      final List<JSONObject> rest = readEvents(in);
+      final JSONObject summary = terminal(rest, "summary");
+      assertThat(summary.getLong("verticesCreated")).isEqualTo(8);
+      assertThat(summary.getLong("bytesRead")).isEqualTo(announced);
+      assertThat(countEvents(rest, "progress")).as("the remaining chunks are acknowledged too").isGreaterThan(0);
+    }
+
+    assertThat(countVertices(100_000, 100_020)).isEqualTo(8);
+  }
+
+  /**
+   * The terminal line is not a second, parallel shape of the answer: it is the very object the buffered encoding
+   * would have sent, produced by the same code. A client can therefore apply one piece of logic to both.
+   */
+  @Test
+  @Timeout(60)
+  void theSummaryLineCarriesTheSameObjectTheUnaryEncodingWouldHaveSent() throws Exception {
+    final JSONObject buffered = postBuffered(ndjsonVertices(200_000, 6), "?vertexBatchSize=2", NDJSON, 200);
+    final JSONObject streamed = terminal(postStreamed(ndjsonVertices(200_010, 6), "?vertexBatchSize=2", NDJSON),
+        "summary");
+
+    assertThat(streamed.keySet())
+        .as("the summary must carry the same fields as the buffered body, so a client parses one shape")
+        .isEqualTo(buffered.keySet());
+    assertThat(streamed.getLong("verticesCreated")).isEqualTo(buffered.getLong("verticesCreated"));
+    assertThat(streamed.getLong("linesRead")).isEqualTo(buffered.getLong("linesRead"));
+    assertThat(streamed.getLong("linesSkipped")).isEqualTo(buffered.getLong("linesSkipped"));
+    assertThat(streamed.getLong("bytesRead")).isEqualTo(buffered.getLong("bytesRead"));
+    assertThat(streamed.getJSONObject("idMapping").length())
+        .isEqualTo(buffered.getJSONObject("idMapping").length());
+  }
+
+  /**
+   * The additive half of the contract: a caller that does not ask for the stream must not be able to tell that
+   * it exists. No {@code Accept}, another type, and the RFC 9110 spelling of "anything but that one" all keep
+   * the single buffered object under {@code application/json}.
+   */
+  @Test
+  @Timeout(60)
+  void theUnaryEncodingIsUnchangedWhenTheStreamIsNotNegotiated() throws Exception {
+    final String[] accepts = { null, "application/json", "application/json, application/x-ndjson;q=0" };
+    for (int i = 0; i < accepts.length; i++) {
+      final String accept = accepts[i];
+      final HttpURLConnection conn = open("?vertexBatchSize=2", NDJSON, accept);
+      writeBody(conn, ndjsonVertices(300_000 + i * 10, 4));
+
+      try {
+        assertThat(conn.getResponseCode()).as("accept=" + accept).isEqualTo(200);
+        assertThat(conn.getContentType()).as("accept=" + accept).contains("application/json");
+        final JSONObject result = new JSONObject(readAll(conn.getInputStream()));
+        assertThat(result.getLong("verticesCreated")).isEqualTo(4);
+        assertThat(result.has("progress")).as("a buffered answer carries no stream envelope").isFalse();
+      } finally {
+        conn.disconnect();
+      }
+    }
+  }
+
+  /**
+   * A failure that the load itself reaches - a malformed reference, a vertex after the first edge - happens with
+   * a 200 already on the wire. The status it would have carried travels in band instead, alongside the
+   * partial-commit counters, because those are what the client reconciles with: the load is not atomic.
+   */
+  @Test
+  @Timeout(60)
+  void aClientInputFailureAfterTheStreamStartedIsReportedInBand() throws Exception {
+    final String body = """
+        {"@type":"vertex","@class":"V1","@id":"s1","id":400000}
+        {"@type":"vertex","@class":"V1","@id":"s2","id":400001}
+        {"@type":"edge","@class":"E1","@from":"s1","@to":"nobody-declared-this"}
+        """;
+
+    final List<JSONObject> events = postStreamed(body.getBytes(StandardCharsets.UTF_8), "?vertexBatchSize=1", NDJSON);
+    assertThat(countEvents(events, "progress")).isGreaterThan(0);
+
+    final JSONObject error = terminal(events, "error");
+    assertThat(error.getInt("status"))
+        .as("the status the buffered encoding would have sent, in band because 200 is already on the wire")
+        .isEqualTo(400);
+    assertThat(error.getString("error")).contains("nobody-declared-this");
+    assertThat(error.getBoolean("partialCommit")).isTrue();
+    assertThat(error.getLong("verticesCreated")).isEqualTo(2);
+  }
+
+  /**
+   * A body that stops before its announced length is the failure issue #5470 exists for, and it must stay just
+   * as loud on this encoding: never a summary line with a partial count, always the truncation with the counts
+   * needed to resume.
+   */
+  @Test
+  @Timeout(60)
+  void aTruncatedUploadAfterTheStreamStartedIsReportedInBand() throws Exception {
+    final byte[] sent = ndjsonVertices(500_000, 4);
+
+    try (final Socket socket = new Socket("127.0.0.1", httpPort())) {
+      socket.setSoTimeout(30_000);
+      final OutputStream out = socket.getOutputStream();
+      out.write(requestHead("?vertexBatchSize=1", NDJSON, 1_000_000));
+      out.write(sent);
+      out.flush();
+      socket.shutdownOutput();
+
+      final BufferedReader raw = new BufferedReader(
+          new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+      assertThat(readStatusLine(raw)).contains("200");
+      final NdJsonBodyReader in = new NdJsonBodyReader(raw, readHeaders(raw));
+
+      final JSONObject error = terminal(readEvents(in), "error");
+      assertThat(error.getInt("status"))
+          .as("a truncated upload keeps the 408 it always had, in band")
+          .isEqualTo(408);
+      assertThat(error.getBoolean("partialCommit")).isTrue();
+      assertThat(error.getLong("verticesCreated")).isEqualTo(4);
+      assertThat(error.getLong("bytesRead")).isEqualTo(sent.length);
+    }
+  }
+
+  /**
+   * The other side of the in-band rule, and the one that is easy to get wrong: a failure raised BEFORE anything
+   * has been written can still be answered with a real status code, so it must be. Downgrading a
+   * {@code DuplicatedKeyException} to a 200 whose body has to be parsed would tell a client's retry policy - which
+   * keys on the status - the opposite of what 409 means.
+   */
+  @Test
+  @Timeout(60)
+  void aFailureBeforeTheStreamStartedKeepsItsRealStatusCode() throws Exception {
+    // V1.id carries a unique index, so loading the same id twice is refused by the engine on the first commit -
+    // before a single progress line exists.
+    postStreamed(ndjsonVertices(600_000, 1), "?vertexBatchSize=1", NDJSON);
+
+    final HttpURLConnection conn = open("?vertexBatchSize=1", NDJSON, NDJSON);
+    writeBody(conn, ndjsonVertices(600_000, 1));
+    try {
+      assertThat(conn.getResponseCode())
+          .as("a duplicate key is answered 409 on both encodings: nothing had been written yet")
+          .isEqualTo(409);
+    } finally {
+      conn.disconnect();
+    }
+
+    // Same rule for a request the handler refuses on its parameters, which it parses before writing anything.
+    final HttpURLConnection bad = open("?refMode=whatever", NDJSON, NDJSON);
+    writeBody(bad, ndjsonVertices(600_100, 1));
+    try {
+      assertThat(bad.getResponseCode()).isEqualTo(400);
+    } finally {
+      bad.disconnect();
+    }
+  }
+
+  /** The edge phase is acknowledged too, on the {@code commitEvery} boundary GraphBatch writes edges at. */
+  @Test
+  @Timeout(60)
+  void theEdgePhaseIsAcknowledgedOnItsOwnBoundary() throws Exception {
+    final StringBuilder body = new StringBuilder();
+    for (int i = 0; i < 6; i++)
+      body.append("{\"@type\":\"vertex\",\"@class\":\"V1\",\"@id\":\"e").append(i).append("\",\"id\":")
+          .append(700_000 + i).append("}\n");
+    for (int i = 0; i < 5; i++)
+      body.append("{\"@type\":\"edge\",\"@class\":\"E1\",\"@from\":\"e").append(i).append("\",\"@to\":\"e")
+          .append(i + 1).append("\"}\n");
+
+    final List<JSONObject> events = postStreamed(body.toString().getBytes(StandardCharsets.UTF_8),
+        "?vertexBatchSize=2&commitEvery=2", NDJSON);
+
+    assertThat(events.stream().filter(e -> e.has("progress"))
+        .map(e -> e.getJSONObject("progress").getString("phase")).toList())
+        .as("both phases report, so a client is not blind for the whole of the edge half")
+        .contains("vertices", "edges");
+    assertThat(terminal(events, "summary").getLong("edgesCreated")).isEqualTo(5);
+  }
+
+  /** The encoding is a property of the response, so it is available whatever format the request body is in. */
+  @Test
+  @Timeout(60)
+  void aCsvPayloadStreamsProgressToo() throws Exception {
+    final StringBuilder body = new StringBuilder("@type,@class,@id,id\n");
+    for (int i = 0; i < 4; i++)
+      body.append("vertex,V1,c").append(i).append(',').append(800_000 + i).append('\n');
+
+    final List<JSONObject> events = postStreamed(body.toString().getBytes(StandardCharsets.UTF_8),
+        "?vertexBatchSize=2", "text/csv");
+    assertThat(countEvents(events, "progress")).isGreaterThan(0);
+    assertThat(terminal(events, "summary").getLong("verticesCreated")).isEqualTo(4);
+  }
+
+  /**
+   * The idempotency cache is keyed on method, path, database and body - never on the negotiated encoding - so a
+   * hit recorded by a buffered request would be replayed to a streaming caller as one {@code application/json}
+   * object its reader cannot parse. A streaming request stays out of that cache entirely.
+   */
+  @Test
+  @Timeout(60)
+  void anIdempotentRetryNeverReplaysABufferedBodyToAStreamingCaller() throws Exception {
+    final String requestId = "batch-streaming-7311";
+
+    final HttpURLConnection first = open("?vertexBatchSize=2", NDJSON, null);
+    first.setRequestProperty("X-Request-Id", requestId);
+    writeBody(first, ndjsonVertices(900_000, 2));
+    try {
+      assertThat(first.getResponseCode()).isEqualTo(200);
+      assertThat(first.getContentType()).contains("application/json");
+    } finally {
+      first.disconnect();
+    }
+
+    final HttpURLConnection second = open("?vertexBatchSize=2", NDJSON, NDJSON);
+    second.setRequestProperty("X-Request-Id", requestId);
+    writeBody(second, ndjsonVertices(900_010, 2));
+    try {
+      assertThat(second.getResponseCode()).isEqualTo(200);
+      assertThat(second.getContentType())
+          .as("the streaming caller must not be served the buffered body cached by the earlier retry")
+          .contains(NDJSON);
+      assertThat(terminal(parseEvents(readAll(second.getInputStream())), "summary").getLong("verticesCreated"))
+          .isEqualTo(2);
+    } finally {
+      second.disconnect();
+    }
+  }
+
+  /** A standalone database has no Raft index to bookmark, so the terminal line must not invent one. */
+  @Test
+  @Timeout(60)
+  void theCommitIndexIsAbsentOnAStandaloneDatabase() throws Exception {
+    final JSONObject summary = terminal(postStreamed(ndjsonVertices(950_000, 2), "?vertexBatchSize=2", NDJSON),
+        "summary");
+    assertThat(summary.has("commitIndex")).isFalse();
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+
+  /**
+   * The port the server under test actually bound, never the 2480 it was asked for. Anything already listening
+   * there - an IDE-left server, another agent's run - would otherwise take these requests and answer them as a
+   * different build, which surfaces as an authentication failure or as a content type this branch does not
+   * produce rather than as a port conflict.
+   */
+  private int httpPort() {
+    return getServer(0).getHttpServer().getPort();
+  }
+
+  private byte[] ndjsonVertices(final int firstId, final int count) {
+    final StringBuilder body = new StringBuilder();
+    for (int i = 0; i < count; i++)
+      body.append("{\"@type\":\"vertex\",\"@class\":\"V1\",\"@id\":\"t").append(firstId + i).append("\",\"id\":")
+          .append(firstId + i).append("}\n");
+    return body.toString().getBytes(StandardCharsets.UTF_8);
+  }
+
+  private byte[] requestHead(final String queryString, final String contentType, final int contentLength) {
+    final String auth = Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes());
+    return ("POST /api/v1/batch/" + getDatabaseName() + queryString + " HTTP/1.1\r\n"
+        + "Host: 127.0.0.1:" + httpPort() + "\r\n"
+        + "Authorization: Basic " + auth + "\r\n"
+        + "Content-Type: " + contentType + "\r\n"
+        + "Accept: " + NDJSON + "\r\n"
+        + "Content-Length: " + contentLength + "\r\n"
+        + "\r\n").getBytes(StandardCharsets.UTF_8);
+  }
+
+  private HttpURLConnection open(final String queryString, final String contentType, final String accept)
+      throws Exception {
+    final HttpURLConnection conn = (HttpURLConnection) new URL(
+        "http://127.0.0.1:" + httpPort() + "/api/v1/batch/" + getDatabaseName() + queryString).openConnection();
+    conn.setRequestMethod("POST");
+    conn.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+    conn.setRequestProperty("Content-Type", contentType);
+    if (accept != null)
+      conn.setRequestProperty("Accept", accept);
+    conn.setDoOutput(true);
+    return conn;
+  }
+
+  private void writeBody(final HttpURLConnection conn, final byte[] body) throws Exception {
+    conn.setFixedLengthStreamingMode(body.length);
+    try (final DataOutputStream wr = new DataOutputStream(conn.getOutputStream())) {
+      wr.write(body);
+    }
+  }
+
+  private JSONObject postBuffered(final byte[] body, final String queryString, final String contentType,
+      final int expectedStatus) throws Exception {
+    final HttpURLConnection conn = open(queryString, contentType, null);
+    writeBody(conn, body);
+    try {
+      assertThat(conn.getResponseCode()).isEqualTo(expectedStatus);
+      return new JSONObject(readAll(conn.getInputStream()));
+    } finally {
+      conn.disconnect();
+    }
+  }
+
+  private List<JSONObject> postStreamed(final byte[] body, final String queryString, final String contentType)
+      throws Exception {
+    final HttpURLConnection conn = open(queryString, contentType, NDJSON);
+    writeBody(conn, body);
+    try {
+      assertThat(conn.getResponseCode()).isEqualTo(200);
+      assertThat(conn.getContentType()).contains(NDJSON);
+      return parseEvents(readAll(conn.getInputStream()));
+    } finally {
+      conn.disconnect();
+    }
+  }
+
+  private static String readAll(final java.io.InputStream in) throws Exception {
+    try (in) {
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  private static List<JSONObject> parseEvents(final String body) {
+    final List<JSONObject> events = new ArrayList<>();
+    for (final String line : body.split("\n"))
+      if (!line.isBlank())
+        events.add(new JSONObject(line));
+    return events;
+  }
+
+  private static List<JSONObject> readEvents(final NdJsonBodyReader in) throws Exception {
+    final List<JSONObject> events = new ArrayList<>();
+    for (String line = in.nextLine(); line != null; line = in.nextLine()) {
+      if (line.isBlank())
+        continue;
+      final JSONObject event = new JSONObject(line);
+      events.add(event);
+      // The terminal line ends the stream; the connection may stay open past it.
+      if (event.has("summary") || event.has("error"))
+        break;
+    }
+    return events;
+  }
+
+  private static JSONObject terminal(final List<JSONObject> events, final String kind) {
+    assertThat(events).as("the stream must end with a terminal line").isNotEmpty();
+    final JSONObject last = events.get(events.size() - 1);
+    assertThat(last.has(kind)).as("expected a '" + kind + "' terminal line, got " + last).isTrue();
+    return last.getJSONObject(kind);
+  }
+
+  private static long countEvents(final List<JSONObject> events, final String kind) {
+    return events.stream().filter(e -> e.has(kind)).count();
+  }
+
+  private static String readStatusLine(final BufferedReader in) throws Exception {
+    return in.readLine();
+  }
+
+  private static java.util.Map<String, String> readHeaders(final BufferedReader in) throws Exception {
+    final java.util.Map<String, String> headers = new java.util.HashMap<>();
+    for (String line = in.readLine(); line != null && !line.isEmpty(); line = in.readLine()) {
+      final int colon = line.indexOf(':');
+      if (colon > 0)
+        headers.put(line.substring(0, colon).trim().toLowerCase(), line.substring(colon + 1).trim());
+    }
+    return headers;
+  }
+
+  /**
+   * Reads the NDJSON lines of a response taken off a raw socket, whichever transfer encoding Undertow chose for
+   * it. The distinction is not cosmetic: a streamed answer whose connection stays alive is chunked, so a reader
+   * that treated the body as plain text would parse the hexadecimal chunk sizes as JSON, while the truncated
+   * load that retires its connection sends the same lines with no framing at all.
+   * <p>
+   * Chunk sizes count bytes and this reads characters, which agrees here because every line is ASCII JSON.
+   */
+  private static final class NdJsonBodyReader {
+    private final BufferedReader        in;
+    private final boolean               chunked;
+    private final java.util.ArrayDeque<String> pending = new java.util.ArrayDeque<>();
+
+    private NdJsonBodyReader(final BufferedReader in, final java.util.Map<String, String> headers) {
+      this.in = in;
+      this.chunked = "chunked".equalsIgnoreCase(headers.getOrDefault("transfer-encoding", ""));
+    }
+
+    private String nextLine() throws Exception {
+      if (!chunked)
+        return in.readLine();
+
+      while (pending.isEmpty()) {
+        final String sizeLine = in.readLine();
+        if (sizeLine == null)
+          return null;
+        if (sizeLine.isBlank())
+          continue;
+        final int size = Integer.parseInt(sizeLine.trim().split(";")[0], 16);
+        if (size == 0)
+          return null;
+
+        final char[] buffer = new char[size];
+        int read = 0;
+        while (read < size) {
+          final int n = in.read(buffer, read, size - read);
+          if (n < 0)
+            break;
+          read += n;
+        }
+        in.readLine(); // the CRLF that closes the chunk
+        for (final String line : new String(buffer, 0, read).split("\n"))
+          if (!line.isBlank())
+            pending.add(line);
+      }
+      return pending.poll();
+    }
+  }
+
+  private long countVertices(final int fromId, final int toId) throws Exception {
+    final JSONObject count = executeCommand(0, "sql",
+        "SELECT count(*) as total FROM V1 WHERE id >= " + fromId + " AND id < " + toId);
+    return count.getJSONObject("result").getJSONArray("records").getJSONObject(0).getLong("total");
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/BatchStreamingApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/BatchStreamingApiSpecTest.java
@@ -77,8 +77,10 @@ class BatchStreamingApiSpecTest {
         .contains("phase", "verticesCreated", "edgesCreated", "linesRead", "linesSkipped", "bytesRead");
 
     assertThat(((Schema<?>) event.getProperties().get("error")).getProperties())
-        .as("the status the buffered encoding would have used travels in band, since 200 is already sent")
-        .containsKey("status");
+        .as("the status the buffered encoding would have used travels in band, since 200 is already sent, and "
+            + "the bookmark is on the FAILED line too - a batch is not atomic, so a failed load still committed "
+            + "the chunks a READ_YOUR_WRITES client has to read back")
+        .containsKeys("status", "commitIndex");
     assertThat(((Schema<?>) event.getProperties().get("summary")).getProperties())
         .as("so does the read-your-writes bookmark, which can no longer be a response header")
         .containsKey("commitIndex");

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/BatchStreamingApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/BatchStreamingApiSpecTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler.openapi;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7311: the streaming batch encoding is only reachable by a generated client if the document says it
+ * exists - the content type on the 200, the {@code Accept} header that selects it, and the shape of a line.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class BatchStreamingApiSpecTest {
+  private final OpenAPI openAPI = new OpenAPI();
+
+  @BeforeEach
+  void contribute() {
+    openAPI.setPaths(new Paths());
+    openAPI.setComponents(new Components());
+    new CoreApiSpec().contribute(openAPI);
+  }
+
+  @Test
+  void theBatch200OffersBothEncodings() {
+    final Operation post = openAPI.getPaths().get("/api/v1/batch/{database}").getPost();
+    assertThat(post.getResponses().get("200").getContent().keySet())
+        .as("the buffered body stays the documented default and the stream is offered alongside it")
+        .contains("application/json", "application/x-ndjson");
+  }
+
+  @Test
+  void anAcceptHeaderParameterSelectsTheStream() {
+    final Operation post = openAPI.getPaths().get("/api/v1/batch/{database}").getPost();
+    final Parameter accept = post.getParameters().stream()
+        .filter(p -> "Accept".equals(p.getName()) && "header".equals(p.getIn()))
+        .findFirst().orElse(null);
+
+    assertThat(accept).as("a generated client has no other way to ask for the stream").isNotNull();
+    assertThat(accept.getRequired()).isFalse();
+    assertThat(accept.getSchema().getEnum()).contains("application/json", "application/x-ndjson");
+  }
+
+  @Test
+  void theStreamedLineCarriesTheThreeEventKinds() {
+    final Schema<?> event = openAPI.getComponents().getSchemas().get("NdJsonBatchEvent");
+    assertThat(event).isNotNull();
+    assertThat(event.getProperties().keySet()).containsExactlyInAnyOrder("progress", "summary", "error");
+
+    final Schema<?> progress = (Schema<?>) event.getProperties().get("progress");
+    assertThat(progress.getProperties().keySet())
+        .as("a chunk acknowledgement carries the phase, the counters and the line accounting")
+        .contains("phase", "verticesCreated", "edgesCreated", "linesRead", "linesSkipped", "bytesRead");
+
+    assertThat(((Schema<?>) event.getProperties().get("error")).getProperties())
+        .as("the status the buffered encoding would have used travels in band, since 200 is already sent")
+        .containsKey("status");
+    assertThat(((Schema<?>) event.getProperties().get("summary")).getProperties())
+        .as("so does the read-your-writes bookmark, which can no longer be a response header")
+        .containsKey("commitIndex");
+  }
+
+  @Test
+  void theDescriptionTellsACallerHowToAskForIt() {
+    final Operation post = openAPI.getPaths().get("/api/v1/batch/{database}").getPost();
+    assertThat(post.getDescription())
+        .contains("application/x-ndjson")
+        .contains("progress")
+        .as("a progress counter is an upper bound, exactly like the partial-commit counters")
+        .contains("records attempted");
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/BatchStreamingApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/BatchStreamingApiSpecTest.java
@@ -80,7 +80,7 @@ class BatchStreamingApiSpecTest {
         .as("the status the buffered encoding would have used travels in band, since 200 is already sent, and "
             + "the bookmark is on the FAILED line too - a batch is not atomic, so a failed load still committed "
             + "the chunks a READ_YOUR_WRITES client has to read back")
-        .containsKeys("status", "commitIndex");
+        .containsKeys("status", "commitIndex", "statusMapped");
     assertThat(((Schema<?>) event.getProperties().get("summary")).getProperties())
         .as("so does the read-your-writes bookmark, which can no longer be a response header")
         .containsKey("commitIndex");
@@ -94,5 +94,18 @@ class BatchStreamingApiSpecTest {
         .contains("progress")
         .as("a progress counter is an upper bound, exactly like the partial-commit counters")
         .contains("records attempted");
+  }
+
+  /**
+   * The 400 and 408 this operation declares are not made unreachable by negotiating the stream: a load that
+   * fails before it has acknowledged anything still carries them, because the status line has not been sent
+   * yet. A document that implied otherwise would send a generated client looking for those failures only in
+   * the body.
+   */
+  @Test
+  void theDescriptionSaysAPreStreamFailureKeepsItsStatusCode() {
+    final Operation post = openAPI.getPaths().get("/api/v1/batch/{database}").getPost();
+    assertThat(post.getDescription()).contains("before it has acknowledged anything");
+    assertThat(post.getResponses().keySet()).contains("400", "408");
   }
 }


### PR DESCRIPTION
Closes #7311

`POST /api/v1/batch/{database}` already reads an `application/x-ndjson` request body incrementally, so the
*ingress* half of the gRPC client-streaming insert existed over HTTP. What had no counterpart was the
per-chunk **response**: a `/batch` caller learned nothing until the whole body had been consumed and the single
summary object was written, where an `InsertBidirectional` caller learns the outcome of chunk *n* while it is
still sending chunk *n+1*. This adds that half. A caller that sends `Accept: application/x-ndjson` receives a
newline-delimited stream - a `progress` line at every vertex commit and every `commitEvery` edges, then exactly
one `summary` or `error` line - written while its own upload is still being read. A caller that does not
negotiate it receives the same bytes under the same status as before. The load itself is unchanged and shared:
`streamRecords` still returns the one `ExecutionResponse` it always returned, and the streaming path turns that
into the terminal line rather than into a status line and a body, so the two encodings cannot disagree about
what a load did.

## The two decisions the issue asked to settle first

1. **Is the bidirectional shape worth expressing over HTTP, or does it belong to `/ws`?** The half that carries
   information is `BatchAck`, and HTTP/1.1 expresses it: a server may begin its response before the request body
   is complete, and Undertow's blocking exchange lets one worker thread read the request and write the response
   in turn. The `Start` / `Commit` control frames - a client changing the shape of the session mid-stream, a
   server pushing unsolicited messages - need a real duplex channel and stay on `/ws`, which is why OpenAPI 3.0
   cannot describe them. Filed as #7382.
2. **Is an incremental response additive?** Only if negotiated, so it is selected by `Accept`, exactly the way
   #7306 negotiated the streaming query. The unary shape is untouched.

## Things that are not obvious from the diff

- **The bookmark had to move in band.** `X-ArcadeDB-Commit-Index` (issue #5862) is a response header, and on
  this encoding the response has already started by the time the commit index is known - a header set then is
  dropped without a word. It travels in the terminal line instead, and `RemoteDatabase` reads it from there.
- **The response starts lazily.** Nothing is written until the first progress line, so a load that fails before
  it commits anything - a `DuplicatedKeyException`, a security failure, an invalid `refMode` - still reaches the
  standard error mapping and is answered with the status that mapping chose. Once a line is on the wire the
  status cannot be taken back, and only then is a failure reported in band with its intended status in the
  `error` object's `status` field.
- **A follower relays the encoding.** Without forwarding `Accept`, a client asking a follower for the stream
  would have been handed the leader's buffered object under `application/json` - a silent downgrade of the one
  thing it negotiated. `buildForwardRequest` gained an overload rather than a parameter, so the five existing
  tests that pin its signature are untouched.
- **A streamed request stays out of the idempotency replay cache.** The key is built from method, path,
  database and body, never from the negotiated encoding, so a hit recorded by an earlier buffered request would
  have been replayed to a streaming caller as one `application/json` object its reader cannot parse. The skip is
  gated on `supportsNdJsonEncoding()`, so a route that cannot stream keeps its replay protection whatever
  `Accept` says. **Secondary fix:** because the gate lives on the shared base handler, this closes the same
  replay hazard for `PostCommandHandler`'"'"'s streaming responses from #7306, which were not excluded from the
  cache before this PR.
- **A progress line is an upper bound on what is durable**, exactly like the partial-commit counters: vertices
  are committed at each flush, but `GraphBatch` buffers edges and writes them at close, so an edge-phase line
  counts records *accepted*. Stated in the javadoc, the OpenAPI description and the handler.

## Test plan

- [ ] `mvn -o -pl server -am verify -Dit.test=PostBatchStreamingIT` - 10 tests. The one that matters is
      `progressReachesTheClientBeforeTheBodyHasBeenFullySent`: it holds back half the payload and asserts the
      acknowledgement it reads carries a `bytesRead` strictly below the announced `Content-Length`, which a
      server answering only at the end of the body could not produce.
- [ ] `mvn -o -pl server -am verify -Dit.test=RemoteGraphBatchProgressIT` - the Java driver, including an edge
      that spans two flushes and so can only resolve through the mapping in the terminal line.
- [ ] `mvn -o -pl server -am test -Dtest=BatchStreamingApiSpecTest` - the generated document.
- [ ] `mvn -o -pl ha-raft -am verify -Dit.test=RaftBatchStreamingForwardIT` - a stream posted to a follower,
      relayed by the leader, with the bookmark surviving the hop. `@Tag("slow")`: it spins a 3-node cluster.
- [ ] Regression: `PostBatchHandlerIT`, `Issue5470BatchErrorDeliveryIT`, `Issue5618BatchLineAccountingIT`,
      `RemoteGraphBatchIT`, `Issue7306HttpStreamingQueryIT`, `Issue7306RemoteDatabaseStreamingAndVectorIT`,
      `NdJsonResultStreamTest`, `CoreApiSpecTest`, `IdempotencyCacheTest`, and the whole `network` module
      (478 tests) - all green.

Both mutations were run to prove the tests can fail: forcing `streaming` to `false` fails 9 of the 10
`PostBatchStreamingIT` methods (the timing one with a read timeout, which is the defect itself), leaving only
the "unchanged when not negotiated" one passing; dropping the relayed `Accept` fails
`RaftBatchStreamingForwardIT` on "a follower must not answer a negotiated stream with the buffered encoding".

## Coverage

Fixed and tested through their own entry point:

| Entry point | Test |
|---|---|
| Standalone/leader `POST /batch`, `Accept: application/x-ndjson` | `progressReachesTheClientBeforeTheBodyHasBeenFullySent` |
| The terminal `summary` == the unary 200 body | `theSummaryLineCarriesTheSameObjectTheUnaryEncodingWouldHaveSent` |
| Client-input failure after the stream started (400 in band) | `aClientInputFailureAfterTheStreamStartedIsReportedInBand` |
| Truncated upload after the stream started (408 in band) | `aTruncatedUploadAfterTheStreamStartedIsReportedInBand` |
| Failure **before** the stream started keeps its real status | `aFailureBeforeTheStreamStartedKeepsItsRealStatusCode` |
| No `Accept`, another type, or `;q=0` | `theUnaryEncodingIsUnchangedWhenTheStreamIsNotNegotiated` |
| Edge phase acknowledged on the `commitEvery` boundary | `theEdgePhaseIsAcknowledgedOnItsOwnBoundary` |
| CSV request body | `aCsvPayloadStreamsProgressToo` |
| Idempotency replay never hands a buffered body to a streaming caller | `anIdempotentRetryNeverReplaysABufferedBodyToAStreamingCaller` |
| No `commitIndex` on a standalone database | `theCommitIndexIsAbsentOnAStandaloneDatabase` |
| HA follower relay, with the bookmark | `RaftBatchStreamingForwardIT` |
| `RemoteDatabase` / `RemoteGraphBatch` | `RemoteGraphBatchProgressIT` (4 tests) |
| OpenAPI document | `BatchStreamingApiSpecTest` (4 tests) |

**Known gaps**

- **#7388** - raised in review: a streamed response is unbounded. The progress lines accumulate with the size
  of the load (~one 200-byte line per `vertexBatchSize` records), so a client that uploads millions of records
  without reading anything until it has finished can fill the socket buffers and block the worker thread inside
  a response `write()`, which stops it reading the upload too. The read side is watched
  (`httpStreamingReadTimeout`); the write side is not. Not bounded here because each candidate bound - a rate
  floor, a line cap, a write-side watchdog - changes what a client observes and invalidates a different one of
  the cadence tests; the issue lays out all three. The PR'"'"'s original risk note compared one line to the whole
  upload, which was the wrong comparison, and has been corrected in the javadoc, the OpenAPI description and
  the tracking doc.

- **#7382** - the `Start` / `Commit` control frames of `InsertBidirectional`, and a server free to push
  unsolicited messages, need a duplex channel. Not expressible over HTTP request/response under any encoding;
  belongs to `/ws`.
- **#7381** - pre-existing, found by this sweep: the idempotency key of the **buffered** `/batch` encoding does
  not cover the payload, because `parseRequestPayload` deliberately returns `null` so the body is never
  buffered. Two different loads sharing an `X-Request-Id` therefore replay each other. This PR closes it for the
  streaming encoding only, by keeping those requests out of the cache; fixing the buffered one needs a decision
  the issue lays out.

**One review surface this branch could not read:** Codacy reports 4 new issues (1 high ErrorProne, 3 minor
CodeStyle) and exposes them only through its dashboard - not through the PR comment, the check-run summary or
the API. `.codacy.yml` excludes test sources, so all four are in the production code changed here. Worth a
look before merging; the likeliest candidates (`catch (final Throwable t)`, and `NdJsonBatchResponse` being an
`AutoCloseable` deliberately not in a try-with-resources, because it has to still be open in the `catch` that
writes the in-band failure) are both intentional and explained in the code, but that is a guess about what the
tool flagged rather than a reading of it.

Nothing else in the completeness table is unaccounted for. `docs/7311-http-streaming-batch-insert.md` carries
the sweep, the greps behind it, the adversarial pass and the residual risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwTsBYjyoDn2vKXQGmt5bK



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional NDJSON streaming responses for batch HTTP inserts.
  - Clients can receive per-chunk progress updates followed by a summary or error event.
  - Added remote graph batch progress listeners for monitoring uploads.
  - Added streaming support through Raft forwarding, including commit information and partial-failure details.
  - Updated API documentation to describe the new response format.

- **Bug Fixes**
  - Improved handling of failures before and during streamed batch operations, including accurate status and progress information.
  - Preserved existing buffered behavior when streaming is not requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->