### PR TITLE
fix(#7351): emit the read-your-writes bookmark before a streamed response commits

### DIFF
--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftStreamedQueryBookmarkIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftStreamedQueryBookmarkIT.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.remote.ReadConsistency;
+import com.arcadedb.remote.RemoteDatabase;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7351: a query answered with the NDJSON streaming encoding of issue #7306 has to carry the
+ * {@code X-ArcadeDB-Commit-Index} read-your-writes bookmark, exactly as the buffered encoding of the same
+ * query does.
+ * <p>
+ * The bookmark used to be emitted only by {@link com.arcadedb.server.http.handler.DatabaseAbstractHandler}
+ * <b>after</b> the handler body returned. On a streamed response the body has been written and the stream
+ * closed by then, so the response headers were serialized long before: the {@code put} landed on a header map
+ * nothing would read again, and the header simply never reached the client. A client that switched from
+ * {@code query()} to {@code queryStream()} silently stopped advancing its bookmark, and its next
+ * {@code READ_YOUR_WRITES} read could be served by a follower that had not applied the write it was reading
+ * after.
+ * <p>
+ * Both halves are asserted here, because either one alone would leave the client where it started: the server
+ * has to emit the header before the first byte, and the driver has to capture it off the streamed response.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("slow")
+class RaftStreamedQueryBookmarkIT extends BaseRaftHATest {
+
+  private static final String   TYPE_NAME    = "StreamBookmark";
+  private static final String   NDJSON       = "application/x-ndjson";
+  private static final String   BOOKMARK     = "X-ArcadeDB-Commit-Index";
+  private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(30);
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    config.setValue(GlobalConfiguration.HA_QUORUM, "majority");
+  }
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  /**
+   * The POST {@code /query} endpoint under {@code Accept: application/x-ndjson}. The comparison against the
+   * buffered answer to the same query is the point: a bookmark that is present but does not mean what the
+   * buffered one means would be worse than an absent one, because a client cannot tell.
+   */
+  @Test
+  void aStreamedQueryCarriesTheSameBookmarkTheBufferedOneDoes() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    httpCommand(leaderIndex, "CREATE DOCUMENT TYPE " + TYPE_NAME + " IF NOT EXISTS");
+    httpCommand(leaderIndex, "INSERT INTO " + TYPE_NAME + " SET id = 'v1'");
+    waitForAllServers();
+
+    final long buffered = bookmarkOf(sendBuffered(leaderIndex, "SELECT FROM " + TYPE_NAME));
+    assertThat(buffered)
+        .as("the buffered encoding must carry the bookmark, otherwise this test proves nothing about the "
+            + "streamed one")
+        .isGreaterThanOrEqualTo(0);
+
+    final HttpResponse<InputStream> streamed = sendStreamedPost(leaderIndex, "SELECT FROM " + TYPE_NAME);
+    assertThat(streamed.statusCode()).isEqualTo(200);
+    assertThat(streamed.headers().firstValue("content-type").orElse(""))
+        .as("the request has to actually have been streamed for the assertion below to mean anything")
+        .contains(NDJSON);
+
+    final long streamedBookmark = bookmarkOf(streamed);
+    assertThat(streamedBookmark)
+        .as("a streamed query response must carry the '%s' read-your-writes bookmark, exactly as the buffered "
+            + "response to the same query does", BOOKMARK)
+        .isGreaterThanOrEqualTo(buffered);
+
+    drain(streamed);
+  }
+
+  /**
+   * The GET {@code /query/{db}/{language}/{command}} endpoint streams through the same helper, and is the one a
+   * browser or curl reaches for, so it is asserted separately rather than assumed.
+   */
+  @Test
+  void aStreamedGetQueryCarriesTheBookmarkToo() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    httpCommand(leaderIndex, "CREATE DOCUMENT TYPE " + TYPE_NAME + "Get IF NOT EXISTS");
+    httpCommand(leaderIndex, "INSERT INTO " + TYPE_NAME + "Get SET id = 'g1'");
+    waitForAllServers();
+
+    final HttpResponse<InputStream> streamed = sendStreamedGet(leaderIndex, "SELECT FROM " + TYPE_NAME + "Get");
+    assertThat(streamed.statusCode()).isEqualTo(200);
+    assertThat(streamed.headers().firstValue("content-type").orElse("")).contains(NDJSON);
+
+    assertThat(bookmarkOf(streamed))
+        .as("the GET query endpoint streams through the same helper and must emit the bookmark as well")
+        .isGreaterThanOrEqualTo(0);
+
+    drain(streamed);
+  }
+
+  /**
+   * The end the issue is actually about: {@code RemoteDatabase.getLastCommitIndex()} must advance after a
+   * {@code queryStream} exactly as it does after a {@code query}, so a client that switches encodings keeps its
+   * read-your-writes barrier.
+   */
+  @Test
+  void queryStreamAdvancesTheDriverBookmarkLikeQueryDoes() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final String dbName = getDatabaseName();
+    final String password = BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS;
+
+    try (final RemoteDatabase client = new RemoteDatabase("127.0.0.1", httpPort(leaderIndex), dbName, "root",
+        password)) {
+      client.setReadConsistency(ReadConsistency.READ_YOUR_WRITES);
+
+      client.command("sql", "CREATE DOCUMENT TYPE " + TYPE_NAME + "Driver IF NOT EXISTS");
+      client.command("sql", "INSERT INTO " + TYPE_NAME + "Driver SET id = 'd1'");
+
+      final long afterWrite = client.getLastCommitIndex();
+      assertThat(afterWrite).as("the write must have produced a bookmark").isGreaterThanOrEqualTo(0);
+
+      // A second write, so the index the streamed read can report is strictly ahead of the one the driver
+      // already holds: an assertion against a bookmark that could not have moved would pass on a driver that
+      // ignores the header entirely.
+      client.command("sql", "INSERT INTO " + TYPE_NAME + "Driver SET id = 'd2'");
+      final long afterSecondWrite = client.getLastCommitIndex();
+      assertThat(afterSecondWrite).isGreaterThanOrEqualTo(afterWrite);
+
+      // Rewind the driver's own bookmark, which is the only way to tell "the streamed response advanced it"
+      // from "it was already there". updateLastCommitIndex() cannot do it: it folds with Math::max, precisely
+      // so a bookmark never goes backwards in normal use.
+      final var bookmarkField = RemoteDatabase.class.getDeclaredField("lastCommitIndex");
+      bookmarkField.setAccessible(true);
+      ((AtomicLong) bookmarkField.get(client)).set(-1L);
+      assertThat(client.getLastCommitIndex()).isEqualTo(-1);
+
+      try (final ResultSet rs = client.queryStream("sql", "SELECT FROM " + TYPE_NAME + "Driver")) {
+        assertThat(rs.stream().count()).isEqualTo(2);
+      }
+
+      assertThat(client.getLastCommitIndex())
+          .as("getLastCommitIndex() must advance after queryStream exactly as it does after query, otherwise a "
+              + "client that switches to the streaming encoding silently loses read-your-writes")
+          .isGreaterThanOrEqualTo(afterSecondWrite);
+    }
+  }
+
+  private long bookmarkOf(final HttpResponse<?> response) {
+    return response.headers().firstValue(BOOKMARK).map(Long::parseLong).orElse(-1L);
+  }
+
+  private void drain(final HttpResponse<InputStream> response) throws Exception {
+    try (final InputStream in = response.body()) {
+      in.readAllBytes();
+    }
+  }
+
+  private HttpResponse<String> sendBuffered(final int serverIndex, final String command) throws Exception {
+    final JSONObject payload = new JSONObject().put("language", "sql").put("command", command);
+    final HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create(baseUrl(serverIndex) + "/query/" + getDatabaseName()))
+        .timeout(HTTP_TIMEOUT)
+        .header("Authorization", basicAuth())
+        .header("Content-Type", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString(payload.toString()))
+        .build();
+    final HttpResponse<String> response = newClient().send(request, HttpResponse.BodyHandlers.ofString());
+    assertThat(response.statusCode()).isEqualTo(200);
+    return response;
+  }
+
+  private HttpResponse<InputStream> sendStreamedPost(final int serverIndex, final String command) throws Exception {
+    final JSONObject payload = new JSONObject().put("language", "sql").put("command", command);
+    final HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create(baseUrl(serverIndex) + "/query/" + getDatabaseName()))
+        .timeout(HTTP_TIMEOUT)
+        .header("Authorization", basicAuth())
+        .header("Content-Type", "application/json")
+        .header("Accept", NDJSON)
+        .POST(HttpRequest.BodyPublishers.ofString(payload.toString()))
+        .build();
+    return newClient().send(request, HttpResponse.BodyHandlers.ofInputStream());
+  }
+
+  private HttpResponse<InputStream> sendStreamedGet(final int serverIndex, final String command) throws Exception {
+    // URLEncoder targets application/x-www-form-urlencoded, where a space is '+'. This is a path segment, where
+    // '+' is a literal plus and a space has to be %20, or the server parses a different query and answers 400.
+    final String url = baseUrl(serverIndex) + "/query/" + getDatabaseName() + "/sql/"
+        + URLEncoder.encode(command, StandardCharsets.UTF_8).replace("+", "%20");
+    final HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create(url))
+        .timeout(HTTP_TIMEOUT)
+        .header("Authorization", basicAuth())
+        .header("Accept", NDJSON)
+        .GET()
+        .build();
+    return newClient().send(request, HttpResponse.BodyHandlers.ofInputStream());
+  }
+
+  private String httpCommand(final int serverIndex, final String sql) throws Exception {
+    final JSONObject payload = new JSONObject().put("language", "sql").put("command", sql);
+    final HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create(baseUrl(serverIndex) + "/command/" + getDatabaseName()))
+        .timeout(HTTP_TIMEOUT)
+        .header("Authorization", basicAuth())
+        .header("Content-Type", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString(payload.toString()))
+        .build();
+    final HttpResponse<String> response = newClient().send(request, HttpResponse.BodyHandlers.ofString());
+    assertThat(response.statusCode()).as("command '%s' failed: %s", sql, response.body()).isEqualTo(200);
+    return response.body();
+  }
+
+  private String baseUrl(final int serverIndex) {
+    return "http://127.0.0.1:" + httpPort(serverIndex) + "/api/v1";
+  }
+
+  /**
+   * The port a node actually bound, never the 248n it was asked for: anything already listening there would
+   * otherwise take these requests and answer them as a different build.
+   */
+  private int httpPort(final int serverIndex) {
+    return getServer(serverIndex).getHttpServer().getPort();
+  }
+
+  private static String basicAuth() {
+    return "Basic " + Base64.getEncoder().encodeToString(
+        ("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static HttpClient newClient() {
+    return HttpClient.newBuilder().connectTimeout(HTTP_TIMEOUT).build();
+  }
+}

--- a/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
@@ -484,8 +484,12 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
    * (issue #5845). The server emits this header on every begin/commit/rollback response once the database
    * has an applied index, so all three call sites can carry the just-committed bookmark forward for the next
    * {@link ReadConsistency#READ_YOUR_WRITES} read.
+   * <p>
+   * Also used by {@link #streamingCommand}, whose response body is an {@link java.io.InputStream} rather than a
+   * {@code String} - hence the wildcard: the bookmark lives entirely in the headers, and a streamed read has to
+   * advance it exactly as the buffered one does (issue #7351).
    */
-  void captureCommitIndexHeader(final HttpResponse<String> response) {
+  void captureCommitIndexHeader(final HttpResponse<?> response) {
     response.headers().firstValue("X-ArcadeDB-Commit-Index").ifPresent(val -> {
       try {
         updateLastCommitIndex(Long.parseLong(val));
@@ -858,6 +862,11 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
 
       final HttpResponse<InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
       body = response.body();
+
+      // Before the status check, and deliberately: on an HA cluster the bookmark is meaningful on a refused
+      // request too - whatever the server had applied when it answered is still a valid barrier for the next
+      // read (issue #7351). Same capture the buffered path makes in RemoteHttpComponent.httpCommand.
+      captureCommitIndexHeader(response);
 
       if (response.statusCode() != 200) {
         // The failure body is small and already complete: read it so the standard error mapping can name the

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -93,6 +93,9 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
   // Response header set by session-establishing routes (e.g. /begin). Its presence means the response
   // is session-scoped and must not be replayed from the idempotency cache (the session id would be lost).
   private static final HttpString SESSION_ID_HEADER = HttpString.tryFromString(HttpSessionManager.ARCADEDB_SESSION_ID);
+  // The read-your-writes bookmark echo, cached for the same reason and because it is now looked up as well as
+  // written: the response-commit listener of issue #7351 has to ask whether the eager emission already set it.
+  static final         HttpString COMMIT_INDEX_HEADER = HttpString.tryFromString("X-ArcadeDB-Commit-Index");
   // Bounded wait for a concurrent identical retry to observe the in-flight winner's result before it
   // gives up and executes on its own. Caps worker-thread blocking so a slow request cannot pile up retries.
   private static final long       IN_FLIGHT_WAIT_MS = 5_000L;
@@ -1344,7 +1347,43 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
       return;
     final long lastApplied = haDb.getLastAppliedIndex();
     if (lastApplied >= 0)
-      exchange.getResponseHeaders().put(new HttpString("X-ArcadeDB-Commit-Index"), String.valueOf(lastApplied));
+      exchange.getResponseHeaders().put(COMMIT_INDEX_HEADER, String.valueOf(lastApplied));
+  }
+
+  /**
+   * Guarantees the {@code X-ArcadeDB-Commit-Index} bookmark reaches the client even when the handler writes the
+   * response itself, which the eager {@link #emitCommitIndexBookmark} call in
+   * {@link DatabaseAbstractHandler#execute} cannot do (issue #7351).
+   * <p>
+   * That call runs <b>after</b> the handler body returns. For a buffered response that is before anything has
+   * been written, so the header is serialized with the rest. For a <b>streamed</b> response - the NDJSON query
+   * encoding of issue #7306 - the body has been written and the output stream closed by the time the handler
+   * returns, so the response headers went out long before: the {@code put} lands on a header map nothing will
+   * read again, and the header is dropped with no error and no log line.
+   * <p>
+   * Rather than repeating the emission inside every streaming path - which is a fix that has to be remembered
+   * again the next time one is added - this registers it on the exchange, where Undertow runs it at the one
+   * moment that is correct on both encodings: immediately before the response is committed, i.e. before the
+   * first byte of a streamed body and before the buffered body is written. A response that already carries the
+   * header keeps the value it was given, so the buffered encoding stays byte-identical to what it sent before
+   * and the eager call remains the one that decides its value.
+   * <p>
+   * On a read that value is a lower bound on the state the response reflects, which is exactly what the
+   * bookmark means: a client feeding it back as {@code X-ArcadeDB-Read-After} asks a follower to have applied
+   * at least that much. Emitting it before the rows can therefore only be conservative, never stale.
+   * <p>
+   * Not usable on the streamed <b>write</b> path: {@code PostBatchHandler}'s per-chunk encoding only learns its
+   * commit index after the load has run, by which time the response has started, so it carries the bookmark in
+   * band in its terminal line instead (issue #7311).
+   */
+  protected static void emitCommitIndexBookmarkOnResponseCommit(final HttpServerExchange exchange,
+      final HAReplicatedDatabase haDb) {
+    if (haDb == null)
+      return;
+    exchange.addResponseCommitListener(ex -> {
+      if (!ex.getResponseHeaders().contains(COMMIT_INDEX_HEADER))
+        emitCommitIndexBookmark(ex, haDb);
+    });
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/http/handler/DatabaseAbstractHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/DatabaseAbstractHandler.java
@@ -118,6 +118,14 @@ public abstract class DatabaseAbstractHandler extends AbstractServerHttpHandler 
     // Resolve HA database for read consistency (may be wrapped inside ServerDatabase).
     final HAReplicatedDatabase haDbForRead = resolveHAReplicatedDatabase(database);
 
+    // A handler that writes the response itself - the NDJSON streaming query encoding of issue #7306 - has
+    // already closed the output stream by the time the emitCommitIndexBookmark call below runs, so that call
+    // lands on a header map nothing will serialize again and the bookmark is silently dropped (issue #7351).
+    // Registered here rather than inside the streaming path, so it holds for any response however written and
+    // for whatever streams next. It defers to the eager call below wherever that one got there first, which is
+    // every buffered response.
+    emitCommitIndexBookmarkOnResponseCommit(exchange, haDbForRead);
+
     final AtomicReference<ExecutionResponse> response = new AtomicReference<>();
     try {
       // Set read consistency context for HA follower reads.

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -40,9 +40,8 @@ import java.util.List;
 public class CoreApiSpec implements OpenApiContributor {
   /** Media type of the streaming query encoding (issue #7306). */
   private static final String NDJSON = "application/x-ndjson";
-
-
   private static final String SESSION_HEADER = HttpSessionManager.ARCADEDB_SESSION_ID;
+  private static final String COMMIT_INDEX_HEADER = "X-ArcadeDB-Commit-Index";
 
   private static final String SESSION_REQUEST_DESCRIPTION = """
       Session id returned by 'beginTransaction'. Present it on every call that must run inside that \
@@ -219,6 +218,7 @@ public class CoreApiSpec implements OpenApiContributor {
     getOp.addParametersItem(ndJsonAcceptParam());
     getOp.setResponses(createGetQueryResponses());
     addNdJsonAlternative(getOp.getResponses());
+    addCommitIndexBookmarkHeader(getOp.getResponses());
     pathItem.setGet(getOp);
 
     return pathItem;
@@ -238,6 +238,7 @@ public class CoreApiSpec implements OpenApiContributor {
     postOp.setRequestBody(SpecBuilders.jsonBody("Query request with command and optional parameters", "QueryRequest", true));
     postOp.setResponses(createQueryResponses());
     addNdJsonAlternative(postOp.getResponses());
+    addCommitIndexBookmarkHeader(postOp.getResponses());
     pathItem.setPost(postOp);
 
     return pathItem;
@@ -257,6 +258,7 @@ public class CoreApiSpec implements OpenApiContributor {
     postOp.setRequestBody(SpecBuilders.jsonBody("Command request with command and optional parameters", "CommandRequest", true));
     postOp.setResponses(createCommandResponses());
     addNdJsonAlternative(postOp.getResponses());
+    addCommitIndexBookmarkHeader(postOp.getResponses());
     pathItem.setPost(postOp);
 
     return pathItem;
@@ -699,6 +701,20 @@ public class CoreApiSpec implements OpenApiContributor {
     final MediaType ndjson = new MediaType();
     ndjson.setSchema(SpecBuilders.ref("NdJsonQueryEvent"));
     responses.get("200").getContent().addMediaType(NDJSON, ndjson);
+  }
+
+  /**
+   * Declares the read-your-writes bookmark on a 200. It is emitted on both encodings - on the streamed one
+   * before the first row, since a header cannot be set once the body has started (issue #7351) - so it is a
+   * property of the response rather than of either media type, and a generated client can rely on it either
+   * way.
+   */
+  private static void addCommitIndexBookmarkHeader(final ApiResponses responses) {
+    responses.get("200").addHeaderObject(COMMIT_INDEX_HEADER, SpecBuilders.stringHeader("""
+        On a replicated (HA) database, the last Raft index this server had applied when it answered. Feed it \
+        back as 'X-ArcadeDB-Read-After' on the next request to get read-your-writes consistency from a \
+        follower. Absent on a standalone database, and on a replicated one that has applied nothing yet.\
+        """));
   }
 
   /**

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import org.junit.jupiter.api.BeforeEach;
@@ -344,6 +345,30 @@ class CoreApiSpecTest {
           .as(path + " has no requiresTransaction() override, so its 404 must still cover the "
               + "stale-session case")
           .contains("Remote transaction session not found or expired");
+    }
+  }
+
+  /**
+   * Issue #7351: the read-your-writes bookmark is emitted on the streamed encoding as well as the buffered one,
+   * so it belongs on the response rather than on either media type - and a generated client has no way to know
+   * it exists unless the document says so.
+   */
+  @Test
+  void everyQueryOperationDeclaresTheReadYourWritesBookmarkHeader() {
+    final List<Operation> operations = List.of(
+        openAPI.getPaths().get("/api/v1/query/{database}/{language}/{command}").getGet(),
+        openAPI.getPaths().get("/api/v1/query/{database}").getPost(),
+        openAPI.getPaths().get("/api/v1/command/{database}").getPost());
+
+    for (final Operation operation : operations) {
+      final Header bookmark = operation.getResponses().get("200").getHeaders().get("X-ArcadeDB-Commit-Index");
+      assertThat(bookmark)
+          .as("%s must declare the read-your-writes bookmark on its 200", operation.getOperationId())
+          .isNotNull();
+      assertThat(bookmark.getDescription())
+          .as("the description has to name the request-side header the value is fed back as, or a client "
+              + "cannot act on it")
+          .contains("X-ArcadeDB-Read-After");
     }
   }
 }


### PR DESCRIPTION
Closes #7351.

## The bug

`DatabaseAbstractHandler.execute()` emits `X-ArcadeDB-Commit-Index` **after** the handler body returns:

```java
response.set(execute(exchange, user, database, payload));
...
emitCommitIndexBookmark(exchange, haDbForRead);
```

That is fine for a buffered response, whose body has not been written yet. For a response the handler writes itself - the NDJSON streaming encoding of #7306 - the body has been written and the output stream closed by the time `execute()` returns, so the response headers were serialized long before. The `getResponseHeaders().put(...)` lands on a header map nothing will read again: no error, no log line, no header.

The effect is silent. A client that switches from `RemoteDatabase.query()` to `RemoteDatabase.queryStream()` on an HA cluster stops advancing its read-your-writes bookmark, so a later `READ_YOUR_WRITES` request sends a stale (or absent) `X-ArcadeDB-Read-After` and may be answered by a follower that has not applied the write it is reading after. The streamed rows themselves are unaffected - what is lost is the barrier for the *next* request.

## The fix, and why not the one the issue proposed

The issue proposed emitting the header inside `AbstractQueryHandler.streamResultSetAsNdJson`, right before `exchange.setStatusCode(200)`. That works, but it fixes one streaming path and has to be remembered again for the next one - and the issue itself notes the shape is not HA-specific: *any* header the request pipeline sets after `execute()` returns has this problem.

So it is registered on the exchange instead, as an Undertow **response-commit listener**, which runs at the one moment that is correct on both encodings: immediately before the response is committed, i.e. before the first byte of a streamed body and before a buffered body is written.

- A response that **already** carries the header keeps the value the eager call gave it, so every buffered answer stays byte-identical and the eager call is still the one that decides its value.
- Nothing at all is registered on a standalone database, so a non-replicated deployment pays nothing.
- On a read the emitted value is a lower bound on the state the response reflects, which is exactly what the bookmark means - a client feeding it back asks a follower to have applied *at least* that much - so emitting it before the rows can only be conservative, never stale.

Not usable on the streamed **write** path: `PostBatchHandler` only learns its commit index after the load has run, by which time the response has started, so it keeps carrying the bookmark in band in its terminal line (#7311). The Javadoc says so, next to the listener.

## The other half: the driver

`RemoteDatabase.streamingCommand` never looked at the response headers, so even a server that sent the bookmark would not have advanced `getLastCommitIndex()`. It now captures it - before the status check, since the value is a valid barrier on a refused request too - through the same `captureCommitIndexHeader` the buffered path uses, widened to `HttpResponse<?>` because a streamed body is an `InputStream`.

## Contract

The OpenAPI document declares `X-ArcadeDB-Commit-Index` on the query and command 200s, where it had only ever been mentioned in prose. It is a property of the response rather than of either media type, since both encodings now emit it.

## Verification

`RaftStreamedQueryBookmarkIT` (new, 3 tests, `ha-raft`): **3/3 red before the fix, 3/3 green after**.

1. `aStreamedQueryCarriesTheSameBookmarkTheBufferedOneDoes` - POST `/query` under `Accept: application/x-ndjson`, compared against the buffered answer to the same query rather than against a bare `>= 0`: a bookmark that is present but does not mean what the buffered one means would be worse than an absent one.
2. `aStreamedGetQueryCarriesTheBookmarkToo` - the GET endpoint, asserted rather than assumed.
3. `queryStreamAdvancesTheDriverBookmarkLikeQueryDoes` - the end the issue is about. The driver's own bookmark is rewound first (`updateLastCommitIndex` folds with `Math::max`, so it cannot go backwards), which is the only way to tell "the streamed response advanced it" from "it was already there".

Also green: `Issue7306HttpStreamingQueryIT` (18), the whole `openapi` spec suite (135 + the new `everyQueryOperationDeclaresTheReadYourWritesBookmarkHeader`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Read-your-writes commit bookmarks are now correctly included in streamed query and command responses.
  - Streaming queries now update the client’s commit position consistently with buffered queries.
  - Commit bookmarks are preserved even when a streamed request returns an error response.

- **Documentation**
  - API documentation now describes the commit-index response header for query and command endpoints, including how to use it for subsequent read-after requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->