### PR TITLE
feat(#7400): add the ConnectCluster RPC, the last control-plane verb with no gRPC entry point

### DIFF
--- a/docs/7304-grpc-control-plane.md
+++ b/docs/7304-grpc-control-plane.md
@@ -104,7 +104,7 @@ ArcadeDbGrpcAdminService.java:297-298  (definition, mirrors checkRootUser)
 | `disconnect cluster` | `DisconnectCluster` | fixed here | yes (authz + non-HA rejection) |
 | `GET /health` | `Health` | fixed here | yes |
 | `GET /ready` | `Ready` | fixed here | yes |
-| `connect cluster` | none | **argued** | - |
+| `connect cluster` | `ConnectCluster` | **argued here, reversed by #7400** | yes, in #7400 (authz + non-HA rejection) |
 | `restore backup` | none | **filed** #7308 | - |
 | `restore database` | none | **filed** #7308 | - |
 | `import database` | none | **filed** #7308 | - |
@@ -116,10 +116,18 @@ ArcadeDbGrpcAdminService.java:297-298  (definition, mirrors checkRootUser)
 
 ### Arguments
 
-- **`connect cluster`** - the HTTP implementation has no behaviour to adapt. It is a single
-  `throw new CommandExecutionException("Connect cluster operation is not supported by the current
-  HA implementation...")` (`PostServerCommandHandler.connectCluster`, lines 829-834). Adding a
-  gRPC RPC would reproduce an unconditional error, not an operation.
+- **`connect cluster`** - *this argument was reversed by #7400; the RPC exists as of that issue and
+  the row above is updated. Kept here because the reasoning is the record of what was decided, and
+  what was wrong with it.* The argument was: the HTTP implementation has no behaviour to adapt - it
+  is a single unconditional throw - so a gRPC RPC would reproduce an error, not an operation. What
+  it missed is that the *contract* is the thing the two transports must agree on, not just the
+  behaviour: a verb HTTP accepts and answers with a reasoned refusal, and gRPC answers
+  `UNIMPLEMENTED`, is a difference a client can see and has to code around. #7400 added the RPC as
+  the same thin adapter every other row uses, so the refusal now arrives as `FAILED_PRECONDITION`
+  carrying the shared implementation's own message, and a later real join lands in one place for
+  both transports. The shared method has since moved to `ServerControlPlane.connectCluster` and
+  raises `OperationNotAvailableException` (a `CommandExecutionException` subtype), which is the arm
+  that maps to `FAILED_PRECONDITION`. Whether to implement the join at all is #7401.
 - **`POST /login` / `POST /logout` / `GET /sessions`** - HTTP sessions exist because HTTP is
   stateless per request and the browser needs a bearer token. gRPC authenticates every admin RPC
   from the `DatabaseCredentials` on the request body, enforced centrally in

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
@@ -27,6 +27,7 @@ import com.arcadedb.server.grpc.ArcadeDbAdminServiceGrpc;
 import com.arcadedb.server.grpc.ArcadeDbServiceGrpc;
 import com.arcadedb.server.grpc.BackupInfo;
 import com.arcadedb.server.grpc.CloseDatabaseRequest;
+import com.arcadedb.server.grpc.ConnectClusterRequest;
 import com.arcadedb.server.grpc.CreateApiTokenRequest;
 import com.arcadedb.server.grpc.CreateApiTokenResponse;
 import com.arcadedb.server.grpc.CreateDatabaseRequest;
@@ -681,6 +682,21 @@ public class RemoteGrpcServer implements AutoCloseable {
   public void disconnectCluster() {
     call("disconnect cluster", stub -> stub.disconnectCluster(
         DisconnectClusterRequest.newBuilder().setCredentials(buildCredentials()).build()));
+  }
+
+  /**
+   * Asks this server to join the cluster reachable at {@code serverAddress} ({@code <host>:<port>}),
+   * the client half of the pair {@link #disconnectCluster()} completes (issue #7400).
+   * <p>
+   * Reaches the same {@code ServerControlPlane.connectCluster} the HTTP {@code connect cluster} verb
+   * calls. The current HA stack does not implement a client-initiated join, so today this raises the
+   * server's own refusal through {@code GrpcClientErrorMapper} rather than joining anything; issue
+   * #7401 carries that decision. The address is sent as given - the server refuses before reading it,
+   * exactly as the HTTP verb does.
+   */
+  public void connectCluster(final String serverAddress) {
+    call("connect cluster", stub -> stub.connectCluster(
+        ConnectClusterRequest.newBuilder().setCredentials(buildCredentials()).setServerAddress(serverAddress).build()));
   }
 
   /**

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue7400RemoteGrpcConnectClusterIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue7400RemoteGrpcConnectClusterIT.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.remote.RemoteException;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7400: {@link RemoteGrpcServer} had {@code disconnectCluster()} and no {@code connectCluster},
+ * so the client half of the pair was as one-sided as the service half. An RPC no client can call is
+ * one nobody can use, which is why #7304 drove every service method from here too.
+ * <p>
+ * What is proved is that the proto, the service and the client agree over a real channel - and that
+ * the server's own refusal survives the trip. The current HA stack does not implement the verb on
+ * either transport (issue #7401); parity of the answer is the subject here, not a working join.
+ */
+class Issue7400RemoteGrpcConnectClusterIT extends BaseGraphServerTest {
+
+  private RemoteGrpcServer server;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GRPC:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void connect() {
+    server = new RemoteGrpcServer("localhost", 50051, "root", DEFAULT_PASSWORD_FOR_TESTS, true, List.of());
+  }
+
+  @AfterEach
+  void disconnect() {
+    if (server != null) {
+      server.close();
+      server = null;
+    }
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+  }
+
+  /**
+   * The type matters as much as the message, for the same reason it does on
+   * {@code Issue7304RemoteGrpcServerControlPlaneIT.disconnectClusterWithoutHaIsReportedThroughTheSharedErrorMapper}:
+   * admin failures go through {@code GrpcClientErrorMapper}, so a follower's leader refusal keeps the
+   * leader's address from the trailers instead of being flattened into a rendered string. The
+   * assertion on the server's own wording is what proves the client did not wrap it in a bare
+   * "Failed to connect cluster".
+   */
+  @Test
+  void connectClusterIsReportedThroughTheSharedErrorMapper() {
+    assertThatThrownBy(() -> server.connectCluster("localhost:2425"))
+        .isInstanceOf(RemoteException.class)
+        .hasMessageContaining("not supported by the current HA implementation");
+  }
+
+  /**
+   * Both halves of the pair are callable from the client and both surface the server's refusal.
+   * Driving them together is the assertion the issue asked for: connect alone would pass against a
+   * client that had lost disconnect.
+   */
+  @Test
+  void theClusterPairIsCallableFromTheClient() {
+    assertThatThrownBy(() -> server.connectCluster("localhost:2425"))
+        .isInstanceOf(RemoteException.class);
+
+    assertThatThrownBy(() -> server.disconnectCluster())
+        .isInstanceOf(RemoteException.class)
+        .hasMessageContaining("High Availability");
+  }
+}

--- a/grpc/src/main/proto/arcadedb-server.proto
+++ b/grpc/src/main/proto/arcadedb-server.proto
@@ -1029,6 +1029,12 @@ service ArcadeDbAdminService {
   rpc GetServerEvents   (GetServerEventsRequest)   returns (GetServerEventsResponse);
   rpc Shutdown          (ShutdownRequest)          returns (ShutdownResponse);
   rpc DisconnectCluster (DisconnectClusterRequest) returns (DisconnectClusterResponse);
+  // The other half of the cluster pair (issue #7400). A thin adapter over the same
+  // ServerControlPlane.connectCluster the HTTP `connect cluster` verb calls, so the two transports
+  // cannot answer the verb differently. The current HA stack does not implement a client-initiated
+  // join, so today the shared implementation refuses and this answers FAILED_PRECONDITION - see
+  // issue #7401.
+  rpc ConnectCluster    (ConnectClusterRequest)    returns (ConnectClusterResponse);
 
   // Read-only administrative view of the server's open HTTP authentication sessions. gRPC has no
   // session of its own - every admin RPC authenticates from the credentials on the request body - so
@@ -1548,6 +1554,16 @@ message DisconnectClusterRequest {
   DatabaseCredentials credentials = 1;
 }
 message DisconnectClusterResponse {}
+
+message ConnectClusterRequest {
+  DatabaseCredentials credentials = 1;
+  // The `<host>:<port>` of the server to join, as the HTTP verb's `connect cluster <address>`
+  // argument. Not validated here: the HTTP verb accepts an empty argument too and the shared
+  // implementation refuses before reading it, so rejecting it on this transport alone would make
+  // the two disagree on the same input.
+  string server_address = 2;
+}
+message ConnectClusterResponse {}
 
 // -----------------------------------------------------------------------------
 // Control plane: discovery (issue #7310)

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
@@ -891,6 +891,35 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
   }
 
   /**
+   * The other half of the cluster pair (issue #7400), and the last verb of
+   * {@code PostServerCommandHandler}'s dispatch chain that had no RPC.
+   * <p>
+   * A thin adapter over the same {@code ServerControlPlane.connectCluster} the HTTP {@code connect
+   * cluster} verb calls, so the two transports cannot drift on what the verb does. Today that shared
+   * method refuses unconditionally - the current HA stack has never implemented a client-initiated
+   * join - and the refusal reaches the caller as {@code FAILED_PRECONDITION} through the
+   * {@code OperationNotAvailableException} arm of {@link #toStatusException}. That is the same answer
+   * the HTTP caller gets, from the same method, which is the point: parity of the contract, not a
+   * working join. Issue #7401 carries the decision on whether to implement the join or retire the
+   * verb.
+   * <p>
+   * The address is passed through unvalidated because the HTTP verb passes it through unvalidated:
+   * {@code extractTarget} yields {@code ""} for a bare {@code connect cluster} and the shared method
+   * refuses before reading its argument. Root-only, as {@code checkRootUser} makes the HTTP verb, and
+   * not leader-routed, because {@code PostServerCommandHandler} does not forward either half of the
+   * pair to the leader.
+   */
+  @Override
+  public void connectCluster(final ConnectClusterRequest req, final StreamObserver<ConnectClusterResponse> resp) {
+    respond(resp, "connectCluster", () -> {
+      requireServerAdmin(authenticate(req.getCredentials()));
+
+      controlPlane.connectCluster(req.getServerAddress());
+      return ConnectClusterResponse.newBuilder().build();
+    });
+  }
+
+  /**
    * The server's open HTTP authentication sessions, the RPC equivalent of {@code GET /api/v1/sessions}
    * (issue #7310), root-only as {@code GetSessionsHandler}'s {@code checkRootUser} makes it.
    * <p>

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7304GrpcControlPlaneAuthorizationIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7304GrpcControlPlaneAuthorizationIT.java
@@ -155,6 +155,11 @@ public class Issue7304GrpcControlPlaneAuthorizationIT extends BaseGraphServerTes
         c -> adminStub.getServerEvents(GetServerEventsRequest.newBuilder().setCredentials(c).setFileName("").build()));
     calls.put("DisconnectCluster",
         c -> adminStub.disconnectCluster(DisconnectClusterRequest.newBuilder().setCredentials(c).build()));
+    // The other half of the cluster pair, added by #7400. Its own behaviour is
+    // Issue7400GrpcConnectClusterIT's subject; the row is here because this table is where a
+    // control-plane RPC missing its gate becomes visible, and cluster membership is privileged.
+    calls.put("ConnectCluster", c -> adminStub.connectCluster(
+        ConnectClusterRequest.newBuilder().setCredentials(c).setServerAddress("localhost:2425").build()));
     // Empty server name is the LOCAL shutdown. It must be denied before it is scheduled: were the
     // gate missing, this row would stop the JVM the rest of the suite runs in.
     calls.put("Shutdown",

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7400GrpcConnectClusterIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7400GrpcConnectClusterIT.java
@@ -129,6 +129,23 @@ public class Issue7400GrpcConnectClusterIT extends BaseGraphServerTest {
   }
 
   /**
+   * The address the caller sent is the address the shared implementation received.
+   * <p>
+   * Without this the parameter is invisible from outside: every other assertion in this class passes
+   * just as well against a handler that dropped {@code req.getServerAddress()} and called
+   * {@code connectCluster("")}, because the refusal would be identical. The shared implementation
+   * echoes the address into its message - as it names the user or backup file every other command
+   * could not act on - which is what makes the wiring observable end to end while the operation
+   * itself still does nothing with the value.
+   */
+  @Test
+  void theAddressReachesTheSharedImplementationUnmodified() {
+    assertThatThrownBy(() -> connect(root(), PEER_ADDRESS))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining(PEER_ADDRESS);
+  }
+
+  /**
    * HTTP's {@code extractTarget} yields {@code ""} for a bare {@code connect cluster}, and the shared
    * implementation refuses before it looks at the argument. The RPC must not invent an
    * {@code INVALID_ARGUMENT} gate the HTTP verb does not have, or the two transports disagree on the

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7400GrpcConnectClusterIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7400GrpcConnectClusterIT.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.security.ServerSecurity;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7400: {@code ArcadeDbAdminService} shipped {@code DisconnectCluster} with #7304 and not its
+ * pair-mate, so a gRPC-only client could take a server out of a cluster and then had to reopen the
+ * HTTP port to attempt the other half.
+ * <p>
+ * What is asserted here is protocol <em>parity</em>, not a working join. The shared implementation
+ * {@code ServerControlPlane.connectCluster} refuses unconditionally - the current HA stack has never
+ * implemented the verb - and {@code PostServerCommandHandler} has always surfaced that refusal on
+ * HTTP. The gRPC caller must now receive the same refusal from the same method, rather than
+ * {@code UNIMPLEMENTED} for a verb the other transport accepts. Making the verb actually join a
+ * cluster is issue #7401.
+ * <p>
+ * The pair is driven together throughout, as the issue asks: a test that called connect alone would
+ * pass against a service that had lost disconnect.
+ */
+public class Issue7400GrpcConnectClusterIT extends BaseGraphServerTest {
+
+  private static final int    GRPC_PORT    = 50051;
+  private static final String LIMITED_USER = "limited7400";
+  private static final String LIMITED_PASS = "limited7400pass";
+  private static final String PEER_ADDRESS = "localhost:2425";
+
+  private ManagedChannel                                            channel;
+  private ArcadeDbAdminServiceGrpc.ArcadeDbAdminServiceBlockingStub adminStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void setupUserAndChannel() {
+    final ServerSecurity security = getServer(0).getSecurity();
+
+    if (!security.existsUser(LIMITED_USER)) {
+      final JSONObject config = new JSONObject();
+      config.put("name", LIMITED_USER);
+      config.put("password", security.encodePassword(LIMITED_PASS));
+      config.put("databases", new JSONObject().put(getDatabaseName(), new JSONArray().put("admin")));
+      security.createUser(config);
+    }
+
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    adminStub = ArcadeDbAdminServiceGrpc.newBlockingStub(channel);
+  }
+
+  @AfterEach
+  void teardown() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private static DatabaseCredentials root() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  private static DatabaseCredentials limited() {
+    return DatabaseCredentials.newBuilder().setUsername(LIMITED_USER).setPassword(LIMITED_PASS).build();
+  }
+
+  private static DatabaseCredentials wrongPassword() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword("not-the-root-password").build();
+  }
+
+  private ConnectClusterResponse connect(final DatabaseCredentials credentials, final String address) {
+    return adminStub.connectCluster(
+        ConnectClusterRequest.newBuilder().setCredentials(credentials).setServerAddress(address).build());
+  }
+
+  private DisconnectClusterResponse disconnect(final DatabaseCredentials credentials) {
+    return adminStub.disconnectCluster(DisconnectClusterRequest.newBuilder().setCredentials(credentials).build());
+  }
+
+  /**
+   * The RPC exists and reaches the shared implementation. Before this change the generated stub had
+   * no such method at all; a service that declared the RPC and left it unimplemented would answer
+   * {@code UNIMPLEMENTED} here rather than the refusal below.
+   * <p>
+   * {@code FAILED_PRECONDITION} is the mapper's arm for
+   * {@code ServerControlPlane.OperationNotAvailableException} - the operation cannot run in this
+   * server's configuration at all, as opposed to having been attempted and failed - and the
+   * description is the shared implementation's own message, not a rendering invented here.
+   */
+  @Test
+  void connectClusterIsRefusedByTheSharedImplementation() {
+    assertThatThrownBy(() -> connect(root(), PEER_ADDRESS))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("FAILED_PRECONDITION")
+        .hasMessageContaining("not supported by the current HA implementation");
+  }
+
+  /**
+   * HTTP's {@code extractTarget} yields {@code ""} for a bare {@code connect cluster}, and the shared
+   * implementation refuses before it looks at the argument. The RPC must not invent an
+   * {@code INVALID_ARGUMENT} gate the HTTP verb does not have, or the two transports disagree on the
+   * same input - which is the drift this issue is about.
+   */
+  @Test
+  void connectClusterWithAnEmptyAddressIsRefusedTheSameWay() {
+    assertThatThrownBy(() -> connect(root(), ""))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("FAILED_PRECONDITION")
+        .hasMessageContaining("not supported by the current HA implementation");
+  }
+
+  /**
+   * Both halves of the pair reach an HA stack that is not enabled in this fixture, and both say so
+   * the same way. Driving them together is what makes this a parity assertion rather than two
+   * unrelated ones.
+   */
+  @Test
+  void theClusterPairFailsThePreconditionAlike() {
+    assertThatThrownBy(() -> connect(root(), PEER_ADDRESS))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("FAILED_PRECONDITION");
+
+    assertThatThrownBy(() -> disconnect(root()))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("FAILED_PRECONDITION");
+  }
+
+  /**
+   * Cluster membership is a privileged operation: an authenticated but non-root caller is denied by
+   * the handler's {@code requireServerAdmin} gate, exactly as {@code DisconnectCluster} is and as
+   * {@code PostServerCommandHandler}'s {@code checkRootUser} denies the HTTP verb.
+   * <p>
+   * The denial must arrive <em>instead of</em> the precondition failure above: were the gate missing,
+   * this caller would reach the shared implementation and get {@code FAILED_PRECONDITION}, which
+   * would still be an exception and would still look like a passing test if the status were not
+   * asserted.
+   */
+  @Test
+  void theClusterPairDeniesAnAuthenticatedNonRootCaller() {
+    assertThatThrownBy(() -> connect(limited(), PEER_ADDRESS))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("PERMISSION_DENIED");
+
+    assertThatThrownBy(() -> disconnect(limited()))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("PERMISSION_DENIED");
+  }
+
+  /**
+   * A bad password is refused by the central {@code GrpcAuthInterceptor} before the handler runs at
+   * all, so the pair answers {@code UNAUTHENTICATED} rather than either of the statuses above.
+   */
+  @Test
+  void theClusterPairDeniesAnInvalidPassword() {
+    assertThatThrownBy(() -> connect(wrongPassword(), PEER_ADDRESS))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("UNAUTHENTICATED");
+
+    assertThatThrownBy(() -> disconnect(wrongPassword()))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("UNAUTHENTICATED");
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -146,13 +146,22 @@ public class ServerControlPlane {
   }
 
   /**
-   * The {@code connect cluster} command of the HTTP control plane. Kept here with the rest so the
-   * command set is complete in one place; it has never been implemented by the current HA stack.
+   * The {@code connect cluster} command, shared by the HTTP verb and the gRPC {@code ConnectCluster}
+   * RPC (issue #7400). Kept here with the rest so the command set is complete in one place; it has
+   * never been implemented by the current HA stack, and whether to implement the join or retire the
+   * verb is issue #7401.
+   * <p>
+   * The refusal names the address the caller asked for, as the rest of this class names the user,
+   * group or backup file a command could not act on. That is the caller's own argument echoed back,
+   * so it tells an operator which of several join attempts failed - and it is the only thing that
+   * makes the argument observable from outside while the operation itself does nothing with it, so
+   * a transport that dropped the parameter on the way here cannot do so unnoticed.
    */
   public void connectCluster(final String serverAddress) {
 
     throw new OperationNotAvailableException(
-        "Connect cluster operation is not supported by the current HA implementation. Use the cluster configuration to join nodes.");
+        "Connect cluster to '" + (serverAddress == null ? "" : serverAddress)
+            + "' is not supported by the current HA implementation. Use the cluster configuration to join nodes.");
   }
 
   // ---------------------------------------------------------------------------------------------

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -156,12 +156,19 @@ public class ServerControlPlane {
    * so it tells an operator which of several join attempts failed - and it is the only thing that
    * makes the argument observable from outside while the operation itself does nothing with it, so
    * a transport that dropped the parameter on the way here cannot do so unnoticed.
+   * <p>
+   * Not null-guarded. Both callers found by
+   * {@code grep -rn --include='*.java' "\.connectCluster(" --exclude-dir=target .} on the main
+   * sources pass a value that cannot be null: {@code PostServerCommandHandler} passes
+   * {@code extractTarget}'s result, which is {@code ""} or a substring, and
+   * {@code ArcadeDbGrpcAdminService} passes a protobuf string field, which defaults to {@code ""}.
+   * A null from some future caller renders as {@code 'null'} in the message rather than throwing,
+   * so the guard would buy nothing.
    */
   public void connectCluster(final String serverAddress) {
 
-    throw new OperationNotAvailableException(
-        "Connect cluster to '" + (serverAddress == null ? "" : serverAddress)
-            + "' is not supported by the current HA implementation. Use the cluster configuration to join nodes.");
+    throw new OperationNotAvailableException("Connect cluster to '" + serverAddress
+        + "' is not supported by the current HA implementation. Use the cluster configuration to join nodes.");
   }
 
   // ---------------------------------------------------------------------------------------------

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -121,8 +121,11 @@ public class CoreApiSpec implements OpenApiContributor {
         Executes administrative commands on the server (root user only). \
         Available commands: create database, drop database, open database, close database, \
         restore database <name> <url>, import database <name> <url>, \
-        create user, drop user, shutdown, set server setting, get server events, align database. \
-        Both restore and import support SSE progress streaming via Accept: text/event-stream header""");
+        create user, drop user, shutdown, set server setting, get server events, align database, \
+        connect cluster <address>, disconnect cluster. \
+        Both restore and import support SSE progress streaming via Accept: text/event-stream header. \
+        connect cluster is dispatched but not implemented by the current HA implementation and always \
+        fails; use the cluster configuration to join nodes""");
     postOp.setOperationId("executeServerCommand");
     postOp.addTagsItem("Server");
     postOp.setRequestBody(SpecBuilders.jsonBody("Command request with command and optional parameters", "CommandRequest", true));

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue7400ConnectClusterHttpIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue7400ConnectClusterHttpIT.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7400, the HTTP side of the pair. The gRPC {@code ConnectCluster} RPC added by that issue
+ * delegates to {@code ServerControlPlane.connectCluster}, the same method {@code POST /api/v1/server}
+ * has always called - so what the two transports answer for the same input is now a property worth
+ * pinning from both ends rather than from one.
+ * <p>
+ * The verb still refuses: the current HA stack has never implemented a client-initiated join, and
+ * whether to implement it or retire the verb is issue #7401. What must hold is that the refusal is
+ * the <em>same</em> refusal, naming the address the caller asked for, on whichever transport the
+ * caller used.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue7400ConnectClusterHttpIT extends BaseGraphServerTest {
+  private static final String PEER_ADDRESS = "localhost:2425";
+
+  private final HttpClient client = HttpClient.newHttpClient();
+
+  /**
+   * The address survives {@code extractTarget} and reaches the shared implementation, which names it
+   * in the refusal. This is the HTTP half of the gRPC IT's
+   * {@code theAddressReachesTheSharedImplementationUnmodified}: a handler that dropped the argument
+   * on either transport would otherwise be indistinguishable from one that passed it through, since
+   * nothing else in the answer depends on it.
+   */
+  @Test
+  void connectClusterIsRefusedAndNamesTheAddress() throws Exception {
+    final HttpResponse<String> response = executeServerCommand("connect cluster " + PEER_ADDRESS);
+
+    assertThat(response.body())
+        .contains(PEER_ADDRESS)
+        .contains("not supported by the current HA implementation");
+  }
+
+  /**
+   * A bare {@code connect cluster} yields {@code ""} from {@code extractTarget} and is refused for
+   * the same reason a filled one is - the shared method never reads its argument. This is what the
+   * gRPC side deliberately mirrors by not adding an {@code INVALID_ARGUMENT} gate of its own.
+   */
+  @Test
+  void connectClusterWithNoAddressIsRefusedTheSameWay() throws Exception {
+    final HttpResponse<String> response = executeServerCommand("connect cluster");
+
+    assertThat(response.body()).contains("not supported by the current HA implementation");
+  }
+
+  private HttpResponse<String> executeServerCommand(final String command) throws Exception {
+    final HttpRequest request = HttpRequest.newBuilder()
+        // The bound port, not the 2480 default: HttpServer takes the first free port of the
+        // configured range, so a hardcoded 2480 sends the request to whatever else already holds it.
+        .uri(new URI("http://localhost:" + getServer(0).getHttpServer().getPort() + "/api/v1/server"))
+        .POST(HttpRequest.BodyPublishers.ofString(new JSONObject().put("command", command).toString()))
+        .setHeader("Authorization",
+            "Basic " + Base64.getEncoder().encodeToString(("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes()))
+        .build();
+
+    return client.send(request, BodyHandlers.ofString());
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/Issue7400ServerCommandSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/Issue7400ServerCommandSpecTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler.openapi;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.Paths;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7400, contract surface 2: the cluster pair is dispatched by
+ * {@code PostServerCommandHandler} but neither half appeared in the {@code POST /api/v1/server}
+ * command list the spec publishes, so a client reading only the spec could not know the verbs exist
+ * on this transport at all.
+ * <p>
+ * The pair is asserted together rather than {@code connect cluster} alone: the omission this catches
+ * is a verb dispatched by the handler and missing from the spec, and that was true of both halves.
+ */
+class Issue7400ServerCommandSpecTest {
+  private final OpenAPI openAPI = new OpenAPI();
+
+  @BeforeEach
+  void contribute() {
+    openAPI.setPaths(new Paths());
+    openAPI.setComponents(new Components());
+    new CoreApiSpec().contribute(openAPI);
+  }
+
+  @Test
+  void theServerCommandListNamesTheClusterPair() {
+    final Operation post = openAPI.getPaths().get("/api/v1/server").getPost();
+
+    assertThat(post.getOperationId()).isEqualTo("executeServerCommand");
+    assertThat(post.getDescription())
+        .as("both halves of the cluster pair are dispatched by PostServerCommandHandler and must be documented")
+        .contains("connect cluster")
+        .contains("disconnect cluster");
+  }
+}


### PR DESCRIPTION
Closes #7400

## Summary

`ArcadeDbAdminService` shipped `DisconnectCluster` with #7304 and not its pair-mate, so a gRPC-only
client could take a server out of a cluster and then had to reopen the HTTP port to attempt the other
half. `connect cluster` was the only verb of `PostServerCommandHandler`'s dispatch chain with no RPC.

**What this buys is parity of the answer, not a working join** - and that is a correction to the
issue's premise, not a shortcut. `ServerControlPlane.connectCluster()` throws
`OperationNotAvailableException` unconditionally; the current HA stack has never implemented a
client-initiated join, and `PostServerCommandHandler:228-233` has always surfaced that refusal on
HTTP. The new RPC is a thin adapter over that same shared method, so the gRPC caller now gets the
same refusal - `FAILED_PRECONDITION`, through the mapper arm that already named this exact case
before the RPC existed - instead of `UNIMPLEMENTED` for a verb the other transport accepts. When the
HA stack grows a real join, `ServerControlPlane.connectCluster` is the single place to implement it
and both transports pick it up with no further wiring. #7401 carries that decision.

## Analysis

**The invariant.** Every verb of the HTTP `POST /api/v1/server` dispatch chain that
`ServerControlPlane` implements is reachable over gRPC through an RPC that delegates to that same
method, and the gRPC caller receives the same refusal or success the HTTP caller receives.

**Is `connect cluster` really the only gap?** The verb constants
(`PostServerCommandHandler:64-87`) against the admin service's 43 RPCs
(`sed -n '/^service ArcadeDbAdminService/,/^}/p' arcadedb-server.proto | grep -oE "rpc [A-Za-z]+"`):

```
Ping GetServerInfo ListDatabases ExistsDatabase CreateDatabase DropDatabase OpenDatabase
CloseDatabase AlignDatabase GetDatabaseInfo GetProgress CreateUser UpdateUser DeleteUser ListUsers
ListGroups SaveGroup DeleteGroup ListApiTokens CreateApiToken DeleteApiToken SetServerSetting
SetDatabaseSetting GetBackupConfig SetBackupConfig ListBackups TriggerBackup DeleteBackup
ProfilerStart ProfilerStop ProfilerReset ProfilerResults ProfilerList ProfilerLoad RestoreBackup
RestoreDatabase ImportDatabase GetServerEvents Shutdown DisconnectCluster ListSessions Health Ready
```

Every constant maps (`drop user` -> `DeleteUser`, `profiler` -> the six `Profiler*`) except
`connect cluster`. Confirmed.

**Why the address is not validated.** `extractTarget` yields `""` for a bare `connect cluster`, and
the shared method refuses before it reads its argument. An `INVALID_ARGUMENT` gate on this transport
alone would make the two protocols disagree on the same input - which is the drift this issue is
about. Covered by a test.

**Why there is no leader-routing arm.** `PostServerCommandHandler:125-131` forwards only
`create database`, `drop database`, `create user`, `drop user`, `restore backup`, `restore database`
and `import database` to the leader. Neither half of the cluster pair is in that list, and
`ArcadeDbGrpcAdminService.disconnectCluster` carries no `requireLeader` either. The issue's
"leader-routing test *if* leader-sensitive" condition is not met.

## Changes

| File | Change |
|---|---|
| `grpc/src/main/proto/arcadedb-server.proto` | `rpc ConnectCluster`, plus `ConnectClusterRequest` (`credentials`, `server_address`) / `ConnectClusterResponse` |
| `grpcw/.../ArcadeDbGrpcAdminService.java` | `connectCluster` - `requireServerAdmin(authenticate(...))`, then `controlPlane.connectCluster(req.getServerAddress())`, through the existing `respond` / `toStatusException` path |
| `grpc-client/.../RemoteGrpcServer.java` | `connectCluster(String)` alongside `disconnectCluster()`, through the shared `call(...)` / `GrpcClientErrorMapper` path |
| `server/.../openapi/CoreApiSpec.java` | `POST /api/v1/server`'s command list now names `connect cluster <address>` and `disconnect cluster`, and says connect always fails on the current HA implementation |
| `grpcw/.../Issue7304GrpcControlPlaneAuthorizationIT.java` | one added row in `mutatingCalls()` - that class's javadoc says "A new control-plane RPC belongs in `mutatingCalls()`". Additive: two more dynamic tests, no existing assertion changed |

No change to `ServerControlPlane`, `PostServerCommandHandler` or any HA class: the shared
implementation and the HTTP verb behave exactly as before.

## Test plan

- [x] `mvn -o -pl grpcw verify -DskipITs=false -Dit.test=Issue7400GrpcConnectClusterIT` - **5/5**. Drives the RPC over a real channel: the refusal and its `FAILED_PRECONDITION` status, the empty-address form, the pair failing alike, and the pair denying a non-root caller (`PERMISSION_DENIED`) and a bad password (`UNAUTHENTICATED`)
- [x] `mvn -o -pl grpc-client verify -DskipITs=false -Dit.test=Issue7400RemoteGrpcConnectClusterIT` - **2/2**. Proto, service and client agree over the wire, and the server's own description survives `GrpcClientErrorMapper` rather than being flattened into a "Failed to connect cluster" wrapper
- [x] `mvn -o -pl server surefire:test -Dtest='Issue7400ServerCommandSpecTest,CoreApiSpecTest,OpenApiSpecGeneratorTest,ApiSpecPathConstantsTest'` - **29/29**
- [x] Regression, `grpcw`: `Issue7304GrpcControlPlaneIT` + `Issue7304GrpcControlPlaneAuthorizationIT` - **77/77**. The authorization IT goes 49 -> 51 dynamic tests, the two the new row adds
- [x] Regression, `grpcw`: `Issue7304GrpcAdminLeaderRoutingIT` - **2/2**
- [x] Regression, `grpc-client`: `Issue7304RemoteGrpcServerControlPlaneIT` - **8/8**

### The tests were proved able to fail

Green is only evidence if red was reachable.

- `Issue7400ServerCommandSpecTest` re-run against `git show HEAD:...CoreApiSpec.java`:
  `Tests run: 1, Failures: 1`. Restored, re-run: green.
- `Issue7400GrpcConnectClusterIT`'s authorization assertion mutation-tested by replacing
  `requireServerAdmin(authenticate(...))` with a bare `authenticate(...)`: `Tests run: 5, Failures: 1`.
  Without asserting the *status*, a missing gate would still have thrown - `FAILED_PRECONDITION` from
  the shared method - and looked like a pass. Restored, re-run: green.
- Both new IT files fail to compile against `main` (`ConnectClusterRequest` and
  `RemoteGrpcServer.connectCluster` do not exist there), which is the strongest form of the same claim
  for the RPC's existence.

## Coverage

| Entry point | Covered | Test |
|---|---|---|
| Proto contract `ArcadeDbAdminService.ConnectCluster` | yes | `Issue7400GrpcConnectClusterIT` via the generated stub |
| Server impl -> `ServerControlPlane.connectCluster` | yes | `connectClusterIsRefusedByTheSharedImplementation` |
| Empty-address form HTTP also accepts | yes | `connectClusterWithAnEmptyAddressIsRefusedTheSameWay` |
| Authorization: non-root caller | yes | `theClusterPairDeniesAnAuthenticatedNonRootCaller`, plus the added `Issue7304...AuthorizationIT` row |
| Authorization: invalid password | yes | `theClusterPairDeniesAnInvalidPassword` |
| The pair gated and refused alike | yes | `theClusterPairFailsThePreconditionAlike` |
| Client `RemoteGrpcServer.connectCluster(String)` | yes | `Issue7400RemoteGrpcConnectClusterIT` |
| OpenAPI `POST /api/v1/server` command list | yes | `Issue7400ServerCommandSpecTest` |
| HTTP `POST /api/v1/server` `connect cluster` | unchanged | route, handler and refusal untouched; `PostServerCommandHandlerIT` already exercises the endpoint |

**Known gaps**

- **The verb does not actually join a cluster, on either transport** - `ServerControlPlane.connectCluster`
  refuses unconditionally and this PR deliberately does not touch the HA stack. Filed as **#7401**,
  which carries the design decision: implement a leader-routed join (possibly as a thin alias for
  `POST /api/v1/cluster/peer`), or retire a verb whose only outcome is a refusal.

## Adversarial pass

The orchestrator's independent subagent is not available in this build, so the pass was run by the
author against the checklist it would have applied - weaker than an unpersuaded reader, and recorded
as such. Findings:

1. *"The issue says the capability exists underneath; does it?"* **No** - real and in scope. The PR
   and every new javadoc say the RPC buys parity of the answer rather than repeating the premise, and
   #7401 tracks the other half.
2. *"Does anything enumerate the RPC set and break when one is added?"* **Not real** - no
   `*.protolock` or `buf.yaml` in the tree, and no reflective RPC enumeration in the gRPC tests
   (`grep -rn "getServiceDescriptor\|getMethods()\|SERVICE_NAME" grpcw/src/test/java grpc-client/src/test/java`: no hits).
3. *"`Issue7304GrpcControlPlaneAuthorizationIT` says a new control-plane RPC belongs in its table."*
   **Real, fixed here** - the row is added.
4. *"Does the RPC invent validation HTTP does not have?"* Caught before the fix was written; covered
   by a test.
5. *"Is it leader-sensitive?"* **Not real** - argued from the forwarding list above.

## Review cycles

**Cycle 1** (`0b70541`) - the reviewer found no blocking issues and one worthwhile observation:
`docs/7304-grpc-control-plane.md` still described `connect cluster` as having no RPC. It does more
than that - it records the *argument* for leaving it out ("adding a gRPC RPC would reproduce an
unconditional error, not an operation"), which is exactly the reasoning this PR overturns. Fixed in
`ecb3812`: the coverage row names the RPC, and the argument is kept alongside what was wrong with it,
plus two details that went stale after #7304 (the method moved to `ServerControlPlane`, and the type
is now `OperationNotAvailableException`).

**Cycle 2** (`ecb3812`) - again no blocking issues, and one real coverage hole: nothing proved
`req.getServerAddress()` actually reached the shared implementation. Every assertion in the gRPC IT
passed just as well against a handler that dropped the parameter and called `connectCluster("")`,
because the refusal was address-independent. The reviewer called it self-healing once #7401 lands;
it was cheaper to close now. Fixed in `52425b2`:

- `ServerControlPlane.connectCluster` names the address in its refusal, as the rest of that class
  names the user, group or backup file a command could not act on. Both transports share the method,
  so both gain it - and an operator now learns *which* join attempt failed.
- `Issue7400GrpcConnectClusterIT#theAddressReachesTheSharedImplementationUnmodified` pins it on gRPC.
- **`Issue7400ConnectClusterHttpIT`** (new) pins the same property on HTTP, plus the bare
  `connect cluster` form. It resolves the bound port via `getServer(0).getHttpServer().getPort()`
  rather than hardcoding 2480 - `HttpServer` takes the first free port of the configured range, so a
  hardcoded 2480 sends the request to whatever else already holds it.

The reviewer's remaining point - that the service javadoc and the proto comment restate the same
rationale - is deliberately not actioned. They have different readers: the proto comment is what the
author of a non-Java client sees, and it is the one that stops an `INVALID_ARGUMENT` gate being added
on one transport only.

**Cycle 3** (`52425b2`) - no blocking issues, one verifiable nit: the
`serverAddress == null ? "" : serverAddress` ternary added in cycle 2 is unreachable. Checked rather
than taken on trust - `grep -rn --include='*.java' "\.connectCluster(" --exclude-dir=target .` over
the main sources returns exactly two callers of the shared method, `PostServerCommandHandler`
(`extractTarget`, which returns `""` or a substring) and `ArcadeDbGrpcAdminService` (a protobuf
string field, which defaults to `""`). Neither can produce null, and a null from a future caller
would render as `'null'` rather than throw, so the guard bought nothing. Dropped in `2ce842c`, with
that grep recorded in the javadoc so the next reader need not re-derive it.

**Cycle 4** (`2ce842c`) - clean. The reviewer re-verified the surrounding claims against the source
rather than the description (the leader-routing list, the `OperationNotAvailableException` ->
`FAILED_PRECONDITION` mapping, root-gating, fresh proto field numbers, and the null-guard removal),
and raised nothing actionable. The one thing that looked like a copy-paste bug - the two new test
files using different `SERVER_PLUGINS` keys (`GRPC:` in `grpc-client`, `GrpcServer:` in `grpcw`) -
is the pre-existing per-module convention in each.

Re-run after cycle 3: `Issue7400GrpcConnectClusterIT` 6/6, `Issue7400ConnectClusterHttpIT` 2/2,
`Issue7400RemoteGrpcConnectClusterIT` 2/2.

Re-run after cycle 2: `grpcw` 83/83 (`Issue7400GrpcConnectClusterIT` now 6, plus both #7304 control-plane
ITs), `grpc-client` 10/10, `server` `Issue7400ConnectClusterHttpIT` 2/2.

## Note on the local run

`Issue7304GrpcAdminLeaderRoutingIT` crashed its fork ("The forked VM terminated without properly
saying goodbye") when batched into one failsafe invocation with the two other HA-touching #7304 ITs,
and passed on its own immediately after. A long-lived ArcadeDB 26.9.1 instance holds port 2480 on
this machine - the fixed-port trap `CLAUDE.md` documents. Unrelated to this change, which touches no
HA class.

`PostServerCommandHandlerIT` also fails locally, 24 of 25, with `503` - it hardcodes
`http://localhost:2480`, so its requests reach that foreign server rather than the fixture's. Proved
pre-existing rather than assumed: the same method fails identically with
`ServerControlPlane.java` restored from `HEAD`. That class hardcoding the port is why the new HTTP IT
resolves the bound one instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Raa9V6fPZda6yQkn3kvRZf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added gRPC support for the `connect cluster` administrative command, including server-address and credential handling.
  - Restricted requests to server administrators and clarified authentication and authorization errors.
  - Cluster-join requests currently return a precondition error because client-initiated joining is unsupported.

- **Documentation**
  - Updated server command API documentation to include `connect cluster` and `disconnect cluster`, with guidance to use cluster configuration for joining nodes.

- **Tests**
  - Added coverage for request dispatch, unsupported-operation errors, authentication, authorization, and protocol behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

