### PR TITLE
fix(#7394): seven low-severity control-plane and gRPC items

### DIFF
--- a/docs/7394-control-plane-grpc-low-severity-batch.md
+++ b/docs/7394-control-plane-grpc-low-severity-batch.md
@@ -355,3 +355,35 @@ one had been.
 | Is the terminal TimeSeries message bounded? | Yes - it carries whatever was left after the last flush, which is by construction under the budget. |
 | Does `asGrpcProtocol` clearing unconditionally strand a thread? | No. On the gRPC worker the context was previously unset, so clearing restores exactly that. The transaction executor is dedicated to one transaction, and `executeCommandInternal` already sets/clears on it the same way. |
 | Does the issue's own claim for item 1 hold? | Half of it. See the item 1 correction above - #7418. |
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/7420
+
+## Review cycles
+
+### Cycle 1 - `4d7b14a1` - clean approval, no changes applied
+
+The `claude` reviewer read the diff and the eight test files and reported **no blocking issues**. It
+independently re-derived the three placement decisions this PR turns on, which is the useful part of the
+review: that `asGrpcProtocol` belongs on `searchInTransaction`'s body rather than the RPC method because the
+in-transaction search runs on the transaction's executor thread; that the `expand` reordering correctly
+leaves the no-full-text-leg early return alone rather than false-triggering the type check on it; and that
+`batch`/`batchBytes` are reset together at every flush point with the terminal message bounded by
+construction.
+
+Three notes, none asking for a change:
+
+| Note | Disposition |
+|---|---|
+| `TimeSeriesPoint` is a public client-facing record, so widening the tag check to `Iterable` is a public-API behaviour change for any external caller passing a custom Iterable-but-not-Collection tag value | Agreed, and verified rather than taken on trust: `requireStorableTagValue` has exactly three production callers (`TimeSeriesPoint`'s compact constructor, `LineProtocolWriter`, `GrpcTimeSeriesSupport.toSamples`), all of which take a caller-supplied `Map<String, Object>`. A custom `Iterable` there was previously stored as the text of an object identity - the exact corruption the check exists to prevent - so refusing it is the fix, not a casualty of it. No change. |
+| `RemoteGrpcServer.profilerStart` going from `void` to `int` is a public API surface change on the gRPC client | Correct, and deliberate: without a return value the Java client is the one caller that cannot see the effective timeout the rest of item 4 exists to report. It is source-compatible (a discarded return value compiles), the method is new in the unreleased 26.10.1 window, and its only in-tree caller (`Issue7304RemoteGrpcServerControlPlaneIT:128`) uses it as a statement. No change. |
+| The reviewer could not run Maven in its environment and read the changed files and call sites manually instead; asks for a green CI run before merge | Not a code note. The verification this branch did run is in the Test results section above; CI is the developer's gate at merge time. No change. |
+
+Working tree empty after the cycle, no deferred items, no actionable comments - the loop's early-exit
+condition, so no second cycle was run. (`docs/review-deferred-47afd7da.md` in this directory predates this
+branch: it came in with PR #7210.)
+
+## Final state
+
+**clean-approval** after 1 review cycle. Merge is the developer's.

--- a/docs/7394-control-plane-grpc-low-severity-batch.md
+++ b/docs/7394-control-plane-grpc-low-severity-batch.md
@@ -1,0 +1,357 @@
+# #7394 - seven low-severity items from the control-plane and gRPC delta
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/7394
+Branch: `fix/7394-low-severity-control-plane-grpc`
+
+## Finding ledger
+
+- [x] 1. Three search RPCs never set `ProtocolContext` - **fixed** on all three, on both the inline and the
+      transaction-executor thread. The issue's "metered as internal" is half right: the context really did
+      report `internal` (proven by reverting the fix), but these legs reach no metric at all on any protocol,
+      which is **#7418**. `insertStream`/`insertBidirectional` carry the same gap: **#7407**
+- [x] 2. `TS_MAX_BATCH_SIZE` bounds rows, not bytes - **fixed**: the row cap is restated as a heuristic and
+      paired with a 2 MiB serialized-size budget on both the raw-row and the aggregated-bucket stream
+- [x] 3. Read-path tag filter accepted what the write path refuses - **fixed** at `TimeSeriesGateway.andTag`,
+      the chokepoint all four protocol paths already share; the refusal also widened to catch `JSONArray`
+- [x] 4. Profiler documented an open-ended recording it never gives - **fixed**: all three claims corrected,
+      and the effective timeout is now reported in the HTTP JSON and in `ProfilerStateResponse`
+- [x] 5. Late `expand` type check - **fixed**: both type checks moved ahead of the searches they followed, so
+      the verdict no longer depends on whether the corpus happened to match
+- [x] 6. `ProfilingResultSet`'s stale #7330 citation - **fixed**
+- [x] 7. Gremlin sibling of #7330 - **fixed**, and it was a data-correctness bug, not a cost one: a mutating
+      traversal under `$profileExecution` ran twice and mutated twice (reproduced: 2 vertices, 2 edges). The
+      profiling pass is now skipped for mutating traversals. The read-only double execution remains: **#7408**
+
+## Analysis
+
+### 1. ProtocolContext on the search RPCs
+
+`ArcadeDbGrpcService.vectorSearch/hybridSearch/fullTextSearch` (lines 5086/5097/5108) hand their body
+to `GrpcUnaryCall.respond` without ever calling `ProtocolContext.set("grpc")`, unlike every other
+handler in the file.
+
+The subtlety the fix has to respect: `searchInTransaction()` runs the body on the *transaction's own
+executor thread* when the request names a live transaction (`submitToActiveTransaction`), not on the
+gRPC worker. `ProtocolContext` is a `ThreadLocal`, so setting it in the RPC method would tag the wrong
+thread on exactly the path #7326 added. The precedent in this same file is `executeCommandInternal()`,
+which sets it *inside* the body that runs on whichever thread was chosen. The fix follows that: the
+set/clear pair wraps `body.apply(...)` inside `searchInTransaction`, so both the inline and the
+transaction-executor paths are tagged.
+
+Which of the three actually executes SQL today:
+
+- `vectorSearch` -> `VectorSearch.search` -> `database.query("sql", ...)` (VectorSearch.java:93) - yes
+- `hybridSearch` -> `HybridSearch.search` -> `database.query("sql", ...)` (HybridSearch.java:377/495/627) - yes
+- `fullTextSearch` -> `FullTextQuery.search` -> reads the index directly, no SQL
+
+`fullTextSearch` is tagged anyway so the three siblings cannot drift, and so the tag is already right
+if that surface ever grows a SQL leg.
+
+**Correction to the issue's diagnosis, found while building the test.** The item says this SQL is
+"metered and traced as `protocol=\"internal\"`". The context half is exactly right - an
+`Issue7394SearchProtocolContextIT` probe run against the unfixed tree reports `internal` on all three
+paths. The metering half is not: these legs are not metered at all, on any protocol.
+`arcadedb.query.duration` is opened by `LocalDatabase.query`/`command` (LocalDatabase.java:2053-2057),
+and every leg reaches SQL through `AnalyzedQuery.execute()` instead, with `database.query(...)` only as
+a fallback arm that is unreachable for `sql` because `SQLQueryEngine`'s `AnalyzedQuery.execute()` never
+returns null (SQLQueryEngine.java:202-210). So a metric-count assertion cannot see this fix, and the
+traffic is absent from the metric rather than misattributed. Filed as **#7418**; the test asserts the
+invariant that does hold - the thread running the search reports `grpc` - from inside the SQL itself,
+via a custom function called from the search's own `filter`.
+
+### 2. TS_MAX_BATCH_SIZE
+
+`ArcadeDbGrpcService:3266-3270` documents the constant as "A message holds this many rows, so an
+unbounded batch size is an unbounded message: the cap keeps one answer under maxInboundMessageSize
+regardless of what was asked for." It caps rows. 10,000 rows of a wide, string-heavy series crosses
+gRPC's 4 MiB default client inbound limit long before the row cap bites, and the failure is the client
+rejecting the frame rather than a status the caller can act on.
+
+Fix: the row cap stays as a cheap first bound and is restated as a heuristic, and a byte budget
+(`TS_MAX_BATCH_BYTES`) is accumulated from each row's/bucket's own `getSerializedSize()` so a batch is
+flushed on whichever bound is reached first.
+
+### 3. Tag-filter asymmetry
+
+Write path: `GrpcTimeSeriesSupport.toSamples` calls `TimeSeriesGateway.requireStorableTagValue`, which
+refuses an array, a `Collection` or a `Map` because a tag is stored by its text form.
+
+Read path: `GrpcTimeSeriesSupport.toTagMap` does not. The value reaches `ColumnDefinition.coerceValue`,
+which for a STRING column answers `value.toString()` - `[B@6bc7c054` for a byte array - which matches
+no stored tag. The client is told "no data" instead of "that value is not valid".
+
+Fix: the check moves into `TimeSeriesGateway.andTag`, the single point every protocol's tag selection
+already converges on (its own javadoc says so), so read and write share one rule across gRPC and HTTP.
+`requireStorableTagValue` is widened from `Collection` to `Iterable` so it also catches `JSONArray`,
+which the HTTP `tags` object path can produce (`JSONArray implements Iterable<Object>` but not
+`Collection`; `JSONObject implements Map` and was already caught).
+
+### 4. Profiler timeout default
+
+Three places state that a zero timeout records until stopped, and none of them is true:
+
+- `ServerControlPlane.profilerStart` javadoc: "A `timeoutSec` of zero or less starts an open-ended
+  recording, which is what the HTTP `profiler start` command does when it carries no timeout."
+- `arcadedb-server.proto` `ProfilerStartRequest.timeout_seconds`: "0 records until ProfilerStop."
+- `RemoteGrpcServer.profilerStart` javadoc: "`timeoutSeconds` of 0 records until `profilerStop()`."
+
+`ServerQueryProfiler.start(int)` does `timeoutSeconds = timeoutSec > 0 ? timeoutSec : DEFAULT_TIMEOUT_SECONDS`
+and `start()` passes `DEFAULT_TIMEOUT_SECONDS` (60). Both spellings of "no timeout" get 60 seconds and
+an auto-stop timer.
+
+Fix: the reporter's second option - keep the bounded default (it is a safety property: an unattended
+recording keeps every server query on the `ProfilingResultSet` wrapping path) and *report* it. The
+effective timeout is now returned from `ServerControlPlane.profilerStart`, so it reaches the HTTP JSON
+response, and it is added to `ProfilerStateResponse.timeout_seconds` so it reaches gRPC callers. All
+three documentation claims are corrected.
+
+### 5. Late expand type check
+
+`HybridSearch.search:171-174`:
+
+```java
+if (expandArgs != null) {
+  requireVertexType(database, vectorQuery.index().typeIndex().getTypeName());
+  if (!fullTextLeg.rows().isEmpty())
+    requireVertexType(database, fullTextLeg.typeName());
+```
+
+The full-text type check is gated on the text query having *matched*. A full-text index declared on a
+document type, with `expand` requested, is a configuration error that reports success whenever the
+query happens to match nothing. `FullTextLeg.typeName()` is non-null whenever the leg ran, so the
+emptiness test is not needed to tell "leg ran" from "leg absent".
+
+Fix: both checks move ahead of the searches they used to follow - the vector type is checked right
+after `VectorLeg.build` and before `runVectorLeg` spends a search, and the full-text type is checked
+inside `runFullTextLeg` as soon as the index resolves and before `FullTextSearch.search` runs. A
+rejected request now does no retrieval I/O at all, which is what "validate up front, where the other
+configuration checks are" asks for.
+
+### 6. Stale ProfilingResultSet citation
+
+`ProfilingResultSet.java:38-45` explains `startNanos` with "...every write statement, and every
+OpenCypher statement while the profiler is recording, because the profiler routes those through
+`CypherExecutionPlan.profile()` which drains the plan eagerly...". Commit `a6a31f7092`/`f7fa4950a6`
+(#7330) removed that reroute: `asksForTimedExecution()` now times the ordinary streaming run and the
+eager `profile()` path is reached only by the explicit `PROFILE` keyword. The write-statement half of
+the claim still holds; the OpenCypher half now points at something that no longer exists.
+
+Fix: restate the parenthetical as what is true today.
+
+### 7. Gremlin sibling of #7330
+
+Confirmed, and it is a data-correctness defect rather than a cost-reporting one.
+`ArcadeGremlin.execute()` (gremlin/ArcadeGremlin.java:72-108):
+
+```java
+final Iterator<?> resultSet = executeStatement();      // run 1
+...
+if (profileExecution) {
+  query += ".profile()";
+  final Iterator<?> profilerResultSet = executeStatement();   // run 2
+  profilerResultSet.hasNext(); profilerResultSet.next();      // ... and drained
+```
+
+`ServerDatabase.command(language, query, Map)` injects `$profileExecution` for **every** statement
+while the server profiler is recording, whatever the language. So on a recording server a Gremlin
+`g.addV('Person')` builds the traversal twice and iterates both: the `.profile()` pass applies the
+mutation, and the caller's iteration of `resultSet` applies it again. Two vertices.
+
+This is #7330's shape exactly - switching the diagnostic on changes what the statement does - but
+structurally different in its remedy: Gremlin has no per-step timer to read off the ordinary run, so
+`.profile()` genuinely *is* a second execution. There is nothing to reroute away from.
+
+Fix: refuse to buy a plan with a second mutation. Before the profiling pass runs, the traversal shape
+is inspected the way `parse()` already inspects it (the analysis engine builds the step list without
+executing it) and the pass is skipped when any step is `Mutating`. A read-only traversal keeps its
+execution plan, so Studio's `profileExecution: "detailed"` is unchanged for reads; a mutating one
+reports no plan rather than mutating twice.
+
+## Completeness
+
+### Invariant
+
+1. Every gRPC RPC that executes SQL tags the executing thread with `ProtocolContext.set("grpc")`, on
+   the thread that actually runs it.
+2. A streamed `TimeSeriesQueryResult` never exceeds the byte budget the constant claims to enforce.
+3. A tag value the write path refuses can never be silently accepted as a read filter.
+4. No surface documents the profiler's zero timeout as unbounded, and every start response says when
+   the recording will end.
+5. `expand` against an index declared on a non-vertex type is refused whether or not the retrieval
+   legs matched anything.
+6. No comment cites the OpenCypher profiling reroute #7330 removed.
+7. `$profileExecution` never changes what a statement does to the database.
+
+### Sweep
+
+```
+$ grep -n "ProtocolContext" grpcw/.../ArcadeDbGrpcService.java
+757, 975, 1591, 1691, 2052, 2217, 2630, 2692, 3280, 3295, 3338, 3371, 3407, 3447, 3636, 3662
+$ grep -c "ProtocolContext" grpcw/.../ArcadeDbGrpcAdminService.java
+0
+```
+
+Mapping SQL execution to the enclosing RPC (`awk` over `\.(query|command)\(`):
+
+```
+811   executeCommandInternal   <- executeCommand            ProtocolContext set (757)
+1616  executeQueryInternal     <- executeQuery              ProtocolContext set (1591)
+2261  streamQuery                                           ProtocolContext set (2052)
+2332  streamQuery                                           ProtocolContext set (2052)
+2430  streamQuery (paged)                                   ProtocolContext set (2052)
+4169  tryUpsertByRecord   <- bulkInsert / insertStream / insertBidirectional
+4189  keyExistsByRecord   <- bulkInsert / insertStream / insertBidirectional
+$ grep -n "\.query(\|\.command(" engine/.../query/search/*.java
+HybridSearch.java:377, 495, 627 ; VectorSearch.java:93   <- vectorSearch / hybridSearch RPCs, NOT set
+```
+
+`bulkInsert` sets the context (2630); `insertStream` (2698) and `insertBidirectional` (3842) do not,
+so the upsert/conflict lookup SQL those two run is metered as `internal`. Same defect, different
+shape - see the coverage table.
+
+```
+$ grep -rn "toTagMap" --include="*.java" .
+ArcadeDbGrpcService.java:3420  (timeSeriesQuery)
+ArcadeDbGrpcService.java:3644  (timeSeriesLatest)
+$ grep -rn "buildTagFilter\|andTag(" --include="*.java" . | grep -v TimeSeriesGateway.java
+GetTimeSeriesLatestHandler:118    -> buildTagFilterFromQueryParams (values are always String)
+PostTimeSeriesQueryHandler:241    -> TimeSeriesHandlerUtils.buildTagFilter(JSONObject)  <- JSONArray reachable
+PostGrafanaQueryHandler:116       -> TimeSeriesHandlerUtils.buildTagFilter(JSONObject)  <- JSONArray reachable
+PromQLEvaluator:547               -> LabelMatcher values are String
+```
+
+```
+$ grep -rn "profilerStart\|ProfilerStateResponse" --include="*.java" --include="*.proto" . | grep -v /test/
+arcadedb-server.proto:1016, 1427
+RemoteGrpcServer.java:631-635
+ServerControlPlane.java:1059
+PostServerCommandHandler.java:360
+ArcadeDbGrpcAdminService.java:697-702
+$ grep -rn "profileExecution" --include="*.java" . | grep -v /test/
+ArcadeGremlin.java:72-79            <- second execution
+ServerDatabase.java:549,562,575,618 <- injects for EVERY language while recording
+PostCommandHandler.java:250         <- Studio 'detailed'
+OpenCypherQueryEngine.java:307      <- timing only since #7330
+BasicCommandContext.java:542        <- SQL: timing only
+```
+
+### Coverage table
+
+| # | Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|---|
+| 1 | gRPC `VectorSearch` (no transaction) | yes | yes |
+| 1 | gRPC `VectorSearch` (inside a client transaction, runs on the tx executor thread) | yes | yes |
+| 1 | gRPC `HybridSearch` | yes | yes |
+| 1 | gRPC `FullTextSearch` | yes (tagged; executes no SQL today) | argued: shares `searchInTransaction`, the one place the tag is set |
+| 1 | the search legs reach no metric at all, on any protocol | **filed #7418** | no |
+| 1 | gRPC `insertStream` / `insertBidirectional` upsert-lookup SQL | **filed #7407** | no |
+| 1 | gRPC admin service RPCs | argued: none of the 43 executes SQL; they call `ServerControlPlane`, which is schema/file work | n/a |
+| 1 | HTTP / Postgres / Bolt / Redis / Mongo | argued: each sets its own protocol at the request boundary (grep above) | pre-existing |
+| 2 | gRPC `TimeSeriesQuery` raw-row stream | yes | yes |
+| 2 | gRPC `TimeSeriesQuery` aggregated-bucket stream | yes | yes |
+| 3 | gRPC `TimeSeriesQuery` tag filter | yes | yes |
+| 3 | gRPC `TimeSeriesLatest` tag filter | yes | yes |
+| 3 | HTTP `POST /ts/{db}/query` `tags` object | yes (same `andTag` chokepoint) | yes |
+| 3 | HTTP Grafana `POST /ts/{db}/grafana/query` `tags` object | yes (same chokepoint) | argued: identical call, same test |
+| 3 | HTTP `GET /ts/{db}/latest` `?tag=n:v` | argued: the value is a `String` substring, never an array/collection/map | n/a |
+| 3 | PromQL selector | argued: does not use `andTag` at all - `PromQLEvaluator.buildTagFilter` builds its own `TagFilter`, from `LabelMatcher.value()`, always a parser-produced `String` | n/a |
+| 4 | gRPC `ProfilerStart` | yes | yes |
+| 4 | HTTP `POST /api/v1/server` `profiler start` | yes | yes |
+| 4 | MCP `profiler_start` | argued: `ProfilerStartTool` already requires 1..3600, so zero never reaches it (`Issue6762ToolInputBoundsTest`) | pre-existing |
+| 5 | `HybridSearch.search` with `expand` + a full-text leg that matches nothing | yes | yes |
+| 5 | `HybridSearch.search` with `expand` + a vector index on a non-vertex type | yes (now checked before the vector search runs) | yes |
+| 6 | `ProfilingResultSet` javadoc | yes | n/a (comment) |
+| 7 | Gremlin mutating traversal under `$profileExecution` | yes | yes |
+| 7 | Gremlin read-only traversal under `$profileExecution` | argued: still profiled, plan preserved | yes (regression guard) |
+| 7 | OpenCypher / SQL under `$profileExecution` | argued: timing-only since #7330 / `BasicCommandContext` | pre-existing |
+
+### Reachability
+
+- `ProtocolContext` is read by `QueryMetricsRecorder.Holder.record` and `QueryTracer.Holder.begin`, both
+  called from `LocalDatabase.query/command`. The search legs do NOT take that path (#7418), so the fix is
+  reachable but currently observable only by something else that reads the thread-local - which is what
+  the test does, through a SQL function evaluated by the search itself. Verified failing before the fix
+  (`internal` on all three paths) and passing after.
+- `ServerDatabase` wraps the database for every server-side request, and `getProfiler()` is non-null
+  once `ArcadeDBServer` builds `queryProfiler` (ArcadeDBServer.java:1528), so the Gremlin double
+  execution is reachable on any server with the profiler recording.
+- `TimeSeriesGateway.andTag` is called by four production sites (grep above), not only by tests.
+- `ProfilerStateResponse.timeout_seconds` is a new proto field; the admin service sets it, so it is
+  populated rather than defaulted.
+
+### Residual risk
+
+- Item 1 makes the search RPCs report `grpc` to anything reading `ProtocolContext`, but it does not make
+  `arcadedb.query.duration` appear for them: those legs bypass the metered entry point entirely (#7418).
+  A dashboard is not fixed by this PR, it is only no longer being lied to about the protocol.
+- Item 1 is not fixed for `insertStream`/`insertBidirectional` (filed as #7407). Those two are
+  bidirectional streams whose work hops onto a transaction executor from an observer callback rather
+  than from a single request body, so the set/clear placement is a different change from this one.
+- Item 2 bounds a *batch*. A single row larger than the byte budget is still emitted alone and will
+  still be rejected by a client whose inbound limit is below it; nothing can split one row.
+- Item 4 keeps the 60-second default rather than making a zero timeout unbounded. A caller that wants
+  an unbounded recording still cannot ask for one - that is a feature request, not this fix.
+- Item 7 leaves a read-only Gremlin traversal executing twice under `$profileExecution`, which is
+  what `.profile()` costs in Gremlin. Only the mutation is prevented. Filed as #7408.
+
+## Test results
+
+| Module | Command | Result |
+|---|---|---|
+| engine | `-Dtest='Issue7394*'` | 13/13 pass |
+| engine | `-Dtest='*TimeSeries*,*HybridSearch*,*VectorSearch*,*FullText*,*PromQL*,*Grafana*'` | 590/590 pass |
+| server | `-Dtest='Issue7394*'` | 4/4 pass |
+| server | profiler / control-plane / TS-handler / metrics unit classes | 76/76 pass |
+| grpcw | full unit suite | 238/238 pass |
+| grpcw | `-Dit.test=Issue7394SearchProtocolContextIT` | 4/4 pass |
+| gremlin (via gremlin-it) | `-Dtest='Issue7394*'` | 5/5 pass |
+| gremlin-it | full suite | 404 run, 7 errors - **pre-existing**, see below |
+| mcp | full unit suite | 316/316 pass |
+| grpc-client | full unit suite | 154 run, 6 errors - **pre-existing**, see below |
+
+### Tests proven able to fail
+
+- Item 7: before the fix, `anAddVertexUnderProfileExecutionCreatesOneVertexNotTwo` reported `expected: 1L but
+  was: 2L` and the addE case likewise - the defect reproduced directly.
+- Item 5: before the fix, `aNonVertexFullTextIndexWithExpandIsRefusedEvenWhenTheTextQueryMatchesNothing` was
+  the single red test of the four in its class, which is exactly the corpus-dependence the item describes.
+- Item 1: with the `asGrpcProtocol` wrapper removed, all three search assertions report `internal` instead of
+  `grpc`, while the `theSameSqlRunOutsideAnyProtocolStillReportsInternal` control stays green - so the test
+  cannot pass against a `ProtocolContext` that answers "grpc" for everything.
+
+### Failures that are not this change
+
+A server unrelated to this work has been listening on port 2480 in this environment for six days
+(`lsof -nP -iTCP:2480 -sTCP:LISTEN` -> a java process with an elapsed time of `06-08:49`). Every HTTP-driven
+test in the tree therefore talks to it. The failures it causes read as `503`, `Transaction Error on
+transaction begin`, and `NeedRetry Server is installing a snapshot, please retry`, never as a port conflict -
+the trap `CLAUDE.md` documents.
+
+Both sets were re-run against the pristine files to confirm they are not this change:
+
+- gremlin-it's 7 errors all abort in `AbstractGremlinServerIT.beginTest:66`, before any statement is parsed.
+  Restoring the unmodified `ArcadeGremlin.java` and re-running produced the identical 7.
+- grpc-client's 6 errors (`Issue4562RollbackDeleteTest`, `RemoteGrpcDatabaseRegressionTest`) reproduce
+  identically with `ArcadeDbGrpcService.java` and `RemoteGrpcServer.java` restored to `HEAD`.
+
+## Adversarial pass
+
+The orchestrator's Phase 1.5 spawns one subagent that has not seen the author's reasoning. **The `Task`
+tool is not available in this session** (`ToolSearch` for it returns nothing), so no independent pass ran.
+What follows is a self-review of the diff, recorded as such rather than as the independent check it is
+meant to replace - the whole value of that pass is the reviewer not having been persuaded already, and this
+one had been.
+
+| Question asked of the diff | Answer |
+|---|---|
+| Does widening `requireStorableTagValue` from `Collection` to `Iterable` refuse anything legitimate on the WRITE path? | No. Its only write caller converts values through `GrpcTypeConverter.fromGrpcValue`, which produces boxed primitives, `String`, `byte[]`, `List` and `Map`. `String` is not `Iterable`. Engine TS suite (590) and grpcw (238) both green. |
+| Does `andTag` throwing for an unresolvable NAME break the documented "unknown name contributes nothing"? | No - the value is judged, the name is not. An unknown name with a valid value still contributes nothing; only an unstorable VALUE throws, and it throws under any name. Pinned by `anUnstorableValueIsRefusedEvenUnderANameThatResolvesToNoColumn`. |
+| Does anything reach `andTag` that would now throw where it did not? | `GET /ts/{db}/latest` passes a `String` substring; PromQL does not call it at all (verified: `PromQLEvaluator.buildTagFilter` builds its own `TagFilter`). Only the two JSON-bodied HTTP endpoints and the two gRPC RPCs can carry a non-scalar, which is the fix. |
+| Does the `andTag` javadoc's "every protocol converges here" survive? | It did not - PromQL is a reader that does not converge. Corrected in this PR rather than left standing, since the new `@throws` sits directly under it. |
+| Does moving the vector-type check before `runVectorLeg` change which error a doubly-invalid request reports? | Yes, deliberately: a non-vertex vector index with `expand` now reports the type error instead of whatever the vector leg would have raised. That is the "up front" ordering the issue asks for. No existing test asserted the old order (engine suite green). |
+| Does the Gremlin gate lose an execution plan that used to be produced? | For mutating traversals, yes - by design, that plan cost a second mutation. For statements ending in an eager terminal step, no: appending `.profile()` to those does not parse, so the attempt already landed in the existing `// NO EXECUTION PLAN` catch. Read-only traversals are unaffected, pinned by `aReadOnlyTraversalStillGetsItsExecutionPlan`. |
+| Is the `$profileExecution` flag still consumed when the pass is skipped? | Yes - the `remove()` happens before the gate. Pinned by `theFlagIsRemovedFromTheParametersEvenWhenTheProfilingPassIsSkipped`. |
+| Can `batchBytes` overflow? | Only if one row serialized to ~2 GiB, which protobuf cannot produce and gRPC would reject first. The accumulator is reset at every flush, so it is bounded by 2 MiB plus one row. |
+| Is the terminal TimeSeries message bounded? | Yes - it carries whatever was left after the last flush, which is by construction under the budget. |
+| Does `asGrpcProtocol` clearing unconditionally strand a thread? | No. On the gRPC worker the context was previously unset, so clearing restores exactly that. The transaction executor is dedicated to one transaction, and `executeCommandInternal` already sets/clears on it the same way. |
+| Does the issue's own claim for item 1 hold? | Half of it. See the item 1 correction above - #7418. |

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesGateway.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesGateway.java
@@ -310,20 +310,34 @@ public final class TimeSeriesGateway {
 
   /**
    * ANDs one tag condition onto {@code filter}, resolving {@code tagName} to its position among the
-   * non-timestamp columns. Every protocol's tag selection converges here - the gRPC {@code TimeSeries*} RPCs
-   * through {@link #buildTagFilter(Map, List)}, the {@code tags} object of {@code POST /ts/{database}/query},
-   * and the repeated {@code tag=name:value} parameter of {@code GET /ts/{database}/latest} - so the three
-   * cannot drift apart on how a tag is resolved, which is how two of them came to disagree in the first place
-   * (issue #7321).
+   * non-timestamp columns. Three tag selections converge here - the gRPC {@code TimeSeries*} RPCs through
+   * {@link #buildTagFilter(Map, List)}, the {@code tags} object of {@code POST /ts/{database}/query} (and of
+   * the Grafana query endpoint), and the repeated {@code tag=name:value} parameter of
+   * {@code GET /ts/{database}/latest} - so they cannot drift apart on how a tag is resolved, which is how two
+   * of them came to disagree in the first place (issue #7321). The PromQL evaluator is the one reader that
+   * does NOT: it builds its own {@link TagFilter} from label matchers, whose values are always parser-produced
+   * strings.
    * <p>
    * The value is coerced to the column's declared type so it matches what both storage layers hand back
    * (issue #5475).
+   * <p>
+   * It is first held to {@link #requireStorableTagValue}, the same rule the write path applies. A value that
+   * could never have been written is not a selection that matches nothing - it is a malformed request, and
+   * answering it with an empty series told the caller "no data" when the truth was "that value is not valid"
+   * (issue #7394). The check runs before the name is resolved, because an unstorable value is unstorable
+   * whichever name carries it; an unresolvable NAME still contributes nothing, as it always has.
    *
    * @return {@code filter} unchanged when no TAG column carries that name, a new filter otherwise -
    * {@link TagFilter} is immutable, so the return value must be used
+   *
+   * @throws IllegalArgumentException if {@code tagValue} cannot be stored as a tag. Callers on the gRPC path
+   *                                  let this surface as {@code INVALID_ARGUMENT} through
+   *                                  {@code GrpcErrorMapper}, and the HTTP handlers as a 400
    */
   public static TagFilter andTag(final TagFilter filter, final String tagName, final Object tagValue,
       final List<ColumnDefinition> columns) {
+    requireStorableTagValue(tagName, tagValue);
+
     int nonTsIdx = 0;
     for (final ColumnDefinition col : columns) {
       if (col.getRole() == ColumnDefinition.ColumnRole.TIMESTAMP)
@@ -439,8 +453,13 @@ public final class TimeSeriesGateway {
    * {@code toString()} means something - a string, a number, a boolean, an enum, a temporal - and silently
    * corrupts for anything whose does not. A {@code byte[]} is the sharp case: it has no {@code toString()}
    * override, so it would be stored as {@code [B@6bc7c054}, a different meaningless value on every run
-   * (claude-review on PR #7323). Collections and maps are refused with it: their text form is stable but is not
+   * (claude-review on PR #7323). Iterables and maps are refused with it: their text form is stable but is not
    * a tag value anyone means.
+   * <p>
+   * {@link Iterable} rather than {@link Collection} because the HTTP {@code tags} object hands over JSON types
+   * and {@code JSONArray} implements only the former, so a {@code Collection} test would have let
+   * {@code ["a","b"]} through as a tag value (issue #7394). {@code JSONObject} is a {@link Map} and was already
+   * refused.
    * <p>
    * Fields are deliberately NOT subject to this - they carry typed values into typed columns, and the column
    * decides what it can hold.
@@ -449,7 +468,7 @@ public final class TimeSeriesGateway {
    *                                  surface as {@code INVALID_ARGUMENT} through {@code GrpcErrorMapper}
    */
   public static Object requireStorableTagValue(final String tagName, final Object value) {
-    if (value != null && (value.getClass().isArray() || value instanceof Collection<?> || value instanceof Map<?, ?>))
+    if (value != null && (value.getClass().isArray() || value instanceof Iterable<?> || value instanceof Map<?, ?>))
       throw new IllegalArgumentException("Tag '" + tagName + "' cannot hold a " + value.getClass().getSimpleName()
           + ": a tag is stored by its text form, and this one has none that means anything. "
           + "Use a string, a number or a boolean.");

--- a/engine/src/main/java/com/arcadedb/query/search/HybridSearch.java
+++ b/engine/src/main/java/com/arcadedb/query/search/HybridSearch.java
@@ -150,12 +150,21 @@ public final class HybridSearch {
     final JSONObject expandArgs = requireExpandObject(args);
 
     final VectorLeg.VectorLegQuery vectorQuery = VectorLeg.build(database, args, "vectorIndexName", legLimit(k));
+
+    // Both "is this index on a vertex type?" checks belong here, with the other configuration checks, and not
+    // after the legs have run. Whether an index is declared on a vertex type is a property of the schema, not
+    // of what the query matched, so a request that cannot be served must be refused before it spends a search
+    // (issue #7394). The full-text half is checked inside runFullTextLeg, as soon as that index resolves.
+    final boolean expanding = expandArgs != null;
+    if (expanding)
+      requireVertexType(database, vectorQuery.index().typeIndex().getTypeName());
+
     final List<LegRow> vectorLeg = runVectorLeg(database, vectorQuery);
 
     final JSONObject legs = new JSONObject()
         .put("vector", new JSONObject().put("count", vectorLeg.size()));
 
-    final FullTextLeg fullTextLeg = runFullTextLeg(database, args, legLimit(k), legs);
+    final FullTextLeg fullTextLeg = runFullTextLeg(database, args, legLimit(k), legs, expanding);
 
     final JsonSerializer serializer = JsonSerializer.createJsonSerializer()
         .setIncludeVertexEdges(false)
@@ -168,10 +177,7 @@ public final class HybridSearch {
       legList.add(new Leg("fulltext", fullTextLeg.rows(), weightOf(args, "fulltext", 1.0f), "score"));
 
     Map<RID, ExpansionInfo> expansionInfo = Map.of();
-    if (expandArgs != null) {
-      requireVertexType(database, vectorQuery.index().typeIndex().getTypeName());
-      if (!fullTextLeg.rows().isEmpty())
-        requireVertexType(database, fullTextLeg.typeName());
+    if (expanding) {
       final List<RID> seeds = collectSeeds(vectorLeg, fullTextLeg.rows());
       final Expansion expansion = runExpansionLeg(database, expandArgs, seeds);
       expansionInfo = expansion.info();
@@ -515,7 +521,7 @@ public final class HybridSearch {
   }
 
   private static FullTextLeg runFullTextLeg(final Database database, final JSONObject args, final int limit,
-      final JSONObject legs) {
+      final JSONObject legs, final boolean expanding) {
     final String indexName = args.getString("fulltextIndexName", null);
     final String queryText = args.getString("fulltextQuery", null);
     final boolean hasIndex = indexName != null && !indexName.isBlank();
@@ -540,6 +546,12 @@ public final class HybridSearch {
       throw new IllegalArgumentException("Index '" + indexName + "' is not a full-text index. Available full-text "
           + "indexes in '" + database.getName() + "': " + FullTextSearch.listFullTextIndexes(database), e);
     }
+
+    // Before the search, not after it: whether this index can seed a graph expansion is decided by the type it
+    // is declared on. Checking it once the hits are in made the same invalid configuration pass or fail
+    // depending on whether the corpus happened to contain a match (issue #7394).
+    if (expanding)
+      requireVertexType(database, typeIndex.getTypeName());
 
     final Map<RID, Float> hits = FullTextSearch.search(typeIndex, queryText, limit);
     final List<Map.Entry<RID, Float>> ranked = new ArrayList<>(hits.entrySet());

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue7394ReadTagFilterMatchesTheWriteRuleTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue7394ReadTagFilterMatchesTheWriteRuleTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.schema.Type;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7394 item 3: a tag value the write path refuses must not be silently accepted as a read filter.
+ * <p>
+ * {@code requireStorableTagValue} refuses an array, a collection or a map on the way in, because a tag is
+ * stored by its text form and those have none that means anything - a {@code byte[]} would be stored as
+ * {@code [B@6bc7c054}, a different value on every run. The read side did not apply the same rule, so a filter
+ * value that could never have been written was coerced (a byte array to its object identity), matched nothing
+ * and returned an empty series. The client was told "no data" instead of "that value is not valid".
+ * <p>
+ * The rule now lives in {@link TimeSeriesGateway#andTag}, which every protocol's tag selection already
+ * converges on - the gRPC {@code TimeSeriesQuery}/{@code TimeSeriesLatest} RPCs through
+ * {@link TimeSeriesGateway#buildTagFilter}, and both HTTP {@code tags}-object endpoints through
+ * {@code TimeSeriesHandlerUtils} - so read and write cannot disagree on any of them.
+ *
+ * @see <a href="https://github.com/ArcadeData/arcadedb/issues/7394">issue #7394</a>
+ */
+class Issue7394ReadTagFilterMatchesTheWriteRuleTest {
+
+  /** ts, host (TAG), cpu (FIELD). */
+  private static final List<ColumnDefinition> COLUMNS = List.of(
+      new ColumnDefinition("ts", Type.LONG, ColumnDefinition.ColumnRole.TIMESTAMP),
+      new ColumnDefinition("host", Type.STRING, ColumnDefinition.ColumnRole.TAG),
+      new ColumnDefinition("cpu", Type.DOUBLE, ColumnDefinition.ColumnRole.FIELD));
+
+  @Test
+  void aBytesFilterValueIsRefusedRatherThanMatchingNothing() {
+    assertThatThrownBy(() -> TimeSeriesGateway.buildTagFilter(Map.of("host", new byte[] { 1, 2 }), COLUMNS))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("host");
+  }
+
+  @Test
+  void aListFilterValueIsRefused() {
+    assertThatThrownBy(() -> TimeSeriesGateway.buildTagFilter(Map.of("host", List.of("a", "b")), COLUMNS))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("host");
+  }
+
+  @Test
+  void aMapFilterValueIsRefused() {
+    assertThatThrownBy(() -> TimeSeriesGateway.buildTagFilter(Map.of("host", Map.of("a", "b")), COLUMNS))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("host");
+  }
+
+  /**
+   * The HTTP {@code tags} object hands over the JSON types, and {@code JSONArray} is an {@link Iterable} that
+   * is not a {@code Collection} - so the original {@code Collection} test would have let it through, and its
+   * text form ({@code ["a","b"]}) is not a tag value anyone means. {@code JSONObject} is a {@code Map} and was
+   * already refused; it is pinned here so the pair cannot drift.
+   */
+  @Test
+  void aJsonArrayFilterValueIsRefused() {
+    assertThatThrownBy(() -> TimeSeriesGateway.buildTagFilter(
+        Map.of("host", new JSONArray(List.of("a", "b"))), COLUMNS))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("host");
+  }
+
+  @Test
+  void aJsonObjectFilterValueIsRefused() {
+    assertThatThrownBy(() -> TimeSeriesGateway.buildTagFilter(
+        Map.of("host", new JSONObject().put("a", "b")), COLUMNS))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("host");
+  }
+
+  /**
+   * The value is judged on its own, before the name is resolved: a name that matches no TAG column still
+   * contributes nothing to the filter (issue #7321's documented behaviour, tracked for reporting by #7334),
+   * but an unstorable value is unstorable whichever name carries it, and answering "no data" for it is the
+   * very confusion this refusal removes.
+   */
+  @Test
+  void anUnstorableValueIsRefusedEvenUnderANameThatResolvesToNoColumn() {
+    assertThatThrownBy(() -> TimeSeriesGateway.buildTagFilter(Map.of("nosuchtag", new byte[] { 1 }), COLUMNS))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("nosuchtag");
+  }
+
+  @Test
+  void theOrdinaryScalarFilterValuesStillBuildAFilter() {
+    assertThatCode(() -> TimeSeriesGateway.buildTagFilter(Map.of("host", "web1"), COLUMNS))
+        .doesNotThrowAnyException();
+
+    final TagFilter filter = TimeSeriesGateway.buildTagFilter(Map.of("host", "web1"), COLUMNS);
+    assertThat(filter).isNotNull();
+    // row layout is {timestamp, host, cpu}; TagFilter#matches offsets by the timestamp.
+    assertThat(filter.matches(new Object[] { 1_000L, "web1", 1.0d })).isTrue();
+    assertThat(filter.matches(new Object[] { 1_000L, "web2", 1.0d })).isFalse();
+  }
+
+  @Test
+  void aNumberAndABooleanAreStillAcceptedAsTheyAreOnTheWritePath() {
+    assertThatCode(() -> TimeSeriesGateway.andTag(null, "host", 42, COLUMNS)).doesNotThrowAnyException();
+    assertThatCode(() -> TimeSeriesGateway.andTag(null, "host", true, COLUMNS)).doesNotThrowAnyException();
+  }
+
+  /** A null value is not a malformed one - it is how "no value" is said, and it was always allowed. */
+  @Test
+  void aNullFilterValueIsStillAllowed() {
+    assertThatCode(() -> TimeSeriesGateway.andTag(null, "host", null, COLUMNS)).doesNotThrowAnyException();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/search/Issue7394ExpandTypeCheckIsUpFrontTest.java
+++ b/engine/src/test/java/com/arcadedb/query/search/Issue7394ExpandTypeCheckIsUpFrontTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.search;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7394 item 5: with {@code expand}, a full-text index declared on a non-vertex type used to be
+ * rejected only once the text query happened to match something.
+ * <p>
+ * The check sat behind {@code if (!fullTextLeg.rows().isEmpty())}, so the same request - the same index, the
+ * same {@code expand} - reported success or failure depending on the corpus. A configuration error that
+ * passes whenever the query matches nothing is a configuration error that ships.
+ * <p>
+ * Both type checks now run before the searches they used to follow: the vector index's type is checked
+ * before the vector leg spends a search, and the full-text index's type as soon as the index resolves and
+ * before the text search runs. A rejected request does no retrieval I/O at all.
+ *
+ * @see <a href="https://github.com/ArcadeData/arcadedb/issues/7394">issue #7394</a>
+ */
+class Issue7394ExpandTypeCheckIsUpFrontTest extends TestHelper {
+
+  private static final String VERTEX_TYPE   = "Doc7394";
+  private static final String DOCUMENT_TYPE = "Note7394";
+  private static final String VECTOR_INDEX  = VERTEX_TYPE + "[embedding]";
+  private static final String TEXT_INDEX    = DOCUMENT_TYPE + "[body]";
+
+  /**
+   * A vertex type carrying the vector index, and a plain document type carrying the full-text index - the
+   * shape the issue describes. The corpus is seeded so that "zebra" matches nothing and "alpha" matches.
+   */
+  private void buildSchema() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE " + VERTEX_TYPE);
+      database.command("sql", "CREATE PROPERTY " + VERTEX_TYPE + ".embedding ARRAY_OF_FLOATS");
+      database.command("sql", "CREATE INDEX ON " + VERTEX_TYPE + " (embedding) LSM_VECTOR "
+          + "METADATA { dimensions: 3, similarity: 'COSINE' }");
+
+      database.command("sql", "CREATE DOCUMENT TYPE " + DOCUMENT_TYPE);
+      database.command("sql", "CREATE PROPERTY " + DOCUMENT_TYPE + ".body STRING");
+      database.command("sql", "CREATE INDEX ON " + DOCUMENT_TYPE + " (body) FULL_TEXT");
+
+      database.newVertex(VERTEX_TYPE).set("embedding", new float[] { 1.0f, 0.0f, 0.0f }).save();
+      database.newVertex(VERTEX_TYPE).set("embedding", new float[] { 0.0f, 1.0f, 0.0f }).save();
+      database.newDocument(DOCUMENT_TYPE).set("body", "alpha beta").save();
+    });
+  }
+
+  private JSONObject argsWithExpand(final String fulltextQuery) {
+    return new JSONObject()
+        .put("vectorIndexName", VECTOR_INDEX)
+        .put("queryVector", new JSONArray(new Object[] { 1.0f, 0.0f, 0.0f }))
+        .put("k", 5)
+        .put("fulltextIndexName", TEXT_INDEX)
+        .put("fulltextQuery", fulltextQuery)
+        .put("expand", new JSONObject().put("maxDepth", 1));
+  }
+
+  /** The regression: the text query matches nothing, so the invalid configuration used to pass. */
+  @Test
+  void aNonVertexFullTextIndexWithExpandIsRefusedEvenWhenTheTextQueryMatchesNothing() {
+    buildSchema();
+
+    assertThatThrownBy(() -> HybridSearch.search(database, argsWithExpand("zebra")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Graph expansion requires a vertex type")
+        .hasMessageContaining(DOCUMENT_TYPE);
+  }
+
+  /** The case that was already caught, pinned so the fix does not trade one gate for the other. */
+  @Test
+  void aNonVertexFullTextIndexWithExpandIsStillRefusedWhenTheTextQueryMatches() {
+    buildSchema();
+
+    assertThatThrownBy(() -> HybridSearch.search(database, argsWithExpand("alpha")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Graph expansion requires a vertex type")
+        .hasMessageContaining(DOCUMENT_TYPE);
+  }
+
+  /**
+   * The vector index's own type is checked before the vector leg runs, not after. A document-typed vector
+   * index with {@code expand} is refused without a search being spent on it.
+   */
+  @Test
+  void aNonVertexVectorIndexWithExpandIsRefused() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE " + DOCUMENT_TYPE);
+      database.command("sql", "CREATE PROPERTY " + DOCUMENT_TYPE + ".embedding ARRAY_OF_FLOATS");
+      database.command("sql", "CREATE INDEX ON " + DOCUMENT_TYPE + " (embedding) LSM_VECTOR "
+          + "METADATA { dimensions: 3, similarity: 'COSINE' }");
+      database.newDocument(DOCUMENT_TYPE).set("embedding", new float[] { 1.0f, 0.0f, 0.0f }).save();
+    });
+
+    final JSONObject args = new JSONObject()
+        .put("vectorIndexName", DOCUMENT_TYPE + "[embedding]")
+        .put("queryVector", new JSONArray(new Object[] { 1.0f, 0.0f, 0.0f }))
+        .put("k", 5)
+        .put("expand", new JSONObject().put("maxDepth", 1));
+
+    assertThatThrownBy(() -> HybridSearch.search(database, args))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Graph expansion requires a vertex type")
+        .hasMessageContaining(DOCUMENT_TYPE);
+  }
+
+  /**
+   * Without {@code expand} the same document-typed full-text index is a perfectly ordinary request: the type
+   * check must be conditional on the expansion leg, not on the index.
+   */
+  @Test
+  void aNonVertexFullTextIndexWithoutExpandIsFine() {
+    buildSchema();
+
+    final JSONObject args = new JSONObject()
+        .put("vectorIndexName", VECTOR_INDEX)
+        .put("queryVector", new JSONArray(new Object[] { 1.0f, 0.0f, 0.0f }))
+        .put("k", 5)
+        .put("fulltextIndexName", TEXT_INDEX)
+        .put("fulltextQuery", "alpha");
+
+    final JSONObject result = HybridSearch.search(database, args);
+    assertThat(result.getJSONObject("legs").has("fulltext")).isTrue();
+  }
+}

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGremlin.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGremlin.java
@@ -76,7 +76,7 @@ public class ArcadeGremlin extends ArcadeQuery {
       final Iterator<?> resultSet = executeStatement();
 
       ExecutionPlan executionPlan = null;
-      if (profileExecution) {
+      if (profileExecution && canBeProfiledWithoutRunningItAgain(resultSet)) {
         final String originalQuery = query;
         query += ".profile()";
         try {
@@ -158,6 +158,47 @@ public class ArcadeGremlin extends ArcadeQuery {
     } catch (final Exception e) {
       throw new CommandExecutionException("Error on executing command", e);
     }
+  }
+
+  /**
+   * Whether the {@code .profile()} pass may be run for this statement.
+   * <p>
+   * {@code $profileExecution} asks for the statement to be TIMED, not for it to be run differently - the rule
+   * #7330 established when it stopped rerouting recording-server OpenCypher onto an eager
+   * {@code CypherExecutionPlan.profile()}. Gremlin cannot honour that rule the same way: there is no per-step
+   * timer accumulating during the ordinary run, so {@code .profile()} genuinely is a SECOND execution of the
+   * statement. What can be honoured is the part that matters - the second run must not reach storage.
+   * <p>
+   * {@code ServerDatabase.command(language, query, parameters)} injects the flag for every statement in every
+   * language while the server profiler is recording, so this is not a Studio-only path: without this gate a
+   * {@code g.addV('Person')} issued against a recording server built the traversal twice and drained both,
+   * creating two vertices (issue #7394).
+   * <p>
+   * Two shapes are refused:
+   * <ul>
+   *   <li>a traversal carrying a {@link Mutating} step - the second run would apply the mutation again;</li>
+   *   <li>anything that is not an un-iterated traversal at all - {@code eval()} answers a plain value when the
+   *   statement ended in an eager terminal step such as {@code .next()}, which means the statement has already
+   *   run once and its steps can no longer be inspected. Whether that run mutated cannot be established here,
+   *   so the pass is skipped rather than guessed at. No plan is lost by that: appending {@code .profile()} to a
+   *   statement that already ended in a terminal step does not parse, so the attempt only ever landed in the
+   *   {@code // NO EXECUTION PLAN} catch below.</li>
+   * </ul>
+   * Read-only traversals are unaffected and keep their execution plan; the cost of profiling those is issue
+   * #7408.
+   */
+  private static boolean canBeProfiledWithoutRunningItAgain(final Iterator<?> resultSet) {
+    if (!(resultSet instanceof final GraphTraversal<?, ?> traversal))
+      return false;
+
+    // Strategies have not been applied yet, so this is the same raw step list parse() inspects - and the
+    // gremlin-lang placeholder step types (AddVertexStartStepPlaceholder and friends) implement Mutating just
+    // as the concrete steps do, which is what makes the check reliable on both engines (see #5838).
+    for (final Object step : traversal.asAdmin().getSteps())
+      if (step instanceof Mutating)
+        return false;
+
+    return true;
   }
 
   /**

--- a/gremlin/src/test/java/com/arcadedb/gremlin/Issue7394GremlinProfileDoesNotDoubleMutateTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/Issue7394GremlinProfileDoesNotDoubleMutateTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.gremlin;
+
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7394 item 7: the Gremlin sibling of the double execution #7330 removed from OpenCypher.
+ * <p>
+ * {@code $profileExecution} means "time this statement", not "run it differently" - that is what #7330
+ * settled for OpenCypher, and {@code ServerDatabase} injects the flag for <b>every</b> statement, in every
+ * language, while the server profiler is recording. {@link ArcadeGremlin#execute()} answered it by running
+ * the statement a second time with {@code .profile()} appended and draining that run to build the execution
+ * plan. For a read that costs double; for a mutation the second run <i>applies the mutation again</i>, so
+ * switching on a diagnostic silently doubled every Gremlin write on the server.
+ * <p>
+ * The tests below pin both halves of the fix: a mutating traversal is executed exactly once and reports no
+ * plan, and a read-only traversal still gets its plan (Studio's {@code profileExecution: "detailed"} is
+ * unchanged for reads, which is the behaviour the skip must not take away).
+ *
+ * @see <a href="https://github.com/ArcadeData/arcadedb/issues/7394">issue #7394</a>
+ */
+class Issue7394GremlinProfileDoesNotDoubleMutateTest {
+
+  private ArcadeGraph graph;
+
+  @BeforeEach
+  void setup() {
+    graph = ArcadeGraph.open("./target/test-gremlin-7394-profile");
+    graph.getDatabase().getSchema().createVertexType("Person");
+    graph.getDatabase().getSchema().createEdgeType("Knows");
+  }
+
+  @AfterEach
+  void teardown() {
+    if (graph != null)
+      graph.drop();
+  }
+
+  private long countPersons() {
+    try (final ResultSet rs = graph.getDatabase().query("sql", "SELECT count(*) AS total FROM Person")) {
+      return rs.next().getProperty("total");
+    }
+  }
+
+  @Test
+  void anAddVertexUnderProfileExecutionCreatesOneVertexNotTwo() {
+    graph.getDatabase().transaction(() -> {
+      try (final ResultSet rs = graph.gremlin("g.addV('Person').property('name','Alice')")
+          .setParameters(Map.of("$profileExecution", true))
+          .execute()) {
+        // The traversal is lazy: draining it is what the caller does, and it is the run that must be the
+        // only one to reach storage.
+        rs.stream().forEach(r -> {
+        });
+      }
+    });
+
+    assertThat(countPersons()).isEqualTo(1L);
+  }
+
+  @Test
+  void anAddEdgeUnderProfileExecutionCreatesOneEdgeNotTwo() {
+    graph.getDatabase().transaction(() -> {
+      graph.addVertex("Person").property("name", "Alice");
+      graph.addVertex("Person").property("name", "Bob");
+    });
+
+    graph.getDatabase().transaction(() -> {
+      try (final ResultSet rs = graph.gremlin(
+              "g.V().has('Person','name','Alice').as('a')"
+                  + ".V().has('Person','name','Bob').as('b')"
+                  + ".addE('Knows').from('a').to('b')")
+          .setParameters(Map.of("$profileExecution", true))
+          .execute()) {
+        rs.stream().forEach(r -> {
+        });
+      }
+    });
+
+    try (final ResultSet rs = graph.getDatabase().query("sql", "SELECT count(*) AS total FROM Knows")) {
+      assertThat((Long) rs.next().getProperty("total")).isEqualTo(1L);
+    }
+  }
+
+  @Test
+  void aMutatingTraversalReportsNoExecutionPlanRatherThanBuyingOneWithASecondMutation() {
+    graph.getDatabase().transaction(() -> {
+      try (final ResultSet rs = graph.gremlin("g.addV('Person').property('name','Carol')")
+          .setParameters(Map.of("$profileExecution", true))
+          .execute()) {
+        rs.stream().forEach(r -> {
+        });
+        assertThat(rs.getExecutionPlan()).isEmpty();
+      }
+    });
+
+    assertThat(countPersons()).isEqualTo(1L);
+  }
+
+  @Test
+  void aReadOnlyTraversalStillGetsItsExecutionPlan() {
+    graph.getDatabase().transaction(() -> graph.addVertex("Person").property("name", "Dave"));
+
+    try (final ResultSet rs = graph.gremlin("g.V().hasLabel('Person')")
+        .setParameters(Map.of("$profileExecution", true))
+        .execute()) {
+      rs.stream().forEach(r -> {
+      });
+      assertThat(rs.getExecutionPlan()).isPresent();
+    }
+  }
+
+  /**
+   * The flag is consumed, not left in the bindings. It is not a Gremlin variable, and leaving it there
+   * would bind {@code $profileExecution} into the script engine as if the caller had written it.
+   */
+  @Test
+  void theFlagIsRemovedFromTheParametersEvenWhenTheProfilingPassIsSkipped() {
+    final ArcadeGremlin gremlin = graph.gremlin("g.addV('Person')");
+    gremlin.setParameters(Map.of("$profileExecution", true));
+
+    graph.getDatabase().transaction(() -> {
+      try (final ResultSet rs = gremlin.execute()) {
+        rs.stream().forEach(r -> {
+        });
+      }
+    });
+
+    assertThat(gremlin.getParameters()).doesNotContainKey("$profileExecution");
+  }
+}

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
@@ -628,11 +628,20 @@ public class RemoteGrpcServer implements AutoCloseable {
   }
 
   /**
-   * Starts the query profiler. {@code timeoutSeconds} of 0 records until {@link #profilerStop()}.
+   * Starts the query profiler.
+   * <p>
+   * A {@code timeoutSeconds} of 0 does <b>not</b> record until {@link #profilerStop()} - it applies the
+   * server's own default (60 seconds at the time of writing), and so does any negative value. There is no way
+   * to ask for an unbounded recording: while one runs, every query on the server is wrapped for profiling.
+   * This javadoc claimed otherwise until issue #7394.
+   *
+   * @return the timeout the recording is actually running under, in seconds, as the server reports it - which
+   * is the live recording's own bound, not this call's argument, if a recording was already in flight
    */
-  public void profilerStart(final int timeoutSeconds) {
-    call("profiler start", stub -> stub.profilerStart(
-        ProfilerStartRequest.newBuilder().setCredentials(buildCredentials()).setTimeoutSeconds(timeoutSeconds).build()));
+  public int profilerStart(final int timeoutSeconds) {
+    return call("profiler start", stub -> stub.profilerStart(
+        ProfilerStartRequest.newBuilder().setCredentials(buildCredentials()).setTimeoutSeconds(timeoutSeconds).build()))
+        .getTimeoutSeconds();
   }
 
   public JSONObject profilerStop() {

--- a/grpc/src/main/proto/arcadedb-server.proto
+++ b/grpc/src/main/proto/arcadedb-server.proto
@@ -1404,7 +1404,10 @@ message DeleteBackupResponse {}
 
 message ProfilerStartRequest {
   DatabaseCredentials credentials = 1;
-  // Seconds after which recording stops on its own. 0 records until ProfilerStop.
+  // Seconds after which recording stops on its own. 0 (or negative) applies the server's own default rather
+  // than recording indefinitely - there is no way to ask for an unbounded recording, because while one runs
+  // every server query is wrapped for profiling. The bound that actually applied comes back in
+  // ProfilerStateResponse.timeout_seconds (issue #7394).
   int32 timeout_seconds = 2;
 }
 message ProfilerStopRequest {
@@ -1426,6 +1429,10 @@ message ProfilerLoadRequest {
 
 message ProfilerStateResponse {
   bool recording = 1;
+  // For ProfilerStart, the timeout the recording is actually running under, in seconds: the requested value,
+  // the server default when none was requested, or - when a recording was already in flight, which makes a
+  // second start a no-op - that recording's own. Unset for ProfilerReset.
+  int32 timeout_seconds = 2;
 }
 
 // A profiler run. The document's shape is the profiler's own and changes with it, so it travels as

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
@@ -698,8 +698,14 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
     respond(resp, "profilerStart", () -> {
       requireServerAdmin(authenticate(req.getCredentials()));
 
-      controlPlane.profilerStart(req.getTimeoutSeconds());
-      return ProfilerStateResponse.newBuilder().setRecording(true).build();
+      // The effective timeout, not the requested one: a non-positive request gets the server default and a
+      // start against an already-recording profiler keeps the live recording's bound, so echoing the request
+      // would tell the client a time its recording does not end at (issue #7394).
+      final JSONObject state = controlPlane.profilerStart(req.getTimeoutSeconds());
+      return ProfilerStateResponse.newBuilder()
+          .setRecording(state.getBoolean("recording", true))
+          .setTimeoutSeconds(state.getInt("timeoutSeconds", 0))
+          .build();
     });
   }
 

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -133,6 +133,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 
 /**
@@ -3262,12 +3263,42 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   // ---------------------------------------------------------------------------------------------------------
 
   /** Rows (or buckets) per streamed TimeSeriesQueryResult when the client states no batch size. */
-  private static final int TS_DEFAULT_BATCH_SIZE = 1_000;
+  private static final int TS_DEFAULT_BATCH_SIZE  = 1_000;
   /**
-   * Ceiling on a client-stated batch size. A message holds this many rows, so an unbounded batch size is an
-   * unbounded message: the cap keeps one answer under maxInboundMessageSize regardless of what was asked for.
+   * Ceiling on a client-stated batch size, so an unbounded batch size cannot ask for an unbounded message.
+   * <p>
+   * This is a row count, and a row count is only a HEURISTIC for message size - it used to be documented as if
+   * it kept a message under {@code maxInboundMessageSize}, which it cannot: a series with many tags or long
+   * string values crosses 4 MiB at a row count well inside this cap, and the failure lands on the client as a
+   * rejected frame rather than as a status it can act on (issue #7394). {@link #TS_MAX_BATCH_BYTES} is the
+   * bound that actually holds; this one keeps the per-message row count sane and bounds the accumulator.
    */
-  private static final int TS_MAX_BATCH_SIZE     = 10_000;
+  private static final int TS_MAX_BATCH_SIZE      = 10_000;
+  /**
+   * Byte budget for one streamed {@code TimeSeriesQueryResult}, measured on the serialized rows or buckets it
+   * carries. A batch is emitted as soon as either this or the row count is reached.
+   * <p>
+   * Half of gRPC's 4 MiB default inbound limit, which is what a client that has not raised
+   * {@code maxInboundMessageSize} will accept. The margin covers the parts of the message not counted here -
+   * the type name, the column or aggregation names, and the protobuf framing - without needing to model them.
+   * <p>
+   * This bounds a BATCH, not a row: one row larger than the budget is still emitted on its own, because a row
+   * cannot be split. That is the residual the byte budget cannot remove.
+   */
+  private static final int TS_MAX_BATCH_BYTES     = 2 * 1024 * 1024;
+
+  /**
+   * Whether an accumulating batch should be emitted now: it has reached the client's (capped) row count, or it
+   * has reached the byte budget. Package-private so the two bounds can be exercised without streaming a
+   * multi-megabyte answer through a real server.
+   *
+   * @param rows      rows or buckets accumulated so far
+   * @param bytes     sum of their serialized sizes
+   * @param batchSize the effective row bound for this request
+   */
+  static boolean timeSeriesBatchIsFull(final int rows, final int bytes, final int batchSize) {
+    return rows >= batchSize || bytes >= TS_MAX_BATCH_BYTES;
+  }
 
   @Override
   public void timeSeriesWrite(final TimeSeriesWriteRequest req, final StreamObserver<TimeSeriesWriteSummary> resp) {
@@ -3475,6 +3506,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     final Iterator<Object[]> rows = engine.iterateQuery(fromTs, toTs, columnIndices, tagFilter);
 
     final List<TimeSeriesRow> batch = new ArrayList<>(Math.min(batchSize, 1024));
+    // Serialized size of what is in `batch`, so the message can be bounded by bytes and not only by rows.
+    // TimeSeriesRow memoizes its own size, so accumulating it here costs one field read per row.
+    int batchBytes = 0;
     long emitted = 0;
     boolean truncated = false;
 
@@ -3493,10 +3527,12 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
                 + " rows (arcadedb.server.grpcQueryMaxResultRows); narrow the time range, add a tag filter, or set a limit")
             .asRuntimeException();
 
-      batch.add(GrpcTimeSeriesSupport.toRow(rows.next()));
+      final TimeSeriesRow row = GrpcTimeSeriesSupport.toRow(rows.next());
+      batch.add(row);
+      batchBytes += row.getSerializedSize();
       emitted++;
 
-      if (batch.size() >= batchSize) {
+      if (timeSeriesBatchIsFull(batch.size(), batchBytes, batchSize)) {
         emitTimeSeriesBatch(call, cancelled, serverTimedOut, TimeSeriesQueryResult.newBuilder()
             .setType(req.getType())
             .addAllColumns(columnNames)
@@ -3506,6 +3542,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         if (cancelled.get())
           return;
         batch.clear();
+        batchBytes = 0;
       }
     }
 
@@ -3571,6 +3608,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           .asRuntimeException();
 
     final List<TimeSeriesBucket> batch = new ArrayList<>(Math.min(batchSize, 1024));
+    int batchBytes = 0;
     long emitted = 0;
 
     for (final long timestamp : timestamps) {
@@ -3581,10 +3619,12 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       for (int r = 0; r < requests.size(); r++)
         // NOT setDoubleValue: an absent MIN/MAX answers NaN, which a client would otherwise read as a number.
         bucket.addValues(GrpcTimeSeriesSupport.toSampleValue(result.getValue(timestamp, r)));
-      batch.add(bucket.build());
+      final TimeSeriesBucket built = bucket.build();
+      batch.add(built);
+      batchBytes += built.getSerializedSize();
       emitted++;
 
-      if (batch.size() >= batchSize) {
+      if (timeSeriesBatchIsFull(batch.size(), batchBytes, batchSize)) {
         emitTimeSeriesBatch(call, cancelled, serverTimedOut, TimeSeriesQueryResult.newBuilder()
             .setType(req.getType())
             .addAllAggregations(aliases)
@@ -3594,6 +3634,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         if (cancelled.get())
           return;
         batch.clear();
+        batchBytes = 0;
       }
     }
 
@@ -5126,6 +5167,14 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
    * FAILED_PRECONDITION instead of quietly falling through to a read outside the transaction the caller
    * believes it is inside - the same contract {@code lookupByRid} and {@code updateRecord} carry. A blank id is
    * not a supplied one and legitimately means "no external transaction".
+   * <p>
+   * The {@link ProtocolContext} pair wraps the BODY rather than the RPC method, and that placement is the
+   * point: the context is a thread-local, the vector and hybrid legs execute SQL through
+   * {@code Database.query}, and {@code QueryMetricsRecorder}/{@code QueryTracer} read the protocol off
+   * whichever thread that SQL runs on. In-transaction searches run on the transaction's own executor thread,
+   * not on the calling gRPC worker, so tagging the worker would have left exactly the path #7326 added still
+   * reporting {@code protocol="internal"} (issue #7394). {@code executeCommandInternal} places it the same way
+   * and for the same reason.
    *
    * @param incomingTxId the request's transaction id, or null when the request carried no TransactionContext
    * @param body         the search, which must not retain the database handle beyond the call
@@ -5138,10 +5187,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       throw unknownTransactionStatus(incomingTxId).asRuntimeException();
 
     if (txCtx == null)
-      return body.apply(getDatabase(databaseName, credentials));
+      return asGrpcProtocol(() -> body.apply(getDatabase(databaseName, credentials)));
 
     try {
-      return submitToActiveTransaction(txCtx, () -> body.apply(txCtx.db)).get();
+      return submitToActiveTransaction(txCtx, () -> asGrpcProtocol(() -> body.apply(txCtx.db))).get();
     } catch (final ExecutionException e) {
       // Unwrap so toSearchStatus() sees the real failure - an explicit gRPC status raised by
       // requireTransactionStillActive, or the IllegalArgumentException the shared implementation reports a
@@ -5155,6 +5204,22 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
       throw e;
+    }
+  }
+
+  /**
+   * Runs {@code body} with the calling thread tagged as the gRPC protocol, and untags it afterwards.
+   * <p>
+   * The clear is unconditional because both threads this runs on are pooled and reused - the gRPC worker
+   * across unrelated RPCs, a transaction executor across the RPCs of its transaction - and a tag left behind
+   * would attribute the next piece of work on that thread to gRPC whatever it actually was.
+   */
+  private static <T> T asGrpcProtocol(final Supplier<T> body) {
+    ProtocolContext.set("grpc");
+    try {
+      return body.get();
+    } finally {
+      ProtocolContext.clear();
     }
   }
 

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7394SearchProtocolContextIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7394SearchProtocolContextIT.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.database.ProtocolContext;
+import com.arcadedb.query.sql.SQLQueryEngine;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.function.sql.SQLFunctionAbstract;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7394 item 1: the vector, hybrid and full-text search RPCs ran their SQL without establishing the
+ * protocol context, so nothing that reads {@link ProtocolContext} on that thread could tell the traffic came
+ * from gRPC.
+ * <p>
+ * The assertion is made from inside the SQL itself, by a custom function called from the vector leg's own
+ * {@code filter} predicate that records what {@code ProtocolContext.get()} answers on the thread evaluating
+ * it. That is the exact invariant - the thread that runs the search reports "grpc" - and it is the only way
+ * to see it today: the search legs execute through {@code AnalyzedQuery.execute()} rather than
+ * {@code Database.query}, so {@code arcadedb.query.duration} does not fire for them on ANY protocol (see
+ * issue #7418) and a metric-count assertion would pass or fail for reasons unrelated to this fix.
+ * <p>
+ * The in-transaction case is the one that makes an integration test worth its cost. {@code ProtocolContext}
+ * is a thread-local, and a search naming a live transaction runs on that transaction's own executor thread
+ * (issue #7326), not on the calling gRPC worker - so a fix applied at the RPC method would have left exactly
+ * that path untagged, and only really dispatching through the transaction registry shows it.
+ *
+ * @see <a href="https://github.com/ArcadeData/arcadedb/issues/7394">issue #7394</a>
+ */
+public class Issue7394SearchProtocolContextIT extends BaseGraphServerTest {
+
+  private static final int    GRPC_PORT    = 50051;
+  private static final String VECTOR_TYPE  = "Vec7394";
+  private static final String VECTOR_INDEX = VECTOR_TYPE + "[embedding]";
+
+  /** What {@code ProtocolContext.get()} answered on the thread that evaluated the search's SQL. */
+  private static final AtomicReference<String> OBSERVED_PROTOCOL = new AtomicReference<>();
+
+  private static final Metadata.Key<String> USER_HEADER     =
+      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER =
+      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER =
+      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private ManagedChannel                                  channel;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub stub;
+
+  /** The gRPC auth interceptor authenticates from headers, so every call carries them (see GrpcQueryMetricsIT). */
+  private class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        final MethodDescriptor<ReqT, RespT> method, final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GRPC:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @Override
+  protected void populateDatabase() {
+    super.populateDatabase();
+
+    final Database db = getDatabase(0);
+    db.transaction(() -> {
+      db.command("sql", "CREATE VERTEX TYPE " + VECTOR_TYPE);
+      db.command("sql", "CREATE PROPERTY " + VECTOR_TYPE + ".embedding ARRAY_OF_FLOATS");
+      db.command("sql", "CREATE INDEX ON " + VECTOR_TYPE + " (embedding) LSM_VECTOR "
+          + "METADATA { dimensions: 3, similarity: 'COSINE' }");
+
+      db.newVertex(VECTOR_TYPE).set("embedding", new float[] { 1.0f, 0.0f, 0.0f }).save();
+      db.newVertex(VECTOR_TYPE).set("embedding", new float[] { 0.0f, 1.0f, 0.0f }).save();
+    });
+
+    // Registered on the reusable SQL engine of the server's own database, which is the very instance the gRPC
+    // worker and the transaction executor resolve (LocalDatabase caches reusable engines per database), so the
+    // function is in scope wherever the search actually runs.
+    ((SQLQueryEngine) db.getQueryEngine("sql")).getFunctionFactory().register(
+        new SQLFunctionAbstract("observedprotocol") {
+          @Override
+          public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult,
+              final Object[] params, final CommandContext context) {
+            OBSERVED_PROTOCOL.set(ProtocolContext.get());
+            return ProtocolContext.get();
+          }
+
+          @Override
+          public String getSyntax() {
+            return "records ProtocolContext.get() on the evaluating thread and returns it";
+          }
+        });
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    OBSERVED_PROTOCOL.set(null);
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    stub = ArcadeDbServiceGrpc.newBlockingStub(
+        ClientInterceptors.intercept(channel, new AuthClientInterceptor()));
+  }
+
+  @AfterEach
+  void teardownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private DatabaseCredentials root() {
+    return DatabaseCredentials.newBuilder()
+        .setUsername("root")
+        .setPassword(DEFAULT_PASSWORD_FOR_TESTS)
+        .build();
+  }
+
+  /**
+   * The predicate is always true, so it never changes which records the search answers - it is there to be
+   * evaluated, on the thread the search runs on.
+   */
+  private VectorSearchRequest.Builder vectorRequest() {
+    return VectorSearchRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(root())
+        .setIndexName(VECTOR_INDEX)
+        .addAllQueryVector(List.of(1.0f, 0.0f, 0.0f))
+        .setK(2)
+        .setFilter("observedprotocol() IS NOT NULL");
+  }
+
+  @Test
+  void vectorSearchRunsItsSqlUnderTheGrpcProtocolTag() {
+    stub.vectorSearch(vectorRequest().build());
+
+    assertThat(OBSERVED_PROTOCOL.get()).isEqualTo("grpc");
+  }
+
+  @Test
+  void hybridSearchRunsItsSqlUnderTheGrpcProtocolTag() {
+    stub.hybridSearch(HybridSearchRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(root())
+        .setVectorIndexName(VECTOR_INDEX)
+        .addAllQueryVector(List.of(1.0f, 0.0f, 0.0f))
+        .setK(2)
+        .setFilter("observedprotocol() IS NOT NULL")
+        .build());
+
+    assertThat(OBSERVED_PROTOCOL.get()).isEqualTo("grpc");
+  }
+
+  /**
+   * The path the thread-local placement exists for: the body runs on the transaction's executor thread, so
+   * the tag has to be set there and not on the gRPC worker that dispatched it.
+   */
+  @Test
+  void aVectorSearchInsideAClientTransactionRunsItsSqlUnderTheGrpcProtocolTagToo() {
+    final BeginTransactionResponse tx = stub.beginTransaction(BeginTransactionRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(root())
+        .build());
+
+    try {
+      stub.vectorSearch(vectorRequest()
+          .setTransaction(TransactionContext.newBuilder().setTransactionId(tx.getTransactionId()).build())
+          .build());
+
+      assertThat(OBSERVED_PROTOCOL.get()).isEqualTo("grpc");
+    } finally {
+      stub.rollbackTransaction(RollbackTransactionRequest.newBuilder()
+          .setCredentials(root())
+          .setTransaction(TransactionContext.newBuilder().setTransactionId(tx.getTransactionId()).build())
+          .build());
+    }
+  }
+
+  /**
+   * The control: the same SQL, run by the embedded API on a thread no wire protocol tagged, still reports
+   * {@code internal}. Without this the test would pass just as well against a {@code ProtocolContext} that
+   * answered "grpc" for everything.
+   */
+  @Test
+  void theSameSqlRunOutsideAnyProtocolStillReportsInternal() {
+    // The server's own live handle: the one populateDatabase() used is closed by the time a test body runs.
+    // The result set is lazy, so it has to be consumed or the projection - and the function in it - never runs.
+    try (final ResultSet rs = getServer(0).getDatabase(getDatabaseName())
+        .query("sql", "SELECT observedprotocol() AS p FROM " + VECTOR_TYPE + " LIMIT 1")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat((String) rs.next().getProperty("p")).isEqualTo(ProtocolContext.INTERNAL);
+    }
+
+    assertThat(OBSERVED_PROTOCOL.get()).isEqualTo(ProtocolContext.INTERNAL);
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7394TimeSeriesBatchByteBudgetTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7394TimeSeriesBatchByteBudgetTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7394 item 2: {@code TS_MAX_BATCH_SIZE} bounded a streamed message by row count while its javadoc
+ * claimed it bounded the message's bytes.
+ * <p>
+ * A row count is not a byte count. A series with many tags or long string values crosses gRPC's 4 MiB default
+ * inbound limit at a row count well inside the 10,000 cap, and the client rejects the frame rather than
+ * receiving a status it can act on. The batch is now flushed on whichever bound is reached first.
+ * <p>
+ * The predicate is tested directly rather than by streaming megabytes through a live server: what needs
+ * pinning is that the byte budget can fire while the row count is nowhere near its bound, and that it does so
+ * at a size that leaves room under 4 MiB for the parts of the message the accumulator does not count.
+ *
+ * @see <a href="https://github.com/ArcadeData/arcadedb/issues/7394">issue #7394</a>
+ */
+class Issue7394TimeSeriesBatchByteBudgetTest {
+
+  /** gRPC's own default for {@code maxInboundMessageSize}, which is what an unconfigured client enforces. */
+  private static final int GRPC_DEFAULT_MAX_INBOUND_MESSAGE_SIZE = 4 * 1024 * 1024;
+
+  @Test
+  void aBatchWellUnderTheRowCapIsStillFlushedOnceItReachesTheByteBudget() {
+    // Two rows, no more, but three megabytes of them: the row cap says "keep going", the byte budget must not.
+    assertThat(ArcadeDbGrpcService.timeSeriesBatchIsFull(2, 3 * 1024 * 1024, 10_000)).isTrue();
+  }
+
+  @Test
+  void aSmallBatchIsNotFlushedByEitherBound() {
+    assertThat(ArcadeDbGrpcService.timeSeriesBatchIsFull(2, 1_024, 10_000)).isFalse();
+  }
+
+  @Test
+  void theRowBoundStillFiresForNarrowRowsThatNeverReachTheByteBudget() {
+    assertThat(ArcadeDbGrpcService.timeSeriesBatchIsFull(1_000, 8_000, 1_000)).isTrue();
+    assertThat(ArcadeDbGrpcService.timeSeriesBatchIsFull(999, 8_000, 1_000)).isFalse();
+  }
+
+  /**
+   * The whole point of the budget: a batch emitted at the moment it is declared full is a message a client
+   * with gRPC's default inbound limit can receive, with margin left for the type name, the column names and
+   * the protobuf framing that the accumulator does not count.
+   */
+  @Test
+  void theByteBudgetLeavesHeadroomUnderTheDefaultInboundLimit() {
+    int bytes = 0;
+    int rows = 0;
+    // Grow a batch a realistic wide row at a time until the predicate says to flush, then check what would
+    // have gone on the wire.
+    while (!ArcadeDbGrpcService.timeSeriesBatchIsFull(rows, bytes, 10_000)) {
+      rows++;
+      bytes += 4_096;
+    }
+
+    assertThat(bytes).isLessThan(GRPC_DEFAULT_MAX_INBOUND_MESSAGE_SIZE);
+    // ... and it was the byte bound that fired, not the row cap, which is the case the old code missed.
+    assertThat(rows).isLessThan(10_000);
+  }
+
+  /**
+   * A row larger than the whole budget cannot be split, so it is emitted alone. The predicate has to say
+   * "flush" for it rather than loop forever trying to get under a bound one row already exceeds.
+   */
+  @Test
+  void oneOversizedRowIsFlushedOnItsOwnRatherThanAccumulating() {
+    assertThat(ArcadeDbGrpcService.timeSeriesBatchIsFull(1, 8 * 1024 * 1024, 10_000)).isTrue();
+  }
+
+  /**
+   * The accumulator matches what goes on the wire: the sum of the rows' serialized sizes is what the message
+   * carries, plus the framing the margin covers. Pinned against real protobuf messages so the budget is not
+   * being compared against a number of a different kind.
+   */
+  @Test
+  void theAccumulatedSizeIsTheSerializedSizeOfTheRowsTheMessageCarries() {
+    final List<TimeSeriesRow> rows = new ArrayList<>();
+    int accumulated = 0;
+    for (int i = 0; i < 50; i++) {
+      final TimeSeriesRow row = TimeSeriesRow.newBuilder()
+          .addValues(GrpcValue.newBuilder().setInt64Value(1_000L + i).build())
+          .addValues(GrpcValue.newBuilder().setStringValue("host-" + i + "-with-a-realistically-long-tag").build())
+          .addValues(GrpcValue.newBuilder().setDoubleValue(22.5 + i).build())
+          .build();
+      rows.add(row);
+      accumulated += row.getSerializedSize();
+    }
+
+    final TimeSeriesQueryResult message = TimeSeriesQueryResult.newBuilder()
+        .setType("weather")
+        .addAllRows(rows)
+        .build();
+
+    // The message is the rows plus its own framing and header fields, never less than what was accumulated.
+    assertThat(message.getSerializedSize()).isGreaterThanOrEqualTo(accumulated);
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -1053,8 +1053,17 @@ public class ServerControlPlane {
   // ---------------------------------------------------------------------------------------------
 
   /**
-   * Starts recording. A {@code timeoutSec} of zero or less starts an open-ended recording, which is
-   * what the HTTP {@code profiler start} command does when it carries no timeout.
+   * Starts recording, for {@code timeoutSec} seconds or - when that is not positive, which is what the HTTP
+   * {@code profiler start} command sends when it carries no timeout - for the profiler's own default.
+   * <p>
+   * That default is <b>not</b> "until stopped": {@link ServerQueryProfiler#start(int)} substitutes 60 seconds
+   * and arms an auto-stop timer, and this javadoc used to claim the opposite (issue #7394). Rather than remove
+   * the bound - a recording nobody stops keeps every server query on the {@code ProfilingResultSet} wrapping
+   * path - the response reports the timeout that will actually apply, so neither transport has to know the
+   * default to tell a caller when its recording ends.
+   *
+   * @return {@code result}, {@code recording}, and {@code timeoutSeconds}: the effective bound, which is the
+   * live recording's own when a recording was already running (a second start is a no-op)
    */
   public JSONObject profilerStart(final int timeoutSec) {
     final ServerQueryProfiler profiler = server.getQueryProfiler();
@@ -1063,7 +1072,8 @@ public class ServerControlPlane {
     else
       profiler.start();
 
-    return new JSONObject().put("result", "ok").put("recording", true);
+    return new JSONObject().put("result", "ok").put("recording", true)
+        .put("timeoutSeconds", profiler.getTimeoutSeconds());
   }
 
   public JSONObject profilerStop() {

--- a/server/src/main/java/com/arcadedb/server/monitor/ProfilingResultSet.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/ProfilingResultSet.java
@@ -39,12 +39,18 @@ public class ProfilingResultSet implements ResultSet {
   /**
    * @param startNanos the {@link System#nanoTime()} reading taken <b>before</b> the query was handed to the engine.
    *                   It cannot be taken here: by the time this wrapper is built the engine call has already
-   *                   returned, and everything a non-streaming plan does (every write statement, and every
-   *                   OpenCypher statement while the profiler is recording, because the profiler routes those
-   *                   through {@code CypherExecutionPlan.profile()} which drains the plan eagerly) has already
-   *                   happened. Starting the clock in this constructor therefore measured only the drain of an
+   *                   returned, and everything a non-streaming plan does - every write statement, and any
+   *                   statement whose plan is materialized rather than streamed - has already happened.
+   *                   Starting the clock in this constructor therefore measured only the drain of an
    *                   already-materialized iterator - a few microseconds - and Studio showed a query total far
    *                   below its own step timings (issue #7291).
+   *                   <p>
+   *                   This used to name OpenCypher as the second case, because the profiler rerouted every
+   *                   Cypher statement onto {@code CypherExecutionPlan.profile()} while recording. #7330
+   *                   removed that reroute - {@code $profileExecution} now times the ordinary streaming run,
+   *                   and only the explicit {@code PROFILE} keyword still drains eagerly - so the example no
+   *                   longer describes anything (issue #7394). The reason the reading has to be taken by the
+   *                   caller is unchanged.
    */
   public ProfilingResultSet(final ResultSet delegate, final ServerQueryProfiler profiler, final String database,
       final String language, final String queryText, final long startNanos) {

--- a/server/src/main/java/com/arcadedb/server/monitor/ServerQueryProfiler.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/ServerQueryProfiler.java
@@ -81,10 +81,28 @@ public class ServerQueryProfiler {
     return recording;
   }
 
+  /**
+   * The timeout the current (or most recent) recording is running under, in seconds - always the effective
+   * value, never the one that was asked for: {@link #start(int)} substitutes
+   * {@value #DEFAULT_TIMEOUT_SECONDS} for a non-positive request, and a start against an already-recording
+   * profiler is a no-op that leaves the live recording's timeout in place. Callers report this rather than
+   * their own argument so what they tell the client is when the recording will actually end (issue #7394).
+   */
+  public synchronized int getTimeoutSeconds() {
+    return timeoutSeconds;
+  }
+
+  /** Records for {@value #DEFAULT_TIMEOUT_SECONDS} seconds, the same bound {@link #start(int)} applies to a non-positive request. */
   public void start() {
     start(DEFAULT_TIMEOUT_SECONDS);
   }
 
+  /**
+   * Starts recording, for {@code timeoutSec} seconds or - when that is not positive - for
+   * {@value #DEFAULT_TIMEOUT_SECONDS}. There is deliberately no way to ask for an unbounded recording: while
+   * one is running every server query is wrapped in a {@code ProfilingResultSet}, so a capture nobody
+   * remembers to stop is a cost nobody sees. {@link #getTimeoutSeconds()} answers which bound applied.
+   */
   public synchronized void start(final int timeoutSec) {
     if (recording)
       return;

--- a/server/src/test/java/com/arcadedb/server/Issue7394ProfilerStartReportsItsTimeoutTest.java
+++ b/server/src/test/java/com/arcadedb/server/Issue7394ProfilerStartReportsItsTimeoutTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.monitor.ServerQueryProfiler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #7394 item 4: a recording started with no timeout was documented as open-ended and was not.
+ * <p>
+ * Three surfaces said that a {@code timeoutSeconds} of zero records until the profiler is stopped - this
+ * class's javadoc, {@code ProfilerStartRequest.timeout_seconds} in the proto, and
+ * {@code RemoteGrpcServer.profilerStart}. {@link ServerQueryProfiler#start(int)} does
+ * {@code timeoutSec > 0 ? timeoutSec : DEFAULT_TIMEOUT_SECONDS}, so both spellings of "no timeout" get 60
+ * seconds and an auto-stop timer, and a caller planning a long capture found its recording already stopped.
+ * <p>
+ * The bounded default stays - an unattended recording keeps every server query on the
+ * {@code ProfilingResultSet} wrapping path, so "records forever unless someone remembers" is not the safer
+ * behaviour - and is reported instead. The start response now carries the timeout that will actually apply,
+ * so a caller can tell when its recording ends without having to know the default.
+ *
+ * @see <a href="https://github.com/ArcadeData/arcadedb/issues/7394">issue #7394</a>
+ */
+class Issue7394ProfilerStartReportsItsTimeoutTest {
+
+  private ArcadeDBServer      server;
+  private ServerQueryProfiler profiler;
+  private ServerControlPlane  controlPlane;
+
+  @BeforeEach
+  void setup(@TempDir final Path rootPath) {
+    server = mock(ArcadeDBServer.class);
+    // stop() persists the run under <rootPath>/profiler. Unstubbed, getRootPath() answers null and that path
+    // becomes the literal "null/profiler", dropped into whatever the working directory happens to be.
+    when(server.getRootPath()).thenReturn(rootPath.toString());
+    profiler = new ServerQueryProfiler(server);
+    when(server.getQueryProfiler()).thenReturn(profiler);
+    controlPlane = new ServerControlPlane(server);
+  }
+
+  @AfterEach
+  void teardown() {
+    if (profiler != null && profiler.isRecording())
+      profiler.stop();
+  }
+
+  @Test
+  void aZeroTimeoutReportsTheDefaultItActuallyGets() {
+    final JSONObject response = controlPlane.profilerStart(0);
+
+    assertThat(response.getBoolean("recording")).isTrue();
+    assertThat(response.getInt("timeoutSeconds")).isEqualTo(60);
+    assertThat(profiler.getTimeoutSeconds()).isEqualTo(60);
+  }
+
+  @Test
+  void aNegativeTimeoutReportsTheSameDefault() {
+    final JSONObject response = controlPlane.profilerStart(-1);
+
+    assertThat(response.getInt("timeoutSeconds")).isEqualTo(60);
+  }
+
+  @Test
+  void anExplicitTimeoutIsReportedBackUnchanged() {
+    final JSONObject response = controlPlane.profilerStart(300);
+
+    assertThat(response.getInt("timeoutSeconds")).isEqualTo(300);
+    assertThat(profiler.getTimeoutSeconds()).isEqualTo(300);
+  }
+
+  /**
+   * Starting an already-recording profiler is a no-op, so the reported timeout has to be the one the live
+   * recording is running under - not the one this call asked for and did not get.
+   */
+  @Test
+  void aSecondStartReportsTheTimeoutOfTheRecordingThatIsActuallyRunning() {
+    controlPlane.profilerStart(300);
+
+    final JSONObject response = controlPlane.profilerStart(5);
+
+    assertThat(response.getInt("timeoutSeconds")).isEqualTo(300);
+    assertThat(profiler.getTimeoutSeconds()).isEqualTo(300);
+  }
+}


### PR DESCRIPTION
Closes #7394

Seven items from the control-plane and gRPC delta, each fixed at the point where the property has to hold rather than at the site the report named. Two of them turned out to be more than low severity once traced: the Gremlin one is a data-correctness bug (a mutating traversal ran, and mutated, twice while the profiler was recording), and the profiler one is three separate documentation claims that were all false. One of them is *less* than reported, and that is called out below rather than papered over.

| # | Item | Outcome |
|---|---|---|
| 1 | Search RPCs never set `ProtocolContext` | fixed on all three RPCs, on both the inline and the transaction-executor thread. The "metered as internal" half of the report is corrected below |
| 2 | `TS_MAX_BATCH_SIZE` bounds rows while claiming to bound bytes | row cap restated as a heuristic, paired with a 2 MiB serialized-size budget on both streams |
| 3 | Read path accepts a tag value the write path refuses | fixed at `TimeSeriesGateway.andTag`, the chokepoint all four affected protocol paths share |
| 4 | Profiler documents an open-ended recording it never gives | all three claims corrected; the effective timeout is now reported over HTTP and gRPC |
| 5 | `expand` type check runs after the text search | both type checks moved ahead of the searches they followed |
| 6 | `ProfilingResultSet` cites the reroute #7330 removed | comment restated |
| 7 | Gremlin sibling of #7330's double execution | confirmed and fixed - it was mutating twice, not just costing twice |

### The correction to item 1

The item says the search RPCs' SQL is "metered and traced as `protocol=\"internal\"`". The context half is exactly right: revert the fix and the probe reports `internal` on all three paths. The metering half is not. `arcadedb.query.duration` is opened by `LocalDatabase.query`/`command`, and every search leg reaches SQL through `AnalyzedQuery.execute()` instead - `database.query(...)` sits in a ternary whose fallback arm is unreachable for `sql`, because `SQLQueryEngine`'s `AnalyzedQuery.execute()` never returns null. So this traffic is **absent** from the metric rather than misattributed, on HTTP and MCP as much as on gRPC. Filed as **#7418**. It is also why the test asserts the thread-local from inside the SQL, via a custom function called from the search's own `filter`, instead of counting a metric that cannot move.

### Notes on the fixes worth a reviewer's attention

**Item 1 placement.** The set/clear pair wraps `searchInTransaction`'s *body*, not the RPC method. `ProtocolContext` is a thread-local and an in-transaction search runs on the transaction's own executor thread (#7326), so tagging the gRPC worker would have left precisely that path untagged. `executeCommandInternal` places it the same way for the same reason.

**Item 3 chokepoint.** Putting the check in `andTag` covers gRPC `TimeSeriesQuery`/`TimeSeriesLatest` and both HTTP `tags`-object endpoints at once. `requireStorableTagValue` widened from `Collection` to `Iterable`, which is what catches `JSONArray` (it implements `Iterable` but not `Collection`; `JSONObject` is a `Map` and was already refused). While there: `andTag`'s javadoc claimed every protocol's tag selection converges on it, and the PromQL evaluator does not - it builds its own `TagFilter`. Corrected rather than left standing under the new `@throws`.

**Item 4 direction.** The reporter offered two options. This takes the second: the 60-second bound stays, because while a recording runs every server query is wrapped in a `ProfilingResultSet` and "records until someone remembers" is not the safer default, and the effective timeout is reported instead - a new `ProfilerStateResponse.timeout_seconds`, and `timeoutSeconds` in the HTTP start response. A second start against a live recording reports that recording's bound, not the argument it ignored.

**Item 7 is not the same treatment as #7330.** OpenCypher could stop rerouting because the step timers already accumulate during the ordinary streaming run. Gremlin has no such timer, so `.profile()` genuinely *is* a second execution and there is nothing to reroute away from. What can be honoured is that the second run must not reach storage: the profiling pass is now skipped for any traversal carrying a `Mutating` step, and for anything that is not an un-iterated traversal (a statement that ended in an eager terminal step has already run, and appending `.profile()` to it never parsed anyway). Read-only traversals keep their plan.

## Test plan

- [ ] `mvn -o test -pl engine -Dtest='Issue7394*'` - 13 pass (tag-filter symmetry, expand type check)
- [ ] `mvn -o test -pl server -Dtest='Issue7394*'` - 4 pass (profiler timeout reporting)
- [ ] `mvn -o test -pl gremlin-it -Dtest='Issue7394*'` - 5 pass (gremlin double mutation)
- [ ] `mvn -o test -pl grpcw -Dtest='Issue7394TimeSeriesBatchByteBudgetTest'` - 6 pass (byte budget)
- [ ] `mvn -o verify -pl grpcw -DskipITs=false -Dit.test=Issue7394SearchProtocolContextIT` - 4 pass (protocol context, including the in-transaction thread hop and an `internal` control)
- [ ] Regression: engine `*TimeSeries*,*HybridSearch*,*VectorSearch*,*FullText*,*PromQL*,*Grafana*` 590 pass; grpcw full unit suite 238 pass; mcp full unit suite 316 pass; server profiler/control-plane/TS-handler/metrics units 76 pass

Each fix was also proven able to fail. Item 7 reproduced directly (`expected: 1L but was: 2L` - two vertices, two edges). Item 5's "matches nothing" case was the single red test of four in its class. Item 1 reports `internal` on all three paths with the wrapper removed, while its control stays green.

**Two pre-existing failures, not from this change.** A server unrelated to this work has been listening on port 2480 in the build environment for six days, so every HTTP-driven test reaches it and fails as `503` / `Transaction Error on transaction begin` / `NeedRetry Server is installing a snapshot`. gremlin-it's 7 errors (all aborting in `AbstractGremlinServerIT.beginTest`) and grpc-client's 6 were each re-run with the touched files restored to `HEAD` and reproduce identically.

## Coverage

Fixed and tested through their own entry point:

- gRPC `VectorSearch`, both without a transaction and inside one (the transaction-executor thread)
- gRPC `HybridSearch`; gRPC `FullTextSearch` (tagged through the same shared `searchInTransaction`)
- gRPC `TimeSeriesQuery`, raw-row stream and aggregated-bucket stream
- gRPC `TimeSeriesQuery` and `TimeSeriesLatest` tag filters; HTTP `POST /ts/{db}/query` and the Grafana query endpoint
- gRPC `ProfilerStart` and HTTP `POST /api/v1/server` `profiler start`
- `HybridSearch` with `expand` against a non-vertex full-text index (matching and non-matching) and against a non-vertex vector index
- Gremlin mutating traversal under `$profileExecution`, with the read-only case pinned as a regression guard

Argued with evidence, not fixed: `GET /ts/{db}/latest` (`?tag=n:v` values are always `String` substrings); the PromQL selector (never calls `andTag`); MCP `profiler_start` (already bounded to 1..3600, so zero never reaches it); the 43 gRPC admin RPCs (none executes SQL); HTTP/Postgres/Bolt/Redis/Mongo (each already sets its own protocol at the request boundary).

### Known gaps

- **#7407** - `insertStream` and `insertBidirectional` still meter their upsert-lookup SQL as `internal`. Same defect as item 1, different shape: their work runs from observer callbacks that hop onto a transaction executor, so the set/clear placement is its own change rather than one wrapped call.
- **#7418** - the search legs execute outside the query metrics and tracing wrapper entirely, on every protocol. Item 1 stops the protocol being reported wrongly; it does not make the metric appear.
- **#7408** - a read-only Gremlin traversal still runs twice under `$profileExecution`. Only the mutation is prevented here; removing the second read needs the "profiler recording" / "caller asked for a plan" split #7330 made for OpenCypher.

Residual within this PR: item 2 bounds a batch, so a single row larger than the budget is still emitted alone (a row cannot be split); item 4 keeps the bounded default, so asking for a genuinely unbounded recording is still not possible and would be a feature request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Raa9V6fPZda6yQkn3kvRZf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved time-series streaming reliability with row-count and message-size limits.
  - Time-series reads now honor transaction contexts and reject unknown transactions.
  - Invalid tag-filter values are rejected consistently.
  - Hybrid search validates index types before searching.
  - Profiling no longer repeats mutating Gremlin traversals.
  - Search requests retain the correct protocol context, including transactional searches.

- **New Features**
  - Profiler status now reports the effective recording timeout.
  - Non-positive profiler timeouts use the server’s default duration.
  - Profiling behavior and execution-timing documentation have been clarified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->