### PR TITLE
fix(#7339): bound the life of a Raft gRPC connection a busy peer keeps alive

### DIFF
--- a/docs/7339-raft-grpc-max-connection-age.md
+++ b/docs/7339-raft-grpc-max-connection-age.md
@@ -206,6 +206,49 @@ not bounded. What stands instead is that the IT's probe assertion is the same as
 under sabotage. The IT's own vacuity was caught and fixed by the adversarial pass, which is the
 failure mode a sabotage run would have been looking for.
 
+## Review cycle 1 - PR #7419
+
+Two points from the `claude` review on `14f2b71b`, both checked rather than accepted.
+
+**"the new `arcadedb-engine` test-jar dependency will not resolve under `-am test`."** The reasoning
+was the gremlin/graphql trap `CLAUDE.md` documents: `maven-jar-plugin`'s `test-jar` goal binds to
+`package`, which a `test`-phase reactor run never reaches. Measured instead of argued, with the
+engine test-jar deleted from the local repository AND `engine/target` removed entirely:
+
+```
+$ ls .m2repo/com/arcadedb/arcadedb-engine/26.10.1-SNAPSHOT/
+_remote.repositories  arcadedb-engine-26.10.1-SNAPSHOT-sources.jar
+arcadedb-engine-26.10.1-SNAPSHOT.jar  arcadedb-engine-26.10.1-SNAPSHOT.pom
+maven-metadata-local.xml                       <- no -tests.jar
+
+$ mvn -o -pl engine clean
+[INFO] Deleting .../engine/target
+
+$ mvn -o -pl ha-raft -am test -Dtest=Issue7339BoundsBusyRaftConnectionTest \
+      -Dsurefire.failIfNoSpecifiedTests=false
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
+[INFO] BUILD SUCCESS
+
+$ ls engine/target/*.jar
+no matches                                     <- nothing was packaged, and nothing needed to be
+```
+
+Maven substitutes the reactor module's `target/test-classes` for the `tests`-classified dependency,
+which the gremlin case cannot do because its dependency is on the `shaded` uber-jar - an artifact
+with no directory equivalent. So the trap does not reach this module pair.
+
+The review did land on a real defect in that command, just not the predicted one: with `-am`,
+`-Dtest=` is applied to every module in the reactor, so surefire fails the *upstream* module with
+`No tests matching pattern "Issue7339BoundsBusyRaftConnectionTest" were executed!` before ha-raft
+runs at all. `-Dsurefire.failIfNoSpecifiedTests=false` is what makes it work, and the PR's test plan
+now says so.
+
+**"`Http2ConnectionProbe` replenishes only the connection-level flow-control window."** Correct, and
+it is now stated in the class javadoc together with why per-stream replenishment is deliberately
+absent rather than merely missing: RFC 9113 lets a peer treat a WINDOW_UPDATE on a closed stream as a
+connection error, and every stream this probe opens is closed by the server almost at once. The
+behaviour is unchanged; a future reuser now sees the constraint before hitting it.
+
 ## Residual risk
 
 - The age bound is per connection and unconditional, so it recycles healthy Raft connections too.

--- a/docs/7339-raft-grpc-max-connection-age.md
+++ b/docs/7339-raft-grpc-max-connection-age.md
@@ -2,6 +2,8 @@
 
 Follow-up to #7316 (chain: #7132 -> #7225 -> #7250 -> #7316).
 
+PR: https://github.com/ArcadeData/arcadedb/pull/7419
+
 ## The defect
 
 #7316 gave the Raft gRPC listener a server-side connection-lifetime bound,
@@ -248,6 +250,22 @@ it is now stated in the class javadoc together with why per-stream replenishment
 absent rather than merely missing: RFC 9113 lets a peer treat a WINDOW_UPDATE on a closed stream as a
 connection error, and every stream this probe opens is closed by the server almost at once. The
 behaviour is unchanged; a future reuser now sees the constraint before hitting it.
+
+## Review cycle 2 - clean
+
+`ad4c235a`: "Nothing here needs to hold up merging." The one remark - that
+`Http2ConnectionProbe` replenishes only the connection-level window - was the cycle 1 point read
+again after the javadoc landed, and the review credits that javadoc with covering it. No change
+applied, no item deferred.
+
+## Final state
+
+`clean-approval`, two cycles.
+
+| Cycle | Head | What it was |
+|---|---|---|
+| 1 | `14f2b71b` | the fix, the settings, seven unit tests and the two-test measurement IT |
+| 2 | `ad4c235a` | measured the reviewer's `-am` test-jar prediction and disproved it; documented the probe's connection-only flow control; corrected the test-plan command |
 
 ## Residual risk
 

--- a/docs/7339-raft-grpc-max-connection-age.md
+++ b/docs/7339-raft-grpc-max-connection-age.md
@@ -1,0 +1,222 @@
+# #7339 - a revoked Raft gRPC peer that keeps retrying never lets its connection go idle
+
+Follow-up to #7316 (chain: #7132 -> #7225 -> #7250 -> #7316).
+
+## The defect
+
+#7316 gave the Raft gRPC listener a server-side connection-lifetime bound,
+`arcadedb.ha.grpcMaxConnectionIdleMs` -> `NettyServerBuilder.maxConnectionIdle`. That bound is
+conditional on the peer going quiet. gRPC measures idleness from the most recent moment the
+transport's active-stream count reached zero, and `NettyServerHandler` drives that from the HTTP/2
+stream count, so every RPC - including one the `PeerAllowlistCallInterceptor` answers with
+`PERMISSION_DENIED` - opens and closes a stream and pushes the deadline forward by the whole window.
+
+A revoked peer that keeps *starting* RPCs therefore keeps its connection forever. Two ways to reach
+it, both from the issue: a removed peer whose Ratis division has not learned it was removed keeps
+campaigning and sends a `requestVote` at every election timeout (hundreds of ms), which is shorter
+than any idle window that is safe for healthy connections; and a deliberate squatter can simply keep
+the connection busy on purpose.
+
+Blast radius is the same as #7316's and no larger: the interceptor refuses every RPC on a revoked
+transport, so what survives is a socket plus its HTTP/2 framing state - a resource cost, not reach.
+
+## The invariant
+
+> When `arcadedb.ha.grpcMaxConnectionAgeMs` is greater than zero, every inbound Raft gRPC connection
+> is closed once it reaches that age, whatever RPC traffic the peer keeps starting on it.
+
+`maxConnectionAge` is the only knob gRPC exposes that holds it. The timer is scheduled once, in
+`NettyServerHandler.handlerAdded`, and fires regardless of stream activity:
+
+```
+$ sed -n '/public void handlerAdded/,/maxConnectionIdleManager != null/p' \
+    org/apache/ratis/thirdparty/io/grpc/netty/NettyServerHandler.java
+  public void handlerAdded(final ChannelHandlerContext ctx) throws Exception {
+    serverWriteQueue = new WriteQueue(ctx.channel());
+
+    // init max connection age monitor
+    if (maxConnectionAgeInNanos != MAX_CONNECTION_AGE_NANOS_DISABLED) {
+      maxConnectionAgeMonitor = ctx.executor().schedule(
+          new LogExceptionRunnable(new Runnable() {
+            @Override
+            public void run() {
+              if (gracefulShutdown == null) {
+                gracefulShutdown = new GracefulShutdown("max_age", maxConnectionAgeGraceInNanos);
+```
+
+Two properties of the shaded gRPC (ratis-thirdparty-misc 1.1.0, which ratis 3.3.0 pins) that the
+implementation and the tests both depend on, each read out of the source rather than recalled:
+
+- the GOAWAY debug string names the timer that fired - `"max_age"` here, `"max_idle"` in the
+  `maxConnectionIdleManager` branch immediately below. That is what lets a test say *which* bound
+  closed a connection instead of inferring it from a stopwatch;
+- `NettyServer.initChannel` applies a per-connection jitter of +/-10% to the age
+  (`(long) ((.9D + Math.random() * .2D) * maxConnectionAgeInNanos)`), so a configured age is a
+  centre, not a deadline. No jitter is applied to the idle window.
+
+`NettyServerBuilder.maxConnectionAge` clamps anything under a second up to a second
+(`MIN_MAX_CONNECTION_AGE_NANO`) and treats anything from 1000 days up as disabled
+(`AS_LARGE_AS_INFINITE`), so the only value this code has to handle itself is the one that means off.
+
+### Why the grace window is always passed
+
+`maxConnectionAgeGrace` defaults to `MAX_CONNECTION_AGE_GRACE_NANOS_INFINITE` in gRPC, and
+`GracefulShutdown.graceTimeOverrideMillis` turns that into netty's `-1` - "no timeout". Under an
+infinite grace the age bound stops being a bound on exactly the connection that matters most here: a
+leader's `AppendEntries` to a follower is one long-lived stream, so after the GOAWAY the connection
+would wait for a stream that does not end. `arcadedb.ha.grpcMaxConnectionAgeGraceMs` is therefore
+passed on every call, with a finite default of 5 s.
+
+Stated precisely, because the first draft of this said something stronger than the code holds: what
+the code rules out is *arriving* at an infinite grace by not setting one. An operator who configures
+1000 days or more still gets gRPC's infinite, because `AS_LARGE_AS_INFINITE` is applied inside
+`NettyServerBuilder`. That is documented in the setting's own description rather than clamped, since
+the same threshold disables the age window itself and clamping one but not the other would be the
+more surprising behaviour.
+
+## Completeness
+
+### Commands run
+
+```
+$ grep -rn "setServicesCustomizer\|servicesCustomizer" --include='*.java' .
+./ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue3890RaftParametersPublicationTest.java:79
+./ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue3890RaftParametersPublicationTest.java:116
+./ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7316ReapsIdleRaftConnectionTest.java:106,145,164,196
+./ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java:4335
+
+$ grep -rn "new RaftGrpcServicesCustomizer" --include='*.java' .
+./ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java:4335
+```
+
+One install site: `RaftHAServer.installGrpcServerCustomizations`, reached only from
+`buildParameters`. Nothing else configures the Raft listener's `NettyServerBuilder`.
+
+```
+$ grep -rn "NettyServerBuilder" --include='*.java' . | grep -v /test/
+ha-raft/.../PeerTransportSession.java:42,46          (comments)
+ha-raft/.../RaftGrpcServicesCustomizer.java:24,46,70,71
+grpcw/.../GrpcServerPlugin.java:39,169,175,338,342
+
+$ grep -n "maxConnectionIdle\|maxConnectionAge\|keepAlive\|permitKeepAlive" \
+    grpcw/src/main/java/com/arcadedb/server/grpc/GrpcServerPlugin.java
+181:        .permitKeepAliveTime(10, TimeUnit.SECONDS)
+182:        .permitKeepAliveWithoutCalls(true)
+183:        .keepAliveTime(30, TimeUnit.SECONDS)
+184:        .keepAliveTimeout(10, TimeUnit.SECONDS)
+```
+
+`grpcw` is the one other gRPC listener in the tree, and it sets no lifetime bound either - the same
+*shape*. It is argued rather than fixed below.
+
+### Entry-point coverage
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| `buildParameters` -> `installGrpcServerCustomizations` -> `RaftGrpcServicesCustomizer.customize` -> `maxConnectionAge`, allowlist ON | yes | yes - `theAgeBoundClosesAConnectionTheIdleWindowCannotReach` |
+| same, allowlist OFF (the age is a connection-lifetime setting, not an allowlist setting - the trap #7316 had to be split apart to avoid) | yes | yes - `theAgeBoundIsInstalledWithTheAllowlistDisabled` |
+| the grace window reaches the builder and is finite | yes | yes - `theGraceWindowIsHonouredAndNeverInfinite` |
+| age = 0 leaves a busy connection alone (pre-26.10.1 behaviour, and the default) | yes | yes - `aBusyConnectionSurvivesTheIdleWindowWhenTheAgeIsDisabled` (this is the #7339 repro) |
+| age = 0, idle = 0, allowlist off -> no customizer at all | yes | yes - `noCustomizerIsInstalledWhenNothingNeedsOne` (#7316's row 4, re-asserted with the age at 0) |
+| a negative grace from a config typo must not throw out of `NettyServerBuilder.maxConnectionAgeGrace`'s `checkArgument` at startup | yes | yes - `aNegativeGraceIsClampedRatherThanCrashingStartup` |
+| a live multi-node cluster with the age enabled keeps replicating across the recycle | yes | yes - `Issue7339RaftConnectionAgeRecyclingIT` |
+| `grpcw`'s client-facing listener has no lifetime bound either | **argued** | n/a |
+| a non-zero DEFAULT for the age window | **argued** (measurement recorded below; default stays 0) | n/a |
+
+### Argued rows
+
+**`grpcw`.** The defect this issue chain is about is a connection that outlives the *revocation of
+its peer's reach*: #7250 gave the Raft listener an address allowlist whose decision can flip while a
+connection is established, and #7316/#7339 are about closing the socket that decision stranded.
+`GrpcServerPlugin` has no such mechanism - it authenticates every call against the server's own user
+registry, there is no address-derived per-transport verdict that can change underneath an open
+connection, and therefore no "revoked but still connected" state for an age bound to remedy. Its
+lack of a lifetime bound is an ordinary resource-management question about a client-facing listener,
+with a different threat model and a different blast radius, and it is not made better or worse by
+this change. Not filed: it is a design question for the grpcw listener, not a gap in this fix.
+
+**The default.** The issue asks for the setting to default to 0 and for a measurement before any
+non-zero default. Both are honoured: `HA_GRPC_MAX_CONNECTION_AGE_MS` defaults to `0L`, so nothing
+changes for an existing cluster that does not opt in, and `Issue7339RaftConnectionAgeRecyclingIT` is
+the measurement - a real 3-node Raft cluster with the age set to 3 s and the grace to 1 s, i.e. a
+recycle roughly every 3 s per connection against Ratis's default election timers, writing
+continuously across at least four recycle periods. What it can prove is that the recycle does not
+cost a leadership change or a lost write at that period; what it cannot prove is the right value for
+a production cluster on a real network, which is why the default stays off and the decision stays
+with the maintainer.
+
+## Adversarial pass
+
+Run by the author rather than by an independent subagent: this environment exposes no `Task` tool, so
+the orchestrator's "one subagent that has not been convinced" could not be spawned. Recorded here
+with that caveat, since it is a weaker check than the one the process asks for.
+
+| Finding | Verdict | Disposition |
+|---|---|---|
+| The comment claimed "this code never passes gRPC's infinite" for the grace. gRPC applies `AS_LARGE_AS_INFINITE` inside `NettyServerBuilder`, so a configured 1000 days or more still lands on infinite and the age bound stops bounding. | real, in scope | fixed here: the claim is narrowed to what the code holds, and the setting's description states the threshold |
+| The first version of the IT passed while observing *zero* connections. It counted distinct `PeerTransportSession` instances, and `PeerAddressAllowlistFilter.transportReady` returns early for `isLoopbackAddress()` without registering one - so on an in-process cluster there was nothing to count and the assertion measured nothing. | real, in scope | fixed here: the IT now opens an `Http2ConnectionProbe` against the live leader's Raft port and asserts the GOAWAY names `max_age`. Verified falsifiable by the sabotage below |
+| `@Tag("slow")` on the unit-test class would have hidden it from CI entirely: the `unit-tests` lane passes `-DexcludedGroups=slow,...` across every module, and the `slow-unit-tests` lane runs `-pl engine` only, so an `ha-raft` class tagged `slow` runs in no lane at all. | real, in scope | the unit test is deliberately untagged. The IT keeps `@Tag("slow")` because the `ha-integration-tests` lane passes no group filter and `failsafe.excludedGroups` defaults to empty, so a tag there is inert - which matches the module's existing ITs |
+| Does the age window tear down a snapshot transfer? A snapshot install is the one long operation on a Raft cluster that a period of seconds could plausibly starve. | not real | the bulk payload does not travel on the Raft gRPC listener: `SnapshotHttpHandler` serves it over HTTP at `GET /api/v1/ha/snapshot/{database}`, and a follower behind the compacted log downloads it from there |
+| The customizer is applied to Ratis's ADMIN and CLIENT listeners as well as SERVER, so the age recycles Ratis client channels too. | real, out of scope to change | intended, and identical to what #7316's idle window already does: `GrpcServicesImpl.buildServer` runs the customizer on each builder it constructs. Noted under residual risk rather than filed - it is the documented behaviour of the setting, not a gap |
+| The window is bound once, when `buildParameters` runs at plugin startup, so changing the setting on a running node does nothing until it restarts. | real, out of scope | true of every `arcadedb.ha.grpc*` setting including #7316's, and changing it would mean rebuilding the Ratis server. Noted under residual risk |
+
+## Verification
+
+```
+$ mvn -o -pl ha-raft test -Dtest=Issue7339BoundsBusyRaftConnectionTest
+Tests run: 7, Failures: 0, Errors: 0, Skipped: 0     (10.7 s)
+
+$ mvn -o -pl ha-raft verify -Dit.test=Issue7339RaftConnectionAgeRecyclingIT -DskipTests=true -DskipITs=false
+Tests run: 2, Failures: 0, Errors: 0, Skipped: 0     (43.0 s)
+
+$ mvn -o -pl ha-raft test -DexcludedGroups=benchmark,vector
+Tests run: 415, Failures: 0, Errors: 0, Skipped: 0
+```
+
+The 415-test run ends in a `BUILD FAILURE` that is not a regression: `LeaveClusterTest`'s fork could
+not start because another agent's build on this machine held port 2434
+(`java.net.BindException: Address already in use`, the fixed-port hazard `CLAUDE.md` documents). No
+test failed.
+
+### Proving the tests can fail
+
+Sabotaging the fix - `if (false && maxConnectionAgeMs > 0)` in `RaftGrpcServicesCustomizer` - turns
+exactly the three age assertions red and leaves the defect-reproducing one green:
+
+```
+Tests run: 7, Failures: 3
+  theAgeBoundClosesAConnectionTheIdleWindowCannotReach     expected "max_age" but was null
+  theAgeBoundIsInstalledWithTheAllowlistDisabled           expected "max_age" but was null
+  aZeroGraceStillClosesTheConnection                       expected "max_age" but was null
+  aBusyConnectionSurvivesTheIdleWindowWhenTheAgeIsDisabled PASSES - it is the pre-fix behaviour
+```
+
+The failure lines carry the number that matters: `Probe: 580 RPCs, widest gap between two of them
+107 ms, JVM stalled 0 ms`. 580 refused RPCs over sixty seconds against a one-second idle window, with
+the connection never closed, is the defect stated as a measurement.
+
+Sabotaging the *harness* instead - raising the drumbeat from 100 ms to 2 000 ms, above the idle
+window - closes the connection before the first beat, which is what proves the idle window is armed
+and that the drumbeat is genuinely what defeats it rather than the window being absent.
+
+The same sabotage was **not** run against `Issue7339RaftConnectionAgeRecyclingIT`: every attempt died
+before the fork started, on the port 2434 collision above, and waiting out another agent's build is
+not bounded. What stands instead is that the IT's probe assertion is the same assertion as
+`theAgeBoundIsInstalledWithTheAllowlistDisabled`, against the same helper, and that one is shown red
+under sabotage. The IT's own vacuity was caught and fixed by the adversarial pass, which is the
+failure mode a sabotage run would have been looking for.
+
+## Residual risk
+
+- The age bound is per connection and unconditional, so it recycles healthy Raft connections too.
+  The IT shows a 3 s period surviving on a loopback 3-node cluster; it says nothing about a WAN
+  cluster, a cluster with tuned election timers, or one with hundreds of databases. Anyone turning
+  this on should start well above their election timeout.
+- With the age disabled - the default - #7339 is unchanged: a peer that keeps starting RPCs keeps
+  its connection. The fix is an available remedy, not an automatic one.
+- gRPC's +/-10% jitter means the age is a centre, not a deadline: an individual connection can live
+  up to 10% longer than the configured value.
+- The window is applied to Ratis's ADMIN and CLIENT listeners as well as the SERVER one, so it
+  recycles Ratis client channels on the same period. That is what #7316's idle window already does.
+- Both windows are bound once, when `buildParameters` runs at plugin startup. Changing either on a
+  running node has no effect until it restarts.

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2177,8 +2177,9 @@ public enum GlobalConfiguration {
       already-established connection still gave it: the Raft RPCs running on that connection are closed with \
       a permission error and later ones are refused. gRPC exposes no way to close one established transport on \
       demand, so the connection itself goes when it falls idle, after arcadedb.ha.grpcMaxConnectionIdleMs - or \
-      never, if that window is set to 0. Does not provide peer identity or encryption: use mTLS on untrusted \
-      networks.""",
+      never, if that window is set to 0 or if the peer keeps retrying, since a refused RPC restarts the idle \
+      window too. arcadedb.ha.grpcMaxConnectionAgeMs bounds such a connection's life regardless. Does not \
+      provide peer identity or encryption: use mTLS on untrusted networks.""",
       Boolean.class, true),
 
   HA_GRPC_ALLOWLIST_REFRESH_MS("arcadedb.ha.grpcAllowlistRefreshMs", SCOPE.SERVER,
@@ -2220,6 +2221,35 @@ public enum GlobalConfiguration {
       next call. Values below one second are raised to one second by gRPC. Set to 0 to leave connections unbounded, \
       which is the behaviour before 26.10.1.""",
       Long.class, 300_000L),
+
+  HA_GRPC_MAX_CONNECTION_AGE_MS("arcadedb.ha.grpcMaxConnectionAgeMs", SCOPE.SERVER,
+      """
+      How long in milliseconds an inbound Raft gRPC connection may live before the server closes it with a \
+      graceful GOAWAY, whatever it is carrying. Unlike arcadedb.ha.grpcMaxConnectionIdleMs, which gRPC measures \
+      from the moment the connection's last RPC finished, this timer is armed once when the connection is \
+      established and fires on schedule, so it also closes a connection that is never idle. That is the case the \
+      idle window cannot reach (issue #7339): every RPC opens and closes an HTTP/2 stream and pushes the idle \
+      deadline forward by the whole window, including the RPCs a revoked peer gets PERMISSION_DENIED for, so a \
+      removed peer that keeps campaigning - or a squatter keeping the connection busy on purpose - holds its \
+      socket open indefinitely. \
+      The price is that this recycles healthy connections on the same period: a leader's AppendEntries stream to \
+      each follower is torn down at the end of arcadedb.ha.grpcMaxConnectionAgeGraceMs and re-established, once \
+      per period per peer. Default is 0, which leaves connections unbounded in age and is the behaviour of every \
+      release; a value below one second is raised to one second by gRPC, and gRPC applies a random +/-10% jitter \
+      per connection, so the configured value is a centre rather than a deadline. Set it well above the Raft \
+      election timeout of the cluster it runs on.""",
+      Long.class, 0L),
+
+  HA_GRPC_MAX_CONNECTION_AGE_GRACE_MS("arcadedb.ha.grpcMaxConnectionAgeGraceMs", SCOPE.SERVER,
+      """
+      How long in milliseconds the RPCs still running on a connection that reached \
+      arcadedb.ha.grpcMaxConnectionAgeMs have to finish before the connection is closed underneath them. Read \
+      only when that setting is non-zero. Set to 0 to cancel them at the age boundary instead. gRPC's own \
+      default for this grace is infinite, which is not offered here: a leader's AppendEntries to a follower is \
+      one long-lived stream that does not end on its own, so an infinite grace would stop the age bound from \
+      bounding the very connection it exists for. A negative value is treated as 0, and a value of 1000 days or \
+      more is read by gRPC itself as infinite, which puts the age bound back where it was.""",
+      Long.class, 5_000L),
 
   HA_TLS_ENABLED("arcadedb.ha.tls.enabled", SCOPE.SERVER,
       """

--- a/ha-raft/pom.xml
+++ b/ha-raft/pom.xml
@@ -61,6 +61,15 @@
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
+        <!-- StallAwareStopwatch/JvmStallMonitor: a wall-clock number in a Raft test's failure message is only
+             readable once the JVM-wide stall inside the measured window is reported next to it (issue #6260). -->
+        <dependency>
+            <groupId>com.arcadedb</groupId>
+            <artifactId>arcadedb-engine</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
 
         <!-- Apache Ratis -->
         <dependency>

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java
@@ -126,8 +126,12 @@ import java.util.logging.Level;
  * RPCs already running on it are closed. The socket is not closed on the spot - gRPC's public API exposes no way to
  * close one established transport on demand - but it is no longer left to the peer either: since issue #7316 the
  * Raft listener carries {@code arcadedb.ha.grpcMaxConnectionIdleMs}, so a connection that stops carrying RPCs, which
- * a revoked one does as soon as it stops retrying, is closed with a graceful GOAWAY. The accurate operator-facing
- * claim is that removing a peer revokes its reach immediately and its connection once that connection falls idle.
+ * a revoked one does as soon as it stops retrying, is closed with a graceful GOAWAY. A revoked peer that keeps
+ * retrying never stops, and its refused RPCs push that window forward indefinitely; for that case issue #7339 adds
+ * {@code arcadedb.ha.grpcMaxConnectionAgeMs}, an unconditional bound on the connection's whole life, off by default
+ * because it recycles healthy connections too. The accurate operator-facing claim is that removing a peer revokes
+ * its reach immediately and its connection once that connection falls idle - or, with the age window configured, no
+ * later than that window whether it falls idle or not.
  * <p>
  * This is NOT a substitute for mTLS: it does not authenticate peer identity and does not
  * encrypt the traffic. See GitHub issue #3890. The bounded startup fail-open is an acceptable
@@ -728,7 +732,8 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
           "Revoked the established Raft gRPC transport of %s: the address is no longer in the peer allowlist. "
               + "%d in-flight RPC(s) closed; every further RPC on that transport is refused. gRPC exposes no way to "
               + "close one established transport on demand, so the connection is closed once it has been idle for "
-              + "arcadedb.ha.grpcMaxConnectionIdleMs - a peer that keeps retrying keeps it open until it stops.",
+              + "arcadedb.ha.grpcMaxConnectionIdleMs - a peer that keeps retrying keeps it open until it stops, "
+              + "unless arcadedb.ha.grpcMaxConnectionAgeMs is set, which bounds its life regardless.",
           session.getRemoteIp(), closed);
     }
   }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerTransportSession.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerTransportSession.java
@@ -42,9 +42,11 @@ import java.util.concurrent.ConcurrentHashMap;
  * on demand (checked across {@code ServerTransportFilter} and every public method of {@code NettyServerBuilder}), so
  * revoking is not the same act as disconnecting. What is revoked is everything the socket can carry: in-flight calls
  * are closed with {@link #REVOKED} and every subsequent call on the transport is refused by the interceptor, which
- * sits in the server-wide interceptor chain that every RPC passes. The socket then goes when it falls idle: the one
- * connection-lifetime knob {@code NettyServerBuilder} does expose is builder-wide, and
- * {@link RaftGrpcServicesCustomizer} sets it from {@code arcadedb.ha.grpcMaxConnectionIdleMs} (issue #7316).
+ * sits in the server-wide interceptor chain that every RPC passes. The socket itself goes on whichever of the two
+ * builder-wide connection-lifetime knobs {@code NettyServerBuilder} does expose is configured, both of which
+ * {@link RaftGrpcServicesCustomizer} sets: {@code arcadedb.ha.grpcMaxConnectionIdleMs} once the connection stops
+ * carrying RPCs (issue #7316), and {@code arcadedb.ha.grpcMaxConnectionAgeMs} on schedule whatever it is carrying,
+ * which is the only one that reaches a revoked peer that keeps retrying (issue #7339).
  */
 final class PeerTransportSession {
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGrpcServicesCustomizer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGrpcServicesCustomizer.java
@@ -39,12 +39,23 @@ import java.util.concurrent.TimeUnit;
  * {@code ServerImpl} applies them to every call whatever order the services were added in - so the two are installed
  * together here rather than per service.
  * <p>
- * It also carries the connection-lifetime bound the Raft listener otherwise has none of (issue #7316). Neither of the
- * two surfaces above can close a connection: {@code ServerTransportFilter} is handed no reference to the transport it
- * admits, and a {@code ServerCall} reaches only its own HTTP/2 stream. So a peer whose reach a revocation took away
- * kept its socket until something else dropped it. The only knobs gRPC exposes for that are builder-wide, and
- * {@code GrpcServicesImpl.newNettyServerBuilder} sets none of them, which is why this customizer is where the window
- * is applied.
+ * It also carries the connection-lifetime bounds the Raft listener otherwise has none of (issues #7316, #7339).
+ * Neither of the two surfaces above can close a connection: {@code ServerTransportFilter} is handed no reference to
+ * the transport it admits, and a {@code ServerCall} reaches only its own HTTP/2 stream. So a peer whose reach a
+ * revocation took away kept its socket until something else dropped it. The only knobs gRPC exposes for that are
+ * builder-wide, and {@code GrpcServicesImpl.newNettyServerBuilder} sets none of them, which is why this customizer is
+ * where the windows are applied.
+ * <p>
+ * The two windows answer different halves of the same question, and a deployment can want either, both or neither:
+ * <ul>
+ * <li>{@code maxConnectionIdle} (#7316) is measured from the moment the connection's last RPC finished, so it reaps
+ * the connections that went quiet and never touches one that is carrying traffic - including the leader's
+ * {@code AppendEntries} stream, which is why it was safe to default it on.</li>
+ * <li>{@code maxConnectionAge} (#7339) is armed once, when the connection is established, and fires on schedule
+ * whatever the connection is carrying. It is the only bound that closes a peer which keeps <i>starting</i> RPCs: each
+ * one opens and closes an HTTP/2 stream and pushes the idle deadline forward by the whole window, refused ones
+ * included. It recycles healthy connections on the same period, so it defaults to off.</li>
+ * </ul>
  */
 final class RaftGrpcServicesCustomizer implements GrpcServices.Customizer {
 
@@ -54,16 +65,26 @@ final class RaftGrpcServicesCustomizer implements GrpcServices.Customizer {
   private final ServerTransportFilter[] filters;
   private final ServerInterceptor[]     interceptors;
   private final long                    maxConnectionIdleMs;
+  private final long                    maxConnectionAgeMs;
+  private final long                    maxConnectionAgeGraceMs;
 
   /**
-   * @param maxConnectionIdleMs how long a connection may carry no RPC before the server closes it, or {@code 0} or
-   *                            less to leave connections unbounded, which is what Ratis does on its own
+   * @param maxConnectionIdleMs     how long a connection may carry no RPC before the server closes it, or {@code 0}
+   *                                or less to leave the idle window unbounded, which is what Ratis does on its own
+   * @param maxConnectionAgeMs      how long a connection may live whatever it is carrying, or {@code 0} or less to
+   *                                leave its age unbounded
+   * @param maxConnectionAgeGraceMs how long the RPCs still running on a connection that reached that age have to
+   *                                finish; read only when {@code maxConnectionAgeMs} is positive, and clamped at 0
+   *                                so a negative value from a configuration file cannot throw out of
+   *                                {@code NettyServerBuilder.maxConnectionAgeGrace}'s argument check at startup
    */
   RaftGrpcServicesCustomizer(final ServerTransportFilter[] filters, final ServerInterceptor[] interceptors,
-      final long maxConnectionIdleMs) {
+      final long maxConnectionIdleMs, final long maxConnectionAgeMs, final long maxConnectionAgeGraceMs) {
     this.filters = filters == null ? NO_FILTERS : filters;
     this.interceptors = interceptors == null ? NO_INTERCEPTORS : interceptors;
     this.maxConnectionIdleMs = maxConnectionIdleMs;
+    this.maxConnectionAgeMs = maxConnectionAgeMs;
+    this.maxConnectionAgeGraceMs = Math.max(0L, maxConnectionAgeGraceMs);
   }
 
   @Override
@@ -78,6 +99,16 @@ final class RaftGrpcServicesCustomizer implements GrpcServices.Customizer {
     // anything from 1000 days up as "disabled", so the only value handled here is the one that means off.
     if (maxConnectionIdleMs > 0)
       result = result.maxConnectionIdle(maxConnectionIdleMs, TimeUnit.MILLISECONDS);
+    // The age bound (#7339): the idle window above is pushed forward by every RPC, so it never closes a peer that
+    // keeps starting them. This one is armed once, in NettyServerHandler.handlerAdded, and fires on schedule.
+    // The grace is always passed alongside it rather than left at gRPC's default, which is infinite: under an
+    // infinite grace a connection carrying a stream that does not end - which is exactly what a leader's
+    // AppendEntries is - would wait out its GOAWAY forever, and the bound would not bound. gRPC still reads a
+    // CONFIGURED grace of 1000 days or more as infinite (AS_LARGE_AS_INFINITE), which the setting's description
+    // says; what this line rules out is arriving there by not setting it.
+    if (maxConnectionAgeMs > 0)
+      result = result.maxConnectionAge(maxConnectionAgeMs, TimeUnit.MILLISECONDS)
+          .maxConnectionAgeGrace(maxConnectionAgeGraceMs, TimeUnit.MILLISECONDS);
     return result;
   }
 }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -4310,12 +4310,13 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
 
   /**
    * Installs the one {@code GrpcServices.Customizer} the Raft listener gets: the peer allowlist's transport filter
-   * and call interceptor (issues #7132, #7225, #7250) and the connection-idle window (issue #7316).
+   * and call interceptor (issues #7132, #7225, #7250), the connection-idle window (issue #7316) and the
+   * connection-age window (issue #7339).
    * <p>
-   * The two are configured independently, so this method is not gated on either of them: gating it on
+   * All three are configured independently, so this method is not gated on any of them: gating it on
    * {@code arcadedb.ha.peerAllowlist.enabled}, which is where the allowlist install used to live, would have made
    * {@code arcadedb.ha.grpcMaxConnectionIdleMs} a setting that silently does nothing on exactly the clusters that
-   * turned the allowlist off. When neither is configured no customizer is installed at all, which leaves Ratis's
+   * turned the allowlist off. When none is configured no customizer is installed at all, which leaves Ratis's
    * builder exactly as it was.
    */
   private void installGrpcServerCustomizations(final ContextConfiguration configuration, final Parameters parameters) {
@@ -4329,13 +4330,20 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
 
     // Neither surface can close the connection itself, so the socket of a revoked peer outlived its reach (#7316).
     final long maxConnectionIdleMs = configuration.getValueAsLong(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_IDLE_MS);
-    if (filter == null && maxConnectionIdleMs <= 0)
+    // ...and the idle window only reaps a peer that goes quiet: gRPC restarts it from the last moment the
+    // connection's active-stream count hit zero, so a peer that keeps starting RPCs - a removed peer still
+    // campaigning, or a squatter - pushes it forward forever, refused RPCs included (#7339). The age window is the
+    // unconditional bound for that case, off by default because it recycles healthy connections on the same period.
+    final long maxConnectionAgeMs = configuration.getValueAsLong(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_AGE_MS);
+    final long maxConnectionAgeGraceMs = configuration.getValueAsLong(
+        GlobalConfiguration.HA_GRPC_MAX_CONNECTION_AGE_GRACE_MS);
+    if (filter == null && maxConnectionIdleMs <= 0 && maxConnectionAgeMs <= 0)
       return;
 
     GrpcConfigKeys.Server.setServicesCustomizer(parameters, new RaftGrpcServicesCustomizer(
         filter == null ? new ServerTransportFilter[0] : new ServerTransportFilter[] { filter },
         interceptor == null ? new ServerInterceptor[0] : new ServerInterceptor[] { interceptor },
-        maxConnectionIdleMs));
+        maxConnectionIdleMs, maxConnectionAgeMs, maxConnectionAgeGraceMs));
   }
 
   /** The inbound peer allowlist filter, or {@code null} when it is disabled or has no host to admit. */

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Http2ConnectionProbe.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Http2ConnectionProbe.java
@@ -48,6 +48,14 @@ import java.util.concurrent.atomic.AtomicReference;
  * A reader thread pumps frames continuously and acknowledges SETTINGS and PING - gRPC's graceful shutdown waits on
  * its own PING before closing the socket, so answering it turns an eleven-second wait into a prompt one. Headers are
  * HPACK literals without indexing, so the dynamic table stays empty on both sides and neither has to track state.
+ * <p>
+ * <b>What it is not.</b> The flow control here is connection-level only: it replenishes the stream 0 window and
+ * never a per-stream one. That is sound for what it does - a HEADERS-only request whose answer is a trailers-only
+ * refusal or UNIMPLEMENTED, which carries no DATA at all - and it is a trap for anything else. Pointed at an
+ * endpoint that streams a response larger than the 64 KiB initial stream window, this probe would stall on a
+ * per-stream window it never updates, and the stall would read as "the server went quiet". Replenishing per stream
+ * is deliberately not done rather than left undone: RFC 9113 lets a peer treat a WINDOW_UPDATE on a closed stream
+ * as a connection error, and every stream this probe opens is closed by the server almost immediately.
  *
  * @author Roberto Franchini (r.franchini@arcadedata.com)
  */

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Http2ConnectionProbe.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Http2ConnectionProbe.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.utility.StallAwareStopwatch;
+
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * An HTTP/2 client that watches a Raft gRPC listener's connection-lifetime bounds from the outside, written for
+ * issue #7339 and used both against a customizer applied to a bare {@code NettyServerBuilder} and against the
+ * listener of a live cluster node.
+ * <p>
+ * It exists because the two bounds cannot be told apart by a stopwatch. gRPC names the timer that fired in the
+ * GOAWAY's debug data - {@code "max_age"} or {@code "max_idle"} - so a test can assert <i>which</i> window closed a
+ * connection instead of inferring it from how long that took.
+ * <p>
+ * The other half of issue #7339 is that a connection which keeps <i>starting</i> RPCs is never idle: a stream that
+ * opens and closes restarts the idle window whether the RPC succeeds, is refused by the peer allowlist interceptor,
+ * or comes back UNIMPLEMENTED. {@link #drumUntilClosed} is that peer.
+ * <p>
+ * A reader thread pumps frames continuously and acknowledges SETTINGS and PING - gRPC's graceful shutdown waits on
+ * its own PING before closing the socket, so answering it turns an eleven-second wait into a prompt one. Headers are
+ * HPACK literals without indexing, so the dynamic table stays empty on both sides and neither has to track state.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+final class Http2ConnectionProbe implements AutoCloseable {
+
+  private static final byte[] PREFACE     = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
+  private static final int    DATA        = 0x0;
+  private static final int    HEADERS     = 0x1;
+  private static final int    SETTINGS    = 0x4;
+  private static final int    PING        = 0x6;
+  private static final int    GOAWAY      = 0x7;
+  private static final int    WINDOW_UPD  = 0x8;
+  private static final int    ACK         = 0x1;
+  private static final int    END_STREAM  = 0x1;
+  private static final int    END_HEADERS = 0x4;
+
+  private final Socket                  socket;
+  private final InputStream             in;
+  private final OutputStream            out;
+  private final String                  authority;
+  private final Object                  writeLock = new Object();
+  private final CountDownLatch          closed    = new CountDownLatch(1);
+  private final AtomicReference<String> goAway    = new AtomicReference<>();
+  private final Thread                  pump;
+
+  private int  nextStreamId = 1;
+  private int  beats;
+  private long widestGapMs;
+  private long stallMs;
+
+  /** Connects to {@code host:port} and completes the HTTP/2 handshake. */
+  static Http2ConnectionProbe connectTo(final String host, final int port) throws IOException {
+    final Socket socket = new Socket();
+    socket.connect(new InetSocketAddress(host, port), 10_000);
+    return new Http2ConnectionProbe(socket, host + ":" + port);
+  }
+
+  private Http2ConnectionProbe(final Socket socket, final String authority) throws IOException {
+    this.socket = socket;
+    this.authority = authority;
+    this.in = socket.getInputStream();
+    this.out = socket.getOutputStream();
+    writeFrame(SETTINGS, 0, 0, new byte[0], PREFACE);
+
+    this.pump = new Thread(this::pumpFrames, "issue7339-http2-probe");
+    this.pump.setDaemon(true);
+    this.pump.start();
+  }
+
+  /**
+   * Opens and closes one stream every {@code beatMs} until the server closes the connection or {@code budgetMs}
+   * elapses, whichever comes first. Stops beating as soon as a GOAWAY arrives: a stream created after the server
+   * has announced its last accepted id is a protocol error, and a connection closed for <i>that</i> reason would
+   * look like a pass to a test that only checked whether it closed.
+   */
+  void drumUntilClosed(final long budgetMs, final long beatMs) throws InterruptedException {
+    final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(budgetMs);
+    final long stallAtStart = StallAwareStopwatch.jvmStallNanos();
+    long lastBeatNanos = System.nanoTime();
+
+    while (!closed.await(beatMs, TimeUnit.MILLISECONDS) && System.nanoTime() < deadline) {
+      if (goAway.get() != null)
+        continue; // the server is shutting the connection down; let the pump see it through to EOF
+      try {
+        openAndCloseOneStream();
+      } catch (final IOException closedUnderneathUs) {
+        break;
+      }
+      final long now = System.nanoTime();
+      widestGapMs = Math.max(widestGapMs, TimeUnit.NANOSECONDS.toMillis(now - lastBeatNanos));
+      lastBeatNanos = now;
+      beats++;
+    }
+    stallMs = TimeUnit.NANOSECONDS.toMillis(Math.max(0L, StallAwareStopwatch.jvmStallNanos() - stallAtStart));
+  }
+
+  /** Waits without sending anything, for the case where the question is what an untouched connection is worth. */
+  void awaitClose(final long budgetMs) throws InterruptedException {
+    final long stallAtStart = StallAwareStopwatch.jvmStallNanos();
+    closed.await(budgetMs, TimeUnit.MILLISECONDS);
+    stallMs = TimeUnit.NANOSECONDS.toMillis(Math.max(0L, StallAwareStopwatch.jvmStallNanos() - stallAtStart));
+  }
+
+  /** How many RPCs the drumbeat actually started. */
+  int beats() {
+    return beats;
+  }
+
+  /** The GOAWAY debug string - {@code "max_age"} or {@code "max_idle"} - or null while the connection is open. */
+  String closeReason() {
+    return goAway.get();
+  }
+
+  /** The numbers a red run needs to tell a stalled harness from a server that reaped a busy connection. */
+  String timing() {
+    return "Probe: %d RPCs, widest gap between two of them %,d ms, JVM stalled %,d ms during the run."
+        .formatted(beats, widestGapMs, stallMs);
+  }
+
+  private void openAndCloseOneStream() throws IOException {
+    final byte[] block = headerBlock();
+    final int streamId;
+    synchronized (writeLock) {
+      streamId = nextStreamId;
+      nextStreamId += 2; // client-initiated stream ids are odd and strictly increasing
+    }
+    writeFrame(HEADERS, END_HEADERS | END_STREAM, streamId, block, null);
+  }
+
+  private byte[] headerBlock() {
+    final ByteArrayOutputStream block = new ByteArrayOutputStream();
+    literalHeader(block, ":method", "POST");
+    literalHeader(block, ":scheme", "http");
+    literalHeader(block, ":path", "/arcadedb.issue7339.Drumbeat/Beat");
+    literalHeader(block, ":authority", authority);
+    literalHeader(block, "content-type", "application/grpc");
+    literalHeader(block, "te", "trailers");
+    return block.toByteArray();
+  }
+
+  /** HPACK "literal header field without indexing - new name": neither side indexes, so neither has to remember. */
+  private static void literalHeader(final ByteArrayOutputStream block, final String name, final String value) {
+    block.write(0x00);
+    writeHpackString(block, name);
+    writeHpackString(block, value);
+  }
+
+  private static void writeHpackString(final ByteArrayOutputStream block, final String text) {
+    final byte[] raw = text.getBytes(StandardCharsets.US_ASCII);
+    if (raw.length >= 127)
+      throw new IllegalArgumentException("this encoder only writes 7-bit-prefix lengths: " + text);
+    block.write(raw.length); // H=0, no Huffman coding
+    block.write(raw, 0, raw.length);
+  }
+
+  private void pumpFrames() {
+    try {
+      while (true)
+        readOneFrame();
+    } catch (final IOException endOfConnection) {
+      // EOF or a reset: either way the server let the connection go, which is what the tests measure.
+    } finally {
+      closed.countDown();
+    }
+  }
+
+  private void readOneFrame() throws IOException {
+    final byte[] header = readFully(9);
+    final int length = ((header[0] & 0xff) << 16) | ((header[1] & 0xff) << 8) | (header[2] & 0xff);
+    final int type = header[3] & 0xff;
+    final int flags = header[4] & 0xff;
+    final byte[] payload = readFully(length);
+
+    if (type == SETTINGS && (flags & ACK) == 0)
+      writeFrame(SETTINGS, ACK, 0, new byte[0], null);
+    else if (type == PING && (flags & ACK) == 0)
+      writeFrame(PING, ACK, 0, payload, null);
+    else if (type == GOAWAY && payload.length > 8)
+      // 4 bytes last-stream-id, 4 bytes error code, then the debug data gRPC uses to name the timer that fired.
+      goAway.compareAndSet(null, new String(payload, 8, payload.length - 8, StandardCharsets.US_ASCII));
+    else if (type == DATA && length > 0)
+      // Keep the connection-level flow-control window open: the server's answers are small, but a drumbeat of
+      // hundreds of them must not be able to stall on a window this client never updates.
+      writeFrame(WINDOW_UPD, 0, 0, new byte[] { 0, 0, (byte) (length >>> 8), (byte) length }, null);
+  }
+
+  private byte[] readFully(final int length) throws IOException {
+    final byte[] buffer = new byte[length];
+    int read = 0;
+    while (read < length) {
+      final int n = in.read(buffer, read, length - read);
+      if (n < 0)
+        throw new EOFException("the server closed the connection");
+      read += n;
+    }
+    return buffer;
+  }
+
+  private void writeFrame(final int type, final int flags, final int streamId, final byte[] payload,
+      final byte[] prologue) throws IOException {
+    final byte[] frame = new byte[9 + payload.length];
+    frame[0] = (byte) (payload.length >>> 16);
+    frame[1] = (byte) (payload.length >>> 8);
+    frame[2] = (byte) payload.length;
+    frame[3] = (byte) type;
+    frame[4] = (byte) flags;
+    frame[5] = (byte) (streamId >>> 24);
+    frame[6] = (byte) (streamId >>> 16);
+    frame[7] = (byte) (streamId >>> 8);
+    frame[8] = (byte) streamId;
+    System.arraycopy(payload, 0, frame, 9, payload.length);
+    synchronized (writeLock) {
+      if (prologue != null)
+        out.write(prologue);
+      out.write(frame);
+      out.flush();
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    socket.close();
+    pump.interrupt();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7339BoundsBusyRaftConnectionTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7339BoundsBusyRaftConnectionTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+import org.apache.ratis.conf.Parameters;
+import org.apache.ratis.grpc.GrpcConfigKeys;
+import org.apache.ratis.grpc.server.GrpcServices;
+import org.apache.ratis.thirdparty.io.grpc.Server;
+import org.apache.ratis.thirdparty.io.grpc.netty.NettyServerBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.util.EnumSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for issue #7339, a follow-up to #7316.
+ * <p>
+ * #7316 bounded a Raft gRPC connection that goes <i>quiet</i>: {@code arcadedb.ha.grpcMaxConnectionIdleMs} reaches
+ * {@code NettyServerBuilder.maxConnectionIdle}, and gRPC measures that window from the most recent moment the
+ * transport's active-stream count reached zero. Every RPC opens and closes an HTTP/2 stream and therefore pushes the
+ * deadline forward by the whole window - including the RPCs {@code PeerAllowlistCallInterceptor} answers with
+ * {@code PERMISSION_DENIED}. So a revoked peer that keeps <i>retrying</i>, which a removed peer whose Ratis division
+ * has not learned it was removed does at every election timeout, keeps its connection forever.
+ * <p>
+ * {@code arcadedb.ha.grpcMaxConnectionAgeMs} is the unconditional bound for that case: the timer is scheduled once,
+ * in {@code NettyServerHandler.handlerAdded}, and fires whatever the connection is carrying.
+ * <p>
+ * The tests drive the real production path - {@code RaftHAServer.buildParameters} publishes a
+ * {@code GrpcServices.Customizer}, the test applies it to a {@link NettyServerBuilder} exactly as
+ * {@code GrpcServicesImpl.buildServer} does, starts the server, and watches a real HTTP/2 connection from the
+ * outside - and they read the GOAWAY debug string rather than a stopwatch to say <i>which</i> window closed a
+ * connection: gRPC names the timer that fired, {@code "max_age"} or {@code "max_idle"}.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue7339BoundsBusyRaftConnectionTest {
+
+  private static final String SERVER_LIST = "localhost:2434:2480,localhost:2435:2481";
+
+  /** gRPC raises anything below a second to a second, for both windows, so this is the shortest honoured value. */
+  private static final long MIN_WINDOW_MS = 1_000L;
+
+  /**
+   * One refused RPC every 100 ms against a 1 000 ms idle window. The margin is what keeps the two tests below from
+   * being a bet on the scheduler: for the drumbeat to lapse and let {@code max_idle} fire, the JVM would have to
+   * stop for nine consecutive beats. Both tests report the widest gap they actually saw, so a red run says whether
+   * the harness stalled or the server reaped a busy connection.
+   */
+  private static final long BEAT_MS = 100L;
+
+  // ---------------------------------------------------------------------------
+  // Row 1: the defect - the idle window cannot reach a connection that stays busy
+  // ---------------------------------------------------------------------------
+
+  @Test
+  @Timeout(120)
+  void aBusyConnectionSurvivesTheIdleWindowWhenTheAgeIsDisabled() throws Exception {
+    final ContextConfiguration config = baseConfiguration();
+    config.setValue(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_IDLE_MS, MIN_WINDOW_MS);
+    config.setValue(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_AGE_MS, 0L);
+
+    try (final RaftGrpcServer server = start(config); final Http2ConnectionProbe peer = server.connect()) {
+      peer.drumUntilClosed(5_000L, BEAT_MS);
+
+      // Not a vacuous pass: if the drumbeat were malformed HTTP/2 the server would have answered with a GOAWAY of
+      // its own, and if it never opened a stream the 1 000 ms idle window would have reaped the connection.
+      assertThat(peer.beats())
+          .as("the drumbeat has to have actually opened streams, or this test proves nothing")
+          .isGreaterThan(20);
+      assertThat(peer.closeReason())
+          .as("this is the defect: a peer that keeps starting RPCs pushes the idle deadline forward by the whole "
+              + "window every time, refused RPCs included, so nothing closes its connection. %s", peer.timing())
+          .isNull();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Row 2: the fix - the age window closes it, and it is the age that does it
+  // ---------------------------------------------------------------------------
+
+  @Test
+  @Timeout(120)
+  void theAgeBoundClosesAConnectionTheIdleWindowCannotReach() throws Exception {
+    final ContextConfiguration config = baseConfiguration();
+    config.setValue(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_IDLE_MS, MIN_WINDOW_MS);
+    config.setValue(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_AGE_MS, 3_000L);
+    config.setValue(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_AGE_GRACE_MS, 500L);
+
+    try (final RaftGrpcServer server = start(config); final Http2ConnectionProbe peer = server.connect()) {
+      peer.drumUntilClosed(60_000L, BEAT_MS);
+
+      assertThat(peer.beats()).as("the drumbeat has to have actually opened streams").isGreaterThan(20);
+      assertThat(peer.closeReason())
+          .as("the same drumbeat that defeats the idle window must not defeat the age window, and the GOAWAY has "
+              + "to name the age timer rather than the idle one - max_idle here would mean the harness stalled "
+              + "long enough for the idle window to fire, not that the fix worked. %s", peer.timing())
+          .isEqualTo("max_age");
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Row 3: the age is a connection-lifetime setting, not an allowlist setting
+  // ---------------------------------------------------------------------------
+
+  @Test
+  @Timeout(120)
+  void theAgeBoundIsInstalledWithTheAllowlistDisabled() throws Exception {
+    final ContextConfiguration config = baseConfiguration();
+    config.setValue(GlobalConfiguration.HA_PEER_ALLOWLIST_ENABLED, false);
+    config.setValue(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_IDLE_MS, 0L);
+    config.setValue(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_AGE_MS, MIN_WINDOW_MS);
+
+    final RaftHAServer haServer = detachedServer();
+    final Parameters parameters = haServer.buildParameters(config);
+    assertThat(haServer.allowlistFilterForTest()).as("the allowlist is off, so no filter is built").isNull();
+    assertThat(GrpcConfigKeys.Server.servicesCustomizer(parameters))
+        .as("the age window must still reach the builder, or it is a setting that silently does nothing on "
+            + "exactly the clusters that turned the allowlist off")
+        .isNotNull();
+
+    try (final RaftGrpcServer server = start(parameters); final Http2ConnectionProbe peer = server.connect()) {
+      peer.drumUntilClosed(60_000L, BEAT_MS);
+      assertThat(peer.closeReason()).as("%s", peer.timing()).isEqualTo("max_age");
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Row 4: nothing configured at all - Ratis's builder is left exactly as it was
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void noCustomizerIsInstalledWhenNothingNeedsOne() {
+    final ContextConfiguration config = baseConfiguration();
+    config.setValue(GlobalConfiguration.HA_PEER_ALLOWLIST_ENABLED, false);
+    config.setValue(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_IDLE_MS, 0L);
+    config.setValue(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_AGE_MS, 0L);
+
+    assertThat(GrpcConfigKeys.Server.servicesCustomizer(detachedServer().buildParameters(config)))
+        .as("a third window that nothing turned on must not start installing a customizer on its own")
+        .isNull();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Row 5: the grace reaches the builder, and a typo in it does not stop the node
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void aNegativeGraceIsClampedRatherThanCrashingStartup() {
+    // NettyServerBuilder.maxConnectionAgeGrace checkArgument()s a non-negative value, so an unclamped -1 from a
+    // configuration file would throw out of the customizer while Ratis is building its server - i.e. the node
+    // would not start. Clamping keeps a typo in a tuning knob from being a startup failure.
+    final RaftGrpcServicesCustomizer customizer = new RaftGrpcServicesCustomizer(null, null, 0L, MIN_WINDOW_MS, -1L);
+
+    assertThatCode(() -> customizer.customize(NettyServerBuilder.forPort(0), EnumSet.allOf(GrpcServices.Type.class)))
+        .as("a negative grace must be clamped, not rethrown as a startup failure")
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  @Timeout(120)
+  void aZeroGraceStillClosesTheConnection() throws Exception {
+    // The other end of the grace range: 0 means "cancel whatever is still running at the age boundary". gRPC's own
+    // default for the grace is infinite, which this code never passes - see RaftGrpcServicesCustomizer.
+    final ContextConfiguration config = baseConfiguration();
+    config.setValue(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_IDLE_MS, 0L);
+    config.setValue(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_AGE_MS, MIN_WINDOW_MS);
+    config.setValue(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_AGE_GRACE_MS, 0L);
+
+    try (final RaftGrpcServer server = start(config); final Http2ConnectionProbe peer = server.connect()) {
+      peer.drumUntilClosed(60_000L, BEAT_MS);
+      assertThat(peer.closeReason()).as("%s", peer.timing()).isEqualTo("max_age");
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Row 6: the defaults promise no behaviour change for a cluster that opts out
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void theAgeWindowIsOffByDefault() {
+    assertThat(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_AGE_MS.getDefValue())
+        .as("the age window recycles healthy connections too, so it cannot default on without the measurement "
+            + "issue #7339 asks for - see Issue7339RaftConnectionAgeRecyclingIT")
+        .isEqualTo(0L);
+    assertThat(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_AGE_MS.getType()).isEqualTo(Long.class);
+    assertThat(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_AGE_GRACE_MS.getDefValue()).isEqualTo(5_000L);
+    assertThat(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_AGE_GRACE_MS.getType()).isEqualTo(Long.class);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Harness
+  // ---------------------------------------------------------------------------
+
+  private static ContextConfiguration baseConfiguration() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_SERVER_LIST, SERVER_LIST);
+    return config;
+  }
+
+  private static RaftHAServer detachedServer() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_SERVER_LIST, SERVER_LIST);
+
+    final ArcadeDBServer arcadeServer = mock(ArcadeDBServer.class);
+    when(arcadeServer.getServerName()).thenReturn("ArcadeDB_0");
+
+    return new RaftHAServer(arcadeServer, config);
+  }
+
+  private static RaftGrpcServer start(final ContextConfiguration config) throws IOException {
+    return start(detachedServer().buildParameters(config));
+  }
+
+  private static RaftGrpcServer start(final Parameters parameters) throws IOException {
+    final GrpcServices.Customizer customizer = GrpcConfigKeys.Server.servicesCustomizer(parameters);
+    assertThat(customizer).as("no customizer was published, so there is nothing to start").isNotNull();
+
+    final NettyServerBuilder builder = NettyServerBuilder.forPort(0);
+    final Server server = customizer.customize(builder, EnumSet.allOf(GrpcServices.Type.class)).build().start();
+    return new RaftGrpcServer(server);
+  }
+
+  private record RaftGrpcServer(Server server) implements AutoCloseable {
+
+    Http2ConnectionProbe connect() throws IOException {
+      return Http2ConnectionProbe.connectTo("localhost", server.getPort());
+    }
+
+    @Override
+    public void close() {
+      server.shutdownNow();
+    }
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7339RaftConnectionAgeRecyclingIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7339RaftConnectionAgeRecyclingIT.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The measurement issue #7339 asks for before {@code arcadedb.ha.grpcMaxConnectionAgeMs} could ever default to a
+ * non-zero value.
+ * <p>
+ * The age window is the only bound that closes a revoked peer which keeps retrying, because gRPC restarts the idle
+ * window on every RPC, refused ones included. Its price is that it is unconditional in the other direction too: it
+ * recycles the <i>healthy</i> Raft connections on the same period, and a leader's {@code AppendEntries} to a
+ * follower is one long-lived stream that a recycle tears down and forces to re-establish. ArcadeDB does not move the
+ * Ratis election timers off their defaults, so "does a re-establish cost less than an election timeout" is a
+ * question about a running cluster rather than about the setting.
+ * <p>
+ * This test answers it at a period far more aggressive than anything an operator would configure: a 3-node cluster
+ * with a 3 s age and a 1 s grace, i.e. roughly one recycle per connection every 3 s, writing continuously across at
+ * least four recycle periods. It asserts what a recycle must not cost - a lost write, a divergent replica, or a
+ * leadership change - and it is a regression test for the wiring as much as a measurement.
+ * <p>
+ * What it does <b>not</b> establish is the right production value: loopback with three nodes and one database is
+ * the friendliest case there is. That is why {@code arcadedb.ha.grpcMaxConnectionAgeMs} still defaults to 0 and the
+ * decision is left with the operator, who should start well above their election timeout.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+@Tag("slow")
+class Issue7339RaftConnectionAgeRecyclingIT extends BaseRaftHATest {
+
+  private static final String TYPE = "Issue7339";
+
+  /** gRPC jitters this by +/-10% per connection, so the recycles do not line up across the cluster. */
+  private static final long AGE_MS   = 3_000L;
+  private static final long GRACE_MS = 1_000L;
+
+  /** Long enough to span at least four recycle periods on every connection, jitter included. */
+  private static final long WRITE_WINDOW_MS = 14_000L;
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    config.setValue(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_AGE_MS, AGE_MS);
+    config.setValue(GlobalConfiguration.HA_GRPC_MAX_CONNECTION_AGE_GRACE_MS, GRACE_MS);
+  }
+
+  @Test
+  void replicationSurvivesConnectionsBeingRecycledUnderneathIt() throws InterruptedException {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("a Raft leader must be elected").isGreaterThanOrEqualTo(0);
+    final long termAtStart = raftTerm(leaderIndex);
+
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+    leaderDb.transaction(() -> {
+      if (!leaderDb.getSchema().existsType(TYPE))
+        leaderDb.getSchema().createVertexType(TYPE);
+    });
+
+    // One transaction at a time, on the clock rather than on a count: the point is to keep the AppendEntries
+    // stream busy for longer than several recycle periods, not to move a particular number of records.
+    final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(WRITE_WINDOW_MS);
+    long written = 0;
+    while (System.nanoTime() < deadline) {
+      final long id = written++;
+      leaderDb.transaction(() -> leaderDb.newVertex(TYPE).set("id", id).save());
+      Thread.sleep(20);
+    }
+
+    assertThat(written)
+        .as("the write window has to have produced enough traffic to span several recycle periods")
+        .isGreaterThan(100);
+
+    // Every write the leader accepted has to be on every replica: a connection recycled underneath an in-flight
+    // AppendEntries must cost a retry, never an entry.
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(awaitCountOn(i, TYPE, written))
+          .as("server %d must hold every record written across the recycles", i)
+          .isEqualTo(written);
+
+    assertClusterConsistency();
+
+    // The re-establish has to cost less than an election timeout, which is exactly what a term bump would say it
+    // did not. This is the assertion that would have to be relaxed before a non-zero default could be considered.
+    assertThat(findLeaderIndex())
+        .as("recycling connections must not hand leadership around")
+        .isEqualTo(leaderIndex);
+    assertThat(raftTerm(leaderIndex))
+        .as("a recycle that cost an election would show up as a new Raft term")
+        .isEqualTo(termAtStart);
+  }
+
+  /**
+   * The other half of the measurement, and what stops the one above from passing on a cluster where the setting
+   * never reached the builder: the listener of a node that is right now leading a 3-node cluster does close a
+   * connection at the age window, and the GOAWAY names that window rather than the idle one.
+   * <p>
+   * The probe connects over loopback, which {@code PeerAddressAllowlistFilter.transportReady} admits without
+   * registering a session, so it is a connection to the real listener that cannot disturb the cluster's own.
+   */
+  @Test
+  void theLiveListenerClosesAConnectionAtTheAgeWindow() throws IOException, InterruptedException {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("a Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final int raftPort = getServer(leaderIndex).getConfiguration()
+        .getValueAsInteger(GlobalConfiguration.HA_RAFT_PORT);
+
+    try (final Http2ConnectionProbe probe = Http2ConnectionProbe.connectTo("localhost", raftPort)) {
+      // A drumbeat rather than a quiet wait, so this also covers the case the issue is about: the connection is
+      // never idle, and only the age window can close it. The default idle window is five minutes, far beyond
+      // this budget, so a max_idle here would itself be a finding.
+      probe.drumUntilClosed(60_000L, 100L);
+
+      assertThat(probe.beats()).as("the drumbeat has to have actually opened streams").isGreaterThan(10);
+      assertThat(probe.closeReason())
+          .as("the fully assembled listener of a live cluster node must close a busy connection at "
+              + "arcadedb.ha.grpcMaxConnectionAgeMs. %s", probe.timing())
+          .isEqualTo("max_age");
+    }
+  }
+
+  private long raftTerm(final int serverIndex) {
+    return getRaftPlugin(serverIndex).getRaftHAServer().getCurrentTerm();
+  }
+}


### PR DESCRIPTION
Closes #7339

## Summary

`arcadedb.ha.grpcMaxConnectionIdleMs` (#7316) is measured from the most recent moment a transport's active-stream count reached zero, and gRPC's `NettyServerHandler` drives that from the HTTP/2 stream count. So every RPC opens and closes a stream and pushes the deadline forward by the whole window - including the ones `PeerAllowlistCallInterceptor` answers with `PERMISSION_DENIED`. A revoked peer that keeps *retrying* (a removed peer whose Ratis division has not learned it was removed campaigns at every election timeout) therefore keeps its connection forever, and no idle window that is safe for healthy connections is shorter than that. This PR adds `arcadedb.ha.grpcMaxConnectionAgeMs` and `arcadedb.ha.grpcMaxConnectionAgeGraceMs`, applied from `RaftGrpcServicesCustomizer` alongside the idle window: gRPC arms the age timer once, in `NettyServerHandler.handlerAdded`, and fires it whatever the connection is carrying. It defaults to `0` (disabled) because the same unconditional timer recycles the *healthy* Raft connections on the same period, and the issue asked for a measurement before any non-zero default - `Issue7339RaftConnectionAgeRecyclingIT` is that measurement. The grace is always passed rather than left at gRPC's default of infinite: a leader's `AppendEntries` to a follower is one stream that does not end, so an infinite grace would stop the age bound from bounding the connection it exists for.

## Test plan

- [ ] `mvn -o -pl ha-raft -am test -Dtest=Issue7339BoundsBusyRaftConnectionTest -Dsurefire.failIfNoSpecifiedTests=false` - 7 tests, ~11 s
- [ ] `mvn -o -pl ha-raft -am verify -Dit.test=Issue7339RaftConnectionAgeRecyclingIT -DskipTests=true -DskipITs=false` - 2 tests, ~43 s, real 3-node cluster
- [ ] `mvn -o -pl ha-raft -am test -DexcludedGroups=benchmark,vector` - 415 tests, no failures (see note below)
- [ ] Sabotage check: `if (false && maxConnectionAgeMs > 0)` in `RaftGrpcServicesCustomizer` turns exactly the three age assertions red and leaves `aBusyConnectionSurvivesTheIdleWindowWhenTheAgeIsDisabled` green - it is the pre-fix behaviour
- [ ] Existing neighbours stay green: `Issue7316ReapsIdleRaftConnectionTest`, `Issue3890RaftParametersPublicationTest`, `HAConfigDefaultsTest`, `ConfigValidationTest`, `PeerAddressAllowlistFilterTest`, `Issue4836K8sScaleUpTest`

The 415-test run ends in a `BUILD FAILURE` that is not a regression: `LeaveClusterTest`'s fork could not start because another local build held port 2434 (`java.net.BindException: Address already in use`, the fixed-port hazard `CLAUDE.md` documents). No test failed.

`-Dsurefire.failIfNoSpecifiedTests=false` is required with `-am`: `-Dtest=` reaches every module in the reactor, so surefire fails the upstream module before `ha-raft` runs. The new `arcadedb-engine` test-jar dependency does **not** need `verify` - measured with that jar deleted from the local repository and `engine/target` removed, `-am test` is green and packages nothing, because Maven substitutes the reactor module's `target/test-classes` for a `tests`-classified dependency (the gremlin `shaded` uber-jar has no directory equivalent, which is why that trap does not reach here).

The tests read the GOAWAY debug string rather than a stopwatch, because gRPC names the timer that fired - `"max_age"` or `"max_idle"`. That is what lets `theAgeBoundClosesAConnectionTheIdleWindowCannotReach` assert the age window closed a connection the very same drumbeat keeps out of the idle window's reach, instead of inferring it from how long that took.

## Coverage

| Entry point | Covered | Test |
|---|---|---|
| `buildParameters` -> `installGrpcServerCustomizations` -> `RaftGrpcServicesCustomizer.customize` -> `maxConnectionAge`, allowlist ON | yes | `theAgeBoundClosesAConnectionTheIdleWindowCannotReach` |
| same, allowlist OFF - the age is a connection-lifetime setting, not an allowlist setting | yes | `theAgeBoundIsInstalledWithTheAllowlistDisabled` |
| the grace reaches the builder, and 0 still closes the connection | yes | `aZeroGraceStillClosesTheConnection` |
| age = 0 leaves a busy connection alone - the default, and the #7339 repro | yes | `aBusyConnectionSurvivesTheIdleWindowWhenTheAgeIsDisabled` |
| age = 0, idle = 0, allowlist off -> no customizer at all | yes | `noCustomizerIsInstalledWhenNothingNeedsOne` |
| a negative grace from a config typo must not throw out of `maxConnectionAgeGrace`'s `checkArgument` at startup | yes | `aNegativeGraceIsClampedRatherThanCrashingStartup` |
| the defaults promise no behaviour change for a cluster that does not opt in | yes | `theAgeWindowIsOffByDefault` |
| a live 3-node cluster keeps replicating, and keeps its leader and its term, across the recycles | yes | `Issue7339RaftConnectionAgeRecyclingIT#replicationSurvivesConnectionsBeingRecycledUnderneathIt` |
| the fully assembled listener of a live cluster node closes a busy connection at the age window | yes | `Issue7339RaftConnectionAgeRecyclingIT#theLiveListenerClosesAConnectionAtTheAgeWindow` |

### Known gaps

None filed as follow-up issues. Two rows are argued rather than fixed, with the evidence in `docs/7339-raft-grpc-max-connection-age.md`:

- **`grpcw`'s client-facing listener sets no lifetime bound either** - the same *shape*, but not the same defect. This chain is about a connection outliving the revocation of its peer's reach; `GrpcServerPlugin` authenticates every call against the user registry and has no address-derived per-transport verdict that can flip underneath an open connection, so there is no "revoked but still connected" state for an age bound to remedy. Its lack of a bound is an ordinary resource question about a different listener with a different threat model, unchanged by this PR.
- **A non-zero default** - the issue asks for the setting to default to 0 and for a measurement before changing that, and both are honoured. The IT is the measurement (3 s age, 1 s grace, 3 nodes, writes across four-plus recycle periods, no lost write, no divergent replica, no term bump); what it cannot establish is the right value for a real network, so the default stays off and the decision stays with the operator.

## Residual risk

- The age bound recycles healthy Raft connections too. The IT shows a 3 s period surviving on a loopback 3-node cluster; it says nothing about a WAN cluster, tuned election timers, or hundreds of databases. Start well above your election timeout.
- With the age disabled - the default - #7339 is unchanged. The fix is an available remedy, not an automatic one.
- gRPC applies a per-connection jitter of +/-10% to the age, so a configured value is a centre, not a deadline.
- The window is applied to Ratis's ADMIN and CLIENT listeners as well as SERVER, exactly as #7316's idle window already is.
- Both windows are bound once, at plugin startup; changing either on a running node has no effect until it restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Raa9V6fPZda6yQkn3kvRZf
