### PR TITLE
feat(#7326): gRPC vector, hybrid and full-text search run inside the client transaction

### DIFF
--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
@@ -2177,8 +2177,12 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
    * answers 400 with, so a client can distinguish "I asked for something illegal" from "the server broke".
    */
   public VectorSearchResponse vectorSearch(final VectorSearchRequest request) {
-    return searchCall("VectorSearch", request.toBuilder()
-            .setDatabase(getName()).setCredentials(buildCredentials()).build(),
+    final VectorSearchRequest.Builder builder = request.toBuilder()
+        .setDatabase(getName()).setCredentials(buildCredentials());
+    if (transactionId != null)
+      builder.setTransaction(openTransaction());
+
+    return searchCall("VectorSearch", builder.build(),
         req -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).vectorSearch(req));
   }
 
@@ -2187,8 +2191,12 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
    * {@link #vectorSearch(VectorSearchRequest)}.
    */
   public HybridSearchResponse hybridSearch(final HybridSearchRequest request) {
-    return searchCall("HybridSearch", request.toBuilder()
-            .setDatabase(getName()).setCredentials(buildCredentials()).build(),
+    final HybridSearchRequest.Builder builder = request.toBuilder()
+        .setDatabase(getName()).setCredentials(buildCredentials());
+    if (transactionId != null)
+      builder.setTransaction(openTransaction());
+
+    return searchCall("HybridSearch", builder.build(),
         req -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).hybridSearch(req));
   }
 
@@ -2197,15 +2205,30 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
    * {@link #vectorSearch(VectorSearchRequest)}.
    */
   public FullTextSearchResponse fullTextSearch(final FullTextSearchRequest request) {
-    return searchCall("FullTextSearch", request.toBuilder()
-            .setDatabase(getName()).setCredentials(buildCredentials()).build(),
+    final FullTextSearchRequest.Builder builder = request.toBuilder()
+        .setDatabase(getName()).setCredentials(buildCredentials());
+    if (transactionId != null)
+      builder.setTransaction(openTransaction());
+
+    return searchCall("FullTextSearch", builder.build(),
         req -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).fullTextSearch(req));
   }
 
   /**
-   * Runs one of the three search RPCs. The database name and the credentials are stamped on by the caller rather
-   * than left to the application, so a request built by hand cannot address a database other than the one this
-   * connection is open on.
+   * The {@code TransactionContext} naming this connection's open transaction, in the shape every other
+   * transaction-scoped RPC on this class already sends. Callers guard on {@code transactionId != null} first;
+   * this only assembles the message.
+   */
+  private TransactionContext openTransaction() {
+    return TransactionContext.newBuilder().setTransactionId(transactionId).setDatabase(getName()).build();
+  }
+
+  /**
+   * Runs one of the three search RPCs. The database name, the credentials and this connection's open
+   * transaction are stamped on by the caller rather than left to the application, so a request built by hand
+   * cannot address a database other than the one this connection is open on, and a search issued inside a
+   * transaction reads inside it (issue #7326) the way the HTTP routes always have through the
+   * {@code arcadedb-session-id} header.
    */
   private <Req, Resp> Resp searchCall(final String operation, final Req request, final SearchRpc<Req, Resp> rpc) {
     checkDatabaseIsOpen();

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue7326GrpcSearchInTransactionIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue7326GrpcSearchInTransactionIT.java
@@ -1,0 +1,404 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.remote.RemoteDatabase;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.grpc.FullTextSearchRequest;
+import com.arcadedb.server.grpc.FullTextSearchResponse;
+import com.arcadedb.server.grpc.HybridSearchRequest;
+import com.arcadedb.server.grpc.HybridSearchResponse;
+import com.arcadedb.server.grpc.SearchHit;
+import com.arcadedb.server.grpc.TransactionContext;
+import com.arcadedb.server.grpc.VectorSearchRequest;
+import com.arcadedb.server.grpc.VectorSearchResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7326: the three search RPCs #7306 added carried {@code database} and {@code credentials} but no
+ * {@code TransactionContext}, so a search issued while the client held an open gRPC transaction ran on a gRPC
+ * worker thread rather than on the transaction's own thread and could not observe that transaction's
+ * uncommitted writes. The equivalent HTTP request, which carries {@code arcadedb-session-id} and therefore runs
+ * inside the session's transaction through {@code DatabaseAbstractHandler}, could - and the last test here
+ * asserts that the two protocols now agree, since that equivalence is what #7306 set out to establish.
+ * <p>
+ * What is asserted is the <i>read</i> the search performs, not the index scan that feeds it. A vector or
+ * full-text index is populated at commit replay, so a record created inside the transaction is not yet a
+ * candidate of the scan; every hit the scan does produce is then materialized with
+ * {@code database.lookupByRID(rid, true)} (see {@code VectorSearch.appendResult} and
+ * {@code FullTextQuery.search}), and the vector leg's {@code filter} is a SQL predicate evaluated over that
+ * candidate window. Those are the reads that must be transactional, and they are what an uncommitted UPDATE
+ * observably changes.
+ */
+public class Issue7326GrpcSearchInTransactionIT extends BaseGraphServerTest {
+  private static final String TYPE        = "GrpcTx7326";
+  private static final String DENSE_INDEX = "GrpcTx7326[embedding]";
+  private static final String TEXT_INDEX  = "GrpcTx7326[text]";
+  private static final int    GRPC_PORT   = 50051;
+
+  private RemoteGrpcServer   server;
+  private RemoteGrpcDatabase database;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GRPC:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @Override
+  protected void populateDatabase() {
+    super.populateDatabase();
+
+    final Database db = getDatabase(0);
+    db.transaction(() -> {
+      db.command("sql", "CREATE DOCUMENT TYPE " + TYPE + " BUCKETS 1");
+      db.command("sql", "CREATE PROPERTY " + TYPE + ".name STRING");
+      db.command("sql", "CREATE PROPERTY " + TYPE + ".text STRING");
+      db.command("sql", "CREATE PROPERTY " + TYPE + ".embedding ARRAY_OF_FLOATS");
+      db.command("sql", "CREATE INDEX ON " + TYPE + " (embedding) LSM_VECTOR "
+          + "METADATA { dimensions: 3, similarity: 'COSINE' }");
+      db.command("sql", "CREATE INDEX ON " + TYPE + " (text) FULL_TEXT");
+
+      db.newDocument(TYPE).set("name", "near").set("text", "alpha beta")
+          .set("embedding", new float[] { 1.0f, 0.0f, 0.0f }).save();
+      db.newDocument(TYPE).set("name", "mid").set("text", "beta gamma")
+          .set("embedding", new float[] { 0.9f, 0.1f, 0.0f }).save();
+      db.newDocument(TYPE).set("name", "far").set("text", "gamma delta")
+          .set("embedding", new float[] { 0.0f, 1.0f, 0.0f }).save();
+    });
+  }
+
+  @BeforeEach
+  @Override
+  public void beginTest() {
+    super.beginTest();
+    server = new RemoteGrpcServer("localhost", GRPC_PORT, "root", DEFAULT_PASSWORD_FOR_TESTS, true, List.of());
+    database = new RemoteGrpcDatabase(server, "localhost", GRPC_PORT, getServer(0).getHttpServer().getPort(),
+        getDatabaseName(), "root", DEFAULT_PASSWORD_FOR_TESTS);
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    if (database != null) {
+      try {
+        if (database.isTransactionActive())
+          database.rollback();
+      } catch (final Throwable ignore) {
+        // the test already failed; do not mask it
+      }
+      database.close();
+    }
+    if (server != null)
+      server.close();
+    super.endTest();
+  }
+
+  @Test
+  void vectorSearchInsideATransactionSeesItsUncommittedUpdate() {
+    database.begin();
+    try {
+      database.command("sql", "UPDATE " + TYPE + " SET name = 'renamed-in-tx' WHERE name = 'near'");
+
+      final VectorSearchResponse response = database.vectorSearch(VectorSearchRequest.newBuilder()
+          .setIndexName(DENSE_INDEX)
+          .addAllQueryVector(List.of(1.0f, 0.0f, 0.0f))
+          .setK(3)
+          .build());
+
+      assertThat(names(response.getResultsList()))
+          .as("the search must run inside the caller's transaction and see its uncommitted UPDATE")
+          .containsExactly("renamed-in-tx", "mid", "far");
+    } finally {
+      database.rollback();
+    }
+
+    // Proof the update really was uncommitted: after the rollback the original value is back.
+    final VectorSearchResponse afterRollback = database.vectorSearch(VectorSearchRequest.newBuilder()
+        .setIndexName(DENSE_INDEX)
+        .addAllQueryVector(List.of(1.0f, 0.0f, 0.0f))
+        .setK(3)
+        .build());
+    assertThat(names(afterRollback.getResultsList())).containsExactly("near", "mid", "far");
+  }
+
+  /**
+   * The vector leg's {@code filter} is a SQL predicate over the candidate window, so it is the second read the
+   * search performs and it has to be evaluated inside the transaction too - a hit renamed by the transaction
+   * must be selectable by its new name and not by its old one.
+   */
+  @Test
+  void theVectorFilterIsEvaluatedInsideTheTransaction() {
+    database.begin();
+    try {
+      database.command("sql", "UPDATE " + TYPE + " SET name = 'renamed-in-tx' WHERE name = 'near'");
+
+      final VectorSearchResponse matched = database.vectorSearch(VectorSearchRequest.newBuilder()
+          .setIndexName(DENSE_INDEX)
+          .addAllQueryVector(List.of(1.0f, 0.0f, 0.0f))
+          .setFilter("name = 'renamed-in-tx'")
+          .setK(3)
+          .build());
+      assertThat(names(matched.getResultsList())).containsExactly("renamed-in-tx");
+
+      final VectorSearchResponse stale = database.vectorSearch(VectorSearchRequest.newBuilder()
+          .setIndexName(DENSE_INDEX)
+          .addAllQueryVector(List.of(1.0f, 0.0f, 0.0f))
+          .setFilter("name = 'near'")
+          .setK(3)
+          .build());
+      assertThat(names(stale.getResultsList())).isEmpty();
+    } finally {
+      database.rollback();
+    }
+  }
+
+  @Test
+  void fullTextSearchInsideATransactionSeesItsUncommittedUpdate() {
+    database.begin();
+    try {
+      database.command("sql", "UPDATE " + TYPE + " SET name = 'renamed-in-tx' WHERE name = 'near'");
+
+      final FullTextSearchResponse response = database.fullTextSearch(FullTextSearchRequest.newBuilder()
+          .setIndexName(TEXT_INDEX)
+          .setQueryText("alpha")
+          .setLimit(5)
+          .build());
+
+      assertThat(names(response.getResultsList())).containsExactly("renamed-in-tx");
+    } finally {
+      database.rollback();
+    }
+  }
+
+  @Test
+  void hybridSearchInsideATransactionSeesItsUncommittedUpdate() {
+    database.begin();
+    try {
+      database.command("sql", "UPDATE " + TYPE + " SET name = 'renamed-in-tx' WHERE name = 'near'");
+
+      final HybridSearchResponse response = database.hybridSearch(HybridSearchRequest.newBuilder()
+          .setVectorIndexName(DENSE_INDEX)
+          .addAllQueryVector(List.of(1.0f, 0.0f, 0.0f))
+          .setFulltextIndexName(TEXT_INDEX)
+          .setFulltextQuery("alpha")
+          .setK(3)
+          .build());
+
+      assertThat(names(response.getResultsList())).contains("renamed-in-tx").doesNotContain("near");
+    } finally {
+      database.rollback();
+    }
+  }
+
+  /**
+   * The verification the issue itself asks for: a record created inside the transaction, found by a search
+   * issued inside that same transaction, before any commit. It works on the full-text path because the
+   * full-text index resolves its posting lists through the transaction, so a row written in the transaction is
+   * already a candidate of the scan - which makes this the strongest available form of the assertion, not just
+   * a re-read of an already-indexed hit.
+   * <p>
+   * The dense vector index does not do this: its graph is rebuilt at commit replay, so the same row is not yet a
+   * candidate there. That is an index-layer limit rather than a wire-protocol one - it is identical on HTTP with
+   * a session id, as {@link #httpAndGrpcAgreeOnARecordCreatedInsideTheTransaction} asserts - and it is tracked
+   * separately.
+   */
+  @Test
+  void fullTextSearchInsideATransactionFindsARecordCreatedInIt() {
+    database.begin();
+    try {
+      database.command("sql", "INSERT INTO " + TYPE
+          + " SET name = 'created-in-tx', text = 'zulu', embedding = [1.0, 0.0, 0.0]");
+
+      final FullTextSearchResponse response = database.fullTextSearch(FullTextSearchRequest.newBuilder()
+          .setIndexName(TEXT_INDEX)
+          .setQueryText("zulu")
+          .setLimit(5)
+          .build());
+
+      assertThat(names(response.getResultsList()))
+          .as("a record created inside the transaction must be findable inside it, before the commit")
+          .containsExactly("created-in-tx");
+    } finally {
+      database.rollback();
+    }
+
+    // Rolled back, so it must be gone again - proof the hit above really was uncommitted.
+    final FullTextSearchResponse afterRollback = database.fullTextSearch(FullTextSearchRequest.newBuilder()
+        .setIndexName(TEXT_INDEX)
+        .setQueryText("zulu")
+        .setLimit(5)
+        .build());
+    assertThat(afterRollback.getCount()).isZero();
+  }
+
+  /**
+   * A non-blank transaction id the server no longer knows - reaped, committed or simply invented - must fail
+   * loudly rather than silently reading outside the transaction the caller believes it is inside. This is the
+   * same contract {@code updateRecord} and {@code lookupByRid} already carry.
+   */
+  @Test
+  void aSearchNamingAnUnknownTransactionIsRejected() {
+    final TransactionContext ghost = TransactionContext.newBuilder().setTransactionId("no-such-tx-7326").build();
+
+    assertThatThrownBy(() -> database.vectorSearch(VectorSearchRequest.newBuilder()
+        .setIndexName(DENSE_INDEX)
+        .addAllQueryVector(List.of(1.0f, 0.0f, 0.0f))
+        .setK(3)
+        .setTransaction(ghost)
+        .build()))
+        .hasMessageContaining("no-such-tx-7326");
+
+    assertThatThrownBy(() -> database.hybridSearch(HybridSearchRequest.newBuilder()
+        .setVectorIndexName(DENSE_INDEX)
+        .addAllQueryVector(List.of(1.0f, 0.0f, 0.0f))
+        .setK(3)
+        .setTransaction(ghost)
+        .build()))
+        .hasMessageContaining("no-such-tx-7326");
+
+    assertThatThrownBy(() -> database.fullTextSearch(FullTextSearchRequest.newBuilder()
+        .setIndexName(TEXT_INDEX)
+        .setQueryText("alpha")
+        .setLimit(5)
+        .setTransaction(ghost)
+        .build()))
+        .hasMessageContaining("no-such-tx-7326");
+  }
+
+  /**
+   * The equivalence #7306 set out to establish: the same scenario over HTTP, where the session id already made
+   * the search transactional, must produce the same answer as the gRPC run above.
+   */
+  @Test
+  void httpAndGrpcAgreeOnWhatATransactionalSearchSees() {
+    final List<String> viaGrpc;
+    database.begin();
+    try {
+      database.command("sql", "UPDATE " + TYPE + " SET name = 'renamed-in-tx' WHERE name = 'near'");
+      viaGrpc = names(database.vectorSearch(VectorSearchRequest.newBuilder()
+          .setIndexName(DENSE_INDEX)
+          .addAllQueryVector(List.of(1.0f, 0.0f, 0.0f))
+          .setK(3)
+          .build()).getResultsList());
+    } finally {
+      database.rollback();
+    }
+
+    try (final RemoteDatabase http = new RemoteDatabase("localhost", getServer(0).getHttpServer().getPort(),
+        getDatabaseName(), "root", DEFAULT_PASSWORD_FOR_TESTS)) {
+      http.begin();
+      try {
+        http.command("sql", "UPDATE " + TYPE + " SET name = 'renamed-in-tx' WHERE name = 'near'");
+        final JSONObject response = http.vectorSearch(new JSONObject()
+            .put("indexName", DENSE_INDEX)
+            .put("queryVector", new JSONArray(List.of(1.0, 0.0, 0.0)))
+            .put("k", 3));
+        assertThat(httpNames(response)).isEqualTo(viaGrpc);
+      } finally {
+        http.rollback();
+      }
+    }
+  }
+
+  /**
+   * The other half of the parity claim, for the record the transaction created rather than the one it updated.
+   * Neither protocol finds it through the dense vector index and both find it through the full-text index, so
+   * what the two surfaces expose is the same index behaviour rather than a difference introduced by the wire.
+   * If the vector index ever starts resolving uncommitted rows, this test fails on both halves at once and says
+   * which claim to revisit.
+   */
+  @Test
+  void httpAndGrpcAgreeOnARecordCreatedInsideTheTransaction() {
+    final int grpcVectorHits;
+    final List<String> grpcFullTextHits;
+    database.begin();
+    try {
+      database.command("sql", "INSERT INTO " + TYPE
+          + " SET name = 'created-in-tx', text = 'zulu', embedding = [1.0, 0.0, 0.0]");
+      grpcVectorHits = names(database.vectorSearch(VectorSearchRequest.newBuilder()
+          .setIndexName(DENSE_INDEX)
+          .addAllQueryVector(List.of(1.0f, 0.0f, 0.0f))
+          .setK(10)
+          .build()).getResultsList()).size();
+      grpcFullTextHits = names(database.fullTextSearch(FullTextSearchRequest.newBuilder()
+          .setIndexName(TEXT_INDEX)
+          .setQueryText("zulu")
+          .setLimit(10)
+          .build()).getResultsList());
+    } finally {
+      database.rollback();
+    }
+
+    assertThat(grpcFullTextHits).containsExactly("created-in-tx");
+
+    try (final RemoteDatabase http = new RemoteDatabase("localhost", getServer(0).getHttpServer().getPort(),
+        getDatabaseName(), "root", DEFAULT_PASSWORD_FOR_TESTS)) {
+      http.begin();
+      try {
+        http.command("sql", "INSERT INTO " + TYPE
+            + " SET name = 'created-in-tx', text = 'zulu', embedding = [1.0, 0.0, 0.0]");
+        assertThat(httpNames(http.vectorSearch(new JSONObject()
+            .put("indexName", DENSE_INDEX)
+            .put("queryVector", new JSONArray(List.of(1.0, 0.0, 0.0)))
+            .put("k", 10))))
+            .as("the dense index scan must miss the new row on HTTP exactly as it does on gRPC")
+            .hasSize(grpcVectorHits)
+            .doesNotContain("created-in-tx");
+        assertThat(httpNames(http.fullTextSearch(new JSONObject()
+            .put("indexName", TEXT_INDEX)
+            .put("queryText", "zulu")
+            .put("limit", 10))))
+            .isEqualTo(grpcFullTextHits);
+      } finally {
+        http.rollback();
+      }
+    }
+  }
+
+  // ───────────────────────────── plumbing ─────────────────────────────
+
+  private static List<String> names(final List<SearchHit> hits) {
+    final List<String> names = new ArrayList<>(hits.size());
+    for (final SearchHit hit : hits)
+      names.add(hit.getRecord().getPropertiesMap().get("name").getStringValue());
+    return names;
+  }
+
+  private static List<String> httpNames(final JSONObject response) {
+    final JSONArray results = response.getJSONArray("results");
+    final List<String> names = new ArrayList<>(results.length());
+    for (int i = 0; i < results.length(); i++)
+      names.add(results.getJSONObject(i).getJSONObject("properties").getString("name"));
+    return names;
+  }
+}

--- a/grpc/src/main/proto/arcadedb-server.proto
+++ b/grpc/src/main/proto/arcadedb-server.proto
@@ -227,6 +227,12 @@ message VectorSearchRequest {
 
   // Search an LSM_SPARSE_VECTOR index instead of a dense one.
   bool sparse = 9;
+
+  // Optional externally-managed transaction (issue #7326). When it names a live transaction the search runs on
+  // that transaction's own thread, so it reads exactly what the transaction reads - matching the HTTP routes,
+  // which run inside the session's transaction whenever the request carries `arcadedb-session-id`. A non-blank
+  // id the server no longer knows is refused with FAILED_PRECONDITION rather than silently read outside it.
+  TransactionContext transaction = 15;
 }
 
 // One hit of any of the three searches. `distance` and `score` rank in opposite directions, so which of them is
@@ -302,6 +308,12 @@ message HybridSearchRequest {
 
   // Optional graph expansion leg, seeded from the union of the retrieval legs.
   HybridExpand expand = 14;
+
+  // Optional externally-managed transaction (issue #7326). When it names a live transaction the search runs on
+  // that transaction's own thread, so it reads exactly what the transaction reads - matching the HTTP routes,
+  // which run inside the session's transaction whenever the request carries `arcadedb-session-id`. A non-blank
+  // id the server no longer knows is refused with FAILED_PRECONDITION rather than silently read outside it.
+  TransactionContext transaction = 15;
 }
 
 message HybridSearchResponse {
@@ -342,6 +354,12 @@ message FullTextSearchRequest {
 
   // Maximum number of results. Bounded server-side; 0 means "use the server default".
   int32 limit = 7;
+
+  // Optional externally-managed transaction (issue #7326). When it names a live transaction the search runs on
+  // that transaction's own thread, so it reads exactly what the transaction reads - matching the HTTP routes,
+  // which run inside the session's transaction whenever the request carries `arcadedb-session-id`. A non-blank
+  // id the server no longer knows is refused with FAILED_PRECONDITION rather than silently read outside it.
+  TransactionContext transaction = 8;
 }
 
 message FullTextSearchResponse {

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -132,6 +132,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.logging.Level;
 
 /**
@@ -5084,7 +5085,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   @Override
   public void vectorSearch(final VectorSearchRequest request, final StreamObserver<VectorSearchResponse> resp) {
     GrpcUnaryCall.respond(resp,
-        () -> GrpcVectorSearch.search(getDatabase(request.getDatabase(), request.getCredentials()), request),
+        () -> searchInTransaction(request.hasTransaction() ? request.getTransaction().getTransactionId() : null,
+            request.getDatabase(), request.getCredentials(), db -> GrpcVectorSearch.search(db, request)),
         e -> toSearchStatus("VectorSearch", e));
   }
 
@@ -5094,7 +5096,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   @Override
   public void hybridSearch(final HybridSearchRequest request, final StreamObserver<HybridSearchResponse> resp) {
     GrpcUnaryCall.respond(resp,
-        () -> GrpcVectorSearch.hybridSearch(getDatabase(request.getDatabase(), request.getCredentials()), request),
+        () -> searchInTransaction(request.hasTransaction() ? request.getTransaction().getTransactionId() : null,
+            request.getDatabase(), request.getCredentials(), db -> GrpcVectorSearch.hybridSearch(db, request)),
         e -> toSearchStatus("HybridSearch", e));
   }
 
@@ -5104,8 +5107,55 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   @Override
   public void fullTextSearch(final FullTextSearchRequest request, final StreamObserver<FullTextSearchResponse> resp) {
     GrpcUnaryCall.respond(resp,
-        () -> GrpcVectorSearch.fullTextSearch(getDatabase(request.getDatabase(), request.getCredentials()), request),
+        () -> searchInTransaction(request.hasTransaction() ? request.getTransaction().getTransactionId() : null,
+            request.getDatabase(), request.getCredentials(), db -> GrpcVectorSearch.fullTextSearch(db, request)),
         e -> toSearchStatus("FullTextSearch", e));
+  }
+
+  /**
+   * Runs a search body against the database it must actually read (issue #7326).
+   * <p>
+   * A search is a read, and an ArcadeDB transaction is thread-bound: its uncommitted changes are visible only
+   * on the thread that owns it. So when the request names a live transaction the body runs on that
+   * transaction's own executor thread through {@link #submitToActiveTransaction}, against the transaction's own
+   * database handle - never against a handle re-resolved from the request's database name, which
+   * {@link #authorizeTransactionAccess} also refuses to trust. Without a transaction id the body runs inline on
+   * the calling gRPC worker against a freshly authorized handle, exactly as before.
+   * <p>
+   * A non-blank transaction id the server no longer knows (reaped, committed, or invented) is refused with
+   * FAILED_PRECONDITION instead of quietly falling through to a read outside the transaction the caller
+   * believes it is inside - the same contract {@code lookupByRid} and {@code updateRecord} carry. A blank id is
+   * not a supplied one and legitimately means "no external transaction".
+   *
+   * @param incomingTxId the request's transaction id, or null when the request carried no TransactionContext
+   * @param body         the search, which must not retain the database handle beyond the call
+   */
+  private <T> T searchInTransaction(final String incomingTxId, final String databaseName,
+      final DatabaseCredentials credentials, final Function<Database, T> body) throws Exception {
+    final TransactionContext txCtx = resolveAuthorizedTransaction(incomingTxId, credentials);
+
+    if (isUnknownSuppliedTransaction(incomingTxId, txCtx))
+      throw unknownTransactionStatus(incomingTxId).asRuntimeException();
+
+    if (txCtx == null)
+      return body.apply(getDatabase(databaseName, credentials));
+
+    try {
+      return submitToActiveTransaction(txCtx, () -> body.apply(txCtx.db)).get();
+    } catch (final ExecutionException e) {
+      // Unwrap so toSearchStatus() sees the real failure - an explicit gRPC status raised by
+      // requireTransactionStillActive, or the IllegalArgumentException the shared implementation reports a
+      // crossed bound with - rather than mapping every in-transaction search fault to INTERNAL.
+      final Throwable cause = e.getCause();
+      if (cause instanceof final Error error)
+        throw error;
+      if (cause instanceof final Exception exception)
+        throw exception;
+      throw e;
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw e;
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #7326

## Problem

The three search RPCs added by #7306 (`VectorSearch`, `HybridSearch`, `FullTextSearch`) carried
`database` and `credentials` but no `TransactionContext`, so a search issued while the client held
an open gRPC transaction ran on a gRPC worker thread instead of the transaction's own thread and
could not observe that transaction's uncommitted writes. The HTTP routes never had the gap:
`AbstractVectorSearchHandler` extends `DatabaseAbstractHandler`, which binds the session's
transaction whenever the request carries `arcadedb-session-id`.

## Fix

1. **proto** - `TransactionContext transaction` on `VectorSearchRequest` (15), `HybridSearchRequest`
   (15) and `FullTextSearchRequest` (8); field numbers as the issue specifies, all inside the 1-byte
   tag range.
2. **server** - one shared `searchInTransaction(...)` resolving the transaction exactly as
   `lookupByRid` / `updateRecord` already do (`resolveAuthorizedTransaction`,
   `isUnknownSuppliedTransaction` -> `unknownTransactionStatus`, `submitToActiveTransaction`),
   falling back to `getDatabase(...)` when no transaction is named. It also unwraps the
   `ExecutionException` from the transaction executor before `toSearchStatus` sees it, which is what
   keeps `requireTransactionStillActive`'s FAILED_PRECONDITION and the shared implementation's
   INVALID_ARGUMENT from flattening to INTERNAL.
3. **client** - `RemoteGrpcDatabase` stamps the open transaction on the three search requests the
   same way it already does for `executeQuery`, `lookupByRid`, `updateRecord` and the rest.

| File | Change |
|---|---|
| `grpc/src/main/proto/arcadedb-server.proto` | the three new `transaction` fields |
| `grpcw/.../ArcadeDbGrpcService.java` | new `searchInTransaction(...)`; the three handlers route through it |
| `grpc-client/.../RemoteGrpcDatabase.java` | the three search methods stamp the open transaction |
| `grpc-client/src/test/.../Issue7326GrpcSearchInTransactionIT.java` | new, 8 tests |

## Residual risk, measured

The dense vector index does **not** resolve a row created in the open transaction; the full-text
index **does**. Measured on both protocols, inside one transaction, before any commit (the query
vector is exactly the new row's embedding, so it would rank first if it were a candidate):

```
gRPC  vector   count=1  names=[seed]            <- new row NOT a candidate
gRPC  fulltext count=1  names=[created-in-tx]   <- new row IS found
HTTP  vector   count=1  (only the seed rid)     <- same as gRPC
HTTP  fulltext count=1                          <- same as gRPC
```

So the protocol parity this issue is about does hold: HTTP with a session id behaves identically.
The vector gap is an index-layer limit (the graph is populated at commit replay), filed as **#7378**,
and `httpAndGrpcAgreeOnARecordCreatedInsideTheTransaction` pins the current behaviour on both
protocols so that whichever way #7378 is resolved the test fails and names the claim to revisit.
`fullTextSearchInsideATransactionFindsARecordCreatedInIt` asserts the issue's own proposed
verification on the path where it is achievable.

Everything the search does *with* the candidates it gets is transactional either way: the vector
leg's `filter` and the `database.lookupByRID` that materializes each hit. Neither search
implementation forks work off the calling thread (no executor, stream, future or thread use in
`HybridSearch`, `VectorSearch`, `FullTextQuery`, `VectorLeg`), so nothing escapes the transaction's
executor once the body is dispatched. `arcadedb-server.proto` is the only proto in the tree and no
generated stubs for other languages are checked in, so the new fields need no companion regeneration.

## Verification

```
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0 -- Issue7326GrpcSearchInTransactionIT
```

**Proof the tests can fail.** With `searchInTransaction` temporarily reverted to the pre-fix body
(`return body.apply(getDatabase(databaseName, credentials));`) and only that changed, all six tests
that existed at that point failed:

```
Tests run: 6, Failures: 6, Errors: 0, Skipped: 0
  vectorSearchInsideATransactionSeesItsUncommittedUpdate
  theVectorFilterIsEvaluatedInsideTheTransaction
  fullTextSearchInsideATransactionSeesItsUncommittedUpdate
  hybridSearchInsideATransactionSeesItsUncommittedUpdate
  aSearchNamingAnUnknownTransactionIsRejected
  httpAndGrpcAgreeOnWhatATransactionalSearchSees
```

Regression: `grpc-client` 150 unit tests green; `grpcw` and `grpc-client` IT suites green (25/25 and
27/27) after re-running three classes in isolation whose only errors were
`Failed to bind to address 0.0.0.0:50051` from a parallel build holding the fixed gRPC test port.
`Issue7306GrpcVectorSearchIT`, the suite this is layered on, 5/5. `mvn -o -pl grpc,grpcw,grpc-client
package -DskipTests` clean on the committed tree.

One run errored once in teardown with `ABORTED: Rollback failed: graph`
(`DatabaseIsClosedException`) inside that same port-contention window and did not reproduce in 10
subsequent runs; `BaseGraphServerTest` restarts the server on fixed ports per method, so a start
racing a previous shutdown is an exposure every IT in this module shares and `rollbackTransaction` is
untouched here. Recorded so a future occurrence is not mistaken for a new symptom.

## Argued, no change needed

- **OpenAPI** - HTTP behaviour is unchanged, and `arcadedb-session-id` is documented on *no* route in
  `server/src/main/java/com/arcadedb/server/http/handler/openapi/`, so documenting it on these three
  alone would make the spec less consistent.
- **MCP** - no session or transaction surface exists to plumb through.

## Follow-ups filed

- **#7370** - `TimeSeriesQuery` / `TimeSeriesLatest` carry the identical missing-`TransactionContext`
  gap (found by the completeness sweep).
- **#7378** - the dense vector index does not resolve rows created in the open transaction.

## Process caveat

Phase 1.5's adversarial pass could not be delegated to an isolated subagent - no `Task` tool was
exposed in that environment - so it ran inline, which lacks the not-already-convinced property. It
still caught two real things: that the suite never asserted the issue's own proposed verification
(now added), and that the first residual-risk paragraph was wrong about full-text (corrected by
measurement above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwTsBYjyoDn2vKXQGmt5bK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vector, hybrid, and full-text searches now support execution within an active transaction.
  * Searches performed during a transaction can see that transaction’s uncommitted changes.
  * Search results remain consistent with transaction outcomes, including rollback behavior.

* **Bug Fixes**
  * Invalid or unavailable transaction identifiers now return a clear precondition error instead of executing outside the requested transaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->