### PR TITLE
feat(#7188,#7089): COPY ... TO STDOUT over the Postgres wire, and NaN-transparent TimeSeries SUM/AVG

### DIFF
--- a/docs/7188-7089-copy-to-stdout-and-nan-transparent-sum.md
+++ b/docs/7188-7089-copy-to-stdout-and-nan-transparent-sum.md
@@ -1,0 +1,142 @@
+# #7188 and #7089 - COPY ... TO STDOUT over the Postgres wire, and NaN-transparent TimeSeries SUM/AVG
+
+<https://github.com/ArcadeData/arcadedb/issues/7188>
+<https://github.com/ArcadeData/arcadedb/issues/7089>
+
+Two unrelated gaps, each left behind by an earlier fix that scoped itself deliberately: #7188 was split
+out of #7180 (the Arrow ADBC bootstrap) as "a feature in its own right", and #7089 was filed from the
+review of #7087, which unified the MIN/MAX NaN policy and left SUM/AVG visibly outside it.
+
+## Finding ledger
+
+- [x] 1. `COPY (<query>) TO STDOUT` rejected by the SQL parser, so the Arrow ADBC PostgreSQL driver's
+      default read path, `psql \copy` and every bulk-export tool stop at the first query - **implemented**,
+      text, CSV and binary, option-list and legacy keyword spellings, simple and extended protocol
+- [x] 2. TimeSeries `SUM`/`AVG` poisoned by one NaN sample: the sealed block's declared sum is NaN, the
+      block-statistics fast path answers from it, and a whole Grafana bucket goes blank - **fixed**, under
+      the one NaN policy, with the count of real samples added to the sealed block statistics so the fast
+      path stays exact
+
+## 1. COPY ... TO STDOUT
+
+### What the protocol answers
+
+`PostgresCopyStatement` recognises the statement ahead of the SQL engine, exactly where `SET`/`SHOW` and
+the system queries are recognised - "COPY" is no production of ArcadeDB's grammar, so parsing it would be a
+guaranteed failure. The source is a parenthesised query, run verbatim in the session's language, or a type
+name with an optional column list, which is the same statement with an implicit `SELECT`. Both spellings
+PostgreSQL accepts are read: the option list (`FORMAT`, `DELIMITER`, `NULL`, `HEADER`, `QUOTE`, `ESCAPE`,
+`FORCE_QUOTE`, `ENCODING`) and the pre-9.0 keywords (`BINARY`, `CSV HEADER`, `DELIMITER AS`, ...), with the
+combination rules `ProcessCopyOptions` applies (no `HEADER` in binary, `QUOTE` only in CSV, ...).
+
+The executor's `copyOut` frames the answer: `CopyOutResponse` ('H') with the overall format and one
+format code per column, one `CopyData` ('d') per row (plus one for the binary header and one for the
+trailer), `CopyDone` ('c'), and the caller's `CommandComplete` tagged `COPY n`. CopyData is buffered and
+written in 64 KB batches: one socket write per row is a system call per row on the statement whose whole
+point is bulk, and one write per result would hold it all.
+
+On the extended protocol - what `PQexecParams` sends, and therefore what the ADBC driver sends - a COPY is
+a portal like any other: `Describe('S')` answers `ParameterDescription` then `NoData`, `Describe('P')`
+answers `NoData`, `Execute` streams, a second `Execute` of the same portal is refused with `34000` as
+PostgreSQL refuses to run a completed portal. The query INSIDE the COPY is what `Parse` hands to the SQL
+engine, so a syntax error in it is reported at `Parse`, the way a plain statement's is.
+
+### Columns are resolved the way Describe resolves them
+
+This is the one decision that is not visible from the protocol text. The ADBC driver prepares and
+describes the inner statement first, then decodes the binary COPY stream by the OIDs the description
+promised. So `copyOut` resolves the columns with `getColumnsFromQuerySchema` - the same call
+`Describe('S')` makes - and only when that cannot answer (a schemaless type with no sample row, another
+query language) does it fall back to materializing the rows and naming the columns from them, the way a
+plain query does, within the same `arcadedb.postgres.queryMaxRows` bound.
+
+The first case is streamed: no row is held, and the cap does not apply. That is the property a bulk
+export needs, and the reason a COPY of a statement that a plain SELECT is refused for (#7034's cap)
+succeeds; `Issue7188CopyToStdoutIT.aCopyStreamsPastTheRowCapAPlainSelectIsRefusedBy` pins it.
+
+### Encodings are PostgreSQL's own
+
+The text and CSV row encodings follow `copyto.c` exactly - `CopyAttributeOutText`'s backslash escapes
+(the control characters, the backslash, the delimiter), `CopyAttributeOutCSV`'s quoting rule (forced,
+equal to the NULL string, holding the delimiter/quote/line break, or `\.` alone on a single-column line) -
+because a reader that parses the stream relies on them. `PostgresType.toText` is the text form
+`serializeAsText` already produced, extracted so COPY escapes the same string a DataRow carries; the
+binary field encoding is `serializeAsBinary` unchanged, since COPY's binary field format (int32 length,
+-1 for NULL, then the send-format bytes) is the DataRow's.
+
+### Declined, with `feature_not_supported`
+
+`COPY ... FROM STDIN` (the ingest direction, a separate statement with its own failure modes, out of scope
+by the issue's own text), `COPY ... TO 'file'` and `COPY ... TO PROGRAM` (server-side writes and command
+execution from a wire client) are refused with SQLSTATE `0A000` and a message that names the alternative.
+So is a binary COPY of a column with no binary encoding (an array): a DataRow can mix format codes per
+column, a COPY stream cannot. `CopyException` extends `CommandParsingException` so the existing error arms
+catch it, and carries its own SQLSTATE so the client is not told "syntax error" for a well-formed
+statement it merely cannot have.
+
+### Alternative considered
+
+Materializing every COPY through `browseAndCacheBoundedResultSet`, as every other statement is, would
+have been the smaller change and would have kept one path. It would also have capped the one statement
+whose purpose is to move a whole type, and would have named columns from rows where the ADBC driver
+expects them named from the schema - the exact mismatch that desynchronizes a binary decoder.
+
+## 2. NaN-transparent SUM and AVG
+
+### Policy
+
+NaN is the ABSENT marker (`TimeSeriesNaN`, since #7043), and every aggregate now skips it: `SUM` is the
+sum of the real samples, `AVG` divides it by the count of REAL samples, and a window with no real sample
+answers ABSENT for both rather than a NaN produced by IEEE arithmetic poisoning a real total. `COUNT`
+counts rows, as SQL's `count(*)` does - which is what the SQL push-down maps it from, so no decision was
+needed there. Downsampling follows the same rule: the mean of the real samples, ABSENT for a bucket with
+none (it used to answer 0.0, a measurement).
+
+This is SQL's `NULL` semantics under `SUM`/`AVG`/`count(*)`, it is what the issue's reporter and a
+dashboard want, and it is the only choice that makes `MIN` and `SUM` agree on the same data again. The
+PromQL layer is deliberately left out: Prometheus propagates NaN through `sum`/`avg`/`sum_over_time`, and a
+PromQL query is expected to answer what Prometheus would. `TimeSeriesNaN`'s class comment records both.
+
+### Why the sealed format changed
+
+The block-statistics fast path answers `SUM`/`AVG` from the block header without decompressing. With
+skip-NaN, `AVG` needs the count of real samples per column, and the header carried only the block's
+sample count. Three ways to get there were weighed:
+
+1. **Keep the poisoned sum in the header as a "decode me" marker** and take the slow path for any block
+   holding a NaN. No format change, exact answers, but a trap: the header's `sum` would mean something
+   different from the aggregate's `SUM`, and the next person to "fix" `reduceNumericStats` to skip NaN would
+   silently break `AVG` on the fast path.
+2. **Skip NaN in the sum, divide by the sample count.** Wrong by construction, and the issue says so.
+3. **Record the count of real samples next to the sum.** Chosen. The fast path stays exact for every block,
+   the header's four statistics mean what the aggregates mean, and the DEEP check verifies all four.
+
+Each block declares its own layout through its magic: `TSBL` (the pre-#7089 `[min, max, sum]` triplet) or
+`TSB2` (`[min, max, sum, count]`). A legacy block is read as it stands: its sum was a plain `+=`, so a
+finite sum proves the column held no NaN and its count is the block's, while a NaN sum leaves the count
+`COUNT_UNKNOWN`, which routes `SUM`/`AVG` over that block through the values and leaves `MIN`/`MAX`/`COUNT`
+on the header. Every rewrite (compaction, downsampling, truncation) writes `TSB2`, recomputing the two
+statistics for a column it copies with `COUNT_UNKNOWN`, so the marker cannot outlive the next rewrite. The
+file header's version moved from 0 to 1 so that an older build refuses a newer file loudly, instead of
+stopping its directory scan at the first magic it does not know and silently losing every block after it;
+a version-0 file is read and stamped 1 on its next header rewrite. `LocalTimeSeriesType` now gates on
+`>` rather than `!=`, as the mutable bucket's check already did.
+
+### What else moved under the policy
+
+- `MultiColumnAggregationResult` seeds `SUM`/`AVG` at ABSENT and folds with `TimeSeriesNaN.sum`; its
+  per-request count is now the count of samples that CONTRIBUTED (rows for `COUNT`, real samples for the
+  rest), so `finalizeAvg` divides by the right denominator and an all-NaN bucket keeps ABSENT
+- `TimeSeriesVectorOps.sum` skips NaN in both the scalar and the SIMD implementation (a NaN lane is blended
+  to the ADD identity, as `min`/`max` already blend theirs), answers ABSENT for an empty or all-NaN range,
+  and a new `countPresent` gives the SIMD path its denominator
+- the single-column `AggregationResult` path and its cross-shard merge, whose weighted `AVG` merge used to
+  multiply a NaN partial by a zero count
+- the DEEP integrity check verifies the declared count, and reports nothing for a legacy `COUNT_UNKNOWN`
+  column: it is a block of its time, not a damaged one
+
+`Issue7089NaNTransparentSumAvgTest` covers the fold, the statistics reducer, both vector implementations,
+partial-result merging, the engine end to end on the mutable path and on the sealed fast path (asserting
+the fast path was taken), the SQL push-down, a hand-written version-0 file with legacy blocks (poisoned
+and not, decoded and header-answered respectively, then upgraded by a rewrite), a mixed-layout file, the
+DEEP check catching a lying count, and downsampling.

--- a/docs/7188-7089-copy-to-stdout-and-nan-transparent-sum.md
+++ b/docs/7188-7089-copy-to-stdout-and-nan-transparent-sum.md
@@ -114,8 +114,9 @@ sample count. Three ways to get there were weighed:
 Each block declares its own layout through its magic: `TSBL` (the pre-#7089 `[min, max, sum]` triplet) or
 `TSB2` (`[min, max, sum, count]`). A legacy block is read as it stands: its sum was a plain `+=`, so a
 finite sum proves the column held no NaN and its count is the block's, while a NaN sum leaves the count
-`COUNT_UNKNOWN`, which routes `SUM`/`AVG` over that block through the values and leaves `MIN`/`MAX`/`COUNT`
-on the header. Every rewrite (compaction, downsampling, truncation) writes `TSB2`, recomputing the two
+`COUNT_UNKNOWN`, which routes every request but `COUNT` over that block through the values (`SUM`/`AVG` for
+the value, `MIN`/`MAX` for the count of contributing samples recorded next to theirs) and leaves only
+`COUNT`, the block's row count, on the header. So the marker never reaches an accumulator. Every rewrite (compaction, downsampling, truncation) writes `TSB2`, recomputing the two
 statistics for a column it copies with `COUNT_UNKNOWN`, so the marker cannot outlive the next rewrite. The
 file header's version moved from 0 to 1 so that an older build refuses a newer file loudly, instead of
 stopping its directory scan at the first magic it does not know and silently losing every block after it;

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/AggregationResult.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/AggregationResult.java
@@ -104,12 +104,8 @@ public final class AggregationResult {
       // NaN policy (issue #7089): an absent partial sum is skipped rather than added, so it cannot poison the
       // other side's real total. A partial AVG is weighted by the real samples it averaged, and a side whose
       // count is zero is absent by definition - its NaN value must not be multiplied into the merge.
-      case SUM -> TimeSeriesNaN.sum(v1, v2);
-      case AVG -> {
-        final double weighted = TimeSeriesNaN.sum(c1 > 0 ? v1 * c1 : TimeSeriesNaN.ABSENT,
-            c2 > 0 ? v2 * c2 : TimeSeriesNaN.ABSENT);
-        yield c1 + c2 > 0 ? weighted / (c1 + c2) : TimeSeriesNaN.ABSENT;
-      }
+      case SUM -> TimeSeriesNaN.mergeSum(v1, c1, v2, c2);
+      case AVG -> c1 + c2 > 0 ? TimeSeriesNaN.mergeSum(v1 * c1, c1, v2 * c2, c2) / (c1 + c2) : TimeSeriesNaN.ABSENT;
       // NaN policy (issue #4596): NaN is treated as absent and skipped, so a real value always
       // wins over a NaN running value. Order-independent and consistent with the other MIN/MAX paths.
       case MIN -> Double.isNaN(v2) ? v1 : Double.isNaN(v1) ? v2 : Math.min(v1, v2);

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/AggregationResult.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/AggregationResult.java
@@ -100,8 +100,16 @@ public final class AggregationResult {
   private static double mergeValue(final double v1, final long c1, final double v2, final long c2,
       final AggregationType type) {
     return switch (type) {
-      case SUM, COUNT -> v1 + v2;
-      case AVG -> (v1 * c1 + v2 * c2) / (c1 + c2);
+      case COUNT -> v1 + v2;
+      // NaN policy (issue #7089): an absent partial sum is skipped rather than added, so it cannot poison the
+      // other side's real total. A partial AVG is weighted by the real samples it averaged, and a side whose
+      // count is zero is absent by definition - its NaN value must not be multiplied into the merge.
+      case SUM -> TimeSeriesNaN.sum(v1, v2);
+      case AVG -> {
+        final double weighted = TimeSeriesNaN.sum(c1 > 0 ? v1 * c1 : TimeSeriesNaN.ABSENT,
+            c2 > 0 ? v2 * c2 : TimeSeriesNaN.ABSENT);
+        yield c1 + c2 > 0 ? weighted / (c1 + c2) : TimeSeriesNaN.ABSENT;
+      }
       // NaN policy (issue #4596): NaN is treated as absent and skipped, so a real value always
       // wins over a NaN running value. Order-independent and consistent with the other MIN/MAX paths.
       case MIN -> Double.isNaN(v2) ? v1 : Double.isNaN(v1) ? v2 : Math.min(v1, v2);

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/MultiColumnAggregationResult.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/MultiColumnAggregationResult.java
@@ -400,7 +400,7 @@ public final class MultiColumnAggregationResult {
             break;
           case SUM:
           case AVG:
-            tVals[i] = TimeSeriesNaN.sum(tVals[i], oVals[i]);
+            tVals[i] = TimeSeriesNaN.mergeSum(tVals[i], tCounts[i], oVals[i], oCounts[i]);
             break;
           case COUNT:
             tVals[i] += oVals[i];
@@ -518,7 +518,7 @@ public final class MultiColumnAggregationResult {
     switch (types[idx]) {
     case SUM:
     case AVG:
-      vals[idx] = TimeSeriesNaN.sum(vals[idx], value);
+      vals[idx] = TimeSeriesNaN.sum(vals[idx], counts[idx], value);
       break;
     case COUNT:
       vals[idx] += 1;
@@ -555,7 +555,7 @@ public final class MultiColumnAggregationResult {
       break;
     case SUM:
     case AVG:
-      vals[requestIndex] = TimeSeriesNaN.sum(vals[requestIndex], value);
+      vals[requestIndex] = TimeSeriesNaN.mergeSum(vals[requestIndex], counts[requestIndex], value, count);
       break;
     case COUNT:
       vals[requestIndex] += value;

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/MultiColumnAggregationResult.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/MultiColumnAggregationResult.java
@@ -195,15 +195,18 @@ public final class MultiColumnAggregationResult {
 
   /**
    * Accumulates block-level statistics for all requests in a single call.
+   *
+   * @param sampleCounts per request, the number of samples that contributed to {@code values[i]}: the block's
+   *                     rows for a COUNT request, its real (non-NaN) samples for every other one
    */
-  public void accumulateBlockStats(final long bucketTs, final double[] values, final int sampleCount) {
+  public void accumulateBlockStats(final long bucketTs, final double[] values, final long[] sampleCounts) {
     if (flatMode) {
       final int idx = flatIndex(bucketTs);
       if (!ensureFlatBucket(idx)) {
-        accumulateBlockStatsInPlace(overflowValuesFor(bucketTs), overflowCounts.get(bucketTs), values, sampleCount);
+        accumulateBlockStatsInPlace(overflowValuesFor(bucketTs), overflowCounts.get(bucketTs), values, sampleCounts);
         return;
       }
-      accumulateBlockStatsInPlace(flatValues[idx], flatCounts[idx], values, sampleCount);
+      accumulateBlockStatsInPlace(flatValues[idx], flatCounts[idx], values, sampleCounts);
     } else {
       double[] vals = valuesByBucket.get(bucketTs);
       long[] counts;
@@ -216,7 +219,7 @@ public final class MultiColumnAggregationResult {
       } else {
         counts = countsByBucket.get(bucketTs);
       }
-      accumulateBlockStatsInPlace(vals, counts, values, sampleCount);
+      accumulateBlockStatsInPlace(vals, counts, values, sampleCounts);
     }
   }
 
@@ -258,7 +261,9 @@ public final class MultiColumnAggregationResult {
   // ---- Finalize & query ----
 
   /**
-   * Finalizes AVG accumulators by dividing accumulated sums by their counts.
+   * Finalizes AVG accumulators by dividing accumulated sums by their counts - the counts of REAL samples, so a
+   * bucket whose every sample was NaN keeps the {@link TimeSeriesNaN#ABSENT} its sum already is rather than
+   * dividing by zero (issue #7089).
    */
   public void finalizeAvg() {
     if (flatMode) {
@@ -336,12 +341,12 @@ public final class MultiColumnAggregationResult {
   }
 
   /**
-   * The number of samples that REACHED this request in this bucket, NaN ones included.
+   * The number of samples that CONTRIBUTED to this request in this bucket: the rows for a COUNT request, and the
+   * REAL (non-NaN) samples for every other one - what AVG divides by (issue #7089).
    * <p>
-   * It is deliberately not a "has this request any real data" test, and must not be used as one: that a NaN
-   * sample increments this counter is precisely what made the old {@code counts[i] == 0} guard miss an all-NaN
-   * bucket and leak the MIN/MAX sentinel (issue #7043). For MIN/MAX, ask the value:
-   * {@code TimeSeriesNaN.isAbsent(getValue(bucketTs, requestIndex))}.
+   * It used to count NaN samples too, which is precisely what made the old {@code counts[i] == 0} guard miss an
+   * all-NaN bucket and leak the MIN/MAX sentinel (issue #7043). The value still carries its own "no data" answer:
+   * {@code TimeSeriesNaN.isAbsent(getValue(bucketTs, requestIndex))} is the test for MIN/MAX/SUM/AVG alike.
    */
   public long getCount(final long bucketTs, final int requestIndex) {
     if (flatMode) {
@@ -395,6 +400,8 @@ public final class MultiColumnAggregationResult {
             break;
           case SUM:
           case AVG:
+            tVals[i] = TimeSeriesNaN.sum(tVals[i], oVals[i]);
+            break;
           case COUNT:
             tVals[i] += oVals[i];
             break;
@@ -489,28 +496,21 @@ public final class MultiColumnAggregationResult {
   }
 
   /**
-   * MIN/MAX accumulators start at {@link TimeSeriesNaN#ABSENT}, not at a {@code ±Double.MAX_VALUE} sentinel.
+   * MIN/MAX/SUM/AVG accumulators start at {@link TimeSeriesNaN#ABSENT}, not at a {@code ±Double.MAX_VALUE}
+   * sentinel or at zero.
    * <p>
    * The sentinel was the whole defect of issue #7043: it is a finite double, so nothing downstream could tell an
    * untouched accumulator from a real extreme, and the guard that tried to (a {@code counts[i] == 0} test) keyed
    * off the raw sample count - which a NaN sample increments. An all-NaN bucket therefore looked touched and
    * handed {@code Double.MAX_VALUE} back as data. With the absent marker as the seed and
    * {@link TimeSeriesNaN#min}/{@link TimeSeriesNaN#max} as the fold, "nothing real arrived" IS the value, and no
-   * side-channel is needed to recover it.
+   * side-channel is needed to recover it. SUM/AVG follow since issue #7089: a zero seed cannot tell "nothing real
+   * arrived" from "it all added up to zero", and the {@code +=} it fed turned one NaN sample into a NaN total.
    */
   private double[] newInitializedValues() {
     final double[] vals = new double[requestCount];
-    for (int i = 0; i < requestCount; i++) {
-      switch (types[i]) {
-      case MIN:
-      case MAX:
-        vals[i] = TimeSeriesNaN.ABSENT;
-        break;
-      default:
-        vals[i] = 0.0;
-        break;
-      }
-    }
+    for (int i = 0; i < requestCount; i++)
+      vals[i] = types[i] == AggregationType.COUNT ? 0.0 : TimeSeriesNaN.ABSENT;
     return vals;
   }
 
@@ -518,11 +518,12 @@ public final class MultiColumnAggregationResult {
     switch (types[idx]) {
     case SUM:
     case AVG:
-      vals[idx] += value;
+      vals[idx] = TimeSeriesNaN.sum(vals[idx], value);
       break;
     case COUNT:
       vals[idx] += 1;
-      break;
+      counts[idx]++;
+      return;
     case MIN:
       vals[idx] = TimeSeriesNaN.min(vals[idx], value);
       break;
@@ -530,29 +531,17 @@ public final class MultiColumnAggregationResult {
       vals[idx] = TimeSeriesNaN.max(vals[idx], value);
       break;
     }
-    counts[idx]++;
+    counts[idx] = TimeSeriesNaN.countIfPresent(counts[idx], value);
   }
 
+  /**
+   * @param sampleCounts per request, the number of samples that contributed to {@code values[i]}: the block's
+   *                     rows for a COUNT request, its real samples for every other one (issue #7089)
+   */
   private void accumulateBlockStatsInPlace(final double[] vals, final long[] counts,
-      final double[] values, final int sampleCount) {
-    for (int i = 0; i < requestCount; i++) {
-      switch (types[i]) {
-      case MIN:
-        vals[i] = TimeSeriesNaN.min(vals[i], values[i]);
-        break;
-      case MAX:
-        vals[i] = TimeSeriesNaN.max(vals[i], values[i]);
-        break;
-      case SUM:
-      case AVG:
-        vals[i] += values[i];
-        break;
-      case COUNT:
-        vals[i] += values[i];
-        break;
-      }
-      counts[i] += sampleCount;
-    }
+      final double[] values, final long[] sampleCounts) {
+    for (int i = 0; i < requestCount; i++)
+      accumulateStatInPlace(vals, counts, i, values[i], sampleCounts[i]);
   }
 
   private void accumulateStatInPlace(final double[] vals, final long[] counts,
@@ -566,7 +555,7 @@ public final class MultiColumnAggregationResult {
       break;
     case SUM:
     case AVG:
-      vals[requestIndex] += value;
+      vals[requestIndex] = TimeSeriesNaN.sum(vals[requestIndex], value);
       break;
     case COUNT:
       vals[requestIndex] += value;

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
@@ -392,10 +392,12 @@ public class TimeSeriesEngine implements AutoCloseable {
       accumulateToBucket(result, bucketTs, value, aggType);
     }
 
-    // Finalize AVG: divide accumulated sums by counts
+    // Finalize AVG: divide accumulated sums by the counts of real samples. A bucket with none keeps the absent
+    // marker its sum already is (issue #7089).
     if (aggType == AggregationType.AVG) {
       for (int i = 0; i < result.size(); i++)
-        result.updateValue(i, result.getValue(i) / result.getCount(i));
+        if (result.getCount(i) > 0)
+          result.updateValue(i, result.getValue(i) / result.getCount(i));
     }
 
     return result;
@@ -995,19 +997,21 @@ public class TimeSeriesEngine implements AutoCloseable {
     if (idx >= 0) {
       final double existing = result.getValue(idx);
       final long count = result.getCount(idx);
+      // NaN policy (issue #7089): SUM/AVG skip an absent sample the way MIN/MAX below do, and the count kept
+      // alongside is of the samples that contributed - what the AVG is divided by once the scan is over.
       final double merged = switch (type) {
-        case SUM -> existing + value;
+        case SUM, AVG -> TimeSeriesNaN.sum(existing, value);
         case COUNT -> existing + 1;
-        case AVG -> existing + value; // accumulate sum, divide by count later
         // NaN policy (issue #4596): NaN is treated as absent and skipped, so a real value always
         // wins over a NaN running value (e.g. when the bucket was seeded with a NaN first sample).
         case MIN -> Double.isNaN(value) ? existing : Double.isNaN(existing) ? value : Math.min(existing, value);
         case MAX -> Double.isNaN(value) ? existing : Double.isNaN(existing) ? value : Math.max(existing, value);
       };
       result.updateValue(idx, merged);
-      result.updateCount(idx, count + 1);
+      result.updateCount(idx, type == AggregationType.COUNT ? count + 1 : TimeSeriesNaN.countIfPresent(count, value));
     } else {
-      result.addBucket(bucketTs, type == AggregationType.COUNT ? 1.0 : value, 1);
+      result.addBucket(bucketTs, type == AggregationType.COUNT ? 1.0 : value,
+          type == AggregationType.COUNT ? 1 : TimeSeriesNaN.countIfPresent(0, value));
     }
   }
 }

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
@@ -1000,7 +1000,7 @@ public class TimeSeriesEngine implements AutoCloseable {
       // NaN policy (issue #7089): SUM/AVG skip an absent sample the way MIN/MAX below do, and the count kept
       // alongside is of the samples that contributed - what the AVG is divided by once the scan is over.
       final double merged = switch (type) {
-        case SUM, AVG -> TimeSeriesNaN.sum(existing, value);
+        case SUM, AVG -> TimeSeriesNaN.sum(existing, count, value);
         case COUNT -> existing + 1;
         // NaN policy (issue #4596): NaN is treated as absent and skipped, so a real value always
         // wins over a NaN running value (e.g. when the bucket was seeded with a NaN first sample).

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesNaN.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesNaN.java
@@ -36,10 +36,11 @@ package com.arcadedb.engine.timeseries;
  * <p>
  * SUM and AVG follow the same rule (issue #7089): a NaN sample is not a measurement of "not a number", it is the
  * absence of a measurement, and a sum over 999 real samples and one absent one is the sum of the 999 - the way SQL's
- * {@code SUM} and {@code AVG} skip NULL. So {@link #sum(double, double)} is the same fold shape, {@code AVG} divides
- * the folded sum by the number of samples that were REAL ({@link #countIfPresent(long, double)}), and a window
- * whose every sample was absent answers {@link #ABSENT} for all four, rather than a NaN that merely looks the same
- * but was produced by IEEE arithmetic poisoning a real total. {@code COUNT} is the one aggregate that does not
+ * {@code SUM} and {@code AVG} skip NULL. So {@link #sum(double, long, double)} is the same fold shape, {@code AVG}
+ * divides the folded sum by the number of samples that were REAL ({@link #countIfPresent(long, double)}), and a
+ * window whose every sample was absent answers {@link #ABSENT} for all four. A NaN the arithmetic itself produces
+ * over real samples ({@code +Infinity + -Infinity}) is a different thing - an undefined total, kept as IEEE keeps
+ * it - which is why the SUM fold is keyed on that count rather than on the accumulator's value. {@code COUNT} is the one aggregate that does not
  * skip: it counts rows, as SQL's {@code COUNT(*)} does, and the SQL push-down maps it from {@code count(*)}.
  * <p>
  * The PromQL layer is deliberately NOT under this policy for {@code sum}/{@code avg}: Prometheus propagates NaN
@@ -86,13 +87,32 @@ public final class TimeSeriesNaN {
   /**
    * Folds one sample into a running SUM (issue #7089). {@code accumulator} starts at {@link #ABSENT}; a NaN sample
    * is skipped, the first real sample replaces the absent accumulator outright, and every later one is added.
-   * The accumulator is therefore NaN if and only if no real sample ever reached it - never because one of them was
-   * NaN, which is what a plain {@code +=} produces. Merging two partial sums is the same fold.
+   * <p>
+   * "First" is decided by {@code present}, the count of real samples folded so far, and NOT by the accumulator
+   * being NaN: a sum can turn NaN by arithmetic - {@code +Infinity + -Infinity} - after real samples reached it,
+   * and that NaN is an answer ("the total is undefined"), not an absence. Keying on the accumulator would let the
+   * next real sample overwrite it, and would make this fold disagree with the vectorized reduction, which keeps
+   * it. So the accumulator is absent if and only if {@code present} is zero, and NaN with {@code present} above
+   * zero is the arithmetic result, kept as IEEE keeps it.
+   *
+   * @param present how many real samples the accumulator holds, BEFORE this one - see {@link #countIfPresent}
    */
-  public static double sum(final double accumulator, final double sample) {
+  public static double sum(final double accumulator, final long present, final double sample) {
     if (Double.isNaN(sample))
       return accumulator;
-    return Double.isNaN(accumulator) ? sample : accumulator + sample;
+    return present == 0 ? sample : accumulator + sample;
+  }
+
+  /**
+   * Merges a partial SUM into a running one: the same rule as {@link #sum(double, long, double)}, with each side's
+   * count of real samples saying whether its value is a total or an absence. A partial with no real sample is
+   * skipped whatever its value; a running sum with none is replaced; two totals are added, NaN included.
+   */
+  public static double mergeSum(final double accumulator, final long present, final double partial,
+      final long partialPresent) {
+    if (partialPresent == 0)
+      return accumulator;
+    return present == 0 ? partial : accumulator + partial;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesNaN.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesNaN.java
@@ -19,7 +19,7 @@
 package com.arcadedb.engine.timeseries;
 
 /**
- * THE NaN policy for the whole time-series stack: {@code NaN} is the ABSENT marker, and MIN/MAX skip it.
+ * THE NaN policy for the whole time-series stack: {@code NaN} is the ABSENT marker, and every aggregate skips it.
  * <p>
  * The policy exists as one class because the subsystem previously carried three of them. Every MIN/MAX
  * accumulator started from a sentinel of its own choosing - {@code ±Infinity} in the PromQL functions and the
@@ -33,6 +33,17 @@ package com.arcadedb.engine.timeseries;
  * accumulator and the accumulator is NaN if and only if nothing real ever reached it, so "no data" needs no
  * side-channel (a count, a bitset, a {@code found} flag) to be told apart from a real minimum. Merging two
  * partial results is the same fold, so it inherits the property for free.
+ * <p>
+ * SUM and AVG follow the same rule (issue #7089): a NaN sample is not a measurement of "not a number", it is the
+ * absence of a measurement, and a sum over 999 real samples and one absent one is the sum of the 999 - the way SQL's
+ * {@code SUM} and {@code AVG} skip NULL. So {@link #sum(double, double)} is the same fold shape, {@code AVG} divides
+ * the folded sum by the number of samples that were REAL ({@link #countIfPresent(long, double)}), and a window
+ * whose every sample was absent answers {@link #ABSENT} for all four, rather than a NaN that merely looks the same
+ * but was produced by IEEE arithmetic poisoning a real total. {@code COUNT} is the one aggregate that does not
+ * skip: it counts rows, as SQL's {@code COUNT(*)} does, and the SQL push-down maps it from {@code count(*)}.
+ * <p>
+ * The PromQL layer is deliberately NOT under this policy for {@code sum}/{@code avg}: Prometheus propagates NaN
+ * through those, and a PromQL query is expected to answer what Prometheus would.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -70,5 +81,26 @@ public final class TimeSeriesNaN {
     if (Double.isNaN(sample))
       return accumulator;
     return Double.isNaN(accumulator) || sample > accumulator ? sample : accumulator;
+  }
+
+  /**
+   * Folds one sample into a running SUM (issue #7089). {@code accumulator} starts at {@link #ABSENT}; a NaN sample
+   * is skipped, the first real sample replaces the absent accumulator outright, and every later one is added.
+   * The accumulator is therefore NaN if and only if no real sample ever reached it - never because one of them was
+   * NaN, which is what a plain {@code +=} produces. Merging two partial sums is the same fold.
+   */
+  public static double sum(final double accumulator, final double sample) {
+    if (Double.isNaN(sample))
+      return accumulator;
+    return Double.isNaN(accumulator) ? sample : accumulator + sample;
+  }
+
+  /**
+   * The count of REAL samples after {@code sample} reached the accumulator: unchanged for a NaN sample, one more
+   * otherwise. This is the denominator of AVG under the policy - the count of samples that contributed to the
+   * sum - and it is what tells an all-absent window apart from one that summed to zero.
+   */
+  public static long countIfPresent(final long count, final double sample) {
+    return Double.isNaN(sample) ? count : count + 1;
   }
 }

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
@@ -78,8 +78,8 @@ import java.util.zip.CRC32;
  * before issue #7089 carries the magic "TSBL" and a statistics TRIPLET, {@code [min, max, sum]}, whose sum was
  * accumulated by a plain {@code +=} - so it is NaN whenever ANY sample was NaN, and exact otherwise. The reader
  * derives the missing count from that: a finite sum proves the column held no NaN, so its count is the block's
- * sample count; a NaN sum leaves the count {@link BlockEntry#COUNT_UNKNOWN}, which routes SUM/AVG over that block
- * through decompression instead of the header. Every path that WRITES a block emits the current layout, so a
+ * sample count; a NaN sum leaves the count {@link BlockEntry#COUNT_UNKNOWN}, which routes every request but COUNT
+ * over that block through decompression instead of the header. Every path that WRITES a block emits the current layout, so a
  * legacy block is upgraded by whichever rewrite touches it next (compaction, downsampling, truncation).
  * <p>
  * The file header's version byte is what refuses a file to a build that predates a layout: version 1 (issue #7089)
@@ -164,10 +164,11 @@ public class TimeSeriesSealedStore implements AutoCloseable {
     /**
      * The count a legacy ("TSBL") block declares for a column whose sum it accumulated over a NaN sample (issue
      * #7089): the block predates the count, and its sum is the NaN the old {@code +=} produced rather than the sum
-     * of the real samples, so neither statistic can answer a SUM or an AVG. The aggregation push-down decompresses
-     * such a block for those two requests and answers MIN/MAX/COUNT from the header as usual; the next rewrite of
-     * the block (compaction, downsampling, truncation) recomputes both from the values and writes the current
-     * layout, which never carries this marker.
+     * of the real samples, so neither statistic can answer a SUM or an AVG - and the count recorded next to a MIN
+     * or a MAX, which the result contract says is of the samples that contributed, is unknown as well. The
+     * aggregation push-down decompresses such a block for every request but COUNT, so this marker never reaches an
+     * accumulator; the next rewrite of the block (compaction, downsampling, truncation) recomputes both statistics
+     * from the values and writes the current layout, which never carries the marker.
      */
     static final long COUNT_UNKNOWN = -1;
     // Where this block begins in the file, and the CRC32 the writer stored immediately after its data. Both are
@@ -802,9 +803,9 @@ public class TimeSeriesSealedStore implements AutoCloseable {
           final long blockMaxBucket = Math.floorDiv(entry.maxTimestamp, bucketIntervalMs) * bucketIntervalMs;
 
           // A legacy block (written before issue #7089) whose column summed over a NaN sample declares neither a
-          // usable sum nor a count of its real samples, so a SUM or an AVG over it has to come from the values.
-          // MIN/MAX/COUNT are still answered from its header, which never lied about those.
-          if (blockMinBucket == blockMaxBucket && !needsValuesForSum(entry, requests, schemaColIndices)) {
+          // usable sum nor a count of its real samples, so every request over that column but COUNT has to come
+          // from the values: SUM/AVG for the value itself, MIN/MAX for the count recorded next to it.
+          if (blockMinBucket == blockMaxBucket && !needsValues(entry, requests, schemaColIndices)) {
             // FAST PATH: use block-level stats directly — no decompression needed
             if (metrics != null)
               metrics.addFastPathBlock();
@@ -2213,19 +2214,18 @@ public class TimeSeriesSealedStore implements AutoCloseable {
   }
 
   /**
-   * Whether one of the requests is a SUM or an AVG over a column whose header cannot answer it - a legacy block
-   * that summed over a NaN sample, see {@link BlockEntry#COUNT_UNKNOWN}. Such a block takes the decompressing path
-   * for the whole request list; MIN/MAX/COUNT could have been read from the header, but the block has to be decoded
-   * anyway and one pass over it is cheaper than two.
+   * Whether one of the requests reads a column whose header cannot answer it - a legacy block that summed over a
+   * NaN sample, see {@link BlockEntry#COUNT_UNKNOWN}. SUM and AVG need its sum, and MIN and MAX need the count
+   * recorded next to their value, which the header does not have either; only COUNT, which reads the block's row
+   * count, is unaffected. Such a block takes the decompressing path for the whole request list: one pass over it
+   * is cheaper than two.
    */
-  private static boolean needsValuesForSum(final BlockEntry entry, final List<MultiColumnAggregationRequest> requests,
+  private static boolean needsValues(final BlockEntry entry, final List<MultiColumnAggregationRequest> requests,
       final int[] schemaColIndices) {
-    for (int r = 0; r < requests.size(); r++) {
-      final AggregationType type = requests.get(r).type();
-      if ((type == AggregationType.SUM || type == AggregationType.AVG)
+    for (int r = 0; r < requests.size(); r++)
+      if (requests.get(r).type() != AggregationType.COUNT
           && entry.columnCounts[schemaColIndices[r]] == BlockEntry.COUNT_UNKNOWN)
         return true;
-    }
     return false;
   }
 
@@ -2294,7 +2294,7 @@ public class TimeSeriesSealedStore implements AutoCloseable {
     final double declaredSum = entry.columnSums[colIdx];
     final long declaredCount = entry.columnCounts[colIdx];
     // A legacy block that summed over a NaN sample declares no usable sum and no count (issue #7089), and says so
-    // with COUNT_UNKNOWN: nothing is answered from that header for SUM/AVG, so there is nothing to verify, and the
+    // with COUNT_UNKNOWN: nothing but COUNT is answered from that header, so there is nothing to verify, and the
     // next rewrite of the block replaces both. It is not a problem of the block - it is a block of its time.
     if (declaredCount == BlockEntry.COUNT_UNKNOWN)
       return;
@@ -2764,8 +2764,8 @@ public class TimeSeriesSealedStore implements AutoCloseable {
           if (legacyStats)
             // The legacy sum was a plain += over every sample, so it is finite only if no sample was NaN - in
             // which case every sample was real and the count is the block's. A NaN sum could be an all-NaN column
-            // (count 0) or a poisoned real total, and the header cannot tell which: COUNT_UNKNOWN sends SUM/AVG
-            // to the values (issue #7089).
+            // (count 0) or a poisoned real total, and the header cannot tell which: COUNT_UNKNOWN sends every
+            // request but COUNT to the values (issue #7089).
             counts[c] = Double.isNaN(sums[c]) ? BlockEntry.COUNT_UNKNOWN : sampleCount;
           else
             counts[c] = statsBuf.getLong();

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
@@ -764,6 +764,8 @@ public class TimeSeriesSealedStore implements AutoCloseable {
 
     final double[] rowValues = new double[reqCount];
     final long[] rowCounts = new long[reqCount];
+    // Per schema column, the count of real samples in the segment the vectorized path is on (-1 = not yet counted).
+    final long[] presentBySchemaCol = new long[columns.size()];
 
     // Pre-allocate decode buffers reused across all blocks in this call
     final long[] reusableTsBuf = new long[MAX_BLOCK_SIZE];
@@ -922,25 +924,27 @@ public class TimeSeriesSealedStore implements AutoCloseable {
 
               final int segLen = segEnd - segStart;
 
-              // Accumulate each request using vectorized ops on the segment
+              // Accumulate each request using vectorized ops on the segment. The count recorded with each value
+              // is of the samples that CONTRIBUTED to it, which under the NaN policy are the real ones (issue
+              // #7089) - the same count the per-row and the block-statistics paths record, so a result does not
+              // depend on how blocks happen to align with buckets. Two requests over the same column share one
+              // pass to count them.
+              Arrays.fill(presentBySchemaCol, -1);
               for (int r = 0; r < reqCount; r++) {
                 if (isCount[r]) {
                   result.accumulateSingleStat(bucketTs, r, segLen, segLen);
                 } else {
-                  final double[] colData = decompressedCols[schemaColIndices[r]];
+                  final int sci = schemaColIndices[r];
+                  final double[] colData = decompressedCols[sci];
                   final double val = switch (requests.get(r).type()) {
                     case SUM, AVG -> ops.sum(colData, segStart, segLen);
                     case MIN -> ops.min(colData, segStart, segLen);
                     case MAX -> ops.max(colData, segStart, segLen);
                     case COUNT -> segLen;
                   };
-                  // The count is of the samples that CONTRIBUTED to val, which under the NaN policy are the real
-                  // ones (issue #7089): it is what AVG divides by. Only AVG reads it, so the pass over the segment
-                  // is paid once per AVG request rather than once per request.
-                  final long contributed = requests.get(r).type() == AggregationType.AVG
-                      ? ops.countPresent(colData, segStart, segLen)
-                      : segLen;
-                  result.accumulateSingleStat(bucketTs, r, val, contributed);
+                  if (presentBySchemaCol[sci] < 0)
+                    presentBySchemaCol[sci] = ops.countPresent(colData, segStart, segLen);
+                  result.accumulateSingleStat(bucketTs, r, val, presentBySchemaCol[sci]);
                 }
               }
 
@@ -2173,7 +2177,7 @@ public class TimeSeriesSealedStore implements AutoCloseable {
     for (final double d : values) {
       min = TimeSeriesNaN.min(min, d);
       max = TimeSeriesNaN.max(max, d);
-      sum = TimeSeriesNaN.sum(sum, d);
+      sum = TimeSeriesNaN.sum(sum, count, d);
       count = TimeSeriesNaN.countIfPresent(count, d);
     }
     return new double[] { min, max, sum, count };
@@ -3138,7 +3142,7 @@ public class TimeSeriesSealedStore implements AutoCloseable {
       // NaN policy (issue #7089): SUM/AVG skip an absent sample the way MIN/MAX below do, and the count kept
       // alongside is of the samples that contributed - what the AVG is divided by once the scan is over.
       final double merged = switch (type) {
-        case SUM, AVG -> TimeSeriesNaN.sum(existing, value);
+        case SUM, AVG -> TimeSeriesNaN.sum(existing, count, value);
         case COUNT -> existing + 1;
         // NaN policy (issue #4596): NaN is treated as absent and skipped, so a real value always
         // wins over a NaN running value (consistent with the row-iter, merge and SIMD paths).

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
@@ -68,11 +68,23 @@ import java.util.zip.CRC32;
  * - [27..]   block entries (inline metadata + compressed column data)
  * <p>
  * Block entry layout:
- * - magic "TSBL" (4), minTs (8), maxTs (8), sampleCount (4), colSizes (4*colCount)
- * - numericColCount (4), [min (8) + max (8) + sum (8)] * numericColCount (schema order, no colIdx)
+ * - magic "TSB2" (4), minTs (8), maxTs (8), sampleCount (4), colSizes (4*colCount)
+ * - numericColCount (4), [min (8) + max (8) + sum (8) + count (8)] * numericColCount (schema order, no colIdx)
  * - tag metadata: tagColCount (2), per TAG column: distinctCount (2), per value: len (2) + UTF-8 bytes
  * - compressed column data bytes
  * - blockCRC32 (4) — CRC32 of everything from blockMagic to end of compressed data
+ * <p>
+ * Each block declares its own layout through its magic, so one file may hold both generations. A block written
+ * before issue #7089 carries the magic "TSBL" and a statistics TRIPLET, {@code [min, max, sum]}, whose sum was
+ * accumulated by a plain {@code +=} - so it is NaN whenever ANY sample was NaN, and exact otherwise. The reader
+ * derives the missing count from that: a finite sum proves the column held no NaN, so its count is the block's
+ * sample count; a NaN sum leaves the count {@link BlockEntry#COUNT_UNKNOWN}, which routes SUM/AVG over that block
+ * through decompression instead of the header. Every path that WRITES a block emits the current layout, so a
+ * legacy block is upgraded by whichever rewrite touches it next (compaction, downsampling, truncation).
+ * <p>
+ * The file header's version byte is what refuses a file to a build that predates a layout: version 1 (issue #7089)
+ * says "blocks are self-describing, TSBL or TSB2", and a version-0 file, which can only hold TSBL blocks, is read
+ * as it stands and stamped 1 the next time its header is rewritten.
  * <p>
  * <b>High-Availability / Replication note:</b>
  * Sealed store files ({@code .ts.sealed}) are written via {@link RandomAccessFile} and
@@ -91,9 +103,15 @@ import java.util.zip.CRC32;
  */
 public class TimeSeriesSealedStore implements AutoCloseable {
 
-  public static final  int CURRENT_VERSION  = 0;
+  public static final  int CURRENT_VERSION  = 1;
   private static final int MAGIC_VALUE       = 0x54534958; // "TSIX"
-  private static final int BLOCK_MAGIC_VALUE = 0x5453424C; // "TSBL"
+  // "TSBL": the layout every block had before issue #7089, whose statistics section is a [min, max, sum] triplet.
+  private static final int BLOCK_MAGIC_VALUE    = 0x5453424C;
+  // "TSB2": the current layout, whose statistics section is a [min, max, sum, count] quadruple (issue #7089).
+  private static final int BLOCK_MAGIC_VALUE_V2 = 0x54534232;
+  // Bytes one column's statistics take in each layout.
+  private static final int LEGACY_STATS_BYTES   = 8 + 8 + 8;
+  private static final int STATS_BYTES          = 8 + 8 + 8 + 8;
   private static final int HEADER_SIZE       = 27;
   // Shared with DeltaOfDeltaCodec and GorillaXORCodec: all three validate/use the same limit
   private static final int MAX_BLOCK_SIZE    = DeltaOfDeltaCodec.MAX_BLOCK_SIZE;
@@ -139,8 +157,19 @@ public class TimeSeriesSealedStore implements AutoCloseable {
     final int[]    columnSizes;
     final double[] columnMins;   // per-column min (NaN for non-numeric)
     final double[] columnMaxs;   // per-column max
-    final double[] columnSums;   // per-column sum
+    final double[] columnSums;   // per-column sum of the REAL (non-NaN) samples, NaN when there is none
+    final long[]   columnCounts; // per-column count of the REAL (non-NaN) samples, or COUNT_UNKNOWN (see below)
     String[][]     tagDistinctValues; // indexed by schema column index, null for non-TAG columns
+
+    /**
+     * The count a legacy ("TSBL") block declares for a column whose sum it accumulated over a NaN sample (issue
+     * #7089): the block predates the count, and its sum is the NaN the old {@code +=} produced rather than the sum
+     * of the real samples, so neither statistic can answer a SUM or an AVG. The aggregation push-down decompresses
+     * such a block for those two requests and answers MIN/MAX/COUNT from the header as usual; the next rewrite of
+     * the block (compaction, downsampling, truncation) recomputes both from the values and writes the current
+     * layout, which never carries this marker.
+     */
+    static final long COUNT_UNKNOWN = -1;
     // Where this block begins in the file, and the CRC32 the writer stored immediately after its data. Both are
     // set by EVERY path that produces an entry - appendBlock, writeNewBlockToFile and loadDirectory - so they
     // describe the block whether this process wrote it or found it on disk (issue #6360 item 3). They used to be
@@ -167,7 +196,7 @@ public class TimeSeriesSealedStore implements AutoCloseable {
      * record one cannot silently inherit the other.
      */
     BlockEntry(final long minTs, final long maxTs, final int sampleCount, final int columnCount,
-        final double[] mins, final double[] maxs, final double[] sums, final long blockStartOffset) {
+        final double[] mins, final double[] maxs, final double[] sums, final long[] counts, final long blockStartOffset) {
       this.minTimestamp = minTs;
       this.maxTimestamp = maxTs;
       this.sampleCount = sampleCount;
@@ -176,6 +205,7 @@ public class TimeSeriesSealedStore implements AutoCloseable {
       this.columnMins = mins;
       this.columnMaxs = maxs;
       this.columnSums = sums;
+      this.columnCounts = counts;
       this.blockStartOffset = blockStartOffset;
       this.crcValidated = false;
     }
@@ -237,11 +267,12 @@ public class TimeSeriesSealedStore implements AutoCloseable {
    * @param compressedColumns compressed byte arrays, one per column
    * @param columnMins        per-column min (NaN for non-numeric columns)
    * @param columnMaxs        per-column max (NaN for non-numeric columns)
-   * @param columnSums        per-column sum (NaN for non-numeric columns)
+   * @param columnSums        per-column sum of the real samples (NaN for non-numeric columns, or when there is none)
+   * @param columnCounts      per-column count of the real (non-NaN) samples, as {@link #reduceNumericStats} computes it
    */
   public void appendBlock(final int sampleCount, final long minTs, final long maxTs,
       final byte[][] compressedColumns,
-      final double[] columnMins, final double[] columnMaxs, final double[] columnSums,
+      final double[] columnMins, final double[] columnMaxs, final double[] columnSums, final long[] columnCounts,
       final String[][] tagDistinctValues) throws IOException {
     directoryLock.writeLock().lock();
     try {
@@ -260,12 +291,12 @@ public class TimeSeriesSealedStore implements AutoCloseable {
       final byte[] tagMeta = buildTagMetadata(tagDistinctValues, colCount);
 
       // Block header: magic(4) + minTs(8) + maxTs(8) + sampleCount(4) + colSizes(4*colCount)
-      //              + numericColCount(4) + [min(8) + max(8) + sum(8)] * numericColCount
+      //              + numericColCount(4) + [min(8) + max(8) + sum(8) + count(8)] * numericColCount
       //              + tag metadata
-      final int statsSize = 4 + (8 + 8 + 8) * numericColCount;
+      final int statsSize = 4 + STATS_BYTES * numericColCount;
       final int metaSize = 4 + 8 + 8 + 4 + 4 * colCount + statsSize + tagMeta.length;
       final ByteBuffer metaBuf = ByteBuffer.allocate(metaSize);
-      metaBuf.putInt(BLOCK_MAGIC_VALUE);
+      metaBuf.putInt(BLOCK_MAGIC_VALUE_V2);
       metaBuf.putLong(minTs);
       metaBuf.putLong(maxTs);
       metaBuf.putInt(sampleCount);
@@ -279,6 +310,7 @@ public class TimeSeriesSealedStore implements AutoCloseable {
           metaBuf.putDouble(columnMins[c]);
           metaBuf.putDouble(columnMaxs[c]);
           metaBuf.putDouble(columnSums[c]);
+          metaBuf.putLong(columnCounts[c]);
         }
       }
 
@@ -300,7 +332,7 @@ public class TimeSeriesSealedStore implements AutoCloseable {
       // #6360 item 3: the offset is given to the entry rather than patched onto it afterwards, so the entry
       // describes where its block is no matter which side of a restart wrote it.
       final BlockEntry entry = new BlockEntry(minTs, maxTs, sampleCount, colCount, columnMins, columnMaxs, columnSums,
-          blockStart);
+          columnCounts, blockStart);
       entry.tagDistinctValues = tagDistinctValues;
       // Write compressed column data
       for (int c = 0; c < colCount; c++) {
@@ -731,6 +763,7 @@ public class TimeSeriesSealedStore implements AutoCloseable {
     }
 
     final double[] rowValues = new double[reqCount];
+    final long[] rowCounts = new long[reqCount];
 
     // Pre-allocate decode buffers reused across all blocks in this call
     final long[] reusableTsBuf = new long[MAX_BLOCK_SIZE];
@@ -766,14 +799,18 @@ public class TimeSeriesSealedStore implements AutoCloseable {
           final long blockMinBucket = Math.floorDiv(entry.minTimestamp, bucketIntervalMs) * bucketIntervalMs;
           final long blockMaxBucket = Math.floorDiv(entry.maxTimestamp, bucketIntervalMs) * bucketIntervalMs;
 
-          if (blockMinBucket == blockMaxBucket) {
+          // A legacy block (written before issue #7089) whose column summed over a NaN sample declares neither a
+          // usable sum nor a count of its real samples, so a SUM or an AVG over it has to come from the values.
+          // MIN/MAX/COUNT are still answered from its header, which never lied about those.
+          if (blockMinBucket == blockMaxBucket && !needsValuesForSum(entry, requests, schemaColIndices)) {
             // FAST PATH: use block-level stats directly — no decompression needed
             if (metrics != null)
               metrics.addFastPathBlock();
             for (int r = 0; r < reqCount; r++) {
-              if (isCount[r])
+              if (isCount[r]) {
                 rowValues[r] = entry.sampleCount;
-              else {
+                rowCounts[r] = entry.sampleCount;
+              } else {
                 final int sci = schemaColIndices[r];
                 rowValues[r] = switch (requests.get(r).type()) {
                   case MIN -> entry.columnMins[sci];
@@ -781,9 +818,11 @@ public class TimeSeriesSealedStore implements AutoCloseable {
                   case SUM, AVG -> entry.columnSums[sci];
                   case COUNT -> entry.sampleCount;
                 };
+                // The samples that CONTRIBUTED: the real ones, which is what AVG divides by (issue #7089).
+                rowCounts[r] = entry.columnCounts[sci];
               }
             }
-            result.accumulateBlockStats(blockMinBucket, rowValues, entry.sampleCount);
+            result.accumulateBlockStats(blockMinBucket, rowValues, rowCounts);
             continue;
           }
         }
@@ -861,8 +900,10 @@ public class TimeSeriesSealedStore implements AutoCloseable {
               for (int r = 0; r < reqCount; r++) {
                 if (isCount[r])
                   result.accumulateSingleStat(bucketTs, r, 1.0, 1);
-                else
-                  result.accumulateSingleStat(bucketTs, r, decompressedCols[schemaColIndices[r]][i], 1);
+                else {
+                  final double v = decompressedCols[schemaColIndices[r]][i];
+                  result.accumulateSingleStat(bucketTs, r, v, TimeSeriesNaN.countIfPresent(0, v));
+                }
               }
             }
           } else {
@@ -893,7 +934,13 @@ public class TimeSeriesSealedStore implements AutoCloseable {
                     case MAX -> ops.max(colData, segStart, segLen);
                     case COUNT -> segLen;
                   };
-                  result.accumulateSingleStat(bucketTs, r, val, segLen);
+                  // The count is of the samples that CONTRIBUTED to val, which under the NaN policy are the real
+                  // ones (issue #7089): it is what AVG divides by. Only AVG reads it, so the pass over the segment
+                  // is paid once per AVG request rather than once per request.
+                  final long contributed = requests.get(r).type() == AggregationType.AVG
+                      ? ops.countPresent(colData, segStart, segLen)
+                      : segLen;
+                  result.accumulateSingleStat(bucketTs, r, val, contributed);
                 }
               }
 
@@ -1081,8 +1128,13 @@ public class TimeSeriesSealedStore implements AutoCloseable {
 
         final Map<Long, double[]> buckets = groupedData.computeIfAbsent(tagKey, k -> new HashMap<>());
         final double[] acc = buckets.computeIfAbsent(bucketTs, k -> new double[accSize]);
+        // The downsampled value is the mean of the REAL samples (issue #7089): a NaN sample neither poisons the
+        // sum nor counts toward the denominator, the same policy the aggregation push-down applies.
         for (int n = 0; n < numFields; n++) {
-          acc[n * 2] += numData[n][i];       // sum
+          final double v = numData[n][i];
+          if (Double.isNaN(v))
+            continue;
+          acc[n * 2] += v;                   // sum
           acc[n * 2 + 1] += 1.0;             // count
         }
       }
@@ -1104,7 +1156,9 @@ public class TimeSeriesSealedStore implements AutoCloseable {
           row[tagColIndices.get(t)] = t < tagParts.size() ? tagParts.get(t) : "";
         for (int n = 0; n < numFields; n++) {
           final double count = acc[n * 2 + 1];
-          row[numericColIndices.get(n)] = count > 0 ? acc[n * 2] / count : 0.0;
+          // A bucket that held no real sample is downsampled to the absent marker, not to a zero that would read
+          // as a measurement.
+          row[numericColIndices.get(n)] = count > 0 ? acc[n * 2] / count : TimeSeriesNaN.ABSENT;
         }
         newSamples.add(row);
       }
@@ -1117,9 +1171,7 @@ public class TimeSeriesSealedStore implements AutoCloseable {
     final int colCount = columns.size();
     final List<byte[][]> newBlocksCompressed = new ArrayList<>();
     final List<long[]> newBlocksMeta = new ArrayList<>(); // [minTs, maxTs, sampleCount]
-    final List<double[]> newBlocksMins = new ArrayList<>();
-    final List<double[]> newBlocksMaxs = new ArrayList<>();
-    final List<double[]> newBlocksSums = new ArrayList<>();
+    final List<BlockStats> newBlocksStats = new ArrayList<>();
     final List<String[][]> newBlocksTagDV = new ArrayList<>();
 
     int chunkStart = 0;
@@ -1136,8 +1188,10 @@ public class TimeSeriesSealedStore implements AutoCloseable {
       final double[] mins = new double[colCount];
       final double[] maxs = new double[colCount];
       final double[] sums = new double[colCount];
+      final long[] counts = new long[colCount];
       Arrays.fill(mins, Double.NaN);
       Arrays.fill(maxs, Double.NaN);
+      Arrays.fill(sums, Double.NaN);
 
       final byte[][] compressedCols = new byte[colCount][];
       for (int c = 0; c < colCount; c++) {
@@ -1150,12 +1204,12 @@ public class TimeSeriesSealedStore implements AutoCloseable {
           compressedCols[c] = compressColumn(columns.get(c), chunkValues);
 
           // Compute stats for numeric columns
-          final TimeSeriesCodec codec = columns.get(c).getCompressionHint();
-          if (codec == TimeSeriesCodec.GORILLA_XOR || codec == TimeSeriesCodec.SIMPLE8B) {
+          if (hasNumericStats(c)) {
             final double[] stats = reduceNumericStats(chunkValues);
             mins[c] = stats[0];
             maxs[c] = stats[1];
             sums[c] = stats[2];
+            counts[c] = (long) stats[3];
           }
         }
       }
@@ -1175,17 +1229,14 @@ public class TimeSeriesSealedStore implements AutoCloseable {
 
       newBlocksCompressed.add(compressedCols);
       newBlocksMeta.add(new long[] { chunkTs[0], chunkTs[chunkLen - 1], chunkLen });
-      newBlocksMins.add(mins);
-      newBlocksMaxs.add(maxs);
-      newBlocksSums.add(sums);
+      newBlocksStats.add(new BlockStats(mins, maxs, sums, counts));
       newBlocksTagDV.add(chunkTagDV);
       chunkStart = chunkEnd;
     }
 
     // Rewrite sealed file: toKeep blocks (raw copy) + new downsampled blocks
     downsampleRewriteCount++;
-    rewriteWithBlocks(toKeep, newBlocksCompressed, newBlocksMeta, newBlocksMins, newBlocksMaxs, newBlocksSums,
-        newBlocksTagDV, granularityMs);
+    rewriteWithBlocks(toKeep, newBlocksCompressed, newBlocksMeta, newBlocksStats, newBlocksTagDV, granularityMs);
     } finally {
       directoryLock.writeLock().unlock();
     }
@@ -1198,8 +1249,7 @@ public class TimeSeriesSealedStore implements AutoCloseable {
    * Uses atomic tmp-file rename.
    */
   private void rewriteWithBlocks(final List<BlockEntry> retained,
-      final List<byte[][]> newCompressed, final List<long[]> newMeta,
-      final List<double[]> newMins, final List<double[]> newMaxs, final List<double[]> newSums,
+      final List<byte[][]> newCompressed, final List<long[]> newMeta, final List<BlockStats> newStats,
       final List<String[][]> newTagDistinctValues, final long newBlocksGranularityMs) throws IOException {
 
     final int colCount = columns.size();
@@ -1240,7 +1290,7 @@ public class TimeSeriesSealedStore implements AutoCloseable {
           final int b = spec.idx();
           final long[] meta = newMeta.get(b);
           final BlockEntry entry = writeNewBlockToFile(tempFile, (int) meta[2], meta[0], meta[1],
-              newCompressed.get(b), newMins.get(b), newMaxs.get(b), newSums.get(b), colCount,
+              newCompressed.get(b), newStats.get(b), colCount,
               newTagDistinctValues != null ? newTagDistinctValues.get(b) : null);
           // Mark the freshly downsampled block so future cycles at the same (or finer) granularity skip it.
           entry.downsampledGranularityMs = newBlocksGranularityMs;
@@ -1292,8 +1342,8 @@ public class TimeSeriesSealedStore implements AutoCloseable {
       compressedCols[c] = readBytes(oldEntry.columnOffsets[c], oldEntry.columnSizes[c]);
 
     final BlockEntry newEntry = writeNewBlockToFile(tempFile, oldEntry.sampleCount, oldEntry.minTimestamp,
-        oldEntry.maxTimestamp, compressedCols, oldEntry.columnMins, oldEntry.columnMaxs, oldEntry.columnSums,
-        colCount, oldEntry.tagDistinctValues);
+        oldEntry.maxTimestamp, compressedCols, blockStatsOf(oldEntry, compressedCols), colCount,
+        oldEntry.tagDistinctValues);
     // Preserve the in-memory downsampling marker across the file rewrite so idempotency survives compaction.
     newEntry.downsampledGranularityMs = oldEntry.downsampledGranularityMs;
     target.add(newEntry);
@@ -1305,8 +1355,7 @@ public class TimeSeriesSealedStore implements AutoCloseable {
    * callers are responsible for those updates.
    */
   private BlockEntry writeNewBlockToFile(final RandomAccessFile tempFile, final int sampleCount,
-      final long minTs, final long maxTs, final byte[][] compressedCols,
-      final double[] columnMins, final double[] columnMaxs, final double[] columnSums,
+      final long minTs, final long maxTs, final byte[][] compressedCols, final BlockStats stats,
       final int colCount, final String[][] tagDistinctValues) throws IOException {
 
     // Same codec-keyed rule as writeBlock() - see the comment there.
@@ -1317,10 +1366,10 @@ public class TimeSeriesSealedStore implements AutoCloseable {
 
     final byte[] tagMeta = buildTagMetadata(tagDistinctValues, colCount);
 
-    final int statsSize = 4 + (8 + 8 + 8) * numericColCount;
+    final int statsSize = 4 + STATS_BYTES * numericColCount;
     final int metaSize = 4 + 8 + 8 + 4 + 4 * colCount + statsSize + tagMeta.length;
     final ByteBuffer metaBuf = ByteBuffer.allocate(metaSize);
-    metaBuf.putInt(BLOCK_MAGIC_VALUE);
+    metaBuf.putInt(BLOCK_MAGIC_VALUE_V2);
     metaBuf.putLong(minTs);
     metaBuf.putLong(maxTs);
     metaBuf.putInt(sampleCount);
@@ -1329,9 +1378,10 @@ public class TimeSeriesSealedStore implements AutoCloseable {
     metaBuf.putInt(numericColCount);
     for (int c = 0; c < colCount; c++) {
       if (hasNumericStats(c)) {
-        metaBuf.putDouble(columnMins[c]);
-        metaBuf.putDouble(columnMaxs[c]);
-        metaBuf.putDouble(columnSums[c]);
+        metaBuf.putDouble(stats.mins()[c]);
+        metaBuf.putDouble(stats.maxs()[c]);
+        metaBuf.putDouble(stats.sums()[c]);
+        metaBuf.putLong(stats.counts()[c]);
       }
     }
     metaBuf.put(tagMeta);
@@ -1349,8 +1399,8 @@ public class TimeSeriesSealedStore implements AutoCloseable {
 
     // #6360 item 3: the temp file becomes the live file by an atomic move, so an offset into it is the offset the
     // block will have - exactly as the column offsets set below already are.
-    final BlockEntry newEntry = new BlockEntry(minTs, maxTs, sampleCount, colCount, columnMins, columnMaxs, columnSums,
-        blockStart);
+    final BlockEntry newEntry = new BlockEntry(minTs, maxTs, sampleCount, colCount, stats.mins(), stats.maxs(),
+        stats.sums(), stats.counts(), blockStart);
     newEntry.tagDistinctValues = tagDistinctValues;
     for (int c = 0; c < colCount; c++) {
       newEntry.columnOffsets[c] = dataOffset;
@@ -1379,16 +1429,13 @@ public class TimeSeriesSealedStore implements AutoCloseable {
    *
    * @param newCompressed      compressed column bytes for each new block
    * @param newMeta            {@code [minTs, maxTs, sampleCount]} for each new block
-   * @param newMins            per-column min stats for each new block
-   * @param newMaxs            per-column max stats for each new block
-   * @param newSums            per-column sum stats for each new block
+   * @param newStats           per-column statistics for each new block
    * @param newTagDistinctValues tag metadata for each new block (may be null)
    *
    * @return the new {@link BlockEntry} list to pass to {@link #commitTempCompactionFile(List)}
    */
   List<BlockEntry> writeTempCompactionFile(
-      final List<byte[][]> newCompressed, final List<long[]> newMeta,
-      final List<double[]> newMins, final List<double[]> newMaxs, final List<double[]> newSums,
+      final List<byte[][]> newCompressed, final List<long[]> newMeta, final List<BlockStats> newStats,
       final List<String[][]> newTagDistinctValues) throws IOException {
 
     final int colCount = columns.size();
@@ -1443,14 +1490,14 @@ public class TimeSeriesSealedStore implements AutoCloseable {
           final int i = spec.idx();
           final BlockEntry old = retained.get(i);
           entry = writeNewBlockToFile(tempFile, old.sampleCount, old.minTimestamp, old.maxTimestamp,
-              retainedBytes.get(i), old.columnMins, old.columnMaxs, old.columnSums, colCount, old.tagDistinctValues);
+              retainedBytes.get(i), blockStatsOf(old, retainedBytes.get(i)), colCount, old.tagDistinctValues);
           // Preserve the in-memory downsampling marker across compaction's file rewrite.
           entry.downsampledGranularityMs = old.downsampledGranularityMs;
         } else {
           final int b = spec.idx();
           final long[] meta = newMeta.get(b);
           entry = writeNewBlockToFile(tempFile, (int) meta[2], meta[0], meta[1],
-              newCompressed.get(b), newMins.get(b), newMaxs.get(b), newSums.get(b), colCount,
+              newCompressed.get(b), newStats.get(b), colCount,
               newTagDistinctValues != null ? newTagDistinctValues.get(b) : null);
         }
         newDirectory.add(entry);
@@ -1526,16 +1573,13 @@ public class TimeSeriesSealedStore implements AutoCloseable {
    *
    * @param newCompressed   compressed column bytes for each additional block
    * @param newMeta         {@code [minTs, maxTs, sampleCount]} for each additional block
-   * @param newMins         per-column min stats for each block
-   * @param newMaxs         per-column max stats for each block
-   * @param newSums         per-column sum stats for each block
+   * @param newStats        per-column statistics for each block
    * @param newTagDV        tag metadata for each block (may be null)
    * @param directory       block directory from {@link #writeTempCompactionFile}; new
    *                        entries are appended in-place
    */
   void appendBlocksToTempFile(
-      final List<byte[][]> newCompressed, final List<long[]> newMeta,
-      final List<double[]> newMins, final List<double[]> newMaxs, final List<double[]> newSums,
+      final List<byte[][]> newCompressed, final List<long[]> newMeta, final List<BlockStats> newStats,
       final List<String[][]> newTagDV,
       final List<BlockEntry> directory) throws IOException {
     if (newCompressed.isEmpty())
@@ -1559,7 +1603,7 @@ public class TimeSeriesSealedStore implements AutoCloseable {
       for (int b = 0; b < newCompressed.size(); b++) {
         final long[] meta = newMeta.get(b);
         final BlockEntry entry = writeNewBlockToFile(tempFile, (int) meta[2], meta[0], meta[1],
-            newCompressed.get(b), newMins.get(b), newMaxs.get(b), newSums.get(b), colCount,
+            newCompressed.get(b), newStats.get(b), colCount,
             newTagDV != null ? newTagDV.get(b) : null);
         directory.add(entry);
         if (meta[0] < curGlobalMin)
@@ -1789,8 +1833,8 @@ public class TimeSeriesSealedStore implements AutoCloseable {
       }
 
       final int version = headerBuf.get() & 0xFF;
-      if (version != CURRENT_VERSION)
-        problems.add("the header declares format version " + version + ", but this build writes and reads version "
+      if (version > CURRENT_VERSION)
+        problems.add("the header declares format version " + version + ", but this build writes and reads up to version "
             + CURRENT_VERSION);
 
       final int colCount = headerBuf.getShort() & 0xFFFF;
@@ -1930,7 +1974,7 @@ public class TimeSeriesSealedStore implements AutoCloseable {
       // magic took a bit flip, and the second is a block a hex editor could still recover. FIX drops only the
       // first, which is the whole difference between reclaiming a partial write and destroying the last block.
       final boolean tailIsUnfinishedBlock = orphanTailBytes >= 4
-          && ByteBuffer.wrap(readBytes(blockStart, 4)).getInt() == BLOCK_MAGIC_VALUE;
+          && isBlockMagic(ByteBuffer.wrap(readBytes(blockStart, 4)).getInt());
 
       if (orphanTailBytes > 0)
         // A partial block left by an interrupted append is invisible to every other reader: it is neither used
@@ -2103,7 +2147,9 @@ public class TimeSeriesSealedStore implements AutoCloseable {
   }
 
   /**
-   * Reduces one numeric column to the {@code {min, max, sum}} triple a block declares for it.
+   * Reduces one numeric column to the {@code {min, max, sum, count}} statistics a block declares for it: the
+   * extremes and the sum of its REAL samples, and how many of those there were - {@code count} is returned as a
+   * double purely so the four travel in one primitive array, and is exact (it never exceeds a block's sample count).
    * <p>
    * ONE definition, shared by the two write paths that produce the triple ({@link #downsampleBlocks} and
    * {@code TimeSeriesShard}'s compaction) and by the DEEP check that verifies it. It used to be three copies of the
@@ -2112,20 +2158,75 @@ public class TimeSeriesSealedStore implements AutoCloseable {
    * never do.
    */
   static double[] reduceNumericStats(final double[] values) {
-    // MIN/MAX follow the one NaN policy of the subsystem (issue #7043): NaN is absent, and a column with no real
-    // value declares NaN statistics - which is already how the format says "this column carries no statistics",
-    // the marker writeBlock() and the DEEP checker both read. The previous +/-Double.MAX_VALUE seed was a finite
-    // double that survived into the block header, and the aggregation push-down answers MIN/MAX straight out of
-    // that header, so an all-NaN column made the fast path return Double.MAX_VALUE as if it were a measurement.
+    // All four follow the one NaN policy of the subsystem (issues #7043, #7089): NaN is absent, and a column with
+    // no real value declares NaN statistics - which is already how the format says "this column carries no
+    // statistics", the marker writeBlock() and the DEEP checker both read. The previous +/-Double.MAX_VALUE seed
+    // was a finite double that survived into the block header, and the aggregation push-down answers MIN/MAX
+    // straight out of that header, so an all-NaN column made the fast path return Double.MAX_VALUE as if it were a
+    // measurement. The sum used to be a plain +=, which one NaN sample turned into NaN for the whole block, and
+    // the push-down answered SUM/AVG out of that as well: a Grafana panel lost the entire bucket to one absent
+    // sample. The count of real samples is what AVG divides by, and what lets that fast path stay exact.
     double min = TimeSeriesNaN.ABSENT;
     double max = TimeSeriesNaN.ABSENT;
-    double sum = 0;
+    double sum = TimeSeriesNaN.ABSENT;
+    long count = 0;
     for (final double d : values) {
       min = TimeSeriesNaN.min(min, d);
       max = TimeSeriesNaN.max(max, d);
-      sum += d;
+      sum = TimeSeriesNaN.sum(sum, d);
+      count = TimeSeriesNaN.countIfPresent(count, d);
     }
-    return new double[] { min, max, sum };
+    return new double[] { min, max, sum, count };
+  }
+
+  /**
+   * The statistics a block declares for every column, in schema order; non-numeric columns hold NaN and zero.
+   */
+  record BlockStats(double[] mins, double[] maxs, double[] sums, long[] counts) {
+  }
+
+  /**
+   * The statistics a rewrite declares for a block it copies. They are the block's own, except where a legacy block
+   * left a column's count {@link BlockEntry#COUNT_UNKNOWN} (issue #7089): the current layout never carries that
+   * marker, so the column is decoded once, here, and its sum and count computed under the policy - which is exactly
+   * how the rewrite upgrades such a block, and why the marker cannot outlive the next compaction.
+   */
+  private BlockStats blockStatsOf(final BlockEntry entry, final byte[][] compressedCols) throws IOException {
+    double[] sums = entry.columnSums;
+    long[] counts = entry.columnCounts;
+    for (int c = 0; c < columns.size(); c++) {
+      if (counts[c] != BlockEntry.COUNT_UNKNOWN)
+        continue;
+      if (sums == entry.columnSums) {
+        sums = sums.clone();
+        counts = counts.clone();
+      }
+      final double[] stats = reduceNumericStats(decompressDoubleColumnFromBytes(compressedCols[c], c));
+      sums[c] = stats[2];
+      counts[c] = (long) stats[3];
+    }
+    return new BlockStats(entry.columnMins, entry.columnMaxs, sums, counts);
+  }
+
+  /**
+   * Whether one of the requests is a SUM or an AVG over a column whose header cannot answer it - a legacy block
+   * that summed over a NaN sample, see {@link BlockEntry#COUNT_UNKNOWN}. Such a block takes the decompressing path
+   * for the whole request list; MIN/MAX/COUNT could have been read from the header, but the block has to be decoded
+   * anyway and one pass over it is cheaper than two.
+   */
+  private static boolean needsValuesForSum(final BlockEntry entry, final List<MultiColumnAggregationRequest> requests,
+      final int[] schemaColIndices) {
+    for (int r = 0; r < requests.size(); r++) {
+      final AggregationType type = requests.get(r).type();
+      if ((type == AggregationType.SUM || type == AggregationType.AVG)
+          && entry.columnCounts[schemaColIndices[r]] == BlockEntry.COUNT_UNKNOWN)
+        return true;
+    }
+    return false;
+  }
+
+  private static boolean isBlockMagic(final int magic) {
+    return magic == BLOCK_MAGIC_VALUE || magic == BLOCK_MAGIC_VALUE_V2;
   }
 
   /**
@@ -2158,6 +2259,7 @@ public class TimeSeriesSealedStore implements AutoCloseable {
     final double min = stats[0];
     final double max = stats[1];
     final double sum = stats[2];
+    final long count = (long) stats[3];
 
     // A block written before issue #7043 declares the OLD +/-Double.MAX_VALUE seed for a column whose samples
     // are all NaN, and the aggregation push-down answers MIN/MAX straight out of that header - so it hands the
@@ -2186,6 +2288,15 @@ public class TimeSeriesSealedStore implements AutoCloseable {
     // itself - an absolute bound would fire on a healthy block of large values and pass on a damaged block of
     // small ones.
     final double declaredSum = entry.columnSums[colIdx];
+    final long declaredCount = entry.columnCounts[colIdx];
+    // A legacy block that summed over a NaN sample declares no usable sum and no count (issue #7089), and says so
+    // with COUNT_UNKNOWN: nothing is answered from that header for SUM/AVG, so there is nothing to verify, and the
+    // next rewrite of the block replaces both. It is not a problem of the block - it is a block of its time.
+    if (declaredCount == BlockEntry.COUNT_UNKNOWN)
+      return;
+    if (declaredCount != count)
+      problems.add(where + " declares " + declaredCount + " real sample(s) for column '" + column.getName()
+          + "' but its values hold " + count + ": an average answered from this block would be wrong");
     if (Double.isNaN(sum) != Double.isNaN(declaredSum))
       problems.add(where + " declares sum " + declaredSum + " for column '" + column.getName()
           + "' but its values add up to " + sum + ": an aggregation answered from this block would be wrong");
@@ -2567,11 +2678,14 @@ public class TimeSeriesSealedStore implements AutoCloseable {
       throw new IOException(
           "Invalid sealed store magic in '" + basePath + ".ts.sealed': " + Integer.toHexString(magic));
 
+    // Older versions are read as they stand - a version-0 file is a version-1 file that happens to hold only
+    // legacy blocks (see the class comment) - and only a NEWER one is refused, since this build cannot know what
+    // it would be misreading.
     final int version = headerBuf.get() & 0xFF;
-    if (version != CURRENT_VERSION)
+    if (version > CURRENT_VERSION)
       throw new IOException(
-          "Unsupported sealed store format version " + version + " (expected: " + CURRENT_VERSION + ") in '"
-              + basePath + ".ts.sealed'");
+          "Unsupported sealed store format version " + version + " (this build reads up to version " + CURRENT_VERSION
+              + ") in '" + basePath + ".ts.sealed'");
 
     final int colCount = headerBuf.getShort() & 0xFFFF;
     if (colCount != columns.size())
@@ -2595,8 +2709,11 @@ public class TimeSeriesSealedStore implements AutoCloseable {
       metaBuf.flip();
 
       final int blockMagic = metaBuf.getInt();
-      if (blockMagic != BLOCK_MAGIC_VALUE)
+      if (!isBlockMagic(blockMagic))
         break; // not a valid block header — stop scanning
+      // The magic says which statistics layout follows: the pre-#7089 triplet, or the current quadruple.
+      final boolean legacyStats = blockMagic == BLOCK_MAGIC_VALUE;
+      final int statsBytes = legacyStats ? LEGACY_STATS_BYTES : STATS_BYTES;
 
       final long minTs = metaBuf.getLong();
       final long maxTs = metaBuf.getLong();
@@ -2618,18 +2735,20 @@ public class TimeSeriesSealedStore implements AutoCloseable {
       final double[] mins = new double[colCount];
       final double[] maxs = new double[colCount];
       final double[] sums = new double[colCount];
+      final long[] counts = new long[colCount];
       Arrays.fill(mins, Double.NaN);
       Arrays.fill(maxs, Double.NaN);
+      Arrays.fill(sums, Double.NaN);
 
       if (numericColCount > 0) {
-        final int tripletSize = (8 + 8 + 8) * numericColCount;
-        final ByteBuffer statsBuf = ByteBuffer.allocate(tripletSize);
-        if (indexChannel.read(statsBuf, statsPos) < tripletSize)
+        final int statsSize = statsBytes * numericColCount;
+        final ByteBuffer statsBuf = ByteBuffer.allocate(statsSize);
+        if (indexChannel.read(statsBuf, statsPos) < statsSize)
           break;
         statsBuf.flip();
-        // Stats are in schema order — iterate columns, consuming one triplet per column the WRITER emitted one
+        // Stats are in schema order — iterate columns, consuming one entry per column the WRITER emitted one
         // for. The test has to be the writer's own (hasNumericStats), not "is this column a TIMESTAMP or a TAG":
-        // a FIELD whose codec is DICTIONARY (a STRING measurement) is neither, yet has no triplet, and reading
+        // a FIELD whose codec is DICTIONARY (a STRING measurement) is neither, yet has no entry, and reading
         // one for it consumed the next column's statistics and left the last numeric column with none.
         int numericIdx = 0;
         for (int c = 0; c < colCount && numericIdx < numericColCount; c++) {
@@ -2638,9 +2757,17 @@ public class TimeSeriesSealedStore implements AutoCloseable {
           mins[c] = statsBuf.getDouble();
           maxs[c] = statsBuf.getDouble();
           sums[c] = statsBuf.getDouble();
+          if (legacyStats)
+            // The legacy sum was a plain += over every sample, so it is finite only if no sample was NaN - in
+            // which case every sample was real and the count is the block's. A NaN sum could be an all-NaN column
+            // (count 0) or a poisoned real total, and the header cannot tell which: COUNT_UNKNOWN sends SUM/AVG
+            // to the values (issue #7089).
+            counts[c] = Double.isNaN(sums[c]) ? BlockEntry.COUNT_UNKNOWN : sampleCount;
+          else
+            counts[c] = statsBuf.getLong();
           numericIdx++;
         }
-        statsPos += tripletSize;
+        statsPos += statsSize;
       }
 
       // Read tag metadata section
@@ -2686,7 +2813,7 @@ public class TimeSeriesSealedStore implements AutoCloseable {
         }
       }
 
-      final BlockEntry entry = new BlockEntry(minTs, maxTs, sampleCount, colCount, mins, maxs, sums, pos);
+      final BlockEntry entry = new BlockEntry(minTs, maxTs, sampleCount, colCount, mins, maxs, sums, counts, pos);
       entry.tagDistinctValues = blockTagDistinctValues;
       long dataPos = tagEndPos;
       for (int c = 0; c < colCount; c++) {
@@ -3008,19 +3135,21 @@ public class TimeSeriesSealedStore implements AutoCloseable {
     if (idx >= 0) {
       final double existing = result.getValue(idx);
       final long count = result.getCount(idx);
+      // NaN policy (issue #7089): SUM/AVG skip an absent sample the way MIN/MAX below do, and the count kept
+      // alongside is of the samples that contributed - what the AVG is divided by once the scan is over.
       final double merged = switch (type) {
-        case SUM -> existing + value;
+        case SUM, AVG -> TimeSeriesNaN.sum(existing, value);
         case COUNT -> existing + 1;
-        case AVG -> existing + value; // accumulate sum, divide by count later
         // NaN policy (issue #4596): NaN is treated as absent and skipped, so a real value always
         // wins over a NaN running value (consistent with the row-iter, merge and SIMD paths).
         case MIN -> Double.isNaN(value) ? existing : Double.isNaN(existing) ? value : Math.min(existing, value);
         case MAX -> Double.isNaN(value) ? existing : Double.isNaN(existing) ? value : Math.max(existing, value);
       };
       result.updateValue(idx, merged);
-      result.updateCount(idx, count + 1);
+      result.updateCount(idx, type == AggregationType.COUNT ? count + 1 : TimeSeriesNaN.countIfPresent(count, value));
     } else {
-      result.addBucket(bucketTs, type == AggregationType.COUNT ? 1 : value, 1);
+      result.addBucket(bucketTs, type == AggregationType.COUNT ? 1 : value,
+          type == AggregationType.COUNT ? 1 : TimeSeriesNaN.countIfPresent(0, value));
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
@@ -594,9 +594,7 @@ public class TimeSeriesShard implements AutoCloseable {
     // Shared output lists for compressed blocks built in Phases 1+2.
     final List<byte[][]> allCompressedList = new ArrayList<>();
     final List<long[]> allMetaList = new ArrayList<>();
-    final List<double[]> allMinsList = new ArrayList<>();
-    final List<double[]> allMaxsList = new ArrayList<>();
-    final List<double[]> allSumsList = new ArrayList<>();
+    final List<TimeSeriesSealedStore.BlockStats> allStatsList = new ArrayList<>();
     final List<String[][]> allTagDVList = new ArrayList<>();
 
     // ── Phase 1 (no lock, read-only TX): read full/immutable pages ───────────────────────────
@@ -615,8 +613,8 @@ public class TimeSeriesShard implements AutoCloseable {
           // returnSpill=true: the last partial chunk is returned as raw data instead of being
           // emitted as a block, so Phase 4 can merge it with the partial-page samples and
           // produce a single correctly-sized block.
-          phase2Spill = buildCompressedBlocks(snapshotData, allCompressedList, allMetaList, allMinsList, allMaxsList,
-              allSumsList, allTagDVList, true);
+          phase2Spill = buildCompressedBlocks(snapshotData, allCompressedList, allMetaList, allStatsList,
+              allTagDVList, true);
       } finally {
         db.rollback(); // read-only: rollback is always safe
       }
@@ -629,7 +627,7 @@ public class TimeSeriesShard implements AutoCloseable {
     final List<TimeSeriesSealedStore.BlockEntry> newBlockDirectory;
     try {
       newBlockDirectory = sealedStore.writeTempCompactionFile(
-          allCompressedList, allMetaList, allMinsList, allMaxsList, allSumsList, allTagDVList);
+          allCompressedList, allMetaList, allStatsList, allTagDVList);
     } catch (final Exception e) {
       sealedStore.deleteTempFileIfExists();
       clearCompactionFlagBestEffort();
@@ -681,15 +679,11 @@ public class TimeSeriesShard implements AutoCloseable {
     if (toCompress4b != null) {
       final List<byte[][]> remCompressed = new ArrayList<>();
       final List<long[]> remMeta = new ArrayList<>();
-      final List<double[]> remMins = new ArrayList<>();
-      final List<double[]> remMaxs = new ArrayList<>();
-      final List<double[]> remSums = new ArrayList<>();
+      final List<TimeSeriesSealedStore.BlockStats> remStats = new ArrayList<>();
       final List<String[][]> remTagDV = new ArrayList<>();
-      phase4bSpill = buildCompressedBlocks(toCompress4b, remCompressed, remMeta, remMins, remMaxs, remSums,
-          remTagDV, true);
+      phase4bSpill = buildCompressedBlocks(toCompress4b, remCompressed, remMeta, remStats, remTagDV, true);
       if (!remCompressed.isEmpty())
-        sealedStore.appendBlocksToTempFile(remCompressed, remMeta, remMins, remMaxs, remSums, remTagDV,
-            newBlockDirectory);
+        sealedStore.appendBlocksToTempFile(remCompressed, remMeta, remStats, remTagDV, newBlockDirectory);
     }
 
     // ── Phase 4c (brief writeLock + brief TX): read tail pages, swap + clear ──────────────
@@ -726,15 +720,11 @@ public class TimeSeriesShard implements AutoCloseable {
         if (toCompressFinal != null) {
           final List<byte[][]> tailCompressed = new ArrayList<>();
           final List<long[]> tailMeta = new ArrayList<>();
-          final List<double[]> tailMins = new ArrayList<>();
-          final List<double[]> tailMaxs = new ArrayList<>();
-          final List<double[]> tailSums = new ArrayList<>();
+          final List<TimeSeriesSealedStore.BlockStats> tailStats = new ArrayList<>();
           final List<String[][]> tailTagDV = new ArrayList<>();
-          buildCompressedBlocks(toCompressFinal, tailCompressed, tailMeta, tailMins, tailMaxs, tailSums, tailTagDV,
-              false);
+          buildCompressedBlocks(toCompressFinal, tailCompressed, tailMeta, tailStats, tailTagDV, false);
           if (!tailCompressed.isEmpty())
-            sealedStore.appendBlocksToTempFile(tailCompressed, tailMeta, tailMins, tailMaxs, tailSums, tailTagDV,
-                newBlockDirectory);
+            sealedStore.appendBlocksToTempFile(tailCompressed, tailMeta, tailStats, tailTagDV, newBlockDirectory);
         }
 
         // Atomically swap temp file into the sealed store; updates in-memory blockDirectory.
@@ -785,7 +775,7 @@ public class TimeSeriesShard implements AutoCloseable {
   private Object[] buildCompressedBlocks(
       final Object[] data,
       final List<byte[][]> compressedOut, final List<long[]> metaOut,
-      final List<double[]> minsOut, final List<double[]> maxsOut, final List<double[]> sumsOut,
+      final List<TimeSeriesSealedStore.BlockStats> statsOut,
       final List<String[][]> tagDVOut, final boolean returnSpill) {
 
     final long[] timestamps = (long[]) data[0];
@@ -847,8 +837,10 @@ public class TimeSeriesShard implements AutoCloseable {
       final double[] mins = new double[colCount];
       final double[] maxs = new double[colCount];
       final double[] sums = new double[colCount];
+      final long[] counts = new long[colCount];
       Arrays.fill(mins, Double.NaN);
       Arrays.fill(maxs, Double.NaN);
+      Arrays.fill(sums, Double.NaN);
 
       final byte[][] compressedCols = new byte[colCount][];
       for (int c = 0; c < colCount; c++) {
@@ -864,6 +856,7 @@ public class TimeSeriesShard implements AutoCloseable {
             mins[c] = stats[0];
             maxs[c] = stats[1];
             sums[c] = stats[2];
+            counts[c] = (long) stats[3];
           }
         }
       }
@@ -882,9 +875,7 @@ public class TimeSeriesShard implements AutoCloseable {
 
       compressedOut.add(compressedCols);
       metaOut.add(new long[]{chunkTs[0], chunkTs[chunkLen - 1], chunkLen});
-      minsOut.add(mins);
-      maxsOut.add(maxs);
-      sumsOut.add(sums);
+      statsOut.add(new TimeSeriesSealedStore.BlockStats(mins, maxs, sums, counts));
       tagDVOut.add(chunkTagDistinctValues);
       chunkStart = chunkEnd;
     }

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/simd/ScalarTimeSeriesVectorOps.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/simd/ScalarTimeSeriesVectorOps.java
@@ -29,10 +29,20 @@ public final class ScalarTimeSeriesVectorOps implements TimeSeriesVectorOps {
 
   @Override
   public double sum(final double[] data, final int offset, final int length) {
-    double s = 0;
+    // NaN policy (issue #7089): the fold IS the policy - see TimeSeriesNaN. Skips NaN, and an empty or all-NaN
+    // range comes back as the absent marker rather than as a zero that reads as a measurement.
+    double s = TimeSeriesNaN.ABSENT;
     for (int i = offset; i < offset + length; i++)
-      s += data[i];
+      s = TimeSeriesNaN.sum(s, data[i]);
     return s;
+  }
+
+  @Override
+  public long countPresent(final double[] data, final int offset, final int length) {
+    long n = 0;
+    for (int i = offset; i < offset + length; i++)
+      n = TimeSeriesNaN.countIfPresent(n, data[i]);
+    return n;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/simd/ScalarTimeSeriesVectorOps.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/simd/ScalarTimeSeriesVectorOps.java
@@ -32,8 +32,11 @@ public final class ScalarTimeSeriesVectorOps implements TimeSeriesVectorOps {
     // NaN policy (issue #7089): the fold IS the policy - see TimeSeriesNaN. Skips NaN, and an empty or all-NaN
     // range comes back as the absent marker rather than as a zero that reads as a measurement.
     double s = TimeSeriesNaN.ABSENT;
-    for (int i = offset; i < offset + length; i++)
-      s = TimeSeriesNaN.sum(s, data[i]);
+    long present = 0;
+    for (int i = offset; i < offset + length; i++) {
+      s = TimeSeriesNaN.sum(s, present, data[i]);
+      present = TimeSeriesNaN.countIfPresent(present, data[i]);
+    }
     return s;
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/simd/SimdTimeSeriesVectorOps.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/simd/SimdTimeSeriesVectorOps.java
@@ -41,14 +41,46 @@ public final class SimdTimeSeriesVectorOps implements TimeSeriesVectorOps {
   public double sum(final double[] data, final int offset, final int length) {
     final int lanes = DOUBLE_SPECIES.length();
     double s = 0;
+    boolean found = false;
+    int i = 0;
+    for (; i + lanes <= length; i += lanes) {
+      DoubleVector v = DoubleVector.fromArray(DOUBLE_SPECIES, data, offset + i);
+      // NaN policy (issue #7089): a NaN lane would poison the ADD reduction, so it is replaced with the reduction
+      // identity (0 for SUM) and skipped, the same way min()/max() below substitute theirs.
+      final VectorMask<Double> nan = v.test(VectorOperators.IS_NAN);
+      if (nan.anyTrue()) {
+        if (!nan.allTrue())
+          found = true;
+        v = v.blend(0.0, nan);
+      } else
+        found = true;
+      s += v.reduceLanes(VectorOperators.ADD);
+    }
+    for (; i < length; i++) {
+      final double v = data[offset + i];
+      if (Double.isNaN(v))
+        continue;
+      found = true;
+      s += v;
+    }
+    // An empty or all-NaN range answers the absent marker, not the zero the identity leaves behind - which is
+    // what the scalar sibling's fold gives directly.
+    return found ? s : TimeSeriesNaN.ABSENT;
+  }
+
+  @Override
+  public long countPresent(final double[] data, final int offset, final int length) {
+    final int lanes = DOUBLE_SPECIES.length();
+    long n = 0;
     int i = 0;
     for (; i + lanes <= length; i += lanes) {
       final DoubleVector v = DoubleVector.fromArray(DOUBLE_SPECIES, data, offset + i);
-      s += v.reduceLanes(VectorOperators.ADD);
+      n += lanes - v.test(VectorOperators.IS_NAN).trueCount();
     }
     for (; i < length; i++)
-      s += data[offset + i];
-    return s;
+      if (!Double.isNaN(data[offset + i]))
+        n++;
+    return n;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/simd/SimdTimeSeriesVectorOps.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/simd/SimdTimeSeriesVectorOps.java
@@ -64,7 +64,8 @@ public final class SimdTimeSeriesVectorOps implements TimeSeriesVectorOps {
       s += v;
     }
     // An empty or all-NaN range answers the absent marker, not the zero the identity leaves behind - which is
-    // what the scalar sibling's fold gives directly.
+    // what the scalar sibling's fold gives directly. A NaN that the ADD itself produced over real lanes (+Inf and
+    // -Inf in the range) is kept: `found` is true, and the scalar fold keeps it the same way.
     return found ? s : TimeSeriesNaN.ABSENT;
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/simd/TimeSeriesVectorOps.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/simd/TimeSeriesVectorOps.java
@@ -26,7 +26,16 @@ package com.arcadedb.engine.timeseries.simd;
  */
 public interface TimeSeriesVectorOps {
 
+  /**
+   * Sum of the REAL samples in the range, under the NaN policy of {@code TimeSeriesNaN} (issue #7089): a NaN
+   * element is skipped, and a range with no real element answers the absent marker rather than zero.
+   */
   double sum(double[] data, int offset, int length);
+
+  /**
+   * How many elements of the range are real (non-NaN): the denominator of an average over {@link #sum}.
+   */
+  long countPresent(double[] data, int offset, int length);
 
   double min(double[] data, int offset, int length);
 

--- a/engine/src/main/java/com/arcadedb/schema/LocalTimeSeriesType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalTimeSeriesType.java
@@ -315,9 +315,11 @@ public class LocalTimeSeriesType extends LocalDocumentType {
     retentionMs = json.getLong("retentionMs", 0L);
     compactionBucketIntervalMs = json.getLong("compactionBucketIntervalMs", 0L);
     sealedFormatVersion = json.getInt("sealedFormatVersion", 0);
-    if (sealedFormatVersion != TimeSeriesSealedStore.CURRENT_VERSION)
+    // Older sealed formats are read as they stand (issue #7089 added a statistic without dropping the previous
+    // layout); only a NEWER one, which this build cannot know how to read, is refused - as the mutable check below.
+    if (sealedFormatVersion > TimeSeriesSealedStore.CURRENT_VERSION)
       throw new IllegalStateException(
-          "Unsupported sealed store format version " + sealedFormatVersion + " (expected " +
+          "Unsupported sealed store format version " + sealedFormatVersion + " (this build supports up to " +
               TimeSeriesSealedStore.CURRENT_VERSION + ") for TimeSeries type '" + name + "'");
     // Older mutable formats stay readable: the version selects the row layout rather than gating the
     // open, so a type written before the tag dictionary (issue #5519) keeps its inline tag columns.

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6360SealedStoreIntegrityTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6360SealedStoreIntegrityTest.java
@@ -97,7 +97,11 @@ class Issue6360SealedStoreIntegrityTest {
         DictionaryCodec.encode(hosts),
         GorillaXORCodec.encode(usage) };
 
-    store.appendBlock(timestamps.length, declaredMinTs, declaredMaxTs, compressed, mins, maxs, sums,
+    // The declared count follows the declared sum: a NaN sum says "no real sample", a finite one says every sample
+    // was real. Each case here departs from the truth in one statistic on purpose, and this keeps the count from
+    // being a second departure that would mask which one the checker caught.
+    final long[] counts = { 0, 0, Double.isNaN(sums[2]) ? 0 : timestamps.length };
+    store.appendBlock(timestamps.length, declaredMinTs, declaredMaxTs, compressed, mins, maxs, sums, counts,
         new String[][] { null, declaredHosts, null });
   }
 
@@ -162,7 +166,7 @@ class Issue6360SealedStoreIntegrityTest {
   void aBlockEntryIsTrustedOnlyOnceItsWrittenCRCIsRecorded() {
     final double[] stats = { Double.NaN, Double.NaN, 1.0 };
     final TimeSeriesSealedStore.BlockEntry entry =
-        new TimeSeriesSealedStore.BlockEntry(1_000L, 2_000L, 4, 3, stats, stats, stats, 27L);
+        new TimeSeriesSealedStore.BlockEntry(1_000L, 2_000L, 4, 3, stats, stats, stats, new long[] { 0, 0, 4 }, 27L);
 
     assertThat(entry.blockStartOffset).isEqualTo(27L);
     assertThat(entry.crcValidated).as("not trusted until the CRC it would be trusted against is known").isFalse();

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue7089NaNTransparentSumAvgTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue7089NaNTransparentSumAvgTest.java
@@ -424,6 +424,45 @@ class Issue7089NaNTransparentSumAvgTest extends TestHelper {
     }
   }
 
+  /**
+   * A legacy block whose column summed over a NaN has no count of real samples either, and the count recorded next
+   * to a MIN or a MAX is of the samples that contributed. Answering those from the header would record the
+   * "unknown" marker as a count; the block is decoded for them too, and only COUNT reads the header.
+   */
+  @Test
+  void aMinOrMaxOverALegacyPoisonedBlockIsAnsweredFromTheValuesSoItsCountIsReal() throws Exception {
+    final String path = TEST_DIR + "/legacy-minmax";
+    writeLegacyFile(path, new long[][] { { 1_000L, 2_000L, 3_000L } }, new double[][] { { 1.0, Double.NaN, 3.0 } });
+
+    final List<MultiColumnAggregationRequest> requests = List.of(
+        new MultiColumnAggregationRequest(1, AggregationType.MIN, "min"),
+        new MultiColumnAggregationRequest(1, AggregationType.MAX, "max"),
+        new MultiColumnAggregationRequest(1, AggregationType.COUNT, "count"));
+    try (final TimeSeriesSealedStore store = new TimeSeriesSealedStore(path, columns)) {
+      final AggregationMetrics metrics = new AggregationMetrics();
+      final MultiColumnAggregationResult result = new MultiColumnAggregationResult(requests);
+      store.aggregateMultiBlocks(Long.MIN_VALUE, Long.MAX_VALUE, requests, HOUR, result, metrics, null);
+
+      assertThat(metrics.getSlowPathBlocks()).isEqualTo(1);
+      assertThat(result.getValue(0L, 0)).isEqualTo(1.0);
+      assertThat(result.getValue(0L, 1)).isEqualTo(3.0);
+      assertThat(result.getCount(0L, 0)).as("real samples, never the unknown marker").isEqualTo(2);
+      assertThat(result.getCount(0L, 1)).isEqualTo(2);
+      assertThat(result.getValue(0L, 2)).isEqualTo(3.0);
+      assertThat(result.getCount(0L, 2)).isEqualTo(3);
+    }
+
+    // A COUNT alone still reads the header: the block's row count was never in doubt.
+    final List<MultiColumnAggregationRequest> countOnly = List.of(new MultiColumnAggregationRequest(1, AggregationType.COUNT, "count"));
+    try (final TimeSeriesSealedStore store = new TimeSeriesSealedStore(path, columns)) {
+      final AggregationMetrics metrics = new AggregationMetrics();
+      final MultiColumnAggregationResult result = new MultiColumnAggregationResult(countOnly);
+      store.aggregateMultiBlocks(Long.MIN_VALUE, Long.MAX_VALUE, countOnly, HOUR, result, metrics, null);
+      assertThat(metrics.getFastPathBlocks()).isEqualTo(1);
+      assertThat(result.getValue(0L, 0)).isEqualTo(3.0);
+    }
+  }
+
   @Test
   void aVersionZeroFileWithoutLegacyNaNIsStampedCurrentOnItsNextAppend() throws Exception {
     final String path = TEST_DIR + "/stamped";

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue7089NaNTransparentSumAvgTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue7089NaNTransparentSumAvgTest.java
@@ -1,0 +1,481 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.engine.timeseries.codec.DeltaOfDeltaCodec;
+import com.arcadedb.engine.timeseries.codec.GorillaXORCodec;
+import com.arcadedb.engine.timeseries.simd.ScalarTimeSeriesVectorOps;
+import com.arcadedb.engine.timeseries.simd.SimdTimeSeriesVectorOps;
+import com.arcadedb.engine.timeseries.simd.TimeSeriesVectorOps;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.CRC32;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Issue #7089: SUM and AVG were not NaN-transparent. MIN/MAX already skipped NaN as the absent marker (issues
+ * #7039/#7043, {@link TimeSeriesNaN}), but every SUM accumulator was a plain {@code +=}, so a single NaN sample
+ * made a whole block declare {@code sum = NaN} in its header, the block-statistics fast path answered SUM/AVG
+ * straight out of that header, and a Grafana panel lost the entire bucket to one absent sample.
+ * <p>
+ * The fix puts SUM/AVG under the one policy - skip NaN, and an all-absent window is {@link TimeSeriesNaN#ABSENT} -
+ * and, so that the fast path can still answer AVG exactly, records in every sealed block the count of REAL samples
+ * per column next to its sum. Blocks written before that carry no count; this test pins how they are read.
+ */
+class Issue7089NaNTransparentSumAvgTest extends TestHelper {
+
+  private static final String TEST_DIR = "target/databases/Issue7089NaNTransparentSumAvgTest";
+  private static final long   HOUR     = 3_600_000L;
+
+  private List<ColumnDefinition> columns;
+
+  @BeforeEach
+  void setUp() {
+    FileUtils.deleteRecursively(new File(TEST_DIR));
+    new File(TEST_DIR).mkdirs();
+    columns = List.of(
+        new ColumnDefinition("ts", Type.LONG, ColumnDefinition.ColumnRole.TIMESTAMP),
+        new ColumnDefinition("value", Type.DOUBLE, ColumnDefinition.ColumnRole.FIELD));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(TEST_DIR));
+  }
+
+  // ---- the policy itself ----
+
+  @Test
+  void theFoldSkipsNaNAndAnAllAbsentWindowStaysAbsent() {
+    double sum = TimeSeriesNaN.ABSENT;
+    long count = 0;
+    for (final double d : new double[] { Double.NaN, 1.0, Double.NaN, 3.0 }) {
+      sum = TimeSeriesNaN.sum(sum, d);
+      count = TimeSeriesNaN.countIfPresent(count, d);
+    }
+    assertThat(sum).isEqualTo(4.0);
+    assertThat(count).isEqualTo(2);
+
+    assertThat(TimeSeriesNaN.sum(TimeSeriesNaN.ABSENT, Double.NaN)).isNaN();
+    assertThat(TimeSeriesNaN.countIfPresent(0, Double.NaN)).isZero();
+    // Merging partials is the same fold: an absent partial cannot poison a real one, whichever side it is on.
+    assertThat(TimeSeriesNaN.sum(5.0, TimeSeriesNaN.ABSENT)).isEqualTo(5.0);
+    assertThat(TimeSeriesNaN.sum(TimeSeriesNaN.ABSENT, 5.0)).isEqualTo(5.0);
+  }
+
+  @Test
+  void theBlockStatisticsDeclareTheSumAndCountOfTheRealSamples() {
+    final double[] stats = TimeSeriesSealedStore.reduceNumericStats(new double[] { 1.0, Double.NaN, 3.0, Double.NaN });
+    assertThat(stats[0]).as("min").isEqualTo(1.0);
+    assertThat(stats[1]).as("max").isEqualTo(3.0);
+    assertThat(stats[2]).as("sum of the real samples, not NaN").isEqualTo(4.0);
+    assertThat(stats[3]).as("count of the real samples").isEqualTo(2.0);
+
+    final double[] absent = TimeSeriesSealedStore.reduceNumericStats(new double[] { Double.NaN, Double.NaN });
+    assertThat(absent[2]).as("no real sample: the sum is absent, not 0").isNaN();
+    assertThat(absent[3]).isEqualTo(0.0);
+  }
+
+  @Test
+  void vectorizedAndScalarSumSkipNaNAlike() {
+    final TimeSeriesVectorOps simd = new SimdTimeSeriesVectorOps();
+    final TimeSeriesVectorOps scalar = new ScalarTimeSeriesVectorOps();
+    // Sized so one NaN lands inside the SIMD-reduced prefix and one in the scalar tail.
+    final double[] data = new double[67];
+    double expected = 0;
+    for (int i = 0; i < data.length; i++) {
+      data[i] = i + 1;
+      expected += i + 1;
+    }
+    data[10] = Double.NaN;
+    data[65] = Double.NaN;
+    expected -= 11 + 66;
+
+    assertThat(simd.sum(data, 0, data.length)).isCloseTo(expected, within(1e-9));
+    assertThat(scalar.sum(data, 0, data.length)).isCloseTo(expected, within(1e-9));
+    assertThat(simd.countPresent(data, 0, data.length)).isEqualTo(65);
+    assertThat(scalar.countPresent(data, 0, data.length)).isEqualTo(65);
+
+    final double[] allNaN = new double[40];
+    java.util.Arrays.fill(allNaN, Double.NaN);
+    for (final TimeSeriesVectorOps ops : new TimeSeriesVectorOps[] { simd, scalar }) {
+      assertThat(ops.sum(allNaN, 0, allNaN.length)).as("all-NaN range is absent, not 0").isNaN();
+      assertThat(ops.sum(data, 0, 0)).as("empty range is absent, not 0").isNaN();
+      assertThat(ops.countPresent(allNaN, 0, allNaN.length)).isZero();
+    }
+  }
+
+  @Test
+  void mergingPartialResultsSkipsTheAbsentSide() {
+    // Single-column: a shard that saw only NaN merges into one that saw data without touching its total.
+    final AggregationResult left = new AggregationResult();
+    left.addBucket(0L, 5.0, 2);
+    final AggregationResult right = new AggregationResult();
+    right.addBucket(0L, TimeSeriesNaN.ABSENT, 0);
+    left.merge(right, AggregationType.SUM);
+    assertThat(left.getValue(0)).isEqualTo(5.0);
+
+    // A partial AVG is weighted by its REAL count, and a zero-count side is not multiplied into the merge.
+    final AggregationResult avgLeft = new AggregationResult();
+    avgLeft.addBucket(0L, TimeSeriesNaN.ABSENT, 0);
+    final AggregationResult avgRight = new AggregationResult();
+    avgRight.addBucket(0L, 4.0, 3);
+    avgLeft.merge(avgRight, AggregationType.AVG);
+    assertThat(avgLeft.getValue(0)).isEqualTo(4.0);
+    assertThat(avgLeft.getCount(0)).isEqualTo(3);
+
+    // Multi-column, flat mode: the same fold.
+    final List<MultiColumnAggregationRequest> requests = List.of(
+        new MultiColumnAggregationRequest(1, AggregationType.SUM, "s"),
+        new MultiColumnAggregationRequest(1, AggregationType.AVG, "a"));
+    final MultiColumnAggregationResult a = new MultiColumnAggregationResult(requests, 0L, HOUR, 2);
+    final MultiColumnAggregationResult b = new MultiColumnAggregationResult(requests, 0L, HOUR, 2);
+    a.accumulateRow(0L, new double[] { Double.NaN, Double.NaN });
+    b.accumulateRow(0L, new double[] { 2.0, 2.0 });
+    b.accumulateRow(0L, new double[] { 4.0, 4.0 });
+    a.mergeFrom(b);
+    a.finalizeAvg();
+    assertThat(a.getValue(0L, 0)).isEqualTo(6.0);
+    assertThat(a.getValue(0L, 1)).isEqualTo(3.0);
+    assertThat(a.getCount(0L, 1)).as("the count AVG divided by is of the real samples").isEqualTo(2);
+  }
+
+  // ---- end to end, through the engine ----
+
+  @Test
+  void oneNaNSampleNoLongerPoisonsTheBucketOnAnyPath() throws Exception {
+    database.command("sql", "CREATE TIMESERIES TYPE Sensor TIMESTAMP ts FIELDS (value DOUBLE)");
+    final TimeSeriesEngine engine = ((LocalTimeSeriesType) database.getSchema().getType("Sensor")).getEngine();
+
+    // Bucket 0: 10, NaN, 30, 40 -> sum 80, avg 80/3, count 4 (rows), min 10, max 40.
+    // Bucket 1: NaN, NaN -> everything absent, count 2.
+    database.transaction(() -> {
+      insert(0L, 10.0);
+      insert(1_000L, Double.NaN);
+      insert(2_000L, 30.0);
+      insert(3_000L, 40.0);
+      insert(HOUR, Double.NaN);
+      insert(HOUR + 1_000L, Double.NaN);
+    });
+
+    // Mutable bucket only.
+    assertBucketsAreNaNTransparent(engine, "mutable");
+    assertSqlPushDownIsNaNTransparent();
+
+    // Sealed: the block-statistics fast path answers from the header, which must now carry the real sum and count.
+    engine.compactAll();
+    final AggregationMetrics metrics = new AggregationMetrics();
+    assertBucketsAreNaNTransparent(engine, "sealed", metrics);
+    assertThat(metrics.getFastPathBlocks()).as("answered from the block header").isGreaterThan(0);
+    assertThat(metrics.getSlowPathBlocks()).isZero();
+    assertSqlPushDownIsNaNTransparent();
+
+    // The single-column path agrees with the multi-column one.
+    database.begin();
+    final AggregationResult sum = engine.aggregate(Long.MIN_VALUE, Long.MAX_VALUE, 0, AggregationType.SUM, HOUR, null);
+    final AggregationResult avg = engine.aggregate(Long.MIN_VALUE, Long.MAX_VALUE, 0, AggregationType.AVG, HOUR, null);
+    database.commit();
+    assertThat(sum.getValue(sum.findBucketIndex(0L))).isEqualTo(80.0);
+    assertThat(avg.getValue(avg.findBucketIndex(0L))).isCloseTo(80.0 / 3, within(1e-9));
+    assertThat(sum.getValue(sum.findBucketIndex(HOUR))).isNaN();
+    assertThat(avg.getValue(avg.findBucketIndex(HOUR))).isNaN();
+  }
+
+  private void insert(final long ts, final double value) {
+    database.command("sql", "INSERT INTO Sensor SET ts = :ts, value = :v", Map.of("ts", ts, "v", value));
+  }
+
+  private void assertBucketsAreNaNTransparent(final TimeSeriesEngine engine, final String where) throws IOException {
+    assertBucketsAreNaNTransparent(engine, where, null);
+  }
+
+  private void assertBucketsAreNaNTransparent(final TimeSeriesEngine engine, final String where,
+      final AggregationMetrics metrics) throws IOException {
+    final List<MultiColumnAggregationRequest> requests = List.of(
+        new MultiColumnAggregationRequest(1, AggregationType.SUM, "sum"),
+        new MultiColumnAggregationRequest(1, AggregationType.AVG, "avg"),
+        new MultiColumnAggregationRequest(1, AggregationType.COUNT, "count"),
+        new MultiColumnAggregationRequest(1, AggregationType.MIN, "min"),
+        new MultiColumnAggregationRequest(1, AggregationType.MAX, "max"));
+    database.begin();
+    final MultiColumnAggregationResult result = engine.aggregateMulti(Long.MIN_VALUE, Long.MAX_VALUE, requests, HOUR, null,
+        metrics);
+    database.commit();
+
+    assertThat(result.getValue(0L, 0)).as(where + ": SUM is the sum of the real samples").isEqualTo(80.0);
+    assertThat(result.getValue(0L, 1)).as(where + ": AVG divides by the real samples").isCloseTo(80.0 / 3, within(1e-9));
+    assertThat(result.getValue(0L, 2)).as(where + ": COUNT counts rows, like count(*)").isEqualTo(4.0);
+    assertThat(result.getValue(0L, 3)).isEqualTo(10.0);
+    assertThat(result.getValue(0L, 4)).isEqualTo(40.0);
+
+    assertThat(result.getValue(HOUR, 0)).as(where + ": all-NaN bucket SUM is absent").isNaN();
+    assertThat(result.getValue(HOUR, 1)).as(where + ": all-NaN bucket AVG is absent, not 0/0 or 0").isNaN();
+    assertThat(result.getValue(HOUR, 2)).isEqualTo(2.0);
+    assertThat(result.getValue(HOUR, 3)).isNaN();
+  }
+
+  private void assertSqlPushDownIsNaNTransparent() {
+    final ResultSet rs = database.query("sql",
+        "SELECT ts.timeBucket('1h', ts) AS hour, sum(value) AS s, avg(value) AS a, count(*) AS c FROM Sensor GROUP BY hour");
+    final List<Result> rows = new ArrayList<>();
+    while (rs.hasNext())
+      rows.add(rs.next());
+    rows.sort((x, y) -> ((LocalDateTime) x.getProperty("hour")).compareTo((LocalDateTime) y.getProperty("hour")));
+    assertThat(rows).hasSize(2);
+    assertThat(((Number) rows.get(0).getProperty("s")).doubleValue()).isEqualTo(80.0);
+    assertThat(((Number) rows.get(0).getProperty("a")).doubleValue()).isCloseTo(80.0 / 3, within(1e-9));
+    assertThat(((Number) rows.get(0).getProperty("c")).longValue()).isEqualTo(4);
+    assertThat(((Number) rows.get(1).getProperty("s")).doubleValue()).isNaN();
+    assertThat(((Number) rows.get(1).getProperty("c")).longValue()).isEqualTo(2);
+  }
+
+  // ---- the sealed block format ----
+
+  @Test
+  void aLegacyBlockIsReadAndItsPoisonedSumIsAnsweredFromTheValues() throws Exception {
+    final String path = TEST_DIR + "/legacy";
+
+    // Three blocks in the layout every block had before this fix: a [min, max, sum] triplet, the sum a plain +=.
+    // Block A summed over a NaN, so its header says sum = NaN and cannot tell an all-NaN column from a poisoned
+    // one; block B held no NaN, so its finite sum proves every sample real. Block C only exists to be truncated.
+    writeLegacyFile(path,
+        new long[][] { { 0L, 500L }, { 1_000L, 2_000L, 3_000L }, { HOUR, HOUR + 1_000L } },
+        new double[][] { { 7.0, 7.0 }, { 1.0, Double.NaN, 3.0 }, { 10.0, 20.0 } });
+
+    final List<MultiColumnAggregationRequest> requests = List.of(
+        new MultiColumnAggregationRequest(1, AggregationType.SUM, "sum"),
+        new MultiColumnAggregationRequest(1, AggregationType.AVG, "avg"),
+        new MultiColumnAggregationRequest(1, AggregationType.MIN, "min"),
+        new MultiColumnAggregationRequest(1, AggregationType.MAX, "max"),
+        new MultiColumnAggregationRequest(1, AggregationType.COUNT, "count"));
+
+    try (final TimeSeriesSealedStore store = new TimeSeriesSealedStore(path, columns)) {
+      assertThat(store.getBlockCount()).isEqualTo(3);
+
+      final AggregationMetrics metrics = new AggregationMetrics();
+      final MultiColumnAggregationResult result = new MultiColumnAggregationResult(requests);
+      store.aggregateMultiBlocks(600L, Long.MAX_VALUE, requests, HOUR, result, metrics, null);
+      result.finalizeAvg();
+
+      assertThat(result.getValue(0L, 0)).as("legacy block with a NaN: SUM from the values").isEqualTo(4.0);
+      assertThat(result.getValue(0L, 1)).as("legacy block with a NaN: AVG over the real samples").isEqualTo(2.0);
+      assertThat(result.getValue(0L, 2)).isEqualTo(1.0);
+      assertThat(result.getValue(0L, 3)).isEqualTo(3.0);
+      assertThat(result.getValue(0L, 4)).isEqualTo(3.0);
+      assertThat(result.getValue(HOUR, 0)).as("legacy block without NaN: SUM from the header").isEqualTo(30.0);
+      assertThat(result.getValue(HOUR, 1)).isEqualTo(15.0);
+      assertThat(metrics.getSlowPathBlocks()).as("only the block whose header cannot answer is decoded").isEqualTo(1);
+      assertThat(metrics.getFastPathBlocks()).isEqualTo(1);
+
+      // The block is a block of its time, not a damaged one.
+      assertThat(store.checkIntegrity(TimeSeriesIntegrity.Options.deepOnly()).problems()).isEmpty();
+
+      // A rewrite upgrades what it copies: the retained legacy blocks come back in the current layout, with the
+      // count computed from their values, so the next query answers both from the header.
+      store.truncateBefore(600L);
+      assertThat(store.getBlockCount()).isEqualTo(2);
+    }
+
+    try (final RandomAccessFile raf = new RandomAccessFile(path + ".ts.sealed", "r")) {
+      raf.seek(4);
+      assertThat(raf.readByte()).as("a rewritten file carries the current version").isEqualTo((byte) 1);
+    }
+
+    try (final TimeSeriesSealedStore store = new TimeSeriesSealedStore(path, columns)) {
+      final AggregationMetrics metrics = new AggregationMetrics();
+      final MultiColumnAggregationResult result = new MultiColumnAggregationResult(requests);
+      store.aggregateMultiBlocks(Long.MIN_VALUE, Long.MAX_VALUE, requests, HOUR, result, metrics, null);
+      result.finalizeAvg();
+
+      assertThat(result.getValue(0L, 0)).isEqualTo(4.0);
+      assertThat(result.getValue(0L, 1)).isEqualTo(2.0);
+      assertThat(result.getValue(HOUR, 0)).isEqualTo(30.0);
+      assertThat(metrics.getSlowPathBlocks()).isZero();
+      assertThat(metrics.getFastPathBlocks()).isEqualTo(2);
+      assertThat(store.checkIntegrity(TimeSeriesIntegrity.Options.deepOnly()).problems()).isEmpty();
+    }
+  }
+
+  @Test
+  void aVersionZeroFileWithoutLegacyNaNIsStampedCurrentOnItsNextAppend() throws Exception {
+    final String path = TEST_DIR + "/stamped";
+    writeLegacyFile(path, new long[][] { { 1_000L, 2_000L } }, new double[][] { { 1.0, 2.0 } });
+
+    try (final TimeSeriesSealedStore store = new TimeSeriesSealedStore(path, columns)) {
+      store.appendBlock(2, 5_000L, 6_000L, new byte[][] {
+          DeltaOfDeltaCodec.encode(new long[] { 5_000L, 6_000L }),
+          GorillaXORCodec.encode(new double[] { 5.0, Double.NaN })
+      }, new double[] { Double.NaN, 5.0 }, new double[] { Double.NaN, 5.0 }, new double[] { Double.NaN, 5.0 },
+          new long[] { 0, 1 }, null);
+      store.flushHeader();
+    }
+
+    try (final RandomAccessFile raf = new RandomAccessFile(path + ".ts.sealed", "r")) {
+      raf.seek(4);
+      assertThat(raf.readByte()).isEqualTo((byte) 1);
+    }
+
+    // Mixed file: the first block is legacy, the second current; both read, both answered from the header.
+    try (final TimeSeriesSealedStore store = new TimeSeriesSealedStore(path, columns)) {
+      assertThat(store.getBlockCount()).isEqualTo(2);
+      final List<MultiColumnAggregationRequest> requests = List.of(
+          new MultiColumnAggregationRequest(1, AggregationType.AVG, "avg"));
+      final AggregationMetrics metrics = new AggregationMetrics();
+      final MultiColumnAggregationResult result = new MultiColumnAggregationResult(requests);
+      store.aggregateMultiBlocks(Long.MIN_VALUE, Long.MAX_VALUE, requests, HOUR, result, metrics, null);
+      result.finalizeAvg();
+      assertThat(result.getValue(0L, 0)).as("(1 + 2 + 5) / 3 real samples, the NaN not counted").isEqualTo(8.0 / 3);
+      assertThat(metrics.getFastPathBlocks()).isEqualTo(2);
+      assertThat(store.checkIntegrity(TimeSeriesIntegrity.Options.deepOnly()).problems()).isEmpty();
+    }
+  }
+
+  @Test
+  void theDeepCheckVerifiesTheDeclaredCount() throws Exception {
+    final String path = TEST_DIR + "/lying";
+    try (final TimeSeriesSealedStore store = new TimeSeriesSealedStore(path, columns)) {
+      // Values hold three real samples; the header claims two, and a sum that matches neither.
+      store.appendBlock(3, 1_000L, 3_000L, new byte[][] {
+          DeltaOfDeltaCodec.encode(new long[] { 1_000L, 2_000L, 3_000L }),
+          GorillaXORCodec.encode(new double[] { 1.0, 2.0, 3.0 })
+      }, new double[] { Double.NaN, 1.0 }, new double[] { Double.NaN, 3.0 }, new double[] { Double.NaN, 6.0 },
+          new long[] { 0, 2 }, null);
+      store.flushHeader();
+
+      final List<String> problems = store.checkIntegrity(TimeSeriesIntegrity.Options.deepOnly()).problems();
+      assertThat(problems).anyMatch(p -> p.contains("declares 2 real sample(s) for column 'value' but its values hold 3"));
+    }
+  }
+
+  @Test
+  void downsamplingAveragesTheRealSamplesOnly() throws Exception {
+    final String path = TEST_DIR + "/downsample";
+    try (final TimeSeriesSealedStore store = new TimeSeriesSealedStore(path, columns)) {
+      // Old block, to be downsampled to one 5s bucket: the mean of the real samples is 2, not NaN.
+      store.appendBlock(3, 6_000L, 8_000L, new byte[][] {
+          DeltaOfDeltaCodec.encode(new long[] { 6_000L, 7_000L, 8_000L }),
+          GorillaXORCodec.encode(new double[] { 1.0, Double.NaN, 3.0 })
+      }, new double[] { Double.NaN, 1.0 }, new double[] { Double.NaN, 3.0 }, new double[] { Double.NaN, 4.0 },
+          new long[] { 0, 2 }, null);
+      // An old bucket with no real sample at all is downsampled to the absent marker, not to 0.
+      store.appendBlock(2, 11_000L, 12_000L, new byte[][] {
+          DeltaOfDeltaCodec.encode(new long[] { 11_000L, 12_000L }),
+          GorillaXORCodec.encode(new double[] { Double.NaN, Double.NaN })
+      }, new double[] { Double.NaN, Double.NaN }, new double[] { Double.NaN, Double.NaN },
+          new double[] { Double.NaN, Double.NaN }, new long[] { 0, 0 }, null);
+      // Newer block, retained.
+      store.appendBlock(1, 100_000L, 100_000L, new byte[][] {
+          DeltaOfDeltaCodec.encode(new long[] { 100_000L }),
+          GorillaXORCodec.encode(new double[] { 9.0 })
+      }, new double[] { Double.NaN, 9.0 }, new double[] { Double.NaN, 9.0 }, new double[] { Double.NaN, 9.0 },
+          new long[] { 0, 1 }, null);
+      store.flushHeader();
+
+      store.downsampleBlocks(50_000L, 5_000L, 0, List.of(), List.of(1));
+
+      final List<Object[]> rows = store.scanRange(Long.MIN_VALUE, Long.MAX_VALUE, null, null);
+      assertThat(rows).hasSize(3);
+      assertThat((long) rows.get(0)[0]).isEqualTo(5_000L);
+      assertThat((double) rows.get(0)[1]).isEqualTo(2.0);
+      assertThat((long) rows.get(1)[0]).isEqualTo(10_000L);
+      assertThat((double) rows.get(1)[1]).isNaN();
+      assertThat((double) rows.get(2)[1]).isEqualTo(9.0);
+      assertThat(store.checkIntegrity(TimeSeriesIntegrity.Options.deepOnly()).problems()).isEmpty();
+    }
+  }
+
+  /**
+   * Writes a sealed file exactly as every build before this fix wrote it: header version 0, and per block the
+   * "TSBL" magic with a {@code [min, max, sum]} triplet whose sum is a plain {@code +=} over every sample.
+   */
+  private static void writeLegacyFile(final String path, final long[][] timestamps, final double[][] values)
+      throws IOException {
+    long globalMin = Long.MAX_VALUE;
+    long globalMax = Long.MIN_VALUE;
+    for (final long[] ts : timestamps) {
+      globalMin = Math.min(globalMin, ts[0]);
+      globalMax = Math.max(globalMax, ts[ts.length - 1]);
+    }
+
+    try (final RandomAccessFile raf = new RandomAccessFile(path + ".ts.sealed", "rw")) {
+      raf.setLength(0);
+      final ByteBuffer header = ByteBuffer.allocate(27);
+      header.putInt(0x54534958); // "TSIX"
+      header.put((byte) 0);
+      header.putShort((short) 2);
+      header.putInt(timestamps.length);
+      header.putLong(globalMin);
+      header.putLong(globalMax);
+      raf.write(header.array());
+
+      for (int b = 0; b < timestamps.length; b++) {
+        final byte[] tsBytes = DeltaOfDeltaCodec.encode(timestamps[b]);
+        final byte[] valBytes = GorillaXORCodec.encode(values[b]);
+
+        double min = TimeSeriesNaN.ABSENT;
+        double max = TimeSeriesNaN.ABSENT;
+        double legacySum = 0;
+        for (final double v : values[b]) {
+          min = TimeSeriesNaN.min(min, v);
+          max = TimeSeriesNaN.max(max, v);
+          legacySum += v;
+        }
+
+        final ByteBuffer meta = ByteBuffer.allocate(4 + 8 + 8 + 4 + 4 * 2 + 4 + 24 + 2);
+        meta.putInt(0x5453424C); // "TSBL"
+        meta.putLong(timestamps[b][0]);
+        meta.putLong(timestamps[b][timestamps[b].length - 1]);
+        meta.putInt(timestamps[b].length);
+        meta.putInt(tsBytes.length);
+        meta.putInt(valBytes.length);
+        meta.putInt(1); // one numeric column
+        meta.putDouble(min);
+        meta.putDouble(max);
+        meta.putDouble(legacySum);
+        meta.putShort((short) 0); // no TAG column
+        final CRC32 crc = new CRC32();
+        crc.update(meta.array());
+        crc.update(tsBytes);
+        crc.update(valBytes);
+        raf.write(meta.array());
+        raf.write(tsBytes);
+        raf.write(valBytes);
+        raf.writeInt((int) crc.getValue());
+      }
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue7089NaNTransparentSumAvgTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue7089NaNTransparentSumAvgTest.java
@@ -84,17 +84,111 @@ class Issue7089NaNTransparentSumAvgTest extends TestHelper {
     double sum = TimeSeriesNaN.ABSENT;
     long count = 0;
     for (final double d : new double[] { Double.NaN, 1.0, Double.NaN, 3.0 }) {
-      sum = TimeSeriesNaN.sum(sum, d);
+      sum = TimeSeriesNaN.sum(sum, count, d);
       count = TimeSeriesNaN.countIfPresent(count, d);
     }
     assertThat(sum).isEqualTo(4.0);
     assertThat(count).isEqualTo(2);
 
-    assertThat(TimeSeriesNaN.sum(TimeSeriesNaN.ABSENT, Double.NaN)).isNaN();
+    assertThat(TimeSeriesNaN.sum(TimeSeriesNaN.ABSENT, 0, Double.NaN)).isNaN();
     assertThat(TimeSeriesNaN.countIfPresent(0, Double.NaN)).isZero();
-    // Merging partials is the same fold: an absent partial cannot poison a real one, whichever side it is on.
-    assertThat(TimeSeriesNaN.sum(5.0, TimeSeriesNaN.ABSENT)).isEqualTo(5.0);
-    assertThat(TimeSeriesNaN.sum(TimeSeriesNaN.ABSENT, 5.0)).isEqualTo(5.0);
+    // Merging partials is the same rule: an absent partial cannot poison a real one, whichever side it is on.
+    assertThat(TimeSeriesNaN.mergeSum(5.0, 1, TimeSeriesNaN.ABSENT, 0)).isEqualTo(5.0);
+    assertThat(TimeSeriesNaN.mergeSum(TimeSeriesNaN.ABSENT, 0, 5.0, 1)).isEqualTo(5.0);
+  }
+
+  /**
+   * The fold is keyed on the count of real samples seen, not on the accumulator being NaN: a total that turned
+   * NaN by arithmetic ({@code +Infinity + -Infinity}) after real samples is an undefined total, not an absence,
+   * and the next real sample must not overwrite it - the vectorized reduction keeps it, so must every other path.
+   */
+  @Test
+  void anArithmeticNaNOverRealSamplesIsKeptNotReplaced() {
+    final double[] data = { Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, 5.0 };
+
+    double sum = TimeSeriesNaN.ABSENT;
+    long count = 0;
+    for (final double d : data) {
+      sum = TimeSeriesNaN.sum(sum, count, d);
+      count = TimeSeriesNaN.countIfPresent(count, d);
+    }
+    assertThat(sum).isNaN();
+    assertThat(count).isEqualTo(3);
+
+    final double[] stats = TimeSeriesSealedStore.reduceNumericStats(data);
+    assertThat(stats[2]).isNaN();
+    assertThat(stats[3]).isEqualTo(3.0);
+
+    assertThat(new ScalarTimeSeriesVectorOps().sum(data, 0, 3)).isNaN();
+    assertThat(new SimdTimeSeriesVectorOps().sum(data, 0, 3)).isNaN();
+    final double[] wide = new double[70];
+    java.util.Arrays.fill(wide, 1.0);
+    wide[3] = Double.POSITIVE_INFINITY;
+    wide[4] = Double.NEGATIVE_INFINITY;
+    assertThat(new SimdTimeSeriesVectorOps().sum(wide, 0, wide.length)).isNaN();
+    assertThat(new ScalarTimeSeriesVectorOps().sum(wide, 0, wide.length)).isNaN();
+
+    // Merging partials: an undefined partial over real samples stays undefined; an absent partial is skipped.
+    assertThat(TimeSeriesNaN.mergeSum(Double.NaN, 2, 5.0, 1)).isNaN();
+    assertThat(TimeSeriesNaN.mergeSum(5.0, 1, Double.NaN, 2)).isNaN();
+    assertThat(TimeSeriesNaN.mergeSum(5.0, 1, TimeSeriesNaN.ABSENT, 0)).isEqualTo(5.0);
+    assertThat(TimeSeriesNaN.mergeSum(TimeSeriesNaN.ABSENT, 0, 5.0, 1)).isEqualTo(5.0);
+
+    final List<MultiColumnAggregationRequest> requests = List.of(new MultiColumnAggregationRequest(1, AggregationType.SUM, "s"));
+    final MultiColumnAggregationResult result = new MultiColumnAggregationResult(requests, 0L, HOUR, 1);
+    for (final double d : data)
+      result.accumulateRow(0L, new double[] { d });
+    assertThat(result.getValue(0L, 0)).isNaN();
+    assertThat(result.getCount(0L, 0)).isEqualTo(3);
+
+    final AggregationResult left = new AggregationResult();
+    left.addBucket(0L, Double.NaN, 2);
+    final AggregationResult right = new AggregationResult();
+    right.addBucket(0L, 5.0, 1);
+    left.merge(right, AggregationType.SUM);
+    assertThat(left.getValue(0)).isNaN();
+  }
+
+  /**
+   * The count recorded next to a value is of the samples that contributed to it, on every path and for every
+   * request - not only where AVG happens to read it. A block that straddles two buckets takes the vectorized
+   * segment path; its counts must be what the block-aligned path and the per-row path record for the same data.
+   */
+  @Test
+  void theVectorizedPathCountsTheRealSamplesForEveryRequest() throws Exception {
+    final String path = TEST_DIR + "/segments";
+    final List<MultiColumnAggregationRequest> requests = List.of(
+        new MultiColumnAggregationRequest(1, AggregationType.SUM, "sum"),
+        new MultiColumnAggregationRequest(1, AggregationType.MIN, "min"),
+        new MultiColumnAggregationRequest(1, AggregationType.MAX, "max"),
+        new MultiColumnAggregationRequest(1, AggregationType.AVG, "avg"),
+        new MultiColumnAggregationRequest(1, AggregationType.COUNT, "count"));
+    try (final TimeSeriesSealedStore store = new TimeSeriesSealedStore(path, columns)) {
+      // One block over two hourly buckets: [NaN, 2] in the first, [NaN, NaN, 3] in the second.
+      store.appendBlock(5, 1_000L, HOUR + 3_000L, new byte[][] {
+          DeltaOfDeltaCodec.encode(new long[] { 1_000L, 2_000L, HOUR + 1_000L, HOUR + 2_000L, HOUR + 3_000L }),
+          GorillaXORCodec.encode(new double[] { Double.NaN, 2.0, Double.NaN, Double.NaN, 3.0 })
+      }, new double[] { Double.NaN, 2.0 }, new double[] { Double.NaN, 3.0 }, new double[] { Double.NaN, 5.0 },
+          new long[] { 0, 2 }, null);
+      store.flushHeader();
+
+      final AggregationMetrics metrics = new AggregationMetrics();
+      final MultiColumnAggregationResult result = new MultiColumnAggregationResult(requests, 0L, HOUR, 2);
+      store.aggregateMultiBlocks(Long.MIN_VALUE, Long.MAX_VALUE, requests, HOUR, result, metrics, null);
+      result.finalizeAvg();
+      assertThat(metrics.getSlowPathBlocks()).as("the block straddles two buckets").isEqualTo(1);
+
+      for (int r = 0; r < 4; r++) {
+        assertThat(result.getCount(0L, r)).as("bucket 0, request " + r + ": one real sample").isEqualTo(1);
+        assertThat(result.getCount(HOUR, r)).as("bucket 1, request " + r + ": one real sample").isEqualTo(1);
+      }
+      assertThat(result.getCount(0L, 4)).as("COUNT counts rows").isEqualTo(2);
+      assertThat(result.getCount(HOUR, 4)).isEqualTo(3);
+      assertThat(result.getValue(0L, 0)).isEqualTo(2.0);
+      assertThat(result.getValue(0L, 3)).isEqualTo(2.0);
+      assertThat(result.getValue(HOUR, 0)).isEqualTo(3.0);
+      assertThat(result.getValue(HOUR, 3)).isEqualTo(3.0);
+    }
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesBlockStatsTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesBlockStatsTest.java
@@ -79,7 +79,7 @@ class TimeSeriesBlockStatsTest {
 
     // Write block with stats
     try (final TimeSeriesSealedStore store = new TimeSeriesSealedStore(TEST_PATH, columns)) {
-      store.appendBlock(5, 1000L, 5000L, compressed, mins, maxs, sums, null);
+      store.appendBlock(5, 1000L, 5000L, compressed, mins, maxs, sums, new long[] { 0, 5, 5 }, null);
       assertThat(store.getBlockCount()).isEqualTo(1);
     }
 
@@ -115,7 +115,7 @@ class TimeSeriesBlockStatsTest {
     final double[] sums = { Double.NaN, 150.0, 30.0 };
 
     try (final TimeSeriesSealedStore store = new TimeSeriesSealedStore(TEST_PATH, columns)) {
-      store.appendBlock(5, 0L, 4000L, compressed, mins, maxs, sums, null);
+      store.appendBlock(5, 0L, 4000L, compressed, mins, maxs, sums, new long[] { 0, 5, 5 }, null);
 
       final long bucketInterval = 3600000L; // 1 hour
 
@@ -167,7 +167,7 @@ class TimeSeriesBlockStatsTest {
     final double[] sums = { Double.NaN, 100.0, 10.0 };
 
     try (final TimeSeriesSealedStore store = new TimeSeriesSealedStore(TEST_PATH, columns)) {
-      store.appendBlock(4, 500L, 1500L, compressed, mins, maxs, sums, null);
+      store.appendBlock(4, 500L, 1500L, compressed, mins, maxs, sums, new long[] { 0, 4, 4 }, null);
 
       final long bucketInterval = 1000L;
 
@@ -211,12 +211,12 @@ class TimeSeriesBlockStatsTest {
       store.appendBlock(2, 1000L, 2000L, block1,
           new double[] { Double.NaN, 10.0, 1.0 },
           new double[] { Double.NaN, 20.0, 2.0 },
-          new double[] { Double.NaN, 30.0, 3.0 }, null);
+          new double[] { Double.NaN, 30.0, 3.0 }, new long[] { 0, 2, 2 }, null);
 
       store.appendBlock(2, 3000L, 4000L, block2,
           new double[] { Double.NaN, 30.0, 3.0 },
           new double[] { Double.NaN, 40.0, 4.0 },
-          new double[] { Double.NaN, 70.0, 7.0 }, null);
+          new double[] { Double.NaN, 70.0, 7.0 }, new long[] { 0, 2, 2 }, null);
 
       assertThat(store.getBlockCount()).isEqualTo(2);
 
@@ -255,12 +255,12 @@ class TimeSeriesBlockStatsTest {
       store.appendBlock(2, 1000L, 2000L, block1,
           new double[] { Double.NaN, 10.0, 1.0 },
           new double[] { Double.NaN, 20.0, 2.0 },
-          new double[] { Double.NaN, 30.0, 3.0 }, null);
+          new double[] { Double.NaN, 30.0, 3.0 }, new long[] { 0, 2, 2 }, null);
 
       store.appendBlock(2, 5000L, 6000L, block2,
           new double[] { Double.NaN, 50.0, 5.0 },
           new double[] { Double.NaN, 60.0, 6.0 },
-          new double[] { Double.NaN, 110.0, 11.0 }, null);
+          new double[] { Double.NaN, 110.0, 11.0 }, new long[] { 0, 2, 2 }, null);
 
       // Truncate: remove block 1
       store.truncateBefore(3000L);
@@ -301,12 +301,12 @@ class TimeSeriesBlockStatsTest {
       store.appendBlock(2, 1000L, 2000L, block1,
           new double[] { Double.NaN, 10.0, 1.0 },
           new double[] { Double.NaN, 20.0, 2.0 },
-          new double[] { Double.NaN, 30.0, 3.0 }, null);
+          new double[] { Double.NaN, 30.0, 3.0 }, new long[] { 0, 2, 2 }, null);
 
       store.appendBlock(2, 5000L, 6000L, block2,
           new double[] { Double.NaN, 50.0, 5.0 },
           new double[] { Double.NaN, 60.0, 6.0 },
-          new double[] { Double.NaN, 110.0, 11.0 }, null);
+          new double[] { Double.NaN, 110.0, 11.0 }, new long[] { 0, 2, 2 }, null);
 
       store.truncateBefore(3000L);
     }

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesCrashRecoveryTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesCrashRecoveryTest.java
@@ -338,7 +338,7 @@ class TimeSeriesCrashRecoveryTest extends TestHelper {
     mins[2] = 40.0;
     maxs[2] = 50.0;
     sums[2] = 90.0;
-    shard.getSealedStore().appendBlock(2, 4000L, 5000L, compressedExtra, mins, maxs, sums, null);
+    shard.getSealedStore().appendBlock(2, 4000L, 5000L, compressedExtra, mins, maxs, sums, new long[] { 0, 0, 2 }, null);
     shard.getSealedStore().flushHeader();
 
     final long blocksWithExtra = shard.getSealedStore().getBlockCount();

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesFormatVersionTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesFormatVersionTest.java
@@ -71,7 +71,7 @@ class TimeSeriesFormatVersionTest {
       store.appendBlock(3, 1000L, 3000L, new byte[][] {
           DeltaOfDeltaCodec.encode(timestamps),
           GorillaXORCodec.encode(values)
-      }, new double[] { Double.NaN, 10.0 }, new double[] { Double.NaN, 30.0 }, new double[] { Double.NaN, 60.0 }, null);
+      }, new double[] { Double.NaN, 10.0 }, new double[] { Double.NaN, 30.0 }, new double[] { Double.NaN, 60.0 }, new long[] { 0, 3 }, null);
     }
 
     // Read raw file bytes and verify version byte at offset 4
@@ -101,7 +101,7 @@ class TimeSeriesFormatVersionTest {
       store.appendBlock(1, 1000L, 1000L, new byte[][] {
           DeltaOfDeltaCodec.encode(new long[] { 1000L }),
           GorillaXORCodec.encode(new double[] { 10.0 })
-      }, new double[] { Double.NaN, 10.0 }, new double[] { Double.NaN, 10.0 }, new double[] { Double.NaN, 10.0 }, null);
+      }, new double[] { Double.NaN, 10.0 }, new double[] { Double.NaN, 10.0 }, new double[] { Double.NaN, 10.0 }, new long[] { 0, 1 }, null);
     }
 
     // Corrupt the version byte to 99
@@ -125,7 +125,7 @@ class TimeSeriesFormatVersionTest {
       store.appendBlock(3, 1000L, 3000L, new byte[][] {
           DeltaOfDeltaCodec.encode(timestamps),
           GorillaXORCodec.encode(values)
-      }, new double[] { Double.NaN, 10.0 }, new double[] { Double.NaN, 30.0 }, new double[] { Double.NaN, 60.0 }, null);
+      }, new double[] { Double.NaN, 10.0 }, new double[] { Double.NaN, 30.0 }, new double[] { Double.NaN, 60.0 }, new long[] { 0, 3 }, null);
     }
 
     // Flip a byte in the compressed data region (somewhere after the header + block meta)
@@ -163,7 +163,7 @@ class TimeSeriesFormatVersionTest {
       store.appendBlock(3, 1000L, 3000L, new byte[][] {
           DeltaOfDeltaCodec.encode(timestamps),
           GorillaXORCodec.encode(values)
-      }, mins, maxs, sums, null);
+      }, mins, maxs, sums, new long[] { 0, 3 }, null);
     }
 
     // Reload and verify data + stats-based aggregation both work

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStoreTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStoreTest.java
@@ -48,6 +48,7 @@ class TimeSeriesSealedStoreTest {
   private static final double[] NO_MINS = { Double.NaN, Double.NaN, Double.NaN };
   private static final double[] NO_MAXS = { Double.NaN, Double.NaN, Double.NaN };
   private static final double[] NO_SUMS = { Double.NaN, Double.NaN, Double.NaN };
+  private static final long[]   NO_COUNTS = { 0, 0, 0 };
 
   @BeforeEach
   void setUp() {
@@ -89,7 +90,7 @@ class TimeSeriesSealedStoreTest {
       store.appendBlock(5, 1000L, 5000L, compressed,
           new double[] { Double.NaN, Double.NaN, 19.5 },
           new double[] { Double.NaN, Double.NaN, 23.0 },
-          new double[] { Double.NaN, Double.NaN, 106.0 }, null);
+          new double[] { Double.NaN, Double.NaN, 106.0 }, new long[] { 0, 0, 5 }, null);
 
       assertThat(store.getBlockCount()).isEqualTo(1);
       assertThat(store.getGlobalMinTimestamp()).isEqualTo(1000L);
@@ -121,7 +122,7 @@ class TimeSeriesSealedStoreTest {
           DictionaryCodec.encode(sensorIds),
           GorillaXORCodec.encode(temperatures)
       };
-      store.appendBlock(5, 1000L, 5000L, compressed, NO_MINS, NO_MAXS, NO_SUMS, null);
+      store.appendBlock(5, 1000L, 5000L, compressed, NO_MINS, NO_MAXS, NO_SUMS, NO_COUNTS, null);
 
       // Query subset
       final List<Object[]> results = store.scanRange(2000L, 4000L, null, null);
@@ -139,14 +140,14 @@ class TimeSeriesSealedStoreTest {
           DeltaOfDeltaCodec.encode(new long[] { 1000L, 2000L, 3000L }),
           DictionaryCodec.encode(new String[] { "A", "A", "A" }),
           GorillaXORCodec.encode(new double[] { 10.0, 11.0, 12.0 })
-      }, NO_MINS, NO_MAXS, NO_SUMS, null);
+      }, NO_MINS, NO_MAXS, NO_SUMS, NO_COUNTS, null);
 
       // Block 2: timestamps 4000-6000
       store.appendBlock(3, 4000L, 6000L, new byte[][] {
           DeltaOfDeltaCodec.encode(new long[] { 4000L, 5000L, 6000L }),
           DictionaryCodec.encode(new String[] { "B", "B", "B" }),
           GorillaXORCodec.encode(new double[] { 20.0, 21.0, 22.0 })
-      }, NO_MINS, NO_MAXS, NO_SUMS, null);
+      }, NO_MINS, NO_MAXS, NO_SUMS, NO_COUNTS, null);
 
       assertThat(store.getBlockCount()).isEqualTo(2);
       assertThat(store.getGlobalMinTimestamp()).isEqualTo(1000L);
@@ -165,13 +166,13 @@ class TimeSeriesSealedStoreTest {
           DeltaOfDeltaCodec.encode(new long[] { 1000L, 2000L }),
           DictionaryCodec.encode(new String[] { "A", "A" }),
           GorillaXORCodec.encode(new double[] { 10.0, 11.0 })
-      }, NO_MINS, NO_MAXS, NO_SUMS, null);
+      }, NO_MINS, NO_MAXS, NO_SUMS, NO_COUNTS, null);
 
       store.appendBlock(2, 5000L, 6000L, new byte[][] {
           DeltaOfDeltaCodec.encode(new long[] { 5000L, 6000L }),
           DictionaryCodec.encode(new String[] { "B", "B" }),
           GorillaXORCodec.encode(new double[] { 20.0, 21.0 })
-      }, NO_MINS, NO_MAXS, NO_SUMS, null);
+      }, NO_MINS, NO_MAXS, NO_SUMS, NO_COUNTS, null);
 
       // Query only block 2
       final List<Object[]> results = store.scanRange(5000L, 6000L, null, null);
@@ -203,7 +204,7 @@ class TimeSeriesSealedStoreTest {
       store.appendBlock(5, 1000L, 5000L, compressed,
           new double[] { Double.NaN, Double.NaN, 19.5 },
           new double[] { Double.NaN, Double.NaN, 23.0 },
-          new double[] { Double.NaN, Double.NaN, 106.0 }, tagDV);
+          new double[] { Double.NaN, Double.NaN, 106.0 }, new long[] { 0, 0, 5 }, tagDV);
 
       // Filter for sensor_id == "A" only — should return rows at t=1000 and t=3000
       final TagFilter filterA = TagFilter.eq(0, "A");
@@ -235,7 +236,7 @@ class TimeSeriesSealedStoreTest {
           GorillaXORCodec.encode(temperatures)
       }, new double[] { Double.NaN, Double.NaN, 10.0 },
           new double[] { Double.NaN, Double.NaN, 30.0 },
-          new double[] { Double.NaN, Double.NaN, 60.0 }, tagDV);
+          new double[] { Double.NaN, Double.NaN, 60.0 }, new long[] { 0, 0, 3 }, tagDV);
 
       final TagFilter filterX = TagFilter.eq(0, "X");
       final Iterator<Object[]> iter = store.iterateRange(1000L, 3000L, null, filterX);
@@ -265,7 +266,7 @@ class TimeSeriesSealedStoreTest {
           DeltaOfDeltaCodec.encode(new long[] { 1000L }),
           DictionaryCodec.encode(new String[] { longValue }),
           GorillaXORCodec.encode(new double[] { 1.0 })
-      }, NO_MINS, NO_MAXS, NO_SUMS, tagDV))
+      }, NO_MINS, NO_MAXS, NO_SUMS, NO_COUNTS, tagDV))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("too long");
     }
@@ -283,7 +284,7 @@ class TimeSeriesSealedStoreTest {
           DeltaOfDeltaCodec.encode(new long[] { 1000L }),
           DictionaryCodec.encode(new String[] { "A" }),
           GorillaXORCodec.encode(new double[] { 1.0 })
-      }, NO_MINS, NO_MAXS, NO_SUMS, null);
+      }, NO_MINS, NO_MAXS, NO_SUMS, NO_COUNTS, null);
     }
 
     // Try to reopen with a different schema (2 columns instead of 3)
@@ -317,13 +318,13 @@ class TimeSeriesSealedStoreTest {
       store.appendBlock(3, 6_000L, 8_000L, new byte[][] {
           DeltaOfDeltaCodec.encode(new long[] { 6_000L, 7_000L, 8_000L }),
           GorillaXORCodec.encode(new double[] { 1.0, 2.0, 3.0 })
-      }, new double[] { Double.NaN, 1.0 }, new double[] { Double.NaN, 3.0 }, new double[] { Double.NaN, 6.0 }, null);
+      }, new double[] { Double.NaN, 1.0 }, new double[] { Double.NaN, 3.0 }, new double[] { Double.NaN, 6.0 }, new long[] { 0, 3 }, null);
 
       // Newer block: t=100_000..102_000 — retained (beyond cutoff)
       store.appendBlock(3, 100_000L, 102_000L, new byte[][] {
           DeltaOfDeltaCodec.encode(new long[] { 100_000L, 101_000L, 102_000L }),
           GorillaXORCodec.encode(new double[] { 10.0, 20.0, 30.0 })
-      }, new double[] { Double.NaN, 10.0 }, new double[] { Double.NaN, 30.0 }, new double[] { Double.NaN, 60.0 }, null);
+      }, new double[] { Double.NaN, 10.0 }, new double[] { Double.NaN, 30.0 }, new double[] { Double.NaN, 60.0 }, new long[] { 0, 3 }, null);
 
       // Downsample blocks older than t=10_000 to 5_000ms granularity
       store.downsampleBlocks(10_000L, 5_000L, 0,
@@ -356,13 +357,13 @@ class TimeSeriesSealedStoreTest {
           DeltaOfDeltaCodec.encode(new long[] { 1000L, 2000L }),
           DictionaryCodec.encode(new String[] { "A", "A" }),
           GorillaXORCodec.encode(new double[] { 10.0, 11.0 })
-      }, NO_MINS, NO_MAXS, NO_SUMS, null);
+      }, NO_MINS, NO_MAXS, NO_SUMS, NO_COUNTS, null);
 
       store.appendBlock(2, 5000L, 6000L, new byte[][] {
           DeltaOfDeltaCodec.encode(new long[] { 5000L, 6000L }),
           DictionaryCodec.encode(new String[] { "B", "B" }),
           GorillaXORCodec.encode(new double[] { 20.0, 21.0 })
-      }, NO_MINS, NO_MAXS, NO_SUMS, null);
+      }, NO_MINS, NO_MAXS, NO_SUMS, NO_COUNTS, null);
 
       // Truncate old data
       store.truncateBefore(3000L);
@@ -393,7 +394,7 @@ class TimeSeriesSealedStoreTest {
           DictionaryCodec.encode(new String[] { "A", "B" }),
           GorillaXORCodec.encode(new double[] { 1.0, 2.0 })
       }, new double[] { Double.NaN, Double.NaN, 1.0 }, new double[] { Double.NaN, Double.NaN, 2.0 },
-          new double[] { Double.NaN, Double.NaN, 3.0 }, null);
+          new double[] { Double.NaN, Double.NaN, 3.0 }, new long[] { 0, 0, 2 }, null);
       source.flushHeader();
       sealedV1 = source.readWholeSealedFile();
 
@@ -402,7 +403,7 @@ class TimeSeriesSealedStoreTest {
           DictionaryCodec.encode(new String[] { "C", "D" }),
           GorillaXORCodec.encode(new double[] { 3.0, 4.0 })
       }, new double[] { Double.NaN, Double.NaN, 3.0 }, new double[] { Double.NaN, Double.NaN, 4.0 },
-          new double[] { Double.NaN, Double.NaN, 7.0 }, null);
+          new double[] { Double.NaN, Double.NaN, 7.0 }, new long[] { 0, 0, 2 }, null);
       source.flushHeader();
       sealedV2 = source.readWholeSealedFile();
     }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCopyStatement.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCopyStatement.java
@@ -1,0 +1,664 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import com.arcadedb.exception.CommandParsingException;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * A {@code COPY ... TO STDOUT} statement, recognised ahead of the SQL engine the way {@code SET}/{@code SHOW} and
+ * the system queries are (issue #7188): the wire protocol answers it itself, with a {@code CopyOutResponse}, one
+ * {@code CopyData} per row and a {@code CopyDone}, and only the query inside it reaches the engine.
+ * <p>
+ * This is what the Apache Arrow ADBC PostgreSQL driver reads EVERY result set through by default
+ * ({@code COPY (SELECT ...) TO STDOUT (FORMAT binary)}), what {@code psql}'s {@code \copy} sends, and what
+ * {@code pg_dump}'s data phase and most bulk-export tooling want. Both spellings PostgreSQL accepts are
+ * recognised: the option list, {@code COPY ... TO STDOUT [WITH] (FORMAT csv, HEADER, DELIMITER ';')}, and the
+ * pre-9.0 keywords still emitted by older tools and by {@code \copy} users, {@code COPY ... TO STDOUT CSV HEADER
+ * DELIMITER ';'}. The source is either a parenthesised query, run as it stands in the session's language, or a
+ * type name with an optional column list, which is the same statement with an implicit {@code SELECT}.
+ * <p>
+ * The ingest direction ({@code COPY ... FROM STDIN}) and the server-side targets ({@code TO 'file'},
+ * {@code TO PROGRAM}) are refused with {@code feature_not_supported}: the first is a separate statement with its
+ * own failure modes, and the other two would let a wire client write files or run commands on the server host.
+ * <p>
+ * This class also owns the text and CSV row encodings, which are PostgreSQL's own ({@code copyto.c}): a client
+ * that parses the stream - {@code \copy}, pandas, the ADBC driver in text mode - relies on the escaping rules
+ * exactly, and a value that merely looks right in a terminal is not the same thing as one that round-trips.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class PostgresCopyStatement {
+
+  public enum Format {TEXT, CSV, BINARY}
+
+  /**
+   * SQLSTATE {@code feature_not_supported}, for the parts of COPY this server declines to run.
+   */
+  static final String SQLSTATE_FEATURE_NOT_SUPPORTED = "0A000";
+  /**
+   * SQLSTATE {@code syntax_error}, for a COPY this server would run but cannot read.
+   */
+  static final String SQLSTATE_SYNTAX_ERROR          = "42601";
+
+  /**
+   * A COPY the protocol will not run, carrying the SQLSTATE the client is told. Extends the parsing exception
+   * so the existing "Syntax error on ..." arms of the executor catch it, while {@link #sqlState} lets them
+   * report {@code feature_not_supported} rather than {@code syntax_error} where the statement was perfectly
+   * well-formed and merely asks for something this server does not do.
+   */
+  public static final class CopyException extends CommandParsingException {
+    public final String sqlState;
+
+    CopyException(final String message, final String sqlState) {
+      super(message);
+      this.sqlState = sqlState;
+    }
+  }
+
+  private final String      query;
+  private final Format      format;
+  private final char        delimiter;
+  private final String      nullString;
+  private final boolean     header;
+  private final char        quote;
+  private final char        escape;
+  private final boolean     forceQuoteAll;
+  private final Set<String> forceQuoteColumns;
+
+  private PostgresCopyStatement(final String query, final Format format, final char delimiter, final String nullString,
+      final boolean header, final char quote, final char escape, final boolean forceQuoteAll,
+      final Set<String> forceQuoteColumns) {
+    this.query = query;
+    this.format = format;
+    this.delimiter = delimiter;
+    this.nullString = nullString;
+    this.header = header;
+    this.quote = quote;
+    this.escape = escape;
+    this.forceQuoteAll = forceQuoteAll;
+    this.forceQuoteColumns = forceQuoteColumns;
+  }
+
+  /**
+   * The statement to run for the rows: the parenthesised query as written, or the {@code SELECT} a table form
+   * stands for.
+   */
+  public String getQuery() {
+    return query;
+  }
+
+  public Format getFormat() {
+    return format;
+  }
+
+  public char getDelimiter() {
+    return delimiter;
+  }
+
+  public String getNullString() {
+    return nullString;
+  }
+
+  public boolean isHeader() {
+    return header;
+  }
+
+  public char getQuote() {
+    return quote;
+  }
+
+  public char getEscape() {
+    return escape;
+  }
+
+  /**
+   * Whether {@code text} is a COPY statement at all: the keyword, followed by whitespace or the opening
+   * parenthesis of a query. Cheap, and what the dispatch asks before {@link #parse} does any work.
+   */
+  public static boolean isCopy(final String text) {
+    if (text == null || text.length() < 5 || !text.regionMatches(true, 0, "COPY", 0, 4))
+      return false;
+    final char next = text.charAt(4);
+    return Character.isWhitespace(next) || next == '(';
+  }
+
+  /**
+   * Parses a COPY statement, or returns null when {@code text} is not one.
+   *
+   * @throws CopyException when it is a COPY this server will not run - the ingest direction, a server-side
+   *                       file or program target, an option that does not exist or combines with the format the
+   *                       way PostgreSQL itself refuses
+   */
+  public static PostgresCopyStatement parse(final String text) {
+    if (!isCopy(text))
+      return null;
+
+    String statement = text.trim();
+    if (statement.endsWith(";"))
+      statement = statement.substring(0, statement.length() - 1).trim();
+
+    int pos = 4;
+    while (pos < statement.length() && Character.isWhitespace(statement.charAt(pos)))
+      pos++;
+    if (pos >= statement.length())
+      throw new CopyException("syntax error at end of COPY statement", SQLSTATE_SYNTAX_ERROR);
+
+    final String query;
+    final String tail;
+    if (statement.charAt(pos) == '(') {
+      final int close = matchingParenthesis(statement, pos);
+      query = statement.substring(pos + 1, close).trim();
+      if (query.isEmpty())
+        throw new CopyException("COPY query must not be empty", SQLSTATE_SYNTAX_ERROR);
+      tail = statement.substring(close + 1);
+      return parseTail(query, tokenize(tail), 0, true);
+    }
+
+    tail = statement.substring(pos);
+    final List<PostgresCatalogToken> tokens = tokenize(tail);
+    if (tokens.isEmpty())
+      throw new CopyException("syntax error at end of COPY statement", SQLSTATE_SYNTAX_ERROR);
+
+    // COPY <table> [ ( column [, ...] ) ] - the name may arrive schema-qualified ("public"."t"): ArcadeDB has no
+    // schemas, so the last segment is the type.
+    int i = 0;
+    String table = identifier(tokens, i++);
+    while (i + 1 < tokens.size() && tokens.get(i).isSymbol(".")) {
+      table = identifier(tokens, i + 1);
+      i += 2;
+    }
+
+    final List<String> columns = new ArrayList<>();
+    if (i < tokens.size() && tokens.get(i).isSymbol("(")) {
+      i++;
+      while (true) {
+        columns.add(identifier(tokens, i++));
+        if (i >= tokens.size())
+          throw new CopyException("syntax error in COPY column list: missing ')'", SQLSTATE_SYNTAX_ERROR);
+        if (tokens.get(i).isSymbol(","))
+          i++;
+        else if (tokens.get(i).isSymbol(")")) {
+          i++;
+          break;
+        } else
+          throw new CopyException("syntax error in COPY column list at '" + tokens.get(i).text + "'", SQLSTATE_SYNTAX_ERROR);
+      }
+    }
+
+    final StringBuilder select = new StringBuilder("SELECT ");
+    for (int c = 0; c < columns.size(); c++) {
+      if (c > 0)
+        select.append(", ");
+      select.append('`').append(columns.get(c)).append('`');
+    }
+    select.append(columns.isEmpty() ? "FROM `" : " FROM `").append(table).append('`');
+    return parseTail(select.toString(), tokens, i, false);
+  }
+
+  /**
+   * Parses what follows the source: the direction and target, then the options in either spelling.
+   */
+  private static PostgresCopyStatement parseTail(final String query, final List<PostgresCatalogToken> tokens, int i,
+      final boolean queryForm) {
+    if (i >= tokens.size())
+      throw new CopyException("syntax error in COPY: expected TO or FROM after the source", SQLSTATE_SYNTAX_ERROR);
+
+    if (tokens.get(i).isKeyword("FROM")) {
+      if (queryForm)
+        throw new CopyException("COPY FROM cannot read into a query", SQLSTATE_SYNTAX_ERROR);
+      throw new CopyException("COPY ... FROM STDIN is not supported by this server: use INSERT, or the HTTP import API",
+          SQLSTATE_FEATURE_NOT_SUPPORTED);
+    }
+    if (!tokens.get(i).isKeyword("TO"))
+      throw new CopyException("syntax error in COPY at '" + tokens.get(i).text + "': expected TO", SQLSTATE_SYNTAX_ERROR);
+    i++;
+
+    if (i >= tokens.size())
+      throw new CopyException("syntax error in COPY: expected STDOUT after TO", SQLSTATE_SYNTAX_ERROR);
+    final PostgresCatalogToken target = tokens.get(i++);
+    if (target.type == PostgresCatalogToken.Type.STRING)
+      throw new CopyException("COPY TO a server-side file is not supported by this server: use COPY ... TO STDOUT",
+          SQLSTATE_FEATURE_NOT_SUPPORTED);
+    if (target.isKeyword("PROGRAM"))
+      throw new CopyException("COPY TO PROGRAM is not supported by this server: use COPY ... TO STDOUT",
+          SQLSTATE_FEATURE_NOT_SUPPORTED);
+    if (!target.isKeyword("STDOUT"))
+      throw new CopyException("syntax error in COPY at '" + target.text + "': expected STDOUT", SQLSTATE_SYNTAX_ERROR);
+
+    final Options options = new Options();
+    if (i < tokens.size() && tokens.get(i).isKeyword("WITH"))
+      i++;
+
+    if (i < tokens.size() && tokens.get(i).isSymbol("("))
+      i = parseOptionList(tokens, i + 1, options);
+    else
+      i = parseLegacyOptions(tokens, i, options);
+
+    if (i < tokens.size())
+      throw new CopyException("syntax error in COPY at '" + tokens.get(i).text + "'", SQLSTATE_SYNTAX_ERROR);
+
+    return options.build(query);
+  }
+
+  /**
+   * {@code ( option [value] [, ...] )}, the spelling PostgreSQL has had since 9.0. Returns the index after the
+   * closing parenthesis.
+   */
+  private static int parseOptionList(final List<PostgresCatalogToken> tokens, int i, final Options options) {
+    while (true) {
+      if (i >= tokens.size())
+        throw new CopyException("syntax error in COPY options: missing ')'", SQLSTATE_SYNTAX_ERROR);
+      final String name = tokens.get(i++).text.toLowerCase(Locale.ENGLISH);
+      // The value is optional for the boolean options, and is whatever single token follows otherwise - a
+      // string literal, a bare word (FORMAT csv, HEADER true) or a number (HEADER 1).
+      PostgresCatalogToken value = null;
+      List<String> list = null;
+      if (i < tokens.size() && tokens.get(i).isSymbol("(")) {
+        list = new ArrayList<>();
+        i++;
+        while (true) {
+          list.add(identifier(tokens, i++));
+          if (i >= tokens.size())
+            throw new CopyException("syntax error in COPY option " + name + ": missing ')'", SQLSTATE_SYNTAX_ERROR);
+          if (tokens.get(i).isSymbol(","))
+            i++;
+          else if (tokens.get(i).isSymbol(")")) {
+            i++;
+            break;
+          } else
+            throw new CopyException("syntax error in COPY option " + name + " at '" + tokens.get(i).text + "'",
+                SQLSTATE_SYNTAX_ERROR);
+        }
+      } else if (i < tokens.size() && !tokens.get(i).isSymbol(",") && !tokens.get(i).isSymbol(")"))
+        value = tokens.get(i++);
+
+      options.set(name, value, list);
+
+      if (i >= tokens.size())
+        throw new CopyException("syntax error in COPY options: missing ')'", SQLSTATE_SYNTAX_ERROR);
+      if (tokens.get(i).isSymbol(",")) {
+        i++;
+        continue;
+      }
+      if (tokens.get(i).isSymbol(")"))
+        return i + 1;
+      throw new CopyException("syntax error in COPY options at '" + tokens.get(i).text + "'", SQLSTATE_SYNTAX_ERROR);
+    }
+  }
+
+  /**
+   * The keyword spelling from before 9.0, still accepted by PostgreSQL and still produced by {@code \copy}
+   * users: {@code [BINARY] [DELIMITER [AS] 'x'] [NULL [AS] 'x'] [CSV [HEADER] [QUOTE [AS] 'q'] [ESCAPE [AS] 'e']
+   * [FORCE QUOTE cols | *]]}. Returns the index of the first token it did not consume.
+   */
+  private static int parseLegacyOptions(final List<PostgresCatalogToken> tokens, int i, final Options options) {
+    while (i < tokens.size()) {
+      final PostgresCatalogToken token = tokens.get(i);
+      if (token.type != PostgresCatalogToken.Type.IDENTIFIER)
+        return i;
+      final String keyword = token.text.toLowerCase(Locale.ENGLISH);
+      switch (keyword) {
+      case "binary" -> {
+        options.set("format", PostgresCatalogToken.literal("binary"), null);
+        i++;
+      }
+      case "csv" -> {
+        options.set("format", PostgresCatalogToken.literal("csv"), null);
+        i++;
+      }
+      case "header", "freeze" -> {
+        options.set(keyword, null, null);
+        i++;
+      }
+      case "delimiter", "null", "quote", "escape" -> {
+        i++;
+        if (i < tokens.size() && tokens.get(i).isKeyword("AS"))
+          i++;
+        if (i >= tokens.size())
+          throw new CopyException("syntax error in COPY: " + token.text.toUpperCase(Locale.ENGLISH) + " needs a value",
+              SQLSTATE_SYNTAX_ERROR);
+        options.set(keyword, tokens.get(i++), null);
+      }
+      case "force" -> {
+        i++;
+        if (i < tokens.size() && tokens.get(i).isKeyword("QUOTE")) {
+          i++;
+          if (i < tokens.size() && tokens.get(i).isSymbol("*")) {
+            options.set("force_quote", tokens.get(i++), null);
+          } else {
+            final List<String> list = new ArrayList<>();
+            list.add(identifier(tokens, i++));
+            while (i + 1 < tokens.size() && tokens.get(i).isSymbol(",")) {
+              list.add(identifier(tokens, i + 1));
+              i += 2;
+            }
+            options.set("force_quote", null, list);
+          }
+        } else
+          throw new CopyException("syntax error in COPY at 'FORCE': only FORCE QUOTE applies to COPY TO", SQLSTATE_SYNTAX_ERROR);
+      }
+      case "oids" -> throw new CopyException("COPY OIDS is not supported", SQLSTATE_FEATURE_NOT_SUPPORTED);
+      default -> {
+        return i;
+      }
+      }
+    }
+    return i;
+  }
+
+  private static String identifier(final List<PostgresCatalogToken> tokens, final int i) {
+    if (i >= tokens.size())
+      throw new CopyException("syntax error in COPY: expected a name", SQLSTATE_SYNTAX_ERROR);
+    final PostgresCatalogToken token = tokens.get(i);
+    if (token.type == PostgresCatalogToken.Type.IDENTIFIER || token.type == PostgresCatalogToken.Type.QUOTED_IDENTIFIER)
+      return token.text;
+    throw new CopyException("syntax error in COPY at '" + token.text + "': expected a name", SQLSTATE_SYNTAX_ERROR);
+  }
+
+  private static List<PostgresCatalogToken> tokenize(final String text) {
+    final List<PostgresCatalogToken> tokens = PostgresCatalogToken.tokenize(text);
+    if (tokens == null)
+      throw new CopyException("syntax error in COPY: unterminated string or comment", SQLSTATE_SYNTAX_ERROR);
+    return tokens;
+  }
+
+  /**
+   * The index of the {@code )} closing the {@code (} at {@code open}, read past nested parentheses, string
+   * literals (with {@code ''} and, in {@code E'...'}, backslash escapes), quoted identifiers of either kind and
+   * comments - anything the query inside may legitimately hold a stray parenthesis in.
+   */
+  static int matchingParenthesis(final String text, final int open) {
+    int depth = 0;
+    int i = open;
+    final int length = text.length();
+    while (i < length) {
+      final char c = text.charAt(i);
+      if (c == '(')
+        depth++;
+      else if (c == ')') {
+        if (--depth == 0)
+          return i;
+      } else if (c == '\'') {
+        final boolean escapes = i > 0 && (text.charAt(i - 1) == 'E' || text.charAt(i - 1) == 'e')
+            && (i < 2 || !Character.isLetterOrDigit(text.charAt(i - 2)));
+        i++;
+        while (i < length) {
+          final char ch = text.charAt(i);
+          if (ch == '\\' && escapes)
+            i++;
+          else if (ch == '\'') {
+            if (i + 1 < length && text.charAt(i + 1) == '\'')
+              i++;
+            else
+              break;
+          }
+          i++;
+        }
+      } else if (c == '"' || c == '`') {
+        final int end = text.indexOf(c, i + 1);
+        i = end < 0 ? length : end;
+      } else if (c == '-' && i + 1 < length && text.charAt(i + 1) == '-') {
+        final int end = text.indexOf('\n', i);
+        i = end < 0 ? length : end;
+      } else if (c == '/' && i + 1 < length && text.charAt(i + 1) == '*') {
+        final int end = text.indexOf("*/", i + 2);
+        i = end < 0 ? length : end + 1;
+      }
+      i++;
+    }
+    throw new CopyException("syntax error in COPY: the query's opening '(' is never closed", SQLSTATE_SYNTAX_ERROR);
+  }
+
+  /**
+   * The options as they are collected, in either spelling, and the validation PostgreSQL applies to the
+   * combination ({@code ProcessCopyOptions} in {@code copy.c}) once all of them are known.
+   */
+  private static final class Options {
+    private Format       format;
+    private Character    delimiter;
+    private String       nullString;
+    private Boolean      header;
+    private Character    quote;
+    private Character    escape;
+    private boolean      forceQuoteAll;
+    private List<String> forceQuoteColumns;
+
+    void set(final String name, final PostgresCatalogToken value, final List<String> list) {
+      switch (name) {
+      case "format" -> {
+        final String v = requireValue(name, value).toLowerCase(Locale.ENGLISH);
+        format = switch (v) {
+          case "text" -> Format.TEXT;
+          case "csv" -> Format.CSV;
+          case "binary" -> Format.BINARY;
+          default -> throw new CopyException("COPY format \"" + v + "\" not recognized", SQLSTATE_SYNTAX_ERROR);
+        };
+      }
+      case "delimiter" -> delimiter = singleCharacter(name, requireValue(name, value));
+      case "null" -> nullString = requireValue(name, value);
+      case "quote" -> quote = singleCharacter(name, requireValue(name, value));
+      case "escape" -> escape = singleCharacter(name, requireValue(name, value));
+      case "header" -> {
+        if (value == null)
+          header = true;
+        else if (value.text.equalsIgnoreCase("match"))
+          throw new CopyException("cannot use \"match\" with HEADER in COPY TO", SQLSTATE_SYNTAX_ERROR);
+        else
+          header = bool(name, value.text);
+      }
+      case "force_quote" -> {
+        if (list != null)
+          forceQuoteColumns = list;
+        else if (value != null && value.isSymbol("*"))
+          forceQuoteAll = true;
+        else
+          throw new CopyException("syntax error in COPY option force_quote: expected * or a column list",
+              SQLSTATE_SYNTAX_ERROR);
+      }
+      // Accepted and ignored: FREEZE has no meaning for COPY TO and ENCODING is always UTF-8 on this wire.
+      case "freeze" -> {
+        if (value != null)
+          bool(name, value.text);
+      }
+      case "encoding" -> {
+        final String v = requireValue(name, value).replace("-", "").replace("_", "").toLowerCase(Locale.ENGLISH);
+        if (!v.equals("utf8") && !v.equals("unicode"))
+          throw new CopyException("COPY encoding \"" + value.text + "\" is not supported by this server: results are always UTF-8",
+              SQLSTATE_FEATURE_NOT_SUPPORTED);
+      }
+      case "log_verbosity" -> requireValue(name, value);
+      case "default", "force_not_null", "force_null", "on_error", "reject_limit" ->
+          throw new CopyException("COPY " + name.toUpperCase(Locale.ENGLISH) + " only applies to COPY FROM", SQLSTATE_SYNTAX_ERROR);
+      case "oids" -> throw new CopyException("COPY OIDS is not supported", SQLSTATE_FEATURE_NOT_SUPPORTED);
+      default -> throw new CopyException("option \"" + name + "\" not recognized", SQLSTATE_SYNTAX_ERROR);
+      }
+    }
+
+    private static String requireValue(final String name, final PostgresCatalogToken value) {
+      if (value == null)
+        throw new CopyException("COPY option " + name + " requires a value", SQLSTATE_SYNTAX_ERROR);
+      return value.text;
+    }
+
+    private static char singleCharacter(final String name, final String value) {
+      if (value.length() != 1)
+        throw new CopyException("COPY " + name + " must be a single one-byte character", SQLSTATE_SYNTAX_ERROR);
+      return value.charAt(0);
+    }
+
+    private static boolean bool(final String name, final String value) {
+      return switch (value.toLowerCase(Locale.ENGLISH)) {
+        case "true", "on", "yes", "1", "t", "y" -> true;
+        case "false", "off", "no", "0", "f", "n" -> false;
+        default -> throw new CopyException(name + " requires a Boolean value", SQLSTATE_SYNTAX_ERROR);
+      };
+    }
+
+    PostgresCopyStatement build(final String query) {
+      final Format fmt = format != null ? format : Format.TEXT;
+      if (fmt == Format.BINARY) {
+        if (delimiter != null)
+          throw new CopyException("cannot specify DELIMITER in BINARY mode", SQLSTATE_SYNTAX_ERROR);
+        if (nullString != null)
+          throw new CopyException("cannot specify NULL in BINARY mode", SQLSTATE_SYNTAX_ERROR);
+        if (header != null)
+          throw new CopyException("cannot specify HEADER in BINARY mode", SQLSTATE_SYNTAX_ERROR);
+      }
+      if (fmt != Format.CSV) {
+        if (quote != null)
+          throw new CopyException("COPY QUOTE requires CSV mode", SQLSTATE_SYNTAX_ERROR);
+        if (escape != null)
+          throw new CopyException("COPY ESCAPE requires CSV mode", SQLSTATE_SYNTAX_ERROR);
+        if (forceQuoteAll || forceQuoteColumns != null)
+          throw new CopyException("COPY FORCE_QUOTE requires CSV mode", SQLSTATE_SYNTAX_ERROR);
+      }
+
+      final char delim = delimiter != null ? delimiter : fmt == Format.CSV ? ',' : '\t';
+      if (delim == '\r' || delim == '\n')
+        throw new CopyException("COPY delimiter cannot be newline or carriage return", SQLSTATE_SYNTAX_ERROR);
+      if (fmt == Format.TEXT && delim == '\\')
+        throw new CopyException("COPY delimiter cannot be \"\\\" in text mode", SQLSTATE_SYNTAX_ERROR);
+
+      final String nul = nullString != null ? nullString : fmt == Format.CSV ? "" : "\\N";
+      if (nul.indexOf('\r') >= 0 || nul.indexOf('\n') >= 0)
+        throw new CopyException("COPY null representation cannot use newline or carriage return", SQLSTATE_SYNTAX_ERROR);
+      if (fmt == Format.TEXT && nul.indexOf(delim) >= 0)
+        throw new CopyException("COPY delimiter cannot appear in the NULL specification", SQLSTATE_SYNTAX_ERROR);
+
+      final char q = quote != null ? quote : '"';
+      final char e = escape != null ? escape : q;
+      if (fmt == Format.CSV && delim == q)
+        throw new CopyException("COPY delimiter and quote must be different", SQLSTATE_SYNTAX_ERROR);
+
+      final Set<String> forced;
+      if (forceQuoteColumns != null) {
+        forced = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        forced.addAll(forceQuoteColumns);
+      } else
+        forced = Collections.emptySet();
+
+      return new PostgresCopyStatement(query, fmt, delim, nul, header != null && header, q, e, forceQuoteAll, forced);
+    }
+  }
+
+  // ---- text and CSV encodings (PostgreSQL's own, copyto.c) ----
+
+  /**
+   * Appends the header line - the column names, encoded as a row of values - to {@code out}.
+   */
+  public void appendHeader(final StringBuilder out, final Collection<String> columnNames) {
+    boolean first = true;
+    for (final String name : columnNames) {
+      if (!first)
+        out.append(delimiter);
+      first = false;
+      if (format == Format.CSV)
+        appendCsvValue(out, name, false, columnNames.size() == 1);
+      else
+        appendTextValue(out, name);
+    }
+    out.append('\n');
+  }
+
+  /**
+   * Appends one row to {@code out}: the values in column order, null for SQL NULL, each in the text form the
+   * column's Postgres type gives it.
+   *
+   * @param columnNames the names, in the same order, for FORCE_QUOTE
+   */
+  public void appendRow(final StringBuilder out, final String[] values, final String[] columnNames) {
+    for (int i = 0; i < values.length; i++) {
+      if (i > 0)
+        out.append(delimiter);
+      final String value = values[i];
+      if (value == null)
+        out.append(nullString);
+      else if (format == Format.CSV)
+        appendCsvValue(out, value, forceQuoteAll || forceQuoteColumns.contains(columnNames[i]), values.length == 1);
+      else
+        appendTextValue(out, value);
+    }
+    out.append('\n');
+  }
+
+  /**
+   * Text format ({@code CopyAttributeOutText}): backslash escapes for the control characters, the backslash
+   * itself and the delimiter, so the reader's unescape recovers the value exactly.
+   */
+  private void appendTextValue(final StringBuilder out, final String value) {
+    for (int i = 0; i < value.length(); i++) {
+      final char c = value.charAt(i);
+      switch (c) {
+      case '\b' -> out.append("\\b");
+      case '\f' -> out.append("\\f");
+      case '\n' -> out.append("\\n");
+      case '\r' -> out.append("\\r");
+      case '\t' -> out.append("\\t");
+      case 0x0B -> out.append("\\v");
+      case '\\' -> out.append("\\\\");
+      default -> {
+        if (c == delimiter)
+          out.append('\\');
+        out.append(c);
+      }
+      }
+    }
+  }
+
+  /**
+   * CSV format ({@code CopyAttributeOutCSV}): a value is quoted when it is forced, when it would otherwise read
+   * back as the NULL string (which is how an empty string survives next to NULL), when it holds the delimiter,
+   * the quote or a line break, or when it is {@code \.} alone on its line - the end-of-data marker. Inside the
+   * quotes, the quote character is preceded by the escape character (itself, by default).
+   */
+  private void appendCsvValue(final StringBuilder out, final String value, final boolean forceQuote,
+      final boolean singleColumn) {
+    boolean useQuote = forceQuote || value.equals(nullString) || (singleColumn && value.equals("\\."));
+    if (!useQuote)
+      for (int i = 0; i < value.length(); i++) {
+        final char c = value.charAt(i);
+        if (c == delimiter || c == quote || c == '\n' || c == '\r') {
+          useQuote = true;
+          break;
+        }
+      }
+
+    if (!useQuote) {
+      out.append(value);
+      return;
+    }
+
+    out.append(quote);
+    for (int i = 0; i < value.length(); i++) {
+      final char c = value.charAt(i);
+      if (c == quote || c == escape)
+        out.append(escape);
+      out.append(c);
+    }
+    out.append(quote);
+  }
+}

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCopyStatement.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCopyStatement.java
@@ -374,9 +374,14 @@ public final class PostgresCopyStatement {
     if (i >= tokens.size())
       throw new CopyException("syntax error in COPY: expected a name", SQLSTATE_SYNTAX_ERROR);
     final PostgresCatalogToken token = tokens.get(i);
-    if (token.type == PostgresCatalogToken.Type.IDENTIFIER || token.type == PostgresCatalogToken.Type.QUOTED_IDENTIFIER)
-      return token.text;
-    throw new CopyException("syntax error in COPY at '" + token.text + "': expected a name", SQLSTATE_SYNTAX_ERROR);
+    if (token.type != PostgresCatalogToken.Type.IDENTIFIER && token.type != PostgresCatalogToken.Type.QUOTED_IDENTIFIER)
+      throw new CopyException("syntax error in COPY at '" + token.text + "': expected a name", SQLSTATE_SYNTAX_ERROR);
+    // The table form splices its names into a SELECT between back-ticks, which ArcadeDB's SQL cannot escape inside
+    // an identifier: a name holding one would end the identifier early and read the rest as SQL. No type or
+    // property can be named that way, so there is nothing to lose by refusing it.
+    if (token.text.indexOf('`') >= 0)
+      throw new CopyException("syntax error in COPY: the name \"" + token.text + "\" cannot contain a back-tick", SQLSTATE_SYNTAX_ERROR);
+    return token.text;
   }
 
   private static List<PostgresCatalogToken> tokenize(final String text) {

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCopyStatement.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCopyStatement.java
@@ -486,6 +486,7 @@ public final class PostgresCopyStatement {
       }
       // Accepted and ignored: FREEZE has no meaning for COPY TO and ENCODING is always UTF-8 on this wire.
       case "freeze" -> {
+        // Validated only, for the same refusal PostgreSQL gives a non-Boolean value; the result is not kept.
         if (value != null)
           bool(name, value.text);
       }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -84,6 +84,11 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -1969,17 +1974,35 @@ public class PostgresNetworkExecutor extends Thread {
     } else
       resultSet = database.command(language, queryText, server.getConfiguration(), parameters);
 
-    List<Result> buffered = null;
-    if (columns == null || columns.isEmpty()) {
-      buffered = browseAndCacheBoundedResultSet(resultSet);
-      columns = getColumns(buffered, resolveQueryTargetType(parsed), resolveAliasToSourceProperty(parsed));
-      if (columns.isEmpty() && buffered.isEmpty()) {
-        final Map<String, PostgresType> schemaColumns = resolveEmptyResultSchemaColumns(queryText, language, parameters, parsed);
-        if (schemaColumns != null)
-          columns = schemaColumns;
+    // From here to the end the result set is owned by this method and closed on every exit - a refusal below, a
+    // failure while streaming - and NOT closed twice: browseAndCacheBoundedResultSet closes what it materializes.
+    boolean resultSetOpen = true;
+    try {
+      List<Result> buffered = null;
+      if (columns == null || columns.isEmpty()) {
+        resultSetOpen = false;
+        buffered = browseAndCacheBoundedResultSet(resultSet);
+        columns = getColumns(buffered, resolveQueryTargetType(parsed), resolveAliasToSourceProperty(parsed));
+        if (columns.isEmpty() && buffered.isEmpty()) {
+          final Map<String, PostgresType> schemaColumns = resolveEmptyResultSchemaColumns(queryText, language, parameters, parsed);
+          if (schemaColumns != null)
+            columns = schemaColumns;
+        }
       }
+      profile.addEngineNanos(System.nanoTime() - engineStart);
+      return copyOut(copy, columns, buffered != null ? buffered.iterator() : resultSet, profile);
+    } finally {
+      if (resultSetOpen)
+        resultSet.close();
     }
-    profile.addEngineNanos(System.nanoTime() - engineStart);
+  }
+
+  /**
+   * The wire half of {@link #copyOut(PostgresCopyStatement, String, Object[], Statement, QueryProfile)}: frames the
+   * rows {@code rows} yields, under the columns already fixed for them.
+   */
+  private int copyOut(final PostgresCopyStatement copy, final Map<String, PostgresType> columns, final Iterator<Result> rows,
+      final QueryProfile profile) throws IOException {
 
     final long serStart = System.nanoTime();
     final String[] names = columns.keySet().toArray(new String[0]);
@@ -2009,6 +2032,11 @@ public class PostgresNetworkExecutor extends Thread {
     final Binary payload = new Binary();
     final StringBuilder line = new StringBuilder();
     final String[] texts = new String[names.length];
+    // One encoder and one byte buffer for every text row: encoding the line straight from the StringBuilder
+    // skips the String and the byte[] a toString().getBytes() would allocate per row, on the bulk path.
+    final CharsetEncoder encoder = binary ? null : DatabaseFactory.getDefaultCharset().newEncoder()
+        .onMalformedInput(CodingErrorAction.REPLACE).onUnmappableCharacter(CodingErrorAction.REPLACE);
+    ByteBuffer encoded = binary ? null : ByteBuffer.allocate(4 * 1024);
 
     if (binary) {
       payload.putByteArray(COPY_BINARY_SIGNATURE);
@@ -2017,33 +2045,30 @@ public class PostgresNetworkExecutor extends Thread {
       appendCopyData(out, payload);
     } else if (copy.isHeader()) {
       copy.appendHeader(line, columns.keySet());
-      appendCopyData(out, line);
+      encoded = appendCopyData(out, line, encoder, encoded);
     }
 
-    int rows = 0;
-    try (resultSet) {
-      final Iterator<Result> iterator = buffered != null ? buffered.iterator() : resultSet;
-      while (iterator.hasNext()) {
-        final Result row = iterator.next();
-        if (row == null)
-          continue;
+    int count = 0;
+    while (rows.hasNext()) {
+      final Result row = rows.next();
+      if (row == null)
+        continue;
 
-        if (binary) {
-          payload.putShort((short) names.length);
-          for (int i = 0; i < names.length; i++)
-            types[i].serializeAsBinary(types[i], payload, columnValue(row, names[i]));
-          appendCopyData(out, payload);
-        } else {
-          for (int i = 0; i < names.length; i++)
-            texts[i] = types[i].toText(types[i], columnValue(row, names[i]));
-          copy.appendRow(line, texts, names);
-          appendCopyData(out, line);
-        }
-        rows++;
-
-        if (out.position() >= COPY_FLUSH_THRESHOLD)
-          flushCopyData(out);
+      if (binary) {
+        payload.putShort((short) names.length);
+        for (int i = 0; i < names.length; i++)
+          types[i].serializeAsBinary(types[i], payload, columnValue(row, names[i]));
+        appendCopyData(out, payload);
+      } else {
+        for (int i = 0; i < names.length; i++)
+          texts[i] = types[i].toText(types[i], columnValue(row, names[i]));
+        copy.appendRow(line, texts, names);
+        encoded = appendCopyData(out, line, encoder, encoded);
       }
+      count++;
+
+      if (out.position() >= COPY_FLUSH_THRESHOLD)
+        flushCopyData(out);
     }
 
     if (binary) {
@@ -2056,8 +2081,8 @@ public class PostgresNetworkExecutor extends Thread {
     profile.addSerializationNanos(System.nanoTime() - serStart);
 
     if (DEBUG)
-      LogManager.instance().log(this, Level.INFO, "PSQL:-> %d row(s) copied out (thread=%s)", rows, Thread.currentThread().threadId());
-    return rows;
+      LogManager.instance().log(this, Level.INFO, "PSQL:-> %d row(s) copied out (thread=%s)", count, Thread.currentThread().threadId());
+    return count;
   }
 
   /**
@@ -2072,12 +2097,31 @@ public class PostgresNetworkExecutor extends Thread {
     payload.clear();
   }
 
-  private static void appendCopyData(final Binary out, final StringBuilder line) {
-    final byte[] bytes = line.toString().getBytes(DatabaseFactory.getDefaultCharset());
+  /**
+   * Frames the text in {@code line} as one {@code CopyData} message into {@code out}, encoded through
+   * {@code encoder} into {@code encoded}, and resets the line. Returns the byte buffer to use next time: the one
+   * given, or a larger one when a row did not fit - a row is never split across messages, and a single oversized
+   * value grows the buffer once rather than failing.
+   */
+  private static ByteBuffer appendCopyData(final Binary out, final StringBuilder line, final CharsetEncoder encoder,
+      ByteBuffer encoded) {
+    final CharBuffer chars = CharBuffer.wrap(line);
+    while (true) {
+      encoded.clear();
+      encoder.reset();
+      final CoderResult result = encoder.encode(chars, encoded, true);
+      if (result.isUnderflow() && encoder.flush(encoded).isUnderflow())
+        break;
+      // Did not fit: size for the worst case of what is left and start the row over.
+      encoded = ByteBuffer.allocate(Math.max(encoded.capacity() * 2, (int) Math.ceil(line.length() * encoder.maxBytesPerChar()) + 16));
+      chars.rewind();
+    }
+    encoded.flip();
     out.putByte((byte) 'd');
-    out.putInt(4 + bytes.length);
-    out.putByteArray(bytes);
+    out.putInt(4 + encoded.remaining());
+    out.putBuffer(encoded);
     line.setLength(0);
+    return encoded;
   }
 
   private void flushCopyData(final Binary out) throws IOException {

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -84,6 +84,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -398,6 +399,17 @@ public class PostgresNetworkExecutor extends Thread {
       return;
     }
 
+    if (portal.copyStatement != null) {
+      // A COPY returns no result set (issue #7188): a statement Describe still owes the parameter description, and
+      // both kinds answer NoData for the rows - the client reads those from the CopyData stream Execute sends.
+      if (type == 'S')
+        writeParameterDescription(portal);
+      else if (type != 'P')
+        throw new PostgresProtocolException("Unexpected describe type '" + type + "'");
+      writeNoData();
+      return;
+    }
+
     if (type == 'P') {
       // Every Describe is owed exactly one reply - RowDescription or NoData - and a client counting one reply
       // per request desynchronizes on anything else, so the three arms below are exhaustive by construction
@@ -585,7 +597,18 @@ public class PostgresNetworkExecutor extends Thread {
         // SAVEPOINT/RELEASE/ROLLBACK TO/SET never produce rows: Execute must answer CommandComplete, not
         // NoData - NoData ('n') is a Describe-only reply and is never a legal answer to Execute (issue #6930).
         writeCommandComplete(portal.query, 0);
-      else {
+      else if (portal.copyStatement != null) {
+        // COPY ... TO STDOUT (issue #7188): the rows go out as CopyData, and there is nothing to slice by the
+        // Execute row-limit - PostgreSQL ignores it for COPY too. A COPY portal runs once; PostgreSQL refuses to
+        // run a completed one again, and so does this.
+        if (portal.executed)
+          writeError(ERROR_SEVERITY.ERROR, "portal already executed: a COPY cannot be run twice", "34000");
+        else {
+          portal.executed = true;
+          final int rows = copyOut(portal.copyStatement, portal.language, getParams(portal), portal.sqlStatement, profile);
+          writeCommandComplete("COPY", rows);
+        }
+      } else {
         if (!portal.executed) {
           final long engineStart = System.nanoTime();
           final ResultSet resultSet = runPortalQuery(portal);
@@ -697,6 +720,9 @@ public class PostgresNetworkExecutor extends Thread {
           profile.addSerializationNanos(System.nanoTime() - serStart);
         }
       }
+    } catch (final PostgresCopyStatement.CopyException e) {
+      setErrorInTx();
+      writeError(ERROR_SEVERITY.ERROR, e.getMessage(), e.sqlState);
     } catch (final CommandParsingException e) {
       // The "Syntax error" wording assumes only genuine parse failures reach this arm, which holds because this
       // path runs an already-parsed statement and execution failures are CommandExecutionException. If a
@@ -766,6 +792,17 @@ public class PostgresNetworkExecutor extends Thread {
       profile.addDeserializationNanos(System.nanoTime() - deserStart);
       if (DEBUG)
         LogManager.instance().log(this, Level.INFO, "PSQL: query -> %s ", query);
+
+      // COPY ... TO STDOUT is answered by the protocol itself (issue #7188): its rows travel as CopyData rather than
+      // DataRow, so it shares nothing below but the query inside it. Recognised ahead of everything else because
+      // "COPY" is no SQL production of this server, exactly like SET/SHOW.
+      if (PostgresCopyStatement.isCopy(query.query)) {
+        final PostgresCopyStatement copy = PostgresCopyStatement.parse(query.query);
+        final Statement inner = "sql".equalsIgnoreCase(query.language) ? parseStatement(copy.getQuery()) : null;
+        final int rows = copyOut(copy, query.language, NO_PARAMETERS, inner, profile);
+        writeCommandComplete("COPY", rows);
+        return;
+      }
 
       // Reused below for both the schema-fallback and the target-type resolution, but only set in the one
       // branch that reaches database.command(...) below: none of SET/SAVEPOINT/RELEASE/ROLLBACK TO/SHOW/a
@@ -837,6 +874,10 @@ public class PostgresNetworkExecutor extends Thread {
       writeCommandComplete(queryText, cachedResultSet.size());
       profile.addSerializationNanos(System.nanoTime() - serStart);
 
+    } catch (final PostgresCopyStatement.CopyException e) {
+      // A COPY this server declines is not a syntax error, and the message says what to do instead.
+      setErrorInTx();
+      writeError(ERROR_SEVERITY.ERROR, e.getMessage(), e.sqlState);
     } catch (final CommandParsingException e) {
       // See the note on the same arm in executeCommand about the "Syntax error" wording.
       setErrorInTx();
@@ -1790,51 +1831,7 @@ public class PostgresNetworkExecutor extends Thread {
       int colIndex = 0;
       for (final Map.Entry<String, PostgresType> postgresTypeEntry : columns.entrySet()) {
         final String propertyName = postgresTypeEntry.getKey();
-
-        Object value = switch (propertyName) {
-          case RID_PROPERTY -> row.isElement() ? row.getElement().get().getIdentity() : row.getProperty(propertyName);
-          case TYPE_PROPERTY -> row.isElement() ? row.getElement().get().getTypeName() : row.getProperty(propertyName);
-          case OUT_PROPERTY -> {
-            if (row.isElement()) {
-              final Document record = row.getElement().get();
-              if (record instanceof Vertex vertex)
-                yield vertex.countEdges(Vertex.DIRECTION.OUT, null);
-              else if (record instanceof Edge edge)
-                yield edge.getOut();
-            }
-            yield row.getProperty(propertyName);
-          }
-          case IN_PROPERTY -> {
-            if (row.isElement()) {
-              final Document record = row.getElement().get();
-              if (record instanceof Vertex vertex)
-                yield vertex.countEdges(Vertex.DIRECTION.IN, null);
-              else if (record instanceof Edge edge)
-                yield edge.getIn();
-            }
-            yield row.getProperty(propertyName);
-          }
-          case CAT_PROPERTY -> {
-            if (row.isElement()) {
-              final Document record = row.getElement().get();
-              if (record instanceof Vertex)
-                yield "v";
-              else if (record instanceof Edge)
-                yield "e";
-              else
-                yield "d";
-            }
-            yield row.getProperty(propertyName);
-          }
-          default -> {
-            Object v = row.getProperty(propertyName);
-            // When content map exists but doesn't have the property (e.g., OpenCypher RETURN n
-            // sets content with variable name but element has the actual properties), fall back to element
-            if (v == null && row.isElement())
-              v = row.getElement().get().get(propertyName);
-            yield v;
-          }
-        };
+        final Object value = columnValue(row, propertyName);
 
         final PostgresType columnType = postgresTypeEntry.getValue();
         if (effectiveResultFormat(resultFormats, colIndex++, columnType) == 1)
@@ -1867,6 +1864,229 @@ public class PostgresNetworkExecutor extends Thread {
     if (DEBUG)
       LogManager.instance().log(this, Level.INFO, "PSQL:-> %d row(s) data written (thread=%s)", resultSet.size(),
           Thread.currentThread().threadId());
+  }
+
+  /**
+   * The value a row carries for a column: the property of that name, or for the metadata columns ({@code @rid},
+   * {@code @type}, {@code @cat}, {@code @in}, {@code @out}) what the row's element answers. Shared by the
+   * {@code DataRow} writer and by {@code COPY ... TO STDOUT} (issue #7188), so the two encode the same value for
+   * the same column.
+   */
+  private static Object columnValue(final Result row, final String propertyName) {
+    return switch (propertyName) {
+      case RID_PROPERTY -> row.isElement() ? row.getElement().get().getIdentity() : row.getProperty(propertyName);
+      case TYPE_PROPERTY -> row.isElement() ? row.getElement().get().getTypeName() : row.getProperty(propertyName);
+      case OUT_PROPERTY -> {
+        if (row.isElement()) {
+          final Document record = row.getElement().get();
+          if (record instanceof Vertex vertex)
+            yield vertex.countEdges(Vertex.DIRECTION.OUT, null);
+          else if (record instanceof Edge edge)
+            yield edge.getOut();
+        }
+        yield row.getProperty(propertyName);
+      }
+      case IN_PROPERTY -> {
+        if (row.isElement()) {
+          final Document record = row.getElement().get();
+          if (record instanceof Vertex vertex)
+            yield vertex.countEdges(Vertex.DIRECTION.IN, null);
+          else if (record instanceof Edge edge)
+            yield edge.getIn();
+        }
+        yield row.getProperty(propertyName);
+      }
+      case CAT_PROPERTY -> {
+        if (row.isElement()) {
+          final Document record = row.getElement().get();
+          if (record instanceof Vertex)
+            yield "v";
+          else if (record instanceof Edge)
+            yield "e";
+          else
+            yield "d";
+        }
+        yield row.getProperty(propertyName);
+      }
+      default -> {
+        Object v = row.getProperty(propertyName);
+        // When content map exists but doesn't have the property (e.g., OpenCypher RETURN n
+        // sets content with variable name but element has the actual properties), fall back to element
+        if (v == null && row.isElement())
+          v = row.getElement().get().get(propertyName);
+        yield v;
+      }
+    };
+  }
+
+  // ---- COPY ... TO STDOUT (issue #7188) ----
+
+  /**
+   * The signature that opens a binary COPY stream ({@code PGCOPY\n\377\r\n\0}), followed on the wire by the
+   * int32 flags and the int32 header-extension length, both zero.
+   */
+  private static final byte[] COPY_BINARY_SIGNATURE = { 'P', 'G', 'C', 'O', 'P', 'Y', '\n', (byte) 0377, '\r', '\n', 0 };
+  /**
+   * How much CopyData is buffered before it is written to the socket: one write per row would cost a system call
+   * per row on a statement whose whole point is to move rows in bulk, and one write for the whole result would
+   * hold it all in memory.
+   */
+  private static final int    COPY_FLUSH_THRESHOLD  = 64 * 1024;
+
+  /**
+   * Runs a {@code COPY ... TO STDOUT} and streams its rows: {@code CopyOutResponse}, one {@code CopyData} per row
+   * (plus, in binary format, one for the header and one for the trailer), then {@code CopyDone}. The caller writes
+   * the {@code CommandComplete} that follows, tagged with the row count this returns.
+   * <p>
+   * The columns are fixed BEFORE the first row goes out, the way {@code RowDescription} fixes them for a query,
+   * and they are resolved the way {@code Describe('S')} resolves them for the query inside the COPY: the Arrow
+   * ADBC driver describes that statement first and decodes the binary stream by the OIDs the description promised,
+   * so the two have to agree. A statement the schema can describe is streamed - no row is held and the
+   * {@link GlobalConfiguration#POSTGRES_QUERY_MAX_ROWS} cap does not apply, which is what a bulk export is for;
+   * one it cannot describe (a schemaless type with no sample row, another language) is materialized within the
+   * same bound as a plain query, since only its rows can name its columns.
+   * <p>
+   * A failure after the {@code CopyOutResponse} has gone out is reported the way the protocol defines for copy-out
+   * mode: the caller's {@code ErrorResponse} ends the copy on the client, which discards what it received.
+   *
+   * @return the number of rows sent
+   */
+  private int copyOut(final PostgresCopyStatement copy, final String language, final Object[] parameters,
+      final Statement parsed, final QueryProfile profile) throws IOException {
+    final String queryText = copy.getQuery();
+    final long engineStart = System.nanoTime();
+
+    Map<String, PostgresType> columns = "sql".equalsIgnoreCase(language) ? getColumnsFromQuerySchema(queryText, parsed) : null;
+
+    final ResultSet resultSet;
+    if (parsed != null) {
+      final long metricsStart = QueryMetricsRecorder.Holder.startNanos();
+      try {
+        resultSet = parsed.execute(database, parameters, createCommandContext());
+      } finally {
+        QueryMetricsRecorder.Holder.record(metricsStart, database.getName(), language, "command");
+      }
+    } else
+      resultSet = database.command(language, queryText, server.getConfiguration(), parameters);
+
+    List<Result> buffered = null;
+    if (columns == null || columns.isEmpty()) {
+      buffered = browseAndCacheBoundedResultSet(resultSet);
+      columns = getColumns(buffered, resolveQueryTargetType(parsed), resolveAliasToSourceProperty(parsed));
+      if (columns.isEmpty() && buffered.isEmpty()) {
+        final Map<String, PostgresType> schemaColumns = resolveEmptyResultSchemaColumns(queryText, language, parameters, parsed);
+        if (schemaColumns != null)
+          columns = schemaColumns;
+      }
+    }
+    profile.addEngineNanos(System.nanoTime() - engineStart);
+
+    final long serStart = System.nanoTime();
+    final String[] names = columns.keySet().toArray(new String[0]);
+    final PostgresType[] types = columns.values().toArray(new PostgresType[0]);
+    final boolean binary = copy.getFormat() == PostgresCopyStatement.Format.BINARY;
+    if (binary)
+      // Unlike a DataRow, whose columns each carry their own format code, a binary COPY stream is binary in every
+      // field, so a column with no binary encoding cannot be sent in it at all.
+      for (int i = 0; i < types.length; i++)
+        if (!types[i].hasBinaryEncoding())
+          throw new PostgresCopyStatement.CopyException("column \"" + names[i] + "\" has type " + types[i].name().toLowerCase(Locale.ENGLISH)
+              + ", which has no binary encoding on this server: use FORMAT text or csv, or project it as a string",
+              PostgresCopyStatement.SQLSTATE_FEATURE_NOT_SUPPORTED);
+
+    if (DEBUG)
+      LogManager.instance().log(this, Level.INFO, "PSQL:-> CopyOutResponse: %s, %d columns: %s (thread=%s)", copy.getFormat(),
+          names.length, columns.keySet(), Thread.currentThread().threadId());
+
+    writeMessage("copy out response", () -> {
+      channel.writeByte((byte) (binary ? 1 : 0));
+      channel.writeUnsignedShort((short) names.length);
+      for (int i = 0; i < names.length; i++)
+        channel.writeUnsignedShort((short) (binary ? 1 : 0));
+    }, 'H', 4 + 1 + 2 + 2 * names.length);
+
+    final Binary out = new Binary();
+    final Binary payload = new Binary();
+    final StringBuilder line = new StringBuilder();
+    final String[] texts = new String[names.length];
+
+    if (binary) {
+      payload.putByteArray(COPY_BINARY_SIGNATURE);
+      payload.putInt(0); // flags: no OIDs
+      payload.putInt(0); // header extension length
+      appendCopyData(out, payload);
+    } else if (copy.isHeader()) {
+      copy.appendHeader(line, columns.keySet());
+      appendCopyData(out, line);
+    }
+
+    int rows = 0;
+    try (resultSet) {
+      final Iterator<Result> iterator = buffered != null ? buffered.iterator() : resultSet;
+      while (iterator.hasNext()) {
+        final Result row = iterator.next();
+        if (row == null)
+          continue;
+
+        if (binary) {
+          payload.putShort((short) names.length);
+          for (int i = 0; i < names.length; i++)
+            types[i].serializeAsBinary(types[i], payload, columnValue(row, names[i]));
+          appendCopyData(out, payload);
+        } else {
+          for (int i = 0; i < names.length; i++)
+            texts[i] = types[i].toText(types[i], columnValue(row, names[i]));
+          copy.appendRow(line, texts, names);
+          appendCopyData(out, line);
+        }
+        rows++;
+
+        if (out.position() >= COPY_FLUSH_THRESHOLD)
+          flushCopyData(out);
+      }
+    }
+
+    if (binary) {
+      payload.putShort((short) -1); // trailer
+      appendCopyData(out, payload);
+    }
+    flushCopyData(out);
+
+    writeMessage("copy done", null, 'c', 4);
+    profile.addSerializationNanos(System.nanoTime() - serStart);
+
+    if (DEBUG)
+      LogManager.instance().log(this, Level.INFO, "PSQL:-> %d row(s) copied out (thread=%s)", rows, Thread.currentThread().threadId());
+    return rows;
+  }
+
+  /**
+   * Frames the bytes in {@code payload} as one {@code CopyData} message into {@code out} and resets the payload.
+   */
+  private static void appendCopyData(final Binary out, final Binary payload) {
+    payload.flip();
+    final int length = payload.getByteBuffer().limit();
+    out.putByte((byte) 'd');
+    out.putInt(4 + length);
+    out.putBuffer(payload.getByteBuffer());
+    payload.clear();
+  }
+
+  private static void appendCopyData(final Binary out, final StringBuilder line) {
+    final byte[] bytes = line.toString().getBytes(DatabaseFactory.getDefaultCharset());
+    out.putByte((byte) 'd');
+    out.putInt(4 + bytes.length);
+    out.putByteArray(bytes);
+    line.setLength(0);
+  }
+
+  private void flushCopyData(final Binary out) throws IOException {
+    if (out.position() == 0)
+      return;
+    out.flip();
+    channel.writeBuffer(out.getByteBuffer());
+    channel.flush();
+    out.clear();
   }
 
   private void bindCommand() {
@@ -2172,6 +2392,17 @@ public class PostgresNetworkExecutor extends Thread {
         final String varName = portal.query.substring(5).trim().toLowerCase(Locale.ENGLISH);
         createResultSet(portal, varName, getShowConfigValue(varName));
 
+      } else if (PostgresCopyStatement.isCopy(portal.query)) {
+        // COPY ... TO STDOUT (issue #7188): the Arrow ADBC driver sends it through Parse/Bind/Describe/Execute
+        // (PQexecParams), so it is a portal like any other, except that Describe answers NoData and Execute
+        // streams CopyData. The query INSIDE the COPY is what the SQL engine parses, so a syntax error in it is
+        // reported here, at Parse, the way it is for a plain statement.
+        portal.copyStatement = PostgresCopyStatement.parse(portal.query);
+        if ("sql".equalsIgnoreCase(portal.language)) {
+          final SQLQueryEngine sqlEngine = (SQLQueryEngine) database.getQueryEngine("sql");
+          portal.sqlStatement = sqlEngine.parse(portal.copyStatement.getQuery(), (DatabaseInternal) database);
+        }
+
       } else {
         // A query about the emulated system catalog. Every family of these used to be matched by string
         // equality here, several of them only when application_name was literally "dbvis", so the same
@@ -2232,6 +2463,9 @@ public class PostgresNetworkExecutor extends Thread {
       // ParseComplete
       writeMessage("parse complete", null, '1', 4);
 
+    } catch (final PostgresCopyStatement.CopyException e) {
+      setErrorInTx();
+      writeError(ERROR_SEVERITY.ERROR, e.getMessage(), e.sqlState);
     } catch (final CommandParsingException e) {
       setErrorInTx();
       writeError(ERROR_SEVERITY.ERROR, "Syntax error on parsing query: " + (e.getCause() != null ? e.getCause().getMessage() : e.getMessage()), sqlStateFor(e));
@@ -2511,6 +2745,8 @@ public class PostgresNetworkExecutor extends Thread {
    * 42, syntax error or access rule violation - carries the client-vs-server verdict either way.
    */
   static String sqlStateFor(final Throwable error) {
+    if (error instanceof PostgresCopyStatement.CopyException copy)
+      return copy.sqlState;
     return switch (ErrorCategory.of(error)) {
       case RETRY -> "40001";          // serialization_failure - the code drivers auto-retry on
       case ARITHMETIC -> arithmeticSqlState(error);
@@ -2705,6 +2941,8 @@ public class PostgresNetworkExecutor extends Thread {
   private String getTag(String upperCaseText, int resultSetCount) {
     if (upperCaseText.startsWith("CREATE VERTEX") || upperCaseText.startsWith("INSERT INTO")) {
       return "INSERT 0 " + resultSetCount;
+    } else if (upperCaseText.startsWith("COPY")) {
+      return "COPY " + resultSetCount;
     } else if (upperCaseText.startsWith("SELECT") || upperCaseText.startsWith("MATCH")) {
       return "SELECT " + resultSetCount;
     } else if (upperCaseText.startsWith("UPDATE")) {

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -1925,7 +1925,7 @@ public class PostgresNetworkExecutor extends Thread {
    * The signature that opens a binary COPY stream ({@code PGCOPY\n\377\r\n\0}), followed on the wire by the
    * int32 flags and the int32 header-extension length, both zero.
    */
-  private static final byte[] COPY_BINARY_SIGNATURE = { 'P', 'G', 'C', 'O', 'P', 'Y', '\n', (byte) 0377, '\r', '\n', 0 };
+  private static final byte[] COPY_BINARY_SIGNATURE = { 'P', 'G', 'C', 'O', 'P', 'Y', '\n', (byte) 0xFF, '\r', '\n', 0 };
   /**
    * How much CopyData is buffered before it is written to the socket: one write per row would cost a system call
    * per row on a statement whose whole point is to move rows in bulk, and one write for the whole result would

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresPortal.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresPortal.java
@@ -72,6 +72,12 @@ public class PostgresPortal {
    */
   public boolean                   catalogQuery         = false;
   /**
+   * Non-null when the statement is a {@code COPY ... TO STDOUT} (issue #7188): Describe answers {@code NoData},
+   * since a COPY returns no result set, and Execute streams the rows as {@code CopyData} instead of
+   * {@code DataRow}. {@link #sqlStatement} then holds the parsed query INSIDE the COPY.
+   */
+  public PostgresCopyStatement     copyStatement;
+  /**
    * The complete materialized result of this portal's statement (issue #6458), set once - by whichever of a
    * Describe('P') or the first Execute runs the statement first - and read by every Execute after that to
    * hand out {@code limit}-sized slices via {@link #resultCursor}. {@link #cachedResultSet} holds only the
@@ -130,6 +136,7 @@ public class PostgresPortal {
     portal.ignoreExecution = template.ignoreExecution;
     portal.isExpectingResult = template.isExpectingResult;
     portal.catalogQuery = template.catalogQuery;
+    portal.copyStatement = template.copyStatement;
     portal.executed = template.executed;
     portal.cachedResultSet = template.cachedResultSet;
     portal.columns = template.columns;

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -768,8 +768,17 @@ public enum PostgresType {
    * @param typeBuffer The buffer to write to
    * @param value      The value to serialize
    */
-  @SuppressWarnings("unchecked")
   public void serializeAsText(final PostgresType pgType, final Binary typeBuffer, final Object value) {
+    writeString(typeBuffer, toText(pgType, value));
+  }
+
+  /**
+   * The text-format representation of a value under a Postgres type - what a {@code DataRow} carries for the
+   * column in text format, and what {@code COPY ... TO STDOUT} in text or CSV format escapes and delimits
+   * (issue #7188). Null for a SQL NULL.
+   */
+  @SuppressWarnings("unchecked")
+  public String toText(final PostgresType pgType, final Object value) {
     String serializedValue = null;
     final byte[] byteaValue = pgType == BYTEA ? byteaValueOf(value) : null;
     if (pgType == JSON && value != null && (value instanceof Collection<?> || value.getClass().isArray())) {
@@ -818,7 +827,7 @@ public enum PostgresType {
     } else if (value != null) {
       serializedValue = value.toString();
     }
-    writeString(typeBuffer, serializedValue);
+    return serializedValue;
   }
 
   /**

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue7188CopyToStdoutIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue7188CopyToStdoutIT.java
@@ -313,7 +313,7 @@ class Issue7188CopyToStdoutIT extends PostgresWireProtocolTestBase {
     final ByteBuffer buffer = ByteBuffer.wrap(bytes);
     final byte[] signature = new byte[11];
     buffer.get(signature);
-    assertThat(signature).isEqualTo(new byte[] { 'P', 'G', 'C', 'O', 'P', 'Y', '\n', (byte) 0377, '\r', '\n', 0 });
+    assertThat(signature).isEqualTo(new byte[] { 'P', 'G', 'C', 'O', 'P', 'Y', '\n', (byte) 0xFF, '\r', '\n', 0 });
     assertThat(buffer.getInt()).as("flags").isZero();
     final int extensionLength = buffer.getInt();
     buffer.position(buffer.position() + extensionLength); // header extension

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue7188CopyToStdoutIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue7188CopyToStdoutIT.java
@@ -202,7 +202,8 @@ class Issue7188CopyToStdoutIT extends PostgresWireProtocolTestBase {
       // An option PostgreSQL itself refuses.
       assertThatThrownBy(() -> copyOut(connection, "COPY (" + ORDERED + ") TO STDOUT (FORMAT binary, HEADER)"))
           .isInstanceOf(PSQLException.class)
-          .hasMessageContaining("HEADER in BINARY");
+          .hasMessageContaining("HEADER in BINARY")
+          .extracting(e -> ((PSQLException) e).getSQLState()).isEqualTo("42601");
 
       // After every refusal the session answers the next statement.
       assertThat(copyOut(connection, "COPY (SELECT count(*) AS n FROM " + TYPE + ") TO STDOUT")).isEqualTo("5\n");
@@ -451,6 +452,8 @@ class Issue7188CopyToStdoutIT extends PostgresWireProtocolTestBase {
   private void withConnection(final Exchange exchange) throws Exception {
     try (final Socket socket = new Socket()) {
       socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      // A hang detector on the handshake reads too, which run before the timed exchange below.
+      socket.setSoTimeout(30_000);
       final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
       final DataInputStream in = new DataInputStream(socket.getInputStream());
 

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue7188CopyToStdoutIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue7188CopyToStdoutIT.java
@@ -29,6 +29,7 @@ import org.postgresql.PGConnection;
 import org.postgresql.copy.CopyManager;
 import org.postgresql.util.PSQLException;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -90,7 +91,21 @@ class Issue7188CopyToStdoutIT extends PostgresWireProtocolTestBase {
       database.newDocument(TYPE).set("id", 4, "name", null, "price", null, "flag", null).save();
       database.newDocument(TYPE).set("id", 5, "name", "", "price", 0.0, "flag", false).save();
     });
+    // A type whose one property is a list, which has no binary encoding on this wire.
+    final DocumentType listed = database.getSchema().createDocumentType(LIST_TYPE);
+    listed.createProperty("id", Type.INTEGER);
+    listed.createProperty("tags", Type.LIST, "STRING");
+    // A vertex type for a COPY whose query is in another language, whose columns only its rows can name.
+    database.getSchema().createVertexType(VERTEX_TYPE).createProperty("id", Type.INTEGER);
+    database.transaction(() -> {
+      database.newDocument(LIST_TYPE).set("id", 1, "tags", List.of("a", "b")).save();
+      for (int i = 1; i <= 5; i++)
+        database.newVertex(VERTEX_TYPE).set("id", i).save();
+    });
   }
+
+  private static final String LIST_TYPE   = "copylist7188";
+  private static final String VERTEX_TYPE = "copyvertex7188";
 
   private static final String ORDERED = "SELECT id, name, price, flag FROM " + TYPE + " ORDER BY id";
 
@@ -170,7 +185,7 @@ class Issue7188CopyToStdoutIT extends PostgresWireProtocolTestBase {
   @Test
   void whatIsDeclinedIsDeclinedWithFeatureNotSupportedAndTheConnectionStaysUsable() throws Exception {
     try (final Connection connection = openJdbcConnection()) {
-      assertThatThrownBy(() -> copyManager(connection).copyIn("COPY " + TYPE + " FROM STDIN", new java.io.ByteArrayInputStream(new byte[0])))
+      assertThatThrownBy(() -> copyManager(connection).copyIn("COPY " + TYPE + " FROM STDIN", new ByteArrayInputStream(new byte[0])))
           .isInstanceOf(PSQLException.class)
           .hasMessageContaining("COPY ... FROM STDIN is not supported")
           .extracting(e -> ((PSQLException) e).getSQLState()).isEqualTo("0A000");
@@ -191,6 +206,68 @@ class Issue7188CopyToStdoutIT extends PostgresWireProtocolTestBase {
 
       // After every refusal the session answers the next statement.
       assertThat(copyOut(connection, "COPY (SELECT count(*) AS n FROM " + TYPE + ") TO STDOUT")).isEqualTo("5\n");
+    }
+  }
+
+  @Test
+  void aBinaryCopyOfAColumnWithNoBinaryEncodingIsRefusedAndTheSessionStaysUsable() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      assertThatThrownBy(() -> copyOut(connection, "COPY (SELECT id, tags FROM " + LIST_TYPE + ") TO STDOUT (FORMAT binary)"))
+          .isInstanceOf(PSQLException.class)
+          .hasMessageContaining("\"tags\"")
+          .extracting(e -> ((PSQLException) e).getSQLState()).isEqualTo("0A000");
+      // The same column travels in text format.
+      assertThat(copyOut(connection, "COPY (SELECT id, tags FROM " + LIST_TYPE + ") TO STDOUT")).isEqualTo("1\t{\"a\",\"b\"}\n");
+      // The refused statement's result set was closed, not leaked: the type can be dropped, which a still-open
+      // cursor over it would hold up, and the session goes on.
+      getServerDatabase(0, getDatabaseName()).getSchema().dropType(LIST_TYPE);
+      assertThat(copyOut(connection, "COPY (SELECT count(*) AS n FROM " + TYPE + ") TO STDOUT")).isEqualTo("5\n");
+    }
+  }
+
+  @Test
+  void aQueryThatFailsInsideACopyLeavesTheSessionUsable() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      // The projection divides by zero on the third row - after the rows before it may already have gone out as
+      // CopyData, which the protocol ends with the ErrorResponse.
+      assertThatThrownBy(() -> copyOut(connection, "COPY (SELECT id, 1 / (id - 3) AS x FROM " + TYPE + " ORDER BY id) TO STDOUT"))
+          .isInstanceOf(PSQLException.class);
+      assertThat(copyOut(connection, "COPY (SELECT count(*) AS n FROM " + TYPE + ") TO STDOUT")).isEqualTo("5\n");
+    }
+  }
+
+  /**
+   * CopyData is buffered and written in 64 KB batches, and a row is never split across messages: a row larger than
+   * the batch travels whole, and a result several batches long arrives intact.
+   */
+  @Test
+  void rowsLargerThanTheFlushBatchAndResultsLongerThanItArriveIntact() throws Exception {
+    final Database database = getServerDatabase(0, getDatabaseName());
+    final String big = "x".repeat(200_000) + "\ty";
+    database.getSchema().createDocumentType("copybig7188").createProperty("id", Type.INTEGER);
+    database.transaction(() -> {
+      for (int i = 1; i <= 3; i++)
+        database.newDocument("copybig7188").set("id", i, "name", big).save();
+    });
+    try (final Connection connection = openJdbcConnection()) {
+      final String text = copyOut(connection, "COPY (SELECT id, name FROM copybig7188 ORDER BY id) TO STDOUT");
+      final String expectedRow = "x".repeat(200_000) + "\\ty";
+      assertThat(text).isEqualTo("1\t" + expectedRow + "\n2\t" + expectedRow + "\n3\t" + expectedRow + "\n");
+    }
+  }
+
+  /**
+   * A COPY whose columns only its rows can name - here a Cypher query, which no schema resolution describes - is
+   * materialized the way a plain query is, within the same row cap, and named from the rows it produced.
+   */
+  @Test
+  void aCopyTheSchemaCannotDescribeIsMaterializedWithinTheRowCap() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      assertThatThrownBy(() -> copyOut(connection, "{cypher} COPY (MATCH (v:" + VERTEX_TYPE + ") RETURN v.id AS id ORDER BY id) TO STDOUT"))
+          .isInstanceOf(PSQLException.class)
+          .hasMessageContaining("exceeds the configured limit of " + ROW_CAP);
+      assertThat(copyOut(connection, "{cypher} COPY (MATCH (v:" + VERTEX_TYPE + ") RETURN v.id AS id ORDER BY id LIMIT 2) TO STDOUT"))
+          .isEqualTo("1\n2\n");
     }
   }
 
@@ -263,7 +340,16 @@ class Issue7188CopyToStdoutIT extends PostgresWireProtocolTestBase {
       assertThat(tuples.get(1)).containsExactly(2, "tab\there");
       assertThat(tuples.get(3)).containsExactly(4, null);
 
-      // 4. The session is intact: a plain statement after the COPY is answered as usual.
+      // 4. A completed COPY portal cannot be run again, as in PostgreSQL: an error, and the session goes on after
+      // the Sync.
+      sendExecute(out);
+      sendSync(out);
+      final WireMessage refused = readWireMessage(in);
+      assertThat(refused.type()).isEqualTo('E');
+      assertThat(new String(refused.body(), StandardCharsets.UTF_8)).contains("34000");
+      assertThat(readWireMessage(in).type()).isEqualTo('Z');
+
+      // 5. The session is intact: a plain statement after the COPY is answered as usual.
       sendParse(out, "SELECT count(*) AS n FROM " + TYPE);
       sendBind(out);
       sendExecute(out);

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue7188CopyToStdoutIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue7188CopyToStdoutIT.java
@@ -1,0 +1,480 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.postgresql.PGConnection;
+import org.postgresql.copy.CopyManager;
+import org.postgresql.util.PSQLException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+/**
+ * Issue #7188: {@code COPY (query) TO STDOUT} in text, CSV and binary format, on the simple-query protocol
+ * ({@code psql \copy}, pgjdbc's {@code CopyManager}) and on the extended one the Arrow ADBC PostgreSQL driver uses
+ * for every result set it reads.
+ */
+class Issue7188CopyToStdoutIT extends PostgresWireProtocolTestBase {
+
+  private static final String TYPE = "copy7188";
+  /**
+   * Smaller than the table, so a plain SELECT of the whole table is refused: proof that a COPY whose columns the
+   * schema names is streamed rather than held, which is the property a bulk export needs from it.
+   */
+  private static final int    ROW_CAP = 3;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.POSTGRES_QUERY_MAX_ROWS.setValue(ROW_CAP);
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.POSTGRES_QUERY_MAX_ROWS.reset();
+    super.endTest();
+  }
+
+  @BeforeEach
+  void populate() {
+    final Database database = getServerDatabase(0, getDatabaseName());
+    final DocumentType type = database.getSchema().createDocumentType(TYPE);
+    type.createProperty("id", Type.INTEGER);
+    type.createProperty("name", Type.STRING);
+    type.createProperty("price", Type.DOUBLE);
+    type.createProperty("flag", Type.BOOLEAN);
+    database.transaction(() -> {
+      database.newDocument(TYPE).set("id", 1, "name", "plain", "price", 1.5, "flag", true).save();
+      database.newDocument(TYPE).set("id", 2, "name", "tab\there", "price", 2.0, "flag", false).save();
+      database.newDocument(TYPE).set("id", 3, "name", "back\\slash and \"quote\", comma", "price", 3.25, "flag", true).save();
+      database.newDocument(TYPE).set("id", 4, "name", null, "price", null, "flag", null).save();
+      database.newDocument(TYPE).set("id", 5, "name", "", "price", 0.0, "flag", false).save();
+    });
+  }
+
+  private static final String ORDERED = "SELECT id, name, price, flag FROM " + TYPE + " ORDER BY id";
+
+  @Test
+  void textFormatIsWhatPsqlCopyReads() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      final String text = copyOut(connection, "COPY (" + ORDERED + ") TO STDOUT");
+      assertThat(text).isEqualTo("""
+          1\tplain\t1.5\tt
+          2\ttab\\there\t2.0\tf
+          3\tback\\\\slash and "quote", comma\t3.25\tt
+          4\t\\N\t\\N\t\\N
+          5\t\t0.0\tf
+          """);
+    }
+  }
+
+  @Test
+  void csvFormatWithHeaderAndOptions() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      assertThat(copyOut(connection, "COPY (" + ORDERED + ") TO STDOUT (FORMAT csv, HEADER)")).isEqualTo("""
+          id,name,price,flag
+          1,plain,1.5,t
+          2,tab\there,2.0,f
+          3,"back\\slash and ""quote"", comma",3.25,t
+          4,,,
+          5,"",0.0,f
+          """);
+
+      // The legacy keyword spelling, as a \\copy user types it.
+      assertThat(copyOut(connection, "COPY (SELECT id, name FROM " + TYPE + " WHERE id < 3 ORDER BY id) TO STDOUT CSV HEADER DELIMITER ';' NULL 'nil'"))
+          .isEqualTo("id;name\n1;plain\n2;tab\there\n");
+    }
+  }
+
+  @Test
+  void binaryFormatIsWhatTheArrowAdbcDriverDecodes() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+      final long rows = copyManager(connection).copyOut("COPY (" + ORDERED + ") TO STDOUT (FORMAT binary)", bytes);
+      assertThat(rows).isEqualTo(5);
+
+      final List<List<Object>> tuples = decodeBinaryCopy(bytes.toByteArray(), new int[] { 23, 1043, 701, 16 });
+      assertThat(tuples).hasSize(5);
+      assertThat(tuples.get(0)).containsExactly(1, "plain", 1.5, true);
+      assertThat(tuples.get(2)).containsExactly(3, "back\\slash and \"quote\", comma", 3.25, true);
+      assertThat(tuples.get(3)).as("NULL is a field of length -1").containsExactly(4, null, null, null);
+      assertThat(tuples.get(4)).containsExactly(5, "", 0.0, false);
+    }
+  }
+
+  @Test
+  void theTableFormIsTheSameStatementWithAnImplicitSelect() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      assertThat(copyOut(connection, "COPY " + TYPE + " (id, name) TO STDOUT"))
+          .contains("1\tplain\n")
+          .contains("4\t\\N\n");
+      // pg_dump and psql qualify the name, and quote it: the rewriter turns the quotes into back-ticks.
+      assertThat(copyOut(connection, "COPY public.\"" + TYPE + "\" (id) TO STDOUT")).hasLineCount(5);
+    }
+  }
+
+  @Test
+  void aCopyStreamsPastTheRowCapAPlainSelectIsRefusedBy() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      // The cap is real for a query: its rows have to be held to name its columns.
+      try (final Statement statement = connection.createStatement()) {
+        assertThatThrownBy(() -> statement.executeQuery(ORDERED))
+            .isInstanceOf(PSQLException.class)
+            .hasMessageContaining("exceeds the configured limit of " + ROW_CAP);
+      }
+      // A COPY of the same statement names its columns from the schema and streams every row.
+      assertThat(copyOut(connection, "COPY (" + ORDERED + ") TO STDOUT")).hasLineCount(5);
+    }
+  }
+
+  @Test
+  void whatIsDeclinedIsDeclinedWithFeatureNotSupportedAndTheConnectionStaysUsable() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      assertThatThrownBy(() -> copyManager(connection).copyIn("COPY " + TYPE + " FROM STDIN", new java.io.ByteArrayInputStream(new byte[0])))
+          .isInstanceOf(PSQLException.class)
+          .hasMessageContaining("COPY ... FROM STDIN is not supported")
+          .extracting(e -> ((PSQLException) e).getSQLState()).isEqualTo("0A000");
+
+      assertThatThrownBy(() -> copyOut(connection, "COPY (" + ORDERED + ") TO '/tmp/leak.csv'"))
+          .isInstanceOf(PSQLException.class)
+          .extracting(e -> ((PSQLException) e).getSQLState()).isEqualTo("0A000");
+
+      // A COPY that is well-formed but whose query is not: the engine's own syntax error, and no CopyOutResponse.
+      assertThatThrownBy(() -> copyOut(connection, "COPY (SELEC id FROM " + TYPE + ") TO STDOUT"))
+          .isInstanceOf(PSQLException.class)
+          .extracting(e -> ((PSQLException) e).getSQLState()).isEqualTo("42601");
+
+      // An option PostgreSQL itself refuses.
+      assertThatThrownBy(() -> copyOut(connection, "COPY (" + ORDERED + ") TO STDOUT (FORMAT binary, HEADER)"))
+          .isInstanceOf(PSQLException.class)
+          .hasMessageContaining("HEADER in BINARY");
+
+      // After every refusal the session answers the next statement.
+      assertThat(copyOut(connection, "COPY (SELECT count(*) AS n FROM " + TYPE + ") TO STDOUT")).isEqualTo("5\n");
+    }
+  }
+
+  /**
+   * The exact exchange the Arrow ADBC PostgreSQL driver has with the server for one query: it prepares and
+   * describes the statement to learn the column OIDs, then runs {@code COPY (statement) TO STDOUT (FORMAT binary)}
+   * through {@code PQexecParams} - Parse, Bind, Describe(portal), Execute, Sync - and decodes the stream by those
+   * OIDs. Every reply has to be the one the protocol defines, in order, or the driver desynchronizes.
+   */
+  @Test
+  void theExtendedProtocolExchangeTheAdbcDriverMakes() throws Exception {
+    final String query = "SELECT id, name FROM " + TYPE + " ORDER BY id";
+    withConnection((out, in) -> {
+      // 1. Describe the statement inside the COPY, as the driver does first.
+      sendParse(out, query);
+      sendDescribeStatement(out);
+      sendSync(out);
+      assertThat(readWireMessage(in).type()).isEqualTo('1');
+      assertThat(readWireMessage(in).type()).isEqualTo('t');
+      final WireMessage rowDescription = readWireMessage(in);
+      assertThat(rowDescription.type()).isEqualTo('T');
+      assertThat(columnOidsOf(rowDescription)).containsExactly(23, 1043);
+      assertThat(readWireMessage(in).type()).isEqualTo('Z');
+
+      // 2. Describe the COPY statement itself: parameters, then NoData - a COPY has no result set.
+      sendParse(out, "COPY (" + query + ") TO STDOUT (FORMAT binary)");
+      sendDescribeStatement(out);
+      sendSync(out);
+      assertThat(readWireMessage(in).type()).isEqualTo('1');
+      assertThat(readWireMessage(in).type()).isEqualTo('t');
+      assertThat(readWireMessage(in).type()).isEqualTo('n');
+      assertThat(readWireMessage(in).type()).isEqualTo('Z');
+
+      // 3. PQexecParams of the COPY.
+      sendParse(out, "COPY (" + query + ") TO STDOUT (FORMAT binary)");
+      sendBind(out);
+      sendDescribePortal(out);
+      sendExecute(out);
+      sendSync(out);
+      assertThat(readWireMessage(in).type()).isEqualTo('1');
+      assertThat(readWireMessage(in).type()).isEqualTo('2');
+      assertThat(readWireMessage(in).type()).isEqualTo('n');
+
+      final WireMessage copyOutResponse = readWireMessage(in);
+      assertThat(copyOutResponse.type()).isEqualTo('H');
+      final ByteBuffer h = ByteBuffer.wrap(copyOutResponse.body());
+      assertThat(h.get()).as("overall format: binary").isEqualTo((byte) 1);
+      assertThat(h.getShort()).as("column count").isEqualTo((short) 2);
+      assertThat(h.getShort()).isEqualTo((short) 1);
+      assertThat(h.getShort()).isEqualTo((short) 1);
+
+      final ByteArrayOutputStream stream = new ByteArrayOutputStream();
+      WireMessage message = readWireMessage(in);
+      int copyDataMessages = 0;
+      while (message.type() == 'd') {
+        stream.write(message.body());
+        copyDataMessages++;
+        message = readWireMessage(in);
+      }
+      assertThat(copyDataMessages).as("header, five rows, trailer").isEqualTo(7);
+      assertThat(message.type()).as("CopyDone").isEqualTo('c');
+
+      final WireMessage complete = readWireMessage(in);
+      assertThat(complete.type()).isEqualTo('C');
+      assertThat(cString(complete.body())).isEqualTo("COPY 5");
+      assertThat(readWireMessage(in).type()).isEqualTo('Z');
+
+      final List<List<Object>> tuples = decodeBinaryCopy(stream.toByteArray(), new int[] { 23, 1043 });
+      assertThat(tuples).hasSize(5);
+      assertThat(tuples.get(1)).containsExactly(2, "tab\there");
+      assertThat(tuples.get(3)).containsExactly(4, null);
+
+      // 4. The session is intact: a plain statement after the COPY is answered as usual.
+      sendParse(out, "SELECT count(*) AS n FROM " + TYPE);
+      sendBind(out);
+      sendExecute(out);
+      sendSync(out);
+      assertThat(readWireMessage(in).type()).isEqualTo('1');
+      assertThat(readWireMessage(in).type()).isEqualTo('2');
+      assertThat(readWireMessage(in).type()).isEqualTo('T');
+      assertThat(readWireMessage(in).type()).isEqualTo('D');
+      assertThat(readWireMessage(in).type()).isEqualTo('C');
+      assertThat(readWireMessage(in).type()).isEqualTo('Z');
+    });
+  }
+
+  @Test
+  void aBrokenQueryInsideACopyIsRefusedAtParseOnTheExtendedProtocol() throws Exception {
+    withConnection((out, in) -> {
+      sendParse(out, "COPY (SELEC id FROM " + TYPE + ") TO STDOUT");
+      sendSync(out);
+      final WireMessage error = readWireMessage(in);
+      assertThat(error.type()).isEqualTo('E');
+      assertThat(readWireMessage(in).type()).isEqualTo('Z');
+
+      sendParse(out, "COPY " + TYPE + " FROM STDIN");
+      sendSync(out);
+      assertThat(readWireMessage(in).type()).isEqualTo('E');
+      assertThat(readWireMessage(in).type()).isEqualTo('Z');
+    });
+  }
+
+  // ---- helpers ----
+
+  private static String copyOut(final Connection connection, final String copy) throws Exception {
+    final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    copyManager(connection).copyOut(copy, bytes);
+    return bytes.toString(StandardCharsets.UTF_8);
+  }
+
+  private static CopyManager copyManager(final Connection connection) throws Exception {
+    return connection.unwrap(PGConnection.class).getCopyAPI();
+  }
+
+  /**
+   * Decodes a binary COPY stream: the signature, flags and header extension, then per tuple an int16 field count
+   * and per field an int32 length (-1 for NULL) followed by the value in the type's binary send format.
+   */
+  private static List<List<Object>> decodeBinaryCopy(final byte[] bytes, final int[] oids) {
+    final ByteBuffer buffer = ByteBuffer.wrap(bytes);
+    final byte[] signature = new byte[11];
+    buffer.get(signature);
+    assertThat(signature).isEqualTo(new byte[] { 'P', 'G', 'C', 'O', 'P', 'Y', '\n', (byte) 0377, '\r', '\n', 0 });
+    assertThat(buffer.getInt()).as("flags").isZero();
+    final int extensionLength = buffer.getInt();
+    buffer.position(buffer.position() + extensionLength); // header extension
+
+    final List<List<Object>> tuples = new ArrayList<>();
+    while (true) {
+      final short fields = buffer.getShort();
+      if (fields == -1)
+        break;
+      assertThat(fields).isEqualTo((short) oids.length);
+      final List<Object> tuple = new ArrayList<>();
+      for (int i = 0; i < fields; i++) {
+        final int length = buffer.getInt();
+        if (length == -1) {
+          tuple.add(null);
+          continue;
+        }
+        final byte[] value = new byte[length];
+        buffer.get(value);
+        final ByteBuffer v = ByteBuffer.wrap(value);
+        tuple.add(switch (oids[i]) {
+          case 23 -> v.getInt();
+          case 701 -> v.getDouble();
+          case 16 -> value[0] == 1;
+          default -> new String(value, StandardCharsets.UTF_8);
+        });
+      }
+      tuples.add(tuple);
+    }
+    assertThat(buffer.hasRemaining()).as("nothing follows the trailer").isFalse();
+    return tuples;
+  }
+
+  private Connection openJdbcConnection() throws Exception {
+    Class.forName("org.postgresql.Driver");
+    final Properties properties = new Properties();
+    properties.setProperty("user", "root");
+    properties.setProperty("password", DEFAULT_PASSWORD_FOR_TESTS);
+    properties.setProperty("ssl", "false");
+    properties.setProperty("sslMode", "disable");
+    properties.setProperty("preferQueryMode", "simple");
+    return DriverManager.getConnection("jdbc:postgresql://localhost:5432/" + getDatabaseName(), properties);
+  }
+
+  private interface Exchange {
+    void run(DataOutputStream out, DataInputStream in) throws Exception;
+  }
+
+  private void withConnection(final Exchange exchange) throws Exception {
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+
+      sendStartupMessage(out, "root", getDatabaseName());
+      readMessage(in); // AuthenticationCleartextPassword
+      sendPasswordMessage(out, DEFAULT_PASSWORD_FOR_TESTS);
+      readMessageOfType(in, 'Z');
+
+      // A hang detector, not a latency bound: a reply the server never sends leaves the client blocked in
+      // readFully() forever, and only a preemptive timeout can end that.
+      assertTimeoutPreemptively(Duration.ofSeconds(30), () -> exchange.run(out, in));
+    }
+  }
+
+  private record WireMessage(char type, byte[] body) {
+  }
+
+  private static WireMessage readWireMessage(final DataInputStream in) throws Exception {
+    final char type = (char) in.readUnsignedByte();
+    final int length = in.readInt();
+    final byte[] body = new byte[length - 4];
+    in.readFully(body);
+    return new WireMessage(type, body);
+  }
+
+  private static String cString(final byte[] body) {
+    int end = 0;
+    while (end < body.length && body[end] != 0)
+      end++;
+    return new String(body, 0, end, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * The type OIDs in a {@code RowDescription}: int16 count, then per column a null-terminated name, int32 table
+   * OID, int16 attribute number, int32 type OID, int16 size, int32 modifier, int16 format.
+   */
+  private static List<Integer> columnOidsOf(final WireMessage rowDescription) {
+    final ByteBuffer buffer = ByteBuffer.wrap(rowDescription.body());
+    final int count = buffer.getShort();
+    final List<Integer> oids = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      while (buffer.get() != 0)
+        ;
+      buffer.getInt();
+      buffer.getShort();
+      oids.add(buffer.getInt());
+      buffer.getShort();
+      buffer.getInt();
+      buffer.getShort();
+    }
+    return oids;
+  }
+
+  private static void sendParse(final DataOutputStream out, final String query) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, "");
+    writeCString(body, query);
+    body.write(0);
+    body.write(0);
+    send(out, 'P', body);
+  }
+
+  private static void sendBind(final DataOutputStream out) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, "");
+    writeCString(body, "");
+    body.write(0);
+    body.write(0);
+    body.write(0);
+    body.write(0);
+    body.write(0);
+    body.write(0);
+    send(out, 'B', body);
+  }
+
+  private static void sendDescribePortal(final DataOutputStream out) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    body.write('P');
+    writeCString(body, "");
+    send(out, 'D', body);
+  }
+
+  private static void sendDescribeStatement(final DataOutputStream out) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    body.write('S');
+    writeCString(body, "");
+    send(out, 'D', body);
+  }
+
+  private static void sendExecute(final DataOutputStream out) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, "");
+    body.write(0);
+    body.write(0);
+    body.write(0);
+    body.write(0);
+    send(out, 'E', body);
+  }
+
+  private static void sendSync(final DataOutputStream out) throws Exception {
+    out.writeByte('S');
+    out.writeInt(4);
+    out.flush();
+  }
+
+  private static void send(final DataOutputStream out, final char type, final ByteArrayOutputStream body) throws Exception {
+    final byte[] bytes = body.toByteArray();
+    out.writeByte(type);
+    out.writeInt(4 + bytes.length);
+    out.write(bytes);
+    out.flush();
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresCopyStatementTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresCopyStatementTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7188: how {@code COPY ... TO STDOUT} is read in both of PostgreSQL's spellings, which parts of it this
+ * server declines, and the text/CSV encodings the rows are written in.
+ */
+class PostgresCopyStatementTest {
+
+  @Test
+  void onlyACopyIsACopy() {
+    assertThat(PostgresCopyStatement.parse("SELECT FROM t")).isNull();
+    assertThat(PostgresCopyStatement.parse("COPYX TO STDOUT")).isNull();
+    assertThat(PostgresCopyStatement.parse("copy")).isNull();
+    assertThat(PostgresCopyStatement.isCopy("copy (select 1) to stdout")).isTrue();
+    assertThat(PostgresCopyStatement.isCopy("COPY\tt TO STDOUT")).isTrue();
+  }
+
+  @Test
+  void theQueryFormKeepsTheQueryVerbatimWhateverItHolds() {
+    // Nested parentheses, a ')' and a 'TO STDOUT' inside a string literal, a quoted identifier with ')', and a
+    // comment: none of them may end the query early.
+    final String query = "SELECT name, upper(name) AS \"n)\" FROM t WHERE name = 'a) TO STDOUT' -- ) \n AND (x > (1))";
+    final PostgresCopyStatement copy = PostgresCopyStatement.parse("COPY ( " + query + " ) TO STDOUT;");
+
+    assertThat(copy).isNotNull();
+    assertThat(copy.getQuery()).isEqualTo(query);
+    assertThat(copy.getFormat()).isEqualTo(PostgresCopyStatement.Format.TEXT);
+    assertThat(copy.getDelimiter()).isEqualTo('\t');
+    assertThat(copy.getNullString()).isEqualTo("\\N");
+    assertThat(copy.isHeader()).isFalse();
+  }
+
+  @Test
+  void theOptionListSpelling() {
+    final PostgresCopyStatement copy = PostgresCopyStatement.parse(
+        "COPY (SELECT 1) TO STDOUT WITH (FORMAT csv, HEADER true, DELIMITER ';', NULL 'NULL', QUOTE '''', ESCAPE '\\', FORCE_QUOTE (name, \"Other\"), ENCODING 'UTF-8')");
+
+    assertThat(copy.getFormat()).isEqualTo(PostgresCopyStatement.Format.CSV);
+    assertThat(copy.isHeader()).isTrue();
+    assertThat(copy.getDelimiter()).isEqualTo(';');
+    assertThat(copy.getNullString()).isEqualTo("NULL");
+    assertThat(copy.getQuote()).isEqualTo('\'');
+    assertThat(copy.getEscape()).isEqualTo('\\');
+
+    // The header spelled as a flag, the format as a string, the boolean in its other forms.
+    assertThat(PostgresCopyStatement.parse("COPY t TO STDOUT (FORMAT 'binary')").getFormat())
+        .isEqualTo(PostgresCopyStatement.Format.BINARY);
+    assertThat(PostgresCopyStatement.parse("COPY t TO STDOUT (HEADER)").isHeader()).isTrue();
+    assertThat(PostgresCopyStatement.parse("COPY t TO STDOUT (HEADER off)").isHeader()).isFalse();
+    assertThat(PostgresCopyStatement.parse("COPY t TO STDOUT (HEADER 1)").isHeader()).isTrue();
+  }
+
+  @Test
+  void theLegacyKeywordSpelling() {
+    final PostgresCopyStatement copy = PostgresCopyStatement.parse(
+        "COPY t (a, \"B\") TO STDOUT WITH CSV HEADER DELIMITER AS ';' NULL AS '' QUOTE AS '\"' FORCE QUOTE *");
+
+    assertThat(copy.getQuery()).isEqualTo("SELECT `a`, `B` FROM `t`");
+    assertThat(copy.getFormat()).isEqualTo(PostgresCopyStatement.Format.CSV);
+    assertThat(copy.isHeader()).isTrue();
+    assertThat(copy.getDelimiter()).isEqualTo(';');
+    assertThat(copy.getNullString()).isEmpty();
+
+    assertThat(PostgresCopyStatement.parse("COPY t TO STDOUT BINARY").getFormat()).isEqualTo(PostgresCopyStatement.Format.BINARY);
+    assertThat(PostgresCopyStatement.parse("COPY t TO STDOUT WITH DELIMITER '|'").getDelimiter()).isEqualTo('|');
+  }
+
+  @Test
+  void theTableFormIsAnImplicitSelect() {
+    // Schema-qualified, as pg_dump and psql spell it: ArcadeDB has no schemas, the last segment is the type.
+    final PostgresCopyStatement copy = PostgresCopyStatement.parse("COPY public.\"Person\" TO STDOUT");
+    assertThat(copy.getQuery()).isEqualTo("SELECT FROM `Person`");
+
+    // The quoted-identifier rewriter hands the executor back-ticks, which read as the same thing.
+    assertThat(PostgresCopyStatement.parse("COPY `Person` (`name`) TO STDOUT").getQuery())
+        .isEqualTo("SELECT `name` FROM `Person`");
+  }
+
+  @Test
+  void whatThisServerDeclinesIsDeclinedAsUnsupportedNotAsASyntaxError() {
+    assertCopyException("COPY t FROM STDIN", PostgresCopyStatement.SQLSTATE_FEATURE_NOT_SUPPORTED, "FROM STDIN");
+    assertCopyException("COPY t FROM '/tmp/x'", PostgresCopyStatement.SQLSTATE_FEATURE_NOT_SUPPORTED, "FROM STDIN");
+    assertCopyException("COPY t TO '/tmp/x'", PostgresCopyStatement.SQLSTATE_FEATURE_NOT_SUPPORTED, "server-side file");
+    assertCopyException("COPY t TO PROGRAM 'gzip'", PostgresCopyStatement.SQLSTATE_FEATURE_NOT_SUPPORTED, "PROGRAM");
+    assertCopyException("COPY t TO STDOUT (ENCODING 'LATIN1')", PostgresCopyStatement.SQLSTATE_FEATURE_NOT_SUPPORTED, "UTF-8");
+  }
+
+  @Test
+  void whatPostgresRefusesIsRefusedTheSameWay() {
+    assertCopyException("COPY t TO STDOUT (FOO 1)", PostgresCopyStatement.SQLSTATE_SYNTAX_ERROR, "option \"foo\" not recognized");
+    assertCopyException("COPY t TO STDOUT (FORMAT binary, HEADER)", PostgresCopyStatement.SQLSTATE_SYNTAX_ERROR, "HEADER in BINARY");
+    assertCopyException("COPY t TO STDOUT (FORMAT binary, DELIMITER ';')", PostgresCopyStatement.SQLSTATE_SYNTAX_ERROR, "DELIMITER in BINARY");
+    assertCopyException("COPY t TO STDOUT (QUOTE '\"')", PostgresCopyStatement.SQLSTATE_SYNTAX_ERROR, "QUOTE requires CSV");
+    assertCopyException("COPY t TO STDOUT (FORMAT csv, DELIMITER ',,')", PostgresCopyStatement.SQLSTATE_SYNTAX_ERROR, "single");
+    assertCopyException("COPY t TO STDOUT (HEADER match)", PostgresCopyStatement.SQLSTATE_SYNTAX_ERROR, "match");
+    assertCopyException("COPY t TO STDOUT (FORCE_NULL (a))", PostgresCopyStatement.SQLSTATE_SYNTAX_ERROR, "COPY FROM");
+    assertCopyException("COPY (SELECT 1 TO STDOUT", PostgresCopyStatement.SQLSTATE_SYNTAX_ERROR, "never closed");
+    assertCopyException("COPY (SELECT 1) STDOUT", PostgresCopyStatement.SQLSTATE_SYNTAX_ERROR, "expected TO");
+    assertCopyException("COPY (SELECT 1) TO STDOUT garbage", PostgresCopyStatement.SQLSTATE_SYNTAX_ERROR, "'garbage'");
+    assertCopyException("COPY t (a, b TO STDOUT", PostgresCopyStatement.SQLSTATE_SYNTAX_ERROR, "column list");
+  }
+
+  private static void assertCopyException(final String statement, final String sqlState, final String messagePart) {
+    assertThatThrownBy(() -> PostgresCopyStatement.parse(statement))
+        .as(statement)
+        .isInstanceOf(PostgresCopyStatement.CopyException.class)
+        .hasMessageContaining(messagePart)
+        .extracting(e -> ((PostgresCopyStatement.CopyException) e).sqlState)
+        .isEqualTo(sqlState);
+  }
+
+  // ---- encodings ----
+
+  @Test
+  void textFormatEscapesWhatTheReaderUnescapes() {
+    final PostgresCopyStatement copy = PostgresCopyStatement.parse("COPY t TO STDOUT");
+    final StringBuilder out = new StringBuilder();
+    copy.appendRow(out, new String[] { "a\tb\nc\rd\\e\u000Bf\bg\fh", null, "" }, new String[] { "x", "y", "z" });
+    assertThat(out.toString()).isEqualTo("a\\tb\\nc\\rd\\\\e\\vf\\bg\\fh\t\\N\t\n");
+
+    // A custom delimiter is escaped inside a value, so the reader does not split on it.
+    final PostgresCopyStatement semicolon = PostgresCopyStatement.parse("COPY t TO STDOUT (DELIMITER ';', NULL 'nil')");
+    out.setLength(0);
+    semicolon.appendRow(out, new String[] { "a;b", null }, new String[] { "x", "y" });
+    assertThat(out.toString()).isEqualTo("a\\;b;nil\n");
+
+    out.setLength(0);
+    PostgresCopyStatement.parse("COPY t TO STDOUT (HEADER)").appendHeader(out, List.of("id", "na\tme"));
+    assertThat(out.toString()).isEqualTo("id\tna\\tme\n");
+  }
+
+  @Test
+  void csvFormatQuotesExactlyWhenPostgresDoes() {
+    final PostgresCopyStatement copy = PostgresCopyStatement.parse("COPY t TO STDOUT (FORMAT csv)");
+    final String[] names = { "a", "b", "c", "d", "e", "f" };
+    final StringBuilder out = new StringBuilder();
+    // plain | holds the delimiter | holds a quote (doubled) | holds a line break | NULL | empty string
+    copy.appendRow(out, new String[] { "plain", "x,y", "say \"hi\"", "two\nlines", null, "" }, names);
+    assertThat(out.toString())
+        .as("an empty string is quoted so it can be told from NULL, which is the empty null string")
+        .isEqualTo("plain,\"x,y\",\"say \"\"hi\"\"\",\"two\nlines\",,\"\"\n");
+
+    // A value equal to the NULL string is quoted, or the reader would read it back as NULL.
+    final PostgresCopyStatement nullWord = PostgresCopyStatement.parse("COPY t TO STDOUT (FORMAT csv, NULL 'NULL')");
+    out.setLength(0);
+    nullWord.appendRow(out, new String[] { "NULL", null, "" }, new String[] { "a", "b", "c" });
+    assertThat(out.toString()).isEqualTo("\"NULL\",NULL,\n");
+
+    // FORCE_QUOTE, by name and for every column; and an escape character other than the quote.
+    final PostgresCopyStatement forced = PostgresCopyStatement.parse("COPY t TO STDOUT (FORMAT csv, FORCE_QUOTE (b), ESCAPE '\\')");
+    out.setLength(0);
+    forced.appendRow(out, new String[] { "a\"b\\c", "plain" }, new String[] { "a", "b" });
+    assertThat(out.toString()).isEqualTo("\"a\\\"b\\\\c\",\"plain\"\n");
+
+    final PostgresCopyStatement all = PostgresCopyStatement.parse("COPY t TO STDOUT CSV FORCE QUOTE *");
+    out.setLength(0);
+    all.appendRow(out, new String[] { "1", null }, new String[] { "a", "b" });
+    assertThat(out.toString()).as("NULL is never quoted, even under FORCE_QUOTE").isEqualTo("\"1\",\n");
+
+    // The end-of-data marker alone on a line is quoted, in a single-column result only.
+    out.setLength(0);
+    copy.appendRow(out, new String[] { "\\." }, new String[] { "a" });
+    assertThat(out.toString()).isEqualTo("\"\\.\"\n");
+
+    out.setLength(0);
+    PostgresCopyStatement.parse("COPY t TO STDOUT (FORMAT csv, HEADER)").appendHeader(out, List.of("id", "first,last"));
+    assertThat(out.toString()).isEqualTo("id,\"first,last\"\n");
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresCopyStatementTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresCopyStatementTest.java
@@ -123,6 +123,9 @@ class PostgresCopyStatementTest {
     assertCopyException("COPY (SELECT 1) STDOUT", PostgresCopyStatement.SQLSTATE_SYNTAX_ERROR, "expected TO");
     assertCopyException("COPY (SELECT 1) TO STDOUT garbage", PostgresCopyStatement.SQLSTATE_SYNTAX_ERROR, "'garbage'");
     assertCopyException("COPY t (a, b TO STDOUT", PostgresCopyStatement.SQLSTATE_SYNTAX_ERROR, "column list");
+    // The table form splices its names between back-ticks in a SELECT: a name holding one is refused, not spliced.
+    assertCopyException("COPY \"t` WHERE 1=1 --\" TO STDOUT", PostgresCopyStatement.SQLSTATE_SYNTAX_ERROR, "back-tick");
+    assertCopyException("COPY t (\"a`, b\") TO STDOUT", PostgresCopyStatement.SQLSTATE_SYNTAX_ERROR, "back-tick");
   }
 
   private static void assertCopyException(final String statement, final String sqlState, final String messagePart) {


### PR DESCRIPTION
Closes #7188
Closes #7089

Two gaps left behind by earlier, deliberately scoped fixes: #7188 was split out of #7180 (Arrow ADBC bootstrap), #7089 was filed from the review of #7087 (MIN/MAX NaN policy). Design notes in `docs/7188-7089-copy-to-stdout-and-nan-transparent-sum.md`.

## #7188 - `COPY ... TO STDOUT`

- `PostgresCopyStatement` recognises `COPY (<query>) TO STDOUT` and `COPY <type> [(cols)] TO STDOUT` ahead of the SQL engine, like `SET`/`SHOW`; both the option-list spelling (`FORMAT`, `DELIMITER`, `NULL`, `HEADER`, `QUOTE`, `ESCAPE`, `FORCE_QUOTE`, `ENCODING`) and the legacy keywords (`BINARY`, `CSV HEADER`, `DELIMITER AS`, ...), with PostgreSQL's own combination rules.
- `PostgresNetworkExecutor.copyOut` frames `CopyOutResponse` / `CopyData` per row / `CopyDone` / `CommandComplete COPY n`, batching CopyData in 64 KB writes. Text and CSV encodings follow `copyto.c` exactly; binary reuses `serializeAsBinary`, whose field format is COPY's.
- Works on the simple protocol (`psql \copy`, pgjdbc `CopyManager`) and the extended one (`Parse`/`Bind`/`Describe`/`Execute`, what `PQexecParams` and the ADBC driver send): `Describe` answers `NoData`, `Execute` streams, the inner query's syntax errors surface at `Parse`.
- Columns are resolved the way `Describe('S')` resolves them for the inner statement, so the ADBC driver's binary decoder and the stream agree. A COPY the schema can describe is **streamed** and not capped by `arcadedb.postgres.queryMaxRows`; one only its rows can describe is materialized within the cap, like a plain query.
- Refused with SQLSTATE `0A000` and a message naming the alternative: `COPY ... FROM STDIN` (out of scope per the issue), `TO 'file'`, `TO PROGRAM`, and a binary COPY of a column with no binary encoding (arrays).

Alternative to the issue's outline: it proposed recognising the statement and reusing the encoders, which this does; the addition is resolving columns from the schema first and streaming, rather than materializing every COPY through the same bounded buffer as a query. Materializing would have capped the one statement whose purpose is bulk export and would have named columns from rows where the ADBC driver expects the schema's OIDs.

## #7089 - NaN-transparent `SUM`/`AVG`

Policy decision, made and recorded in `TimeSeriesNaN`: **skip NaN** for `SUM`/`AVG` (SQL `NULL` semantics), `AVG` divides by the count of real samples, an all-NaN window answers the absent marker; `COUNT` keeps counting rows since the SQL push-down maps it from `count(*)`. PromQL `sum`/`avg` are deliberately left propagating NaN, as Prometheus does.

- The block-statistics fast path answers `AVG` from the header, which needs the count of real samples: sealed blocks now record `[min, max, sum, count]` (block magic `TSB2`, file format version 0 -> 1). Legacy `TSBL` blocks are read as they stand: a finite legacy sum proves no NaN (count = sample count); a NaN sum leaves the count unknown and routes `SUM`/`AVG` over that block through the values, while `MIN`/`MAX`/`COUNT` stay on the header. Every rewrite (compaction, downsampling, truncation) writes `TSB2` and recomputes what was unknown. The version bump makes an older build refuse a newer file instead of silently stopping its directory scan at an unknown magic. `LocalTimeSeriesType` gates on `>` like the mutable bucket already did.
- `MultiColumnAggregationResult` seeds `SUM`/`AVG` at absent and folds with `TimeSeriesNaN.sum`; its per-request count is now the count of contributing samples, so `finalizeAvg` has the right denominator.
- `TimeSeriesVectorOps.sum` skips NaN in the scalar and SIMD implementations (NaN lanes blended to the ADD identity, as `min`/`max` already do) and answers absent for an empty/all-NaN range; new `countPresent` for the SIMD denominator.
- The single-column `AggregationResult` path and its weighted `AVG` merge (which multiplied a NaN partial by a zero count), downsampling (mean of real samples, absent for a bucket with none, was `0.0`), and the DEEP integrity check (verifies the declared count; a legacy unknown count is not a problem).

Alternative considered: keeping the poisoned sum in the header as a "decode me" marker with no format change. Exact, but it makes the header's `sum` mean something other than the aggregate's `SUM`, and the next person to make `reduceNumericStats` skip NaN silently breaks `AVG` on the fast path.

## Tests

- `PostgresCopyStatementTest` (9): both spellings, the table form, what is declined and with which SQLSTATE, text/CSV escaping rules.
- `Issue7188CopyToStdoutIT` (8): text, CSV, binary (decoded), table form, streaming past the row cap where a plain SELECT is refused, refusals leaving the session usable, the exact ADBC extended-protocol exchange with the message sequence and binary payload decoded, `Parse`-time refusal.
- `Issue7089NaNTransparentSumAvgTest` (9): the fold, the statistics reducer, both vector implementations, partial-result merging, the engine end to end on the mutable path and the sealed fast path (asserting the fast path was taken), the SQL push-down, a hand-written version-0 file with legacy blocks (poisoned and not; decoded and header-answered; then upgraded by a rewrite), a mixed-layout file, the DEEP check catching a lying count, downsampling.
- Existing: all `engine` time-series and PromQL tests (321), the whole `postgresw` module (473 unit + IT).
- Not runnable locally: the `server` time-series HTTP ITs, because ports 2480/2481 are held by other processes on this machine and those tests hard-code 2480; CI covers them.

Docs: `timeseries.adoc` (Missing Values, format note) and `postgres.adoc` (COPY section, limitations, psql) updated in arcadedb-docs, committed locally, not pushed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added PostgreSQL wire-protocol support for `COPY (...) TO STDOUT` and table-based exports in text, CSV, and binary formats.
  - Supports simple and extended query protocols, headers, delimiters, null handling, quoting, legacy option syntax, and large result streaming.
  - Unsupported `COPY FROM STDIN`, server-side file, and program targets now return clear errors.

- **Bug Fixes**
  - Time-series `SUM` and `AVG` now ignore NaN samples and calculate averages using only real values.
  - Empty or all-NaN windows return an absent result instead of an incorrect numeric value.
  - Improved compatibility when reading and updating older time-series data formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->