### PR TITLE
fix(#7374): carry the database's own user on the gRPC call metadata

### DIFF
--- a/docs/7374-grpc-two-principals.md
+++ b/docs/7374-grpc-two-principals.md
@@ -1,0 +1,192 @@
+# #7374 - gRPC call metadata and request body can carry two different principals
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/7374
+
+## Problem
+
+`RemoteGrpcDatabase` takes its own `userName`/`userPassword` and puts them in every request BODY
+(`buildCredentials()`), but the stubs it issues calls on are built by `RemoteGrpcServer`, which
+attaches call METADATA built from the *server's* own `userName`/`userPassword`
+(`RemoteGrpcServer.createCredentials(String)` reads its own fields).
+
+Server side, `GrpcAuthInterceptor` authenticates from the metadata and puts that name in
+`USER_CONTEXT_KEY`; `ArcadeDbGrpcService.resolvedUsername()` then *prefers* the context user over the
+body credentials. So when server user A and database user B differ, every gRPC call authenticates
+and authorizes as A, and the B the caller passed is silently discarded - while the HTTP half of the
+same object (`RemoteDatabase`) still speaks as B.
+
+## Root cause
+
+`RemoteGrpcDatabase.createBlockingStub()` / `createAsyncStub()` call
+`remoteGrpcServer.newBlockingStub(timeout, databaseName)` / `newAsyncStub(timeout, databaseName)`,
+which have no way to say *which principal*. Same for `getProgress()`, which calls
+`newAdminBlockingStub(timeout)`.
+
+## Fix
+
+Option 1 from the issue ("the smaller surprise"): the database's stubs carry the database's own
+credentials. `RemoteGrpcServer` gains principal-carrying overloads
+(`newBlockingStub`/`newAsyncStub`/`newAdminBlockingStub` taking `userName`/`userPassword`, and
+`createCredentials(database, user, password)`); `RemoteGrpcDatabase` passes its own pair to all three.
+A `null`/blank database user falls back to the server's pair, so the pre-existing behaviour of a
+database constructed without credentials is unchanged (and no `Metadata.put(null)` NPE is introduced).
+
+## Completeness
+
+### Invariant
+
+> Every gRPC call issued by a `RemoteGrpcDatabase` carries in its call metadata the username and
+> password that `RemoteGrpcDatabase` was constructed with, so the principal the server authenticates
+> and the principal in the request body are the same one.
+
+### Enumeration
+
+Every stub the client builds (`grep -rn --include='*.java' -E "newBlockingStub\(|newAsyncStub\(|newAdminBlockingStub\("`,
+main sources only):
+
+```
+grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java:199:  remoteGrpcServer.newBlockingStub(getTimeout(), databaseName)
+grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java:206:  remoteGrpcServer.newAsyncStub(getTimeout(), databaseName)
+grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java:247:  remoteGrpcServer.newAdminBlockingStub(getTimeout())          (getProgress)
+grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java:266/280/291/298/315  (the factories themselves)
+```
+
+Everything else that matched is a test building a raw `ArcadeDbServiceGrpc` stub against its own
+channel, not through `RemoteGrpcServer`.
+
+Every field/stub `RemoteGrpcDatabase` issues calls on
+(`grep -n "blockingStub\|asyncStub" RemoteGrpcDatabase.java`): 32 call sites, all of them
+`blockingStub.withDeadlineAfter(...)` or `asyncStub.withDeadlineAfter(...)` on the two fields assigned
+in the constructor - `withDeadlineAfter` copies the `CallOptions`, credentials included, so fixing the
+two factory methods covers all 32.
+
+No other class in `grpc-client/src/main` builds a stub
+(`grep -rn "Stub\b" grpc-client/src/main/java/.../grpc/ | grep -v "RemoteGrpcServer.java\|RemoteGrpcDatabase.java"` -> no output),
+so `QueryBatch`, `BatchedStreamingResultSet`, `GraphBatchLoadStream`, `RemoteGrpcGraphBatch`,
+`StreamingResultSet` and `RemoteGrpcTransactionExplicitLock` all issue through the database's stubs.
+
+Subclasses (`grep -rn "extends RemoteGrpcDatabase"`): `RemoteGrpcDatabaseWithCompression` only, which
+delegates to the fixed constructor and does not override either factory.
+
+### Coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| `RemoteGrpcDatabase.createBlockingStub()` - query/command/CRUD/streaming/vector/timeseries (all 30 blocking call sites) | yes | yes - `Issue7374GrpcDatabaseCredentialsTest.blockingStubCarriesTheDatabaseUser`, `Issue7374GrpcPrincipalIT` (query, per-type ACL, foreign-database refusal) |
+| `RemoteGrpcDatabase.createAsyncStub()` - bidi ingestion / graph batch (2 async call sites) | yes | yes - `Issue7374GrpcDatabaseCredentialsTest.asyncStubCarriesTheDatabaseUser` |
+| `RemoteGrpcDatabase.getProgress()` -> `newAdminBlockingStub` | yes | yes - `Issue7374GrpcDatabaseCredentialsTest.adminStubCarriesTheDatabaseUser` |
+| `RemoteGrpcDatabaseWithCompression` (subclass) | yes, inherited | yes - `Issue7374GrpcDatabaseCredentialsTest.compressionSubclassInheritsTheDatabaseUser` |
+| `RemoteGrpcDatabase` constructed with a null/blank user | yes - falls back to the server's pair, unchanged behaviour | yes - `Issue7374GrpcDatabaseCredentialsTest.blankDatabaseUserFallsBackToTheServerUser` |
+| `RemoteGrpcServer`'s own RPCs (`listDatabases`, `getProgress(String)`, `createDatabase`, ...) | argued: not in scope | n/a |
+| Server-side `resolvedUsername()` preferring the context user over the body credentials | argued: not in scope | n/a |
+
+### Arguments
+
+- **`RemoteGrpcServer`'s own RPCs.** `RemoteGrpcServer` is the object that holds the server account;
+  when it calls `listDatabases()` or `getProgress(String)` on its own behalf, its user *is* the
+  principal and metadata and body already agree (`buildCredentials()` reads the same two fields as
+  `createCredentials()`). There is no second principal to disagree with.
+- **Server-side precedence.** `ArcadeDbGrpcService.resolvedUsername()` preferring the interceptor's
+  context user is what makes the mismatch invisible, but it is not itself wrong: the metadata
+  credentials are the ones the server actually verified a password for, and the body credentials are
+  unverified when a context user exists. Changing that precedence would mean re-authenticating the
+  body on every call. Once the client sends one principal the question does not arise, and hardening
+  the server against a *deliberately* mismatched client is a separate concern from this client bug.
+
+### Residual risk
+
+A caller that reaches into `RemoteGrpcServer.newBlockingStub(timeout, database)` directly still gets
+the server's principal - that overload is unchanged and is the right one for the server's own calls.
+Nothing in `src/main` does so other than the two fixed factories.
+
+## Changes
+
+- `grpc-client/.../RemoteGrpcServer.java` - added `newBlockingStub(int, String, String, String)`,
+  `newAsyncStub(int, String, String, String)`, `newAdminBlockingStub(int, String, String)` and
+  `createCredentials(String, String, String)`. The pre-existing overloads now delegate to them with a
+  null principal, so they keep meaning "this server's own account" and nothing that called them changes.
+- `grpc-client/.../RemoteGrpcDatabase.java` - `createBlockingStub()` and `createAsyncStub()` pass this
+  database's `userName`/`userPassword`; the admin stub `getProgress()` builds moved into a new
+  protected `createAdminBlockingStub()` that does the same (and is what makes it testable).
+
+Purely additive on the public API: no signature changed, no method removed.
+
+## Reachability
+
+`createBlockingStub()`/`createAsyncStub()` are called from `RemoteGrpcDatabase`'s constructor, which is
+`new`-ed in the `e2e` and `load-tests` modules and is the documented client entry point; the 32 call
+sites listed above all issue on the two fields those calls assign. `createAdminBlockingStub()` is
+called by `getProgress()`. Nothing here is behind a flag.
+
+## Test results
+
+```
+mvn -o -pl grpc-client -DskipITs=true test
+  Tests run: 161, Failures: 0, Errors: 0, Skipped: 0   BUILD SUCCESS
+    (includes Issue7374GrpcDatabaseCredentialsTest: 7, Issue7320GrpcDatabaseHeaderTest: 4,
+     RemoteGrpcServerInsecureCredentialsTest: 6)
+
+mvn -o -pl grpc-client -DskipITs=false -Dit.test=Issue7374GrpcPrincipalIT verify
+  Tests run: 3, Failures: 0, Errors: 0                 BUILD SUCCESS
+
+mvn -o -pl e2e,load-tests -DskipTests test-compile     BUILD SUCCESS
+```
+
+Both suites were run against the pre-fix wiring first, to prove they can fail:
+
+```
+Issue7374GrpcDatabaseCredentialsTest   Tests run: 7, Failures: 5   (expected "scoped7374")
+Issue7374GrpcPrincipalIT#theDatabaseUserIsTheOneTheEngineAuthorizes        FAILED
+Issue7374GrpcPrincipalIT#aForeignDatabaseUserIsRefusedEvenOnARootServer    FAILED
+```
+
+The two that still pass pre-fix are the two that should: `blankDatabaseUserFallsBackToTheServerUser`
+and `serverScopedStubStillCarriesTheServerUser` pin behaviour this change deliberately leaves alone.
+
+### Pre-existing failures on this machine, not caused by this change
+
+`Issue7320ScopedUserGrpcIT` (3 errors) and `Issue7305TimeSeriesGrpcAclIT` (1 failure) fail here because
+`BaseGraphServerTest.command(int, String)` posts to a hardcoded `http://127.0.0.1:2480`, and another
+ArcadeDB server on this machine owns that port - so their DDL lands on a foreign server and the types
+are missing:
+
+```
+Issue7320ScopedUserGrpcIT ... IOException: Server returned HTTP response code: 503 for URL: http://127.0.0.1:2480/api/v1/command/graph
+Issue7305TimeSeriesGrpcAclIT ... RecordNotFoundException: Type 'SecretMetrics' does not exist
+$ lsof -nP -iTCP:2480 -sTCP:LISTEN
+java  50517 frank  264u  IPv6  TCP 127.0.0.1:2480 (LISTEN)
+java  93797 frank  263u  IPv6  TCP *:2480 (LISTEN)
+```
+
+The new `Issue7374GrpcPrincipalIT` avoids that trap on purpose: it runs its DDL against
+`getServer(0).getDatabase(...)` and reaches HTTP only on `getServer(0).getHttpServer().getPort()`.
+
+## Impact
+
+A caller that built a `RemoteGrpcServer` and a `RemoteGrpcDatabase` with the SAME user sees no change -
+which is every test and every documented example. A caller that passed different users now has its gRPC
+calls run as the database's user, which is what it asked for and what the HTTP half of the same object
+already did. That is a behaviour change in the direction of the argument the caller passed, and it can
+newly refuse calls that previously rode in on the server's account - which is the point of the issue.
+
+## Residual risk
+
+See the Completeness section: only `RemoteGrpcServer`'s own server-scoped overloads still carry the
+server's principal, deliberately, and nothing in `src/main` uses them for a database's calls.
+
+## Adversarial pass
+
+Run inline rather than through a subagent: no `Task` tool was available in this session, so the pass was
+done by re-reading the tree against the issue text rather than by an agent that had not been convinced.
+That is a weaker version of the check and is recorded as such.
+
+| Finding | Verified by | Disposition |
+|---|---|---|
+| The data-plane stubs are `final` fields built once in the constructor, so a `RemoteGrpcServer.close()`/`start()` cycle leaves them bound to a terminated channel - while `getProgress()`, built per call, survives it | `grep -n "private final    ArcadeDbServiceGrpc" RemoteGrpcDatabase.java` (lines 158-159, assigned at 185-186, never reassigned); `RemoteGrpcServer.start()` lines 203-237 build a NEW channel after `close()` nulls it | Real, out of scope (channel lifetime, not principal identity). Filed as **#7416** |
+| Credentials could go stale in the cached stubs if a caller changed them after construction | `grep -rn "setUserName\|setUserPassword\|this.userName *=" network/src/main/java/com/arcadedb/remote/ grpc-client/src/main/java/` - the only assignments are the three constructors; there are no setters | Not real. The pair is assign-once, so a stub built in the constructor cannot go stale |
+| `buildCredentials()` (request body) reads the inherited `getUserName()` while the stubs read this class's own `userName` field, so the two could diverge | Both are assigned from the same constructor parameter (`super(...)` at line 180, `this.userName =` at 183). Pinned by `Issue7374GrpcDatabaseCredentialsTest.bodyAndMetadataNameTheSamePrincipal`, which compares them | Not real, and now regression-tested |
+| `Issue7374GrpcDatabaseCredentialsTest` depends on nothing listening on its `DEAD_HTTP_PORT` | `RemoteHttpComponent.requestClusterConfiguration()` swallows every failure except a `SecurityException`, so only a real ArcadeDB server answering 401/403 on that exact port would break it | Accepted risk, documented on the constant |
+
+## Follow-up issues
+
+- **#7416** - `RemoteGrpcDatabase` caches its data-plane stubs on a channel a server restart replaces.

--- a/docs/7374-grpc-two-principals.md
+++ b/docs/7374-grpc-two-principals.md
@@ -190,3 +190,30 @@ That is a weaker version of the check and is recorded as such.
 ## Follow-up issues
 
 - **#7416** - `RemoteGrpcDatabase` caches its data-plane stubs on a channel a server restart replaces.
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/7417
+
+## Review cycles
+
+### Cycle 1 - `876f991` - clean approval
+
+The `claude` reviewer posted one PR comment and no inline comments or formal review. It confirmed the
+root-cause analysis, verified independently that `e2e` and `load-tests` call none of the three stub
+factories directly (so the "purely additive" claim holds), and agreed that the cached-stub/channel gap
+is correctly scoped out to #7416.
+
+Nothing actionable was raised. The three non-blocking notes and what was done with each:
+
+| Note | Disposition |
+|---|---|
+| `Issue7374GrpcDatabaseCredentialsTest` relies on `DEAD_HTTP_PORT = 59374` staying unbound in CI | Skipped, and the reviewer agreed it is reasonable. Breaking it needs a real ArcadeDB server bound to that exact port answering 401/403 - every other outcome, an unbound port included, is swallowed by `requestClusterConfiguration()`. The constant already carries the comment saying so. Removing the risk entirely would mean not constructing a `RemoteDatabase` at all, which is the object under test |
+| The Javadoc is more verbose than the norm elsewhere in `grpc-client` | Skipped on the reviewer's own recommendation ("I'd leave it as-is"): it cross-links #7310/#7320/#7374, which is what makes the two-principal split legible |
+| The `blockingStub`/`asyncStub` channel-lifetime gap | Already filed as #7416 before the PR opened, and named under **Known gaps** in the PR body |
+
+No commits were needed to address review feedback.
+
+## Final state
+
+`clean-approval` after 1 cycle. Merge remains the developer's.

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
@@ -63,6 +63,7 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.EdgeType;
 import com.arcadedb.schema.VertexType;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.grpc.ArcadeDbAdminServiceGrpc;
 import com.arcadedb.server.grpc.ArcadeDbServiceGrpc;
 import com.arcadedb.server.grpc.BatchAck;
 import com.arcadedb.server.grpc.BeginTransactionRequest;
@@ -194,16 +195,39 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
    * caller against the database the calls actually target. Before #7320 no database travelled with the
    * call and the server fell back to the literal name {@code "default"}, which refused every principal
    * whose grants named real databases.
+   * <p>
+   * It also names THIS database's user rather than the {@link RemoteGrpcServer}'s. The two are separate
+   * constructor arguments and a scoped database user on a channel built for root is a supported
+   * combination; before #7374 only the request body carried the database's user, and the server prefers
+   * the principal it authenticated from the metadata - so the user the caller passed here was silently
+   * discarded on gRPC while the inherited HTTP methods still used it.
    */
   protected ArcadeDbServiceGrpc.ArcadeDbServiceBlockingV2Stub createBlockingStub() {
-    return this.remoteGrpcServer.newBlockingStub(getTimeout(), databaseName);
+    return this.remoteGrpcServer.newBlockingStub(getTimeout(), databaseName, userName, userPassword);
   }
 
   /**
    * @see #createBlockingStub()
    */
   protected ArcadeDbServiceGrpc.ArcadeDbServiceStub createAsyncStub() {
-    return this.remoteGrpcServer.newAsyncStub(getTimeout(), databaseName);
+    return this.remoteGrpcServer.newAsyncStub(getTimeout(), databaseName, userName, userPassword);
+  }
+
+  /**
+   * A fresh admin stub carrying this database's user, for the admin-plane RPCs this class issues on its
+   * own behalf. The admin plane authenticates from the request body and reads no database metadata, so
+   * the stub names no database.
+   * <p>
+   * The stub is built per call, not cached: {@code withDeadlineAfter} fixes an ABSOLUTE deadline the
+   * moment it is applied, so a stub held across calls would carry a deadline that has already passed by
+   * the second poll. Building it also re-resolves the channel, so a server restarted through
+   * {@code start()} is honoured. The cost is a few field copies on a shared channel, which is nothing
+   * next to the round trip.
+   *
+   * @see #createBlockingStub()
+   */
+  protected ArcadeDbAdminServiceGrpc.ArcadeDbAdminServiceBlockingV2Stub createAdminBlockingStub() {
+    return this.remoteGrpcServer.newAdminBlockingStub(getTimeout(), userName, userPassword);
   }
 
   @Override
@@ -239,12 +263,8 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
         .setDatabase(getName()).build();
 
     try {
-      // The stub is built per call, not cached: withDeadlineAfter fixes an ABSOLUTE deadline the moment it
-      // is applied, so a stub held across calls would carry a deadline that has already passed by the second
-      // poll. Building it also re-resolves the channel, so a server restarted through start() is honoured.
-      // The cost is a few field copies on a shared channel, which is nothing next to the round trip.
       final GetProgressResponse response = callUnary("GetProgress",
-          () -> remoteGrpcServer.newAdminBlockingStub(getTimeout()).getProgress(request));
+          () -> createAdminBlockingStub().getProgress(request));
 
       final List<JSONObject> operations = new ArrayList<>(response.getOperationsCount());
       for (final OperationProgressInfo info : response.getOperationsList())

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
@@ -279,8 +279,27 @@ public class RemoteGrpcServer implements AutoCloseable {
    */
   public ArcadeDbServiceGrpc.ArcadeDbServiceBlockingV2Stub newBlockingStub(final int timeout, final String database) {
 
+    return newBlockingStub(timeout, database, null, null);
+  }
+
+  /**
+   * A data-plane stub for a principal that is not necessarily this server's own.
+   * <p>
+   * Issue #7374: {@link RemoteGrpcDatabase} takes a user of its own and puts it in every request body, but
+   * built its stubs through the database-only overload above - so the call metadata carried THIS server's
+   * account, the server authenticated that one, and the user the caller passed to the database was
+   * discarded on gRPC while the HTTP half of the same object still used it. A database opened by a scoped
+   * user on a channel built for root is a supported combination, so the stub has to be able to name which.
+   *
+   * @param userName     the principal the calls authenticate as, or {@code null}/blank to use this
+   *                     server's own account
+   * @param userPassword that principal's password
+   */
+  public ArcadeDbServiceGrpc.ArcadeDbServiceBlockingV2Stub newBlockingStub(final int timeout, final String database,
+      final String userName, final String userPassword) {
+
     return ArcadeDbServiceGrpc.newBlockingV2Stub(channel())
-        .withCallCredentials(createCredentials(database))
+        .withCallCredentials(createCredentials(database, userName, userPassword))
         .withDeadlineAfter(timeout, TimeUnit.MILLISECONDS)
         .withCompression("gzip");
   }
@@ -297,8 +316,17 @@ public class RemoteGrpcServer implements AutoCloseable {
    */
   public ArcadeDbServiceGrpc.ArcadeDbServiceStub newAsyncStub(final int timeout, final String database) {
 
+    return newAsyncStub(timeout, database, null, null);
+  }
+
+  /**
+   * @see #newBlockingStub(int, String, String, String)
+   */
+  public ArcadeDbServiceGrpc.ArcadeDbServiceStub newAsyncStub(final int timeout, final String database,
+      final String userName, final String userPassword) {
+
     return ArcadeDbServiceGrpc.newStub(channel())
-        .withCallCredentials(createCredentials(database))
+        .withCallCredentials(createCredentials(database, userName, userPassword))
         .withDeadlineAfter(timeout, TimeUnit.MILLISECONDS)
         .withCompression("gzip");
   }
@@ -313,8 +341,19 @@ public class RemoteGrpcServer implements AutoCloseable {
    * is this instance's own and is not shared for that reason.
    */
   public ArcadeDbAdminServiceGrpc.ArcadeDbAdminServiceBlockingV2Stub newAdminBlockingStub(final int timeout) {
+    return newAdminBlockingStub(timeout, null, null);
+  }
+
+  /**
+   * An admin stub for a principal that is not necessarily this server's own - the metadata half of what
+   * {@link #newAdminBlockingStub(int)}'s caller already does with the request body (issue #7374).
+   *
+   * @see #newBlockingStub(int, String, String, String)
+   */
+  public ArcadeDbAdminServiceGrpc.ArcadeDbAdminServiceBlockingV2Stub newAdminBlockingStub(final int timeout,
+      final String userName, final String userPassword) {
     return ArcadeDbAdminServiceGrpc.newBlockingV2Stub(channel())
-        .withCallCredentials(createCredentials())
+        .withCallCredentials(createCredentials(null, userName, userPassword))
         .withDeadlineAfter(timeout, TimeUnit.MILLISECONDS);
   }
 
@@ -946,6 +985,20 @@ public class RemoteGrpcServer implements AutoCloseable {
    */
   protected CallCredentials createCredentials(final String database) {
     return credentials(userName, userPassword, database);
+  }
+
+  /**
+   * Credentials for {@code user}, or for this server's own account when {@code user} is {@code null} or
+   * blank. The fallback is what keeps a {@link RemoteGrpcDatabase} constructed without credentials of its
+   * own speaking as the server it was opened on, exactly as it did before issue #7374 - metadata carries
+   * no null, so nothing has to special-case one.
+   *
+   * @param database the target database, or {@code null}/blank to omit the key entirely
+   */
+  protected CallCredentials createCredentials(final String database, final String user, final String password) {
+    if (user == null || user.isBlank())
+      return createCredentials(database);
+    return credentials(user, password == null ? "" : password, database);
   }
 
   private CallCredentials credentials(final String user, final String password, final String database) {

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue7374GrpcDatabaseCredentialsTest.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue7374GrpcDatabaseCredentialsTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote.grpc;
+
+import com.arcadedb.ContextConfiguration;
+import io.grpc.CallCredentials;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.stub.AbstractStub;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7374: a {@link RemoteGrpcDatabase} takes its own user, puts it in every request BODY, and
+ * then issued every call on a stub whose METADATA carried the {@link RemoteGrpcServer}'s user
+ * instead. The server prefers the metadata-authenticated principal, so the user the caller passed to
+ * the database was silently discarded on gRPC while the HTTP half of the same object still used it.
+ * <p>
+ * These cases read the credentials back off the stubs {@link RemoteGrpcDatabase} actually builds,
+ * with the two users deliberately different. No RPC is issued, so no server has to be listening: a
+ * gRPC channel connects lazily.
+ */
+class Issue7374GrpcDatabaseCredentialsTest {
+
+  private static final Metadata.Key<String> USER_HEADER     =
+      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER =
+      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER =
+      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private static final String DATABASE      = "graph7374";
+  /**
+   * A port nothing listens on. {@code RemoteDatabase}'s constructor asks the HTTP port for the cluster
+   * configuration and falls back to a direct connection when it cannot reach it, so a refused connection
+   * is the quiet path - whereas a real server answering on 2480 would refuse these invented credentials
+   * and fail the construction. This test is about the metadata the client builds, not about any server.
+   */
+  private static final int    DEAD_HTTP_PORT = 59374;
+  private static final String SERVER_USER   = "root";
+  private static final String SERVER_PWD    = "rootsecret";
+  private static final String DATABASE_USER = "scoped7374";
+  private static final String DATABASE_PWD  = "scopedsecret";
+
+  private RemoteGrpcServer server() {
+    return new RemoteGrpcServer("localhost", 50051, SERVER_USER, SERVER_PWD, true, List.of());
+  }
+
+  private RemoteGrpcDatabase database(final RemoteGrpcServer server, final String user, final String password) {
+    return new RemoteGrpcDatabase(server, "localhost", 50051, DEAD_HTTP_PORT, DATABASE, user, password,
+        new ContextConfiguration());
+  }
+
+  /**
+   * Runs the credentials the way gRPC runs them on every call and returns the metadata they produced.
+   */
+  private static Metadata requestMetadata(final AbstractStub<?> stub) {
+    final CallCredentials credentials = stub.getCallOptions().getCredentials();
+    assertThat(credentials).as("the stub carries call credentials").isNotNull();
+
+    final AtomicReference<Metadata> captured = new AtomicReference<>();
+    credentials.applyRequestMetadata(null, Runnable::run, new CallCredentials.MetadataApplier() {
+      @Override
+      public void apply(final Metadata headers) {
+        captured.set(headers);
+      }
+
+      @Override
+      public void fail(final Status status) {
+        throw new AssertionError("credentials refused to apply: " + status);
+      }
+    });
+
+    final Metadata headers = captured.get();
+    assertThat(headers).as("credentials applied request metadata").isNotNull();
+    return headers;
+  }
+
+  /**
+   * The blocking stub, which carries every unary and server-streaming data-plane RPC.
+   */
+  @Test
+  void blockingStubCarriesTheDatabaseUser() {
+    try (final RemoteGrpcServer server = server();
+        final RemoteGrpcDatabase database = database(server, DATABASE_USER, DATABASE_PWD)) {
+
+      final Metadata headers = requestMetadata(database.createBlockingStub());
+
+      assertThat(headers.get(USER_HEADER)).isEqualTo(DATABASE_USER);
+      assertThat(headers.get(PASSWORD_HEADER)).isEqualTo(DATABASE_PWD);
+      // #7320's fix must survive: the database is still named on the same metadata.
+      assertThat(headers.get(DATABASE_HEADER)).isEqualTo(DATABASE);
+    }
+  }
+
+  /**
+   * The async stub, which carries bidirectional ingestion and the graph batch loader. It builds its
+   * own {@link CallCredentials} instance, so it would keep sending the server's user if only the
+   * blocking one had been fixed.
+   */
+  @Test
+  void asyncStubCarriesTheDatabaseUser() {
+    try (final RemoteGrpcServer server = server();
+        final RemoteGrpcDatabase database = database(server, DATABASE_USER, DATABASE_PWD)) {
+
+      final Metadata headers = requestMetadata(database.createAsyncStub());
+
+      assertThat(headers.get(USER_HEADER)).isEqualTo(DATABASE_USER);
+      assertThat(headers.get(PASSWORD_HEADER)).isEqualTo(DATABASE_PWD);
+      assertThat(headers.get(DATABASE_HEADER)).isEqualTo(DATABASE);
+    }
+  }
+
+  /**
+   * {@code getProgress()} polls the admin plane on the shared channel. Its request body already
+   * carried this database's credentials; the metadata did not.
+   */
+  @Test
+  void adminStubCarriesTheDatabaseUser() {
+    try (final RemoteGrpcServer server = server();
+        final RemoteGrpcDatabase database = database(server, DATABASE_USER, DATABASE_PWD)) {
+
+      final Metadata headers = requestMetadata(database.createAdminBlockingStub());
+
+      assertThat(headers.get(USER_HEADER)).isEqualTo(DATABASE_USER);
+      assertThat(headers.get(PASSWORD_HEADER)).isEqualTo(DATABASE_PWD);
+      // The admin plane authenticates from the request body and reads no database key, so none is
+      // sent - unchanged by this fix.
+      assertThat(headers.containsKey(DATABASE_HEADER)).isFalse();
+    }
+  }
+
+  /**
+   * The body credentials and the metadata credentials must now name the same principal. That is the
+   * property the issue is about, stated directly rather than through either half of it.
+   */
+  @Test
+  void bodyAndMetadataNameTheSamePrincipal() {
+    try (final RemoteGrpcServer server = server();
+        final RemoteGrpcDatabase database = database(server, DATABASE_USER, DATABASE_PWD)) {
+
+      final Metadata headers = requestMetadata(database.createBlockingStub());
+
+      assertThat(headers.get(USER_HEADER)).isEqualTo(database.buildCredentials().getUsername());
+      assertThat(headers.get(PASSWORD_HEADER)).isEqualTo(database.buildCredentials().getPassword());
+    }
+  }
+
+  /**
+   * The subclass overrides neither factory, so it inherits the fix. Asserted rather than assumed:
+   * it is a public class a caller can pick instead.
+   */
+  @Test
+  void compressionSubclassInheritsTheDatabaseUser() {
+    try (final RemoteGrpcServer server = server();
+        final RemoteGrpcDatabaseWithCompression database = new RemoteGrpcDatabaseWithCompression(server,
+            "localhost", 50051, DEAD_HTTP_PORT, DATABASE, DATABASE_USER, DATABASE_PWD, new ContextConfiguration())) {
+
+      assertThat(requestMetadata(database.createBlockingStub()).get(USER_HEADER)).isEqualTo(DATABASE_USER);
+      assertThat(requestMetadata(database.createAsyncStub()).get(USER_HEADER)).isEqualTo(DATABASE_USER);
+    }
+  }
+
+  /**
+   * A database constructed with no user of its own keeps speaking as the server's account, which is
+   * what it did before this fix. Without the fallback the client would put a null on the metadata and
+   * fail with an NPE on the first call instead.
+   */
+  @Test
+  void blankDatabaseUserFallsBackToTheServerUser() {
+    try (final RemoteGrpcServer server = server();
+        final RemoteGrpcDatabase database = database(server, null, null)) {
+
+      final Metadata headers = requestMetadata(database.createBlockingStub());
+
+      assertThat(headers.get(USER_HEADER)).isEqualTo(SERVER_USER);
+      assertThat(headers.get(PASSWORD_HEADER)).isEqualTo(SERVER_PWD);
+    }
+  }
+
+  /**
+   * The pre-existing server-scoped overloads are untouched: they are how {@link RemoteGrpcServer}
+   * issues its OWN calls, where its user is the principal.
+   */
+  @Test
+  void serverScopedStubStillCarriesTheServerUser() {
+    try (final RemoteGrpcServer server = server()) {
+      assertThat(requestMetadata(server.newBlockingStub(1_000, DATABASE)).get(USER_HEADER))
+          .isEqualTo(SERVER_USER);
+      assertThat(requestMetadata(server.newAdminBlockingStub(1_000)).get(USER_HEADER))
+          .isEqualTo(SERVER_USER);
+    }
+  }
+}

--- a/grpc-client/src/test/java/com/arcadedb/server/security/Issue7374GrpcPrincipalIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/server/security/Issue7374GrpcPrincipalIT.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.remote.grpc.RemoteGrpcDatabase;
+import com.arcadedb.remote.grpc.RemoteGrpcServer;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7374: a {@link RemoteGrpcServer} built for one account and a {@link RemoteGrpcDatabase}
+ * built on it for another - the combination the database constructor invites, since it asks for a
+ * user of its own - used to run every gRPC call as the SERVER's account. The database's user reached
+ * the request body and nothing else, and the server prefers the metadata-authenticated principal.
+ * <p>
+ * Every test here builds the server as {@code root} and the database as a scoped user, and then asks
+ * the server which one it saw. It answers in its own refusal messages: {@code LocalDatabase} names
+ * the principal it refused, and {@code GrpcAuthInterceptor} names the database it checked the grant
+ * against.
+ */
+class Issue7374GrpcPrincipalIT extends BaseGraphServerTest {
+
+  private static final int    GRPC_PORT       = 50051;
+  private static final String SCOPED_USER     = "scoped7374";
+  private static final String SCOPED_PWD      = "scoped7374password";
+  private static final String FOREIGN_USER    = "foreign7374";
+  private static final String FOREIGN_PWD     = "foreign7374password";
+  private static final String GROUP           = "acl7374";
+  private static final String OPEN_TYPE       = "Open7374";
+  private static final String RESTRICTED_TYPE = "Restricted7374";
+
+  private RemoteGrpcServer   grpcServer;
+  private RemoteGrpcDatabase database;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    if (database != null) {
+      database.close();
+      database = null;
+    }
+    if (grpcServer != null) {
+      grpcServer.close();
+      grpcServer = null;
+    }
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  /**
+   * The authorization half: the database's user is the one the engine gates on. The scoped user is
+   * denied {@code RESTRICTED_TYPE} and the {@link RemoteGrpcServer} is {@code root}, so before the fix
+   * the query simply returned the row. The refusal names the principal, which is the whole question.
+   */
+  @Test
+  void theDatabaseUserIsTheOneTheEngineAuthorizes() throws Exception {
+    sql("CREATE VERTEX TYPE `" + RESTRICTED_TYPE + "` IF NOT EXISTS");
+    sql("INSERT INTO `" + RESTRICTED_TYPE + "` SET id = 'secret'");
+    createScopedUser();
+
+    connect(SCOPED_USER, SCOPED_PWD);
+
+    assertThatThrownBy(() -> {
+      try (final ResultSet rs = database.query("sql", "SELECT FROM `" + RESTRICTED_TYPE + "`")) {
+        rs.hasNext();
+      }
+    }).as("the query must run as the database's user, not as the server's root")
+        .hasMessageContaining(SCOPED_USER)
+        .hasMessageContaining(RESTRICTED_TYPE);
+  }
+
+  /**
+   * The same connection on a type the scoped user IS granted still works, so the fix refuses by grant
+   * rather than by having broken the credentials.
+   */
+  @Test
+  void theDatabaseUserStillReachesWhatItIsGranted() throws Exception {
+    sql("CREATE VERTEX TYPE `" + OPEN_TYPE + "` IF NOT EXISTS");
+    sql("CREATE VERTEX TYPE `" + RESTRICTED_TYPE + "` IF NOT EXISTS");
+    sql("INSERT INTO `" + OPEN_TYPE + "` SET id = 'visible'");
+    createScopedUser();
+
+    connect(SCOPED_USER, SCOPED_PWD);
+
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS c FROM `" + OPEN_TYPE + "`")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(((Number) rs.next().getProperty("c")).longValue()).isEqualTo(1L);
+    }
+  }
+
+  /**
+   * The authentication half: a database user granted some OTHER database is refused, even though the
+   * {@link RemoteGrpcServer} it shares a channel with is {@code root} and would have been let in. The
+   * refusal names the database the grant was checked against (#7320's wording), which is how this test
+   * tells "refused for the right reason" from "refused for the wrong one".
+   */
+  @Test
+  void aForeignDatabaseUserIsRefusedEvenOnARootServer() throws Exception {
+    sql("CREATE VERTEX TYPE `" + OPEN_TYPE + "` IF NOT EXISTS");
+    createUserGrantedDatabase(FOREIGN_USER, FOREIGN_PWD, "someotherdatabase7374", "admin");
+
+    connect(FOREIGN_USER, FOREIGN_PWD);
+
+    assertThatThrownBy(() -> database.query("sql", "SELECT FROM `" + OPEN_TYPE + "`"))
+        .as("a database user with no grant on this database must not ride in on the server's account")
+        .hasMessageContaining(getDatabaseName());
+  }
+
+  /**
+   * Runs DDL/DML on the server's own embedded database rather than through
+   * {@code BaseGraphServerTest.command(0, ...)}, which posts to a hardcoded {@code 127.0.0.1:2480} - a port
+   * this server does not necessarily own, since the configured range starts there and a server already
+   * listening pushes this one up.
+   */
+  private void sql(final String statement) {
+    getServer(0).getDatabase(getDatabaseName()).command("sql", statement).close();
+  }
+
+  private void connect(final String user, final String password) {
+    // The server holds root; the database holds the scoped principal. That is the mismatch #7374 is about.
+    grpcServer = new RemoteGrpcServer("localhost", GRPC_PORT, "root", DEFAULT_PASSWORD_FOR_TESTS, true, List.of());
+    // The port the test server actually bound: the configured range starts at 2480, but a server already
+    // listening there pushes this one up.
+    database = new RemoteGrpcDatabase(grpcServer, "localhost", GRPC_PORT,
+        getServer(0).getHttpServer().getPort(), getDatabaseName(), user, password);
+  }
+
+  /**
+   * Grants the scoped user every access on every type except {@link #RESTRICTED_TYPE}, whose access
+   * list is empty, on this database only.
+   */
+  private void createScopedUser() throws Exception {
+    final ServerSecurity security = getServer(0).getSecurity();
+
+    security.getDatabaseGroupsConfiguration(getDatabaseName()).put(GROUP,
+        new JSONObject().put("access", new JSONArray().put("updateSecurity").put("updateSchema"))
+            .put("types", new JSONObject()
+                .put("*", new JSONObject().put("access",
+                    new JSONArray().put("readRecord").put("createRecord").put("updateRecord").put("deleteRecord")))
+                .put(RESTRICTED_TYPE, new JSONObject().put("access", new JSONArray()))));
+    security.saveGroups();
+
+    createUserGrantedDatabase(SCOPED_USER, SCOPED_PWD, getDatabaseName(), GROUP);
+  }
+
+  /**
+   * Creates a principal granted {@code database} and nothing else - no {@code "*"} wildcard, so the
+   * grant check is a real one.
+   * <p>
+   * The user goes in through the server's own {@code POST /api/v1/server/users} endpoint rather than
+   * through {@code ServerSecurity.createUser}, because the handler is what encodes the password into
+   * the form the authentication path expects. Same approach as {@code Issue7320ScopedUserGrpcIT}.
+   */
+  private void createUserGrantedDatabase(final String name, final String password, final String database,
+      final String group) throws Exception {
+    final ServerSecurity security = getServer(0).getSecurity();
+    if (security.existsUser(name))
+      security.dropUser(name);
+
+    final JSONObject payload = new JSONObject()
+        .put("name", name)
+        .put("password", password)
+        .put("databases", new JSONObject().put(database, new JSONArray().put(group)));
+
+    final HttpURLConnection connection = (HttpURLConnection) URI.create(
+            "http://127.0.0.1:" + getServer(0).getHttpServer().getPort() + "/api/v1/server/users").toURL()
+        .openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization", "Basic " + Base64.getEncoder()
+        .encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes(StandardCharsets.UTF_8)));
+    connection.setRequestProperty("Content-Type", "application/json");
+    connection.setDoOutput(true);
+    try (final OutputStream out = connection.getOutputStream()) {
+      out.write(payload.toString().getBytes(StandardCharsets.UTF_8));
+    }
+    // The endpoint answers 201 on a fresh user and 200 on a replaced one; both mean the user exists.
+    assertThat(connection.getResponseCode()).isIn(200, 201);
+    connection.disconnect();
+  }
+}


### PR DESCRIPTION
Closes #7374

`RemoteGrpcDatabase` takes its own `userName`/`userPassword` and put them in every request **body**
(`buildCredentials()`), but issued every call on stubs that `RemoteGrpcServer` built from its **own**
account. Server-side, `GrpcAuthInterceptor` authenticates from the call metadata and
`ArcadeDbGrpcService.resolvedUsername()` prefers that principal over the body credentials - so a
database opened as user B on a server built for user A ran every gRPC call as A, while the inherited
HTTP methods on the same object still ran as B. This takes the issue's first option ("the smaller
surprise"): the database's stubs now carry the database's principal, so one object has one identity on
both protocols. `RemoteGrpcServer` gains principal-carrying overloads of `newBlockingStub`,
`newAsyncStub` and `newAdminBlockingStub` plus `createCredentials(database, user, password)`; the
pre-existing overloads delegate to them with a null principal, so they keep meaning "this server's own
account" and no existing caller changes. A null or blank database user falls back to the server's pair,
which keeps a database constructed without credentials behaving exactly as before and keeps a `null` off
the metadata.

## Test plan

- [ ] `mvn -o -pl grpc-client -DskipITs=true test` - 161 tests, green (`Issue7374GrpcDatabaseCredentialsTest` 7, `Issue7320GrpcDatabaseHeaderTest` 4, `RemoteGrpcServerInsecureCredentialsTest` 6)
- [ ] `mvn -o -pl grpc-client -DskipITs=false -Dit.test=Issue7374GrpcPrincipalIT verify` - 3 tests, green
- [ ] `mvn -o -pl e2e,load-tests -DskipTests test-compile` - green (the two modules that construct `RemoteGrpcDatabase`)
- [ ] Both new suites were run against the pre-fix wiring first and fail there: 5 of the 7 unit cases, and both discriminating IT cases. The two unit cases that still pass pre-fix are the two pinning behaviour this change deliberately leaves alone (`blankDatabaseUserFallsBackToTheServerUser`, `serverScopedStubStillCarriesTheServerUser`)

`Issue7374GrpcPrincipalIT` asks the server which principal it saw, rather than asserting on the client:
`LocalDatabase` names the user it refused (`User 'scoped7374' is not allowed to ...`) and
`GrpcAuthInterceptor` names the database it checked the grant against. Both connections are built with
the server as `root` and the database as a scoped user.

## Coverage

| Entry point | Fixed | Test |
|---|---|---|
| `RemoteGrpcDatabase.createBlockingStub()` - query/command/CRUD/streaming/vector/timeseries (30 blocking call sites) | yes | `blockingStubCarriesTheDatabaseUser`, plus all three IT cases |
| `RemoteGrpcDatabase.createAsyncStub()` - bidi ingestion, graph batch (2 async call sites) | yes | `asyncStubCarriesTheDatabaseUser` |
| `RemoteGrpcDatabase.getProgress()` -> `newAdminBlockingStub` | yes | `adminStubCarriesTheDatabaseUser` |
| `RemoteGrpcDatabaseWithCompression` (only subclass; overrides neither factory) | yes, inherited | `compressionSubclassInheritsTheDatabaseUser` |
| Database constructed with a null/blank user | yes - falls back to the server's pair, unchanged | `blankDatabaseUserFallsBackToTheServerUser` |
| `RemoteGrpcServer`'s own RPCs (`listDatabases`, `getProgress(String)`, ...) | argued out of scope | `serverScopedStubStillCarriesTheServerUser` pins them unchanged |
| Server-side `resolvedUsername()` preferring the context user over the body | argued out of scope | - |

The two "argued" rows: `RemoteGrpcServer` is the object that holds the server account, so on its own
calls its user *is* the principal and metadata and body already agree - there is no second principal to
disagree with. And the server preferring the interceptor's context user is not itself wrong: those are
the credentials it actually verified a password for, whereas the body credentials are unverified when a
context user exists. Once the client sends one principal the question does not arise.

**Known gaps**

- **#7416** - `RemoteGrpcDatabase` caches its data-plane stubs on a channel a `RemoteGrpcServer.close()`/`start()` cycle replaces, so the whole data plane of that object fails after a server restart while `getProgress()` - built per call - survives it. Found while auditing the same two fields; out of scope here because it is about channel lifetime rather than principal identity, and wrong the same way before and after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Raa9V6fPZda6yQkn3kvRZf
