### PR TITLE
feat(#7382): a duplex insert session on /ws, with the Start/Commit control frames

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1489,6 +1489,14 @@ public enum GlobalConfiguration {
       "Timeout in seconds for a HTTP session (managing a transaction) to expire. This timeout is computed from the latest command against the session",
       Long.class, 5), // 5 SECONDS DEFAULT
 
+  SERVER_WS_INSERT_SESSION_EXPIRE_TIMEOUT("arcadedb.server.wsInsertSessionExpireTimeout", SCOPE.SERVER,
+      """
+      Timeout in seconds for a /ws duplex insert session (issue #7382) to expire, computed from the latest frame \
+      received on it. An expired session is rolled back and its client told so with an unsolicited error frame. \
+      Deliberately longer than 'httpSessionExpireTimeout': a bulk loader legitimately pauses between chunks while \
+      it reads its source, and losing the session there costs it every chunk it has not been able to commit.""",
+      Long.class, 60), // 1 MINUTE DEFAULT
+
   SERVER_HTTP_AUTH_SESSION_EXPIRE_TIMEOUT("arcadedb.server.httpAuthSessionExpireTimeout", SCOPE.SERVER,
       "Timeout in seconds for a HTTP authentication session to expire. This timeout is computed from the latest request using the auth token. Default is 30 minutes",
       Long.class, 1800), // 30 MINUTES DEFAULT

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
@@ -154,8 +154,12 @@ import java.util.stream.Collectors;
  */
 public class RemoteGrpcDatabase extends RemoteDatabase {
 
-  private final    ArcadeDbServiceGrpc.ArcadeDbServiceBlockingV2Stub blockingStub;
-  private final    ArcadeDbServiceGrpc.ArcadeDbServiceStub           asyncStub;
+  // Not final: a stub binds the channel it was built on, and RemoteGrpcServer.start() after close() builds a
+  // new one. Read through blockingStub() / asyncStub(), which rebuild both when the channel has moved (#7416).
+  private          ArcadeDbServiceGrpc.ArcadeDbServiceBlockingV2Stub blockingStub;
+  private          ArcadeDbServiceGrpc.ArcadeDbServiceStub           asyncStub;
+  /** The {@link RemoteGrpcServer#channelGeneration()} the two stubs above were built under. */
+  private          long                                              stubChannelGeneration;
   private final    RemoteSchema                                      schema;
   private final    String                                            userName;
   private final    String                                            userPassword;
@@ -182,9 +186,43 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     this.userName = userName;
     this.userPassword = userPassword;
     this.databaseName = databaseName;
-    this.blockingStub = createBlockingStub();
-    this.asyncStub = createAsyncStub();
+    rebuildStubs();
     this.schema = new RemoteSchema(this);
+  }
+
+  /**
+   * The data-plane stub every unary call goes through, on the server's CURRENT channel.
+   * <p>
+   * The admin stub was already built per call for this reason - "a server restarted through start() is
+   * honoured" - while these two were built once in the constructor, so after a {@code close()} / {@code start()}
+   * cycle {@code getProgress()} kept working and every query, command, lookup and insert on the same object
+   * failed with {@code UNAVAILABLE: Channel shutdown invoked} (issue #7416). Rebuilding on a generation change
+   * keeps the per-call cost at one volatile read and one compare, and keeps {@link #createBlockingStub()} the
+   * single place a subclass customises stub construction.
+   */
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingV2Stub blockingStub() {
+    if (stubChannelGeneration != remoteGrpcServer.channelGeneration())
+      rebuildStubs();
+    return blockingStub;
+  }
+
+  /** @see #blockingStub() */
+  private ArcadeDbServiceGrpc.ArcadeDbServiceStub asyncStub() {
+    if (stubChannelGeneration != remoteGrpcServer.channelGeneration())
+      rebuildStubs();
+    return asyncStub;
+  }
+
+  /**
+   * The generation is read BEFORE the stubs are built: a restart landing between the read and the build leaves
+   * the stubs on the new channel under the old generation, which only costs one more rebuild on the next call.
+   * Reading it after would let that same restart pin stale stubs under the new generation for good.
+   */
+  private void rebuildStubs() {
+    final long generation = remoteGrpcServer.channelGeneration();
+    blockingStub = createBlockingStub();
+    asyncStub = createAsyncStub();
+    stubChannelGeneration = generation;
   }
 
   /**
@@ -299,7 +337,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     callUnaryVoid("BeginTransaction", () -> {
 
       try {
-        BeginTransactionResponse response = blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
+        BeginTransactionResponse response = blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
             .beginTransaction(request);
         transactionId = response.getTransactionId();
         // Store transaction ID in parent class session management
@@ -350,7 +388,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
         try {
 
-          CommitTransactionResponse response = blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
+          CommitTransactionResponse response = blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
               .commitTransaction(request);
 
           LogManager.instance()
@@ -431,7 +469,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
         try {
 
-          RollbackTransactionResponse response = blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
+          RollbackTransactionResponse response = blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
               .rollbackTransaction(request);
 
           LogManager.instance()
@@ -521,7 +559,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       }
 
       final DeleteRecordResponse resp = callUnary("DeleteRecord",
-          () -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).deleteRecord(req));
+          () -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).deleteRecord(req));
 
       // Prefer the proto's 'deleted' flag (your other overload uses it)
       if (!resp.getDeleted()) {
@@ -556,7 +594,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       }
 
       final DeleteRecordResponse res = callUnary("DeleteRecord",
-          () -> blockingStub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).deleteRecord(req));
+          () -> blockingStub().withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).deleteRecord(req));
 
       return res.getDeleted();
 
@@ -631,7 +669,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
                 requestBuilder.getCommand().length(), requestBuilder.getParametersCount());
 
       final ExecuteCommandResponse response = callUnary("ExecuteCommand",
-          () -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).executeCommand(requestBuilder.build()));
+          () -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).executeCommand(requestBuilder.build()));
 
       if (LogManager.instance().isDebugEnabled())
         LogManager.instance().log(this, Level.FINE, "CLIENT executeCommand: success = %s", response.getSuccess());
@@ -726,7 +764,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       final ExecuteQueryRequest req = requestBuilder.build();
 
       final ExecuteQueryResponse response = callUnary("ExecuteQuery",
-          () -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS) // or getTimeout(MODE_QUERY)
+          () -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS) // or getTimeout(MODE_QUERY)
               .executeQuery(req));
 
       if (LogManager.instance().isDebugEnabled()) {
@@ -766,7 +804,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
     try {
       return callUnary("ExecuteCommand",
-          () -> blockingStub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).executeCommand(reqB.build()));
+          () -> blockingStub().withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).executeCommand(reqB.build()));
     } catch (StatusException | StatusRuntimeException e) {
       // handleGrpcException already called in callUnary, this is unreachable
       throw new IllegalStateException("unreachable");
@@ -787,7 +825,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
     try {
       return callUnary("ExecuteCommand",
-          () -> blockingStub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).executeCommand(reqB.build()));
+          () -> blockingStub().withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).executeCommand(reqB.build()));
     } catch (StatusException | StatusRuntimeException e) {
       // handleGrpcException already called in callUnary, this is unreachable
       throw new IllegalStateException("unreachable");
@@ -819,7 +857,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
         @SuppressWarnings("unused")
         UpdateRecordResponse response =
-            blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).updateRecord(updateBuilder.build());
+            blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).updateRecord(updateBuilder.build());
 
         // If your proto has flags, you can check response.getSuccess()/getUpdated()
         // Otherwise, treat non-exception as success.
@@ -847,7 +885,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
       try {
         CreateRecordResponse response =
-            blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).createRecord(request);
+            blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).createRecord(request);
 
         // Proto returns the newly created RID as a string
         final String ridStr = response.getRid();
@@ -941,7 +979,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     bindActiveTransaction(b);
 
     final BlockingClientCall<?, QueryResult> responseIterator = callServerStreaming("StreamQuery",
-        () -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).streamQuery(b.build()));
+        () -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).streamQuery(b.build()));
 
     // Return a streaming ResultSet implementation
     return new StreamingResultSet(responseIterator, this);
@@ -984,7 +1022,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     bindActiveTransaction(b);
 
     final BlockingClientCall<?, QueryResult> responseIterator = callServerStreaming("StreamQuery",
-        () -> blockingStub.withWaitForReady().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).streamQuery(b.build()));
+        () -> blockingStub().withWaitForReady().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).streamQuery(b.build()));
 
     return new BatchedStreamingResultSet(responseIterator, this);
   }
@@ -1008,7 +1046,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     bindActiveTransaction(b);
 
     final BlockingClientCall<?, QueryResult> responseIterator = callServerStreaming("StreamQuery",
-        () -> blockingStub.withWaitForReady().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).streamQuery(b.build()));
+        () -> blockingStub().withWaitForReady().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).streamQuery(b.build()));
 
     return new Iterator<QueryBatch>() {
       private QueryBatch nextBatch = null;
@@ -1094,7 +1132,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       reqB.setTransaction(tx);
 
     final BlockingClientCall<?, QueryResult> it = callServerStreaming("StreamQuery",
-        () -> blockingStub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).streamQuery(reqB.build()));
+        () -> blockingStub().withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).streamQuery(reqB.build()));
 
     return new Iterator<GrpcRecord>() {
       private Iterator<GrpcRecord> curr = Collections.emptyIterator();
@@ -1208,7 +1246,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       }
 
       final CreateRecordResponse res = callUnary("CreateRecord",
-          () -> blockingStub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).createRecord(req));
+          () -> blockingStub().withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).createRecord(req));
 
       return res.getRid(); // e.g. "#12:0"
 
@@ -1229,7 +1267,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
     try {
       final CreateRecordResponse res = callUnary("CreateRecord",
-          () -> blockingStub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).createRecord(req));
+          () -> blockingStub().withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).createRecord(req));
       return res.getRid();
 
     } catch (StatusRuntimeException | StatusException e) {
@@ -1272,7 +1310,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       }
 
       final UpdateRecordResponse res = callUnary("UpdateRecord",
-          () -> blockingStub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).updateRecord(req));
+          () -> blockingStub().withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).updateRecord(req));
 
       // Most builds expose getSuccess(); if your proto has getUpdated(), swap here.
       return res.getSuccess();
@@ -1306,7 +1344,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       }
 
       final UpdateRecordResponse res = callUnary("UpdateRecord",
-          () -> blockingStub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).updateRecord(req));
+          () -> blockingStub().withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).updateRecord(req));
 
       return res.getSuccess();
 
@@ -1382,7 +1420,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       }
 
       final LookupByRidResponse resp = callUnary("LookupByRid",
-          () -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).lookupByRid(req));
+          () -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).lookupByRid(req));
 
       if (!resp.getFound())
         throw new RecordNotFoundException("Record " + rid + " not found", rid);
@@ -1452,7 +1490,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
       // use callUnary so tx cross-thread checks + rpcSeq happen in one place
       return callUnary("BulkInsert",
-          () -> blockingStub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).bulkInsert(req));
+          () -> blockingStub().withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).bulkInsert(req));
 
     } catch (StatusRuntimeException | StatusException e) {
       handleGrpcException(e); // maps to your domain exceptions and rethrows
@@ -1963,7 +2001,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
         .setBatchSize(100).build();
 
     final BlockingClientCall<?, QueryResult> responseIterator = callServerStreaming("StreamQuery",
-        () -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).streamQuery(request));
+        () -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).streamQuery(request));
 
     return new Iterator<Record>() {
       private Iterator<GrpcRecord> currentBatch = Collections.emptyIterator();
@@ -2254,7 +2292,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       builder.setTransaction(openTransaction());
 
     return searchCall("VectorSearch", builder.build(),
-        req -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).vectorSearch(req));
+        req -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).vectorSearch(req));
   }
 
   /**
@@ -2268,7 +2306,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       builder.setTransaction(openTransaction());
 
     return searchCall("HybridSearch", builder.build(),
-        req -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).hybridSearch(req));
+        req -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).hybridSearch(req));
   }
 
   /**
@@ -2282,7 +2320,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       builder.setTransaction(openTransaction());
 
     return searchCall("FullTextSearch", builder.build(),
-        req -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).fullTextSearch(req));
+        req -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).fullTextSearch(req));
   }
 
   /**
@@ -2348,7 +2386,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
     try {
       final com.arcadedb.server.grpc.TimeSeriesWriteSummary response = callUnary("TimeSeriesWrite",
-          () -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
+          () -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
               .timeSeriesWrite(request.build()));
       return toWriteSummary(response);
     } catch (final StatusRuntimeException | StatusException e) {
@@ -2485,7 +2523,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
     final BlockingClientCall<?, com.arcadedb.server.grpc.TimeSeriesQueryResult> stream =
         callServerStreaming("TimeSeriesQuery",
-            () -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
+            () -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
                 .timeSeriesQuery(request.build()));
 
     final List<String> columns = new ArrayList<>();
@@ -2541,7 +2579,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
     try {
       final TimeSeriesLatestResponse response = callUnary("TimeSeriesLatest",
-          () -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
+          () -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
               .timeSeriesLatest(request.build()));
 
       return new TimeSeriesLatestResult(response.getType(), response.getColumnsList(),
@@ -2668,7 +2706,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       checkCrossThreadUse("STREAM " + opName);
       logTx("STREAM(local)", opName);
     }
-    final var stub = asyncStub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS);
+    final var stub = asyncStub().withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS);
     // Don't double-wrap if the observer is already a ClientResponseObserver (e.g. from wrapClientResponseObserver)
     // because wrapping it again with wrapObserver would hide the ClientResponseObserver interface
     // and prevent beforeStart() from being called.
@@ -2692,7 +2730,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       checkCrossThreadUse("STREAM " + opName);
       logTx("STREAM(local)", opName);
     }
-    final var stub = asyncStub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS);
+    final var stub = asyncStub().withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS);
     invoker.accept(stub, wrapObserver(opName, responseObserver));
     if (debugTx != null) {
       debugTx.rpcSeq.incrementAndGet();

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
@@ -160,6 +160,13 @@ public class RemoteGrpcServer implements AutoCloseable {
   // read it WITHOUT the monitor, so without volatile a reader racing the first start() or a close() has no
   // happens-before edge and may observe a stale (or half-published) value (issue #6762).
   private volatile ManagedChannel channel;
+  /**
+   * Bumped every time {@link #start()} builds a channel and every time {@link #close()} shuts one down. A gRPC
+   * stub binds the channel it was built on, so a
+   * {@link RemoteGrpcDatabase} that cached its stubs compares this against the generation it built them under
+   * and rebuilds them when a {@link #close()} / {@link #start()} cycle has replaced the channel (issue #7416).
+   */
+  private volatile long           channelGeneration;
   private volatile EventLoopGroup eventLoopGroup;
   /**
    * Set the moment {@link #close()} begins and cleared by the next explicit {@link #start()}. Without it,
@@ -235,6 +242,16 @@ public class RemoteGrpcServer implements AutoCloseable {
       chBuilder.usePlaintext();
 
     channel = chBuilder.build();
+    channelGeneration++;
+  }
+
+  /**
+   * Identifies the channel {@link #channel()} currently hands out: the value changes whenever {@link #start()}
+   * builds a new one and whenever {@link #close()} shuts one down. Cheaper than comparing channels, which
+   * {@link #channel()} may wrap in interceptors on every call.
+   */
+  public long channelGeneration() {
+    return channelGeneration;
   }
 
   /**
@@ -348,6 +365,10 @@ public class RemoteGrpcServer implements AutoCloseable {
       channel.shutdownNow();
     } finally {
       channel = null;
+      // Bumped on close as well as on start, so a stub cached against the channel just shut down is rebuilt on
+      // its next use - and, while the server stays closed, that rebuild is refused by channel() with the reason
+      // instead of the dead channel's "Channel shutdown invoked" (issue #7416).
+      channelGeneration++;
       adminServiceBlockingV2Stub = null;
       if (eventLoopGroup != null) {
         eventLoopGroup.shutdownGracefully(0, 2, TimeUnit.SECONDS);
@@ -392,35 +413,60 @@ public class RemoteGrpcServer implements AutoCloseable {
   }
 
   /**
-   * Creates a database with type "graph" or "document".
+   * Creates a database. A name already taken is refused with {@code ALREADY_EXISTS}, the same answer the HTTP
+   * {@code create database} command gives (issue #7413); use {@link #createDatabaseIfMissing(String)} for the
+   * idempotent form.
    */
   public void createDatabase(final String database) {
+    createDatabase(database, false);
+  }
 
+  /**
+   * Creates the database unless one of that name is already there, and says which happened. The decision is
+   * the server's, in one call: the previous exists-then-create pair left a window in which another client's
+   * create made the second half fail.
+   *
+   * @return {@code true} when this call created it, {@code false} when it already existed
+   */
+  public boolean createDatabaseIfMissing(final String database) {
+    return createDatabase(database, true);
+  }
+
+  private boolean createDatabase(final String database, final boolean ifNotExists) {
     try {
-      withDeadline(adminServiceBlockingV2Stub(), defaultTimeoutMs)
-          .createDatabase(CreateDatabaseRequest.newBuilder().setName(database).setCredentials(buildCredentials()).build());
+      return withDeadline(adminServiceBlockingV2Stub(), defaultTimeoutMs)
+          .createDatabase(CreateDatabaseRequest.newBuilder().setName(database).setCredentials(buildCredentials())
+              .setIfNotExists(ifNotExists).build())
+          .getCreated();
     } catch (StatusException e) {
       throw new RuntimeException("Failed to create database: " + e.getMessage(), e);
     }
   }
 
   /**
-   * No-op if already present; creates otherwise.
+   * Drops a database. A name that does not exist is refused with {@code NOT_FOUND}, the same answer the HTTP
+   * {@code drop database} command gives (issue #7413); use {@link #dropDatabaseIfExists(String)} for the
+   * idempotent form.
    */
-  public void createDatabaseIfMissing(final String database) {
-    if (!existsDatabase(database)) {
-      createDatabase(database);
-    }
+  public void dropDatabase(final String database) {
+    dropDatabase(database, false);
   }
 
   /**
-   * Drops a database. If your proto supports 'force', add it here.
+   * Drops the database if there is one of that name, and says which happened.
+   *
+   * @return {@code true} when this call dropped it, {@code false} when there was nothing to drop
    */
-  public void dropDatabase(final String database) {
+  public boolean dropDatabaseIfExists(final String database) {
+    return dropDatabase(database, true);
+  }
 
+  private boolean dropDatabase(final String database, final boolean ifExists) {
     try {
-      withDeadline(adminServiceBlockingV2Stub(), defaultTimeoutMs)
-          .dropDatabase(DropDatabaseRequest.newBuilder().setName(database).setCredentials(buildCredentials()).build());
+      return withDeadline(adminServiceBlockingV2Stub(), defaultTimeoutMs)
+          .dropDatabase(DropDatabaseRequest.newBuilder().setName(database).setCredentials(buildCredentials())
+              .setIfExists(ifExists).build())
+          .getDropped();
     } catch (StatusException e) {
       throw new RuntimeException("Failed to drop database: " + e.getMessage(), e);
     }

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue7416RemoteGrpcDatabaseSurvivesServerRestartIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue7416RemoteGrpcDatabaseSurvivesServerRestartIT.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7416: a {@link RemoteGrpcDatabase} built its two data-plane stubs once, in the constructor, on the
+ * channel its {@link RemoteGrpcServer} had at the time. A {@code close()} / {@code start()} cycle on the server
+ * replaces that channel, and every query, command, lookup and insert on the same database object then failed
+ * with {@code UNAVAILABLE: Channel shutdown invoked} - while {@code getProgress()}, whose admin stub was built
+ * per call, kept working.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7416RemoteGrpcDatabaseSurvivesServerRestartIT extends BaseGraphServerTest {
+  private static final int GRPC_PORT = 50051;
+
+  private RemoteGrpcServer   grpcServer;
+  private RemoteGrpcDatabase database;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @AfterEach
+  void closeClient() {
+    if (database != null)
+      database.close();
+    if (grpcServer != null)
+      grpcServer.close();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+  }
+
+  @Test
+  void theSameDatabaseObjectKeepsWorkingAcrossACloseAndStartOfItsServer() {
+    grpcServer = new RemoteGrpcServer("localhost", GRPC_PORT, "root", DEFAULT_PASSWORD_FOR_TESTS, true, List.of());
+    database = new RemoteGrpcDatabase(grpcServer, "localhost", GRPC_PORT, getServer(0).getHttpServer().getPort(),
+        getDatabaseName(), "root", DEFAULT_PASSWORD_FOR_TESTS);
+
+    assertThat(countV1()).isGreaterThan(0);
+    final long generationBefore = grpcServer.channelGeneration();
+
+    grpcServer.close();
+    // While closed, the same object fails with the reason rather than with a dead channel's UNAVAILABLE.
+    assertThatThrownBy(this::countV1).hasMessageContaining("closed");
+
+    grpcServer.start();
+    assertThat(grpcServer.channelGeneration()).isNotEqualTo(generationBefore);
+
+    // The unary data plane, on the stub the constructor built.
+    assertThat(countV1()).isGreaterThan(0);
+    // A write and a read-back through the same object, so the command path is covered as well as the query one.
+    database.command("sql", "INSERT INTO " + VERTEX1_TYPE_NAME + " SET id = 7416, name = 'after-restart'");
+    try (final ResultSet rs = database.query("sql", "SELECT FROM " + VERTEX1_TYPE_NAME + " WHERE id = 7416")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<String>getProperty("name")).isEqualTo("after-restart");
+    }
+    // The admin stub the class already rebuilt per call, kept as the control.
+    assertThat(database.getProgress()).isNotNull();
+  }
+
+  /** A second restart is followed the same way: the check is per call, not once. */
+  @Test
+  void everyRestartIsFollowedNotJustTheFirst() {
+    grpcServer = new RemoteGrpcServer("localhost", GRPC_PORT, "root", DEFAULT_PASSWORD_FOR_TESTS, true, List.of());
+    database = new RemoteGrpcDatabase(grpcServer, "localhost", GRPC_PORT, getServer(0).getHttpServer().getPort(),
+        getDatabaseName(), "root", DEFAULT_PASSWORD_FOR_TESTS);
+
+    for (int cycle = 0; cycle < 3; cycle++) {
+      grpcServer.close();
+      grpcServer.start();
+      assertThat(countV1()).as("cycle " + cycle).isGreaterThan(0);
+    }
+  }
+
+  private long countV1() {
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS total FROM " + VERTEX1_TYPE_NAME)) {
+      return rs.next().<Long>getProperty("total");
+    }
+  }
+}

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/RemoteGrpcServerIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/RemoteGrpcServerIT.java
@@ -87,6 +87,22 @@ class RemoteGrpcServerIT extends BaseGraphServerTest {
     assertThat(server.existsDatabase("nonexistent_database")).isFalse();
   }
 
+  /** Issue #7413: the client's two create flavours map onto the server's strict and idempotent contracts. */
+  @Test
+  void createIfMissingSaysWhetherItCreatedAndStrictCreateRefusesATakenName() {
+    server = new RemoteGrpcServer("localhost", 50051, "root", DEFAULT_PASSWORD_FOR_TESTS, true, List.of());
+    final String testDb = "test_grpc_if_missing_db";
+    try {
+      assertThat(server.createDatabaseIfMissing(testDb)).isTrue();
+      assertThat(server.createDatabaseIfMissing(testDb)).isFalse();
+      assertThatThrownBy(() -> server.createDatabase(testDb)).hasMessageContaining("ALREADY_EXISTS");
+    } finally {
+      assertThat(server.dropDatabaseIfExists(testDb)).isTrue();
+    }
+    assertThat(server.dropDatabaseIfExists(testDb)).isFalse();
+    assertThatThrownBy(() -> server.dropDatabase(testDb)).hasMessageContaining("NOT_FOUND");
+  }
+
   @Test
   void shouldCreateAndDropDatabase() {
     server = new RemoteGrpcServer("localhost", 50051, "root", DEFAULT_PASSWORD_FOR_TESTS, true, List.of());
@@ -147,13 +163,8 @@ class RemoteGrpcServerIT extends BaseGraphServerTest {
   void shouldHandleDropNonExistentDatabase() {
     server = new RemoteGrpcServer("localhost", 50051, "root", DEFAULT_PASSWORD_FOR_TESTS, true, List.of());
 
-    // Dropping a non-existent database may or may not throw an exception depending on implementation
-    try {
-      server.dropDatabase("nonexistent_database_12345");
-    } catch (final Exception e) {
-      // Expected - database doesn't exist
-      assertThat(e.getMessage()).containsIgnoringCase("not found");
-    }
+    // Strict by contract since issue #7413: the same answer the HTTP `drop database` command gives.
+    assertThatThrownBy(() -> server.dropDatabase("nonexistent_database_12345")).hasMessageContaining("NOT_FOUND");
   }
 
   @Test

--- a/grpc/src/main/proto/arcadedb-server.proto
+++ b/grpc/src/main/proto/arcadedb-server.proto
@@ -1083,14 +1083,25 @@ message CreateDatabaseRequest {
   DatabaseCredentials credentials = 1;
   string name = 2; // database name
   string type = 3; // "graph" or "document" (logical)
+  // When false (the default) a name already taken is answered ALREADY_EXISTS, as the HTTP `create database`
+  // command answers it. When true the call is idempotent: an existing database of that name is left as it
+  // is and the response says so with created = false. Names are exact, never case-folded.
+  bool if_not_exists = 4;
 }
-message CreateDatabaseResponse {}
+message CreateDatabaseResponse {
+  bool created = 1; // true when this call created the database, false when if_not_exists found it already there
+}
 
 message DropDatabaseRequest {
   DatabaseCredentials credentials = 1;
   string name = 2; // database name
+  // When false (the default) a name that does not exist is answered NOT_FOUND, as the HTTP `drop database`
+  // command answers it. When true the call is idempotent and the response says which with dropped = false.
+  bool if_exists = 3;
 }
-message DropDatabaseResponse {}
+message DropDatabaseResponse {
+  bool dropped = 1; // true when this call dropped the database, false when if_exists found nothing to drop
+}
 
 message GetDatabaseInfoRequest {
   DatabaseCredentials credentials = 1;

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
@@ -144,7 +144,9 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
       final ServerSecurityUser user = authenticate(req.getCredentials());
 
       final String name = req.getName(); // proto should define 'name' for the DB
-      final boolean exists = containsDatabaseIgnoreCase(name) && (user == null || user.canAccessToDatabase(name));
+      // Exact name, like createDatabase / dropDatabase (issue #7413): what this reports as existing is what a
+      // create of the same name would refuse.
+      final boolean exists = server.existsDatabase(name) && (user == null || user.canAccessToDatabase(name));
 
       return ExistsDatabaseResponse.newBuilder().setExists(exists).build();
     });
@@ -159,8 +161,15 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
       final String name = req.getName(); // DB name in proto
       final String type = req.getType(); // "graph" or "document" (logical)
 
-      if (containsDatabaseIgnoreCase(name))
-        return CreateDatabaseResponse.newBuilder().build();
+      // Exact name, the registry's and the HTTP command's notion of "the same database": the case-folded guard
+      // this used to be let CreateDatabase("MyDb") answer OK for an existing "mydb" and then DropDatabase("MyDb")
+      // fail inside the drop (issue #7413). An empty OK told a provisioning tool nothing either way; now the
+      // strict default refuses a taken name as HTTP does, and the idempotent form says which happened.
+      if (server.existsDatabase(name)) {
+        if (req.getIfNotExists())
+          return CreateDatabaseResponse.newBuilder().setCreated(false).build();
+        throw new ServerControlPlane.AlreadyExistsException("Database '" + name + "' already exists");
+      }
 
       // Physical creation (READ_WRITE is the common default)
       createDatabasePhysical(name);
@@ -177,7 +186,7 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
             s.createEdgeType("E");
         });
       }
-      return CreateDatabaseResponse.newBuilder().build();
+      return CreateDatabaseResponse.newBuilder().setCreated(true).build();
     });
   }
 
@@ -189,10 +198,16 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
 
       final String name = req.getName();
 
-      if (containsDatabaseIgnoreCase(name))
-        dropDatabasePhysical(name);
+      // See createDatabase: exact name, strict by default, explicit outcome either way (issue #7413).
+      if (!server.existsDatabase(name)) {
+        if (req.getIfExists())
+          return DropDatabaseResponse.newBuilder().setDropped(false).build();
+        throw new ServerControlPlane.NotFoundException("Database '" + name + "' does not exist");
+      }
 
-      return DropDatabaseResponse.newBuilder().build();
+      dropDatabasePhysical(name);
+
+      return DropDatabaseResponse.newBuilder().setDropped(true).build();
     });
   }
 
@@ -210,7 +225,7 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
       if (user != null && !user.canAccessToDatabase(name))
         throw Status.NOT_FOUND.withDescription("Database not found: " + name).asException();
 
-      if (!containsDatabaseIgnoreCase(name))
+      if (!server.existsDatabase(name))
         throw Status.NOT_FOUND.withDescription("Database not found: " + name).asException();
 
       // Use getDatabase which returns a shared ServerDatabase - don't close it
@@ -1154,14 +1169,6 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
    */
   private Collection<String> getDatabaseNames() {
     return server.getDatabaseNames();
-  }
-
-  private boolean containsDatabaseIgnoreCase(String name) {
-    for (String n : getDatabaseNames()) {
-      if (n.equalsIgnoreCase(name))
-        return true;
-    }
-    return false;
   }
 
   /**

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -139,6 +139,9 @@ import java.util.logging.Level;
  * gRPC Service implementation for ArcadeDB
  */
 public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImplBase {
+  /** The {@code protocol} tag every query this service runs is metered under. */
+  private static final String GRPC_PROTOCOL = "grpc";
+
 
   // Pick serializer once
   private static final JsonSerializer FAST = JsonSerializer.createJsonSerializer().setIncludeVertexEdges(false)
@@ -4214,7 +4217,28 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     }
   }
 
+  /**
+   * Runs on whichever thread the caller hands it: {@code bulkInsert}'s own, a transaction's dedicated executor,
+   * or the {@code insertStream} / {@code insertBidirectional} stream executors. The upsert and ignore lookups
+   * inside are real SQL, so the protocol tag is set HERE, around the work, rather than on the RPC's entry thread:
+   * the streaming RPCs do their work from observer callbacks that hop threads, and a tag set in {@code onNext}
+   * never reached the thread the lookup ran on, which metered every conflict probe as {@code internal}
+   * (issue #7407). Left alone when the caller already tagged the thread, so {@code bulkInsert}'s outer
+   * set/clear pair still owns it.
+   */
   private Counts insertRows(InsertContext ctx, Iterator<GrpcRecord> it) {
+    final boolean tagHere = !GRPC_PROTOCOL.equals(ProtocolContext.get());
+    if (tagHere)
+      ProtocolContext.set(GRPC_PROTOCOL);
+    try {
+      return insertRowsTagged(ctx, it);
+    } finally {
+      if (tagHere)
+        ProtocolContext.clear();
+    }
+  }
+
+  private Counts insertRowsTagged(InsertContext ctx, Iterator<GrpcRecord> it) {
 
     Counts c = new Counts();
 

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcAdminServiceIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcAdminServiceIT.java
@@ -22,6 +22,7 @@ import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.server.BaseGraphServerTest;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -186,37 +187,79 @@ public class GrpcAdminServiceIT extends BaseGraphServerTest {
     assertThat(adminStub.existsDatabase(existsRequest).getExists()).isFalse();
   }
 
+  /**
+   * Issue #7413: a name already taken is refused as the HTTP command refuses it, and the idempotent form says
+   * whether it created anything, so a client can tell "created for me" from "already there".
+   */
   @Test
-  void createDatabaseIsIdempotent() {
-    String testDbName = "grpc_idempotent_db_" + System.currentTimeMillis();
-
-    CreateDatabaseRequest request = CreateDatabaseRequest.newBuilder()
+  void createDatabaseRefusesATakenNameUnlessAskedToTolerateIt() {
+    final String testDbName = "grpc_exists_db_" + System.currentTimeMillis();
+    final CreateDatabaseRequest strict = CreateDatabaseRequest.newBuilder()
         .setCredentials(credentials())
         .setName(testDbName)
         .setType("document")
         .build();
+    try {
+      assertThat(adminStub.createDatabase(strict).getCreated()).isTrue();
 
-    // Create twice - should not throw
-    adminStub.createDatabase(request);
-    adminStub.createDatabase(request);
+      assertThatThrownBy(() -> adminStub.createDatabase(strict))
+          .isInstanceOf(StatusRuntimeException.class)
+          .satisfies(e -> assertThat(((StatusRuntimeException) e).getStatus().getCode()).isEqualTo(Status.Code.ALREADY_EXISTS))
+          .hasMessageContaining(testDbName);
 
-    // Cleanup
-    DropDatabaseRequest dropRequest = DropDatabaseRequest.newBuilder()
-        .setCredentials(credentials())
-        .setName(testDbName)
-        .build();
-    adminStub.dropDatabase(dropRequest);
+      final CreateDatabaseResponse tolerated = adminStub.createDatabase(strict.toBuilder().setIfNotExists(true).build());
+      assertThat(tolerated.getCreated()).isFalse();
+    } finally {
+      adminStub.dropDatabase(DropDatabaseRequest.newBuilder().setCredentials(credentials()).setName(testDbName)
+          .setIfExists(true).build());
+    }
   }
 
   @Test
-  void dropNonExistentDatabaseIsIdempotent() {
-    DropDatabaseRequest request = DropDatabaseRequest.newBuilder()
+  void dropDatabaseRefusesAMissingNameUnlessAskedToTolerateIt() {
+    final DropDatabaseRequest strict = DropDatabaseRequest.newBuilder()
         .setCredentials(credentials())
         .setName("nonexistent_db_for_drop_test")
         .build();
 
-    // Should not throw
-    adminStub.dropDatabase(request);
+    assertThatThrownBy(() -> adminStub.dropDatabase(strict))
+        .isInstanceOf(StatusRuntimeException.class)
+        .satisfies(e -> assertThat(((StatusRuntimeException) e).getStatus().getCode()).isEqualTo(Status.Code.NOT_FOUND))
+        .hasMessageContaining("nonexistent_db_for_drop_test");
+
+    assertThat(adminStub.dropDatabase(strict.toBuilder().setIfExists(true).build()).getDropped()).isFalse();
+  }
+
+  /** A database that IS there is dropped and the answer says so, in both forms. */
+  @Test
+  void dropDatabaseReportsWhatItDropped() {
+    final String testDbName = "grpc_dropped_db_" + System.currentTimeMillis();
+    adminStub.createDatabase(CreateDatabaseRequest.newBuilder().setCredentials(credentials()).setName(testDbName).build());
+    assertThat(adminStub.dropDatabase(DropDatabaseRequest.newBuilder().setCredentials(credentials()).setName(testDbName)
+        .setIfExists(true).build()).getDropped()).isTrue();
+    assertThat(adminStub.existsDatabase(ExistsDatabaseRequest.newBuilder().setCredentials(credentials())
+        .setName(testDbName).build()).getExists()).isFalse();
+  }
+
+  /**
+   * Names are exact. The guard used to be case-folded while the registry and the operation were not, so a
+   * differently-cased name was reported as existing by one and unknown by the other.
+   */
+  @Test
+  void databaseNamesAreExactNotCaseFolded() {
+    final String testDbName = "grpc_Cased_db_" + System.currentTimeMillis();
+    adminStub.createDatabase(CreateDatabaseRequest.newBuilder().setCredentials(credentials()).setName(testDbName).build());
+    try {
+      final String otherCase = testDbName.toLowerCase();
+      assertThat(adminStub.existsDatabase(ExistsDatabaseRequest.newBuilder().setCredentials(credentials())
+          .setName(otherCase).build()).getExists()).isFalse();
+      assertThatThrownBy(() -> adminStub.dropDatabase(DropDatabaseRequest.newBuilder().setCredentials(credentials())
+          .setName(otherCase).build()))
+          .isInstanceOf(StatusRuntimeException.class)
+          .satisfies(e -> assertThat(((StatusRuntimeException) e).getStatus().getCode()).isEqualTo(Status.Code.NOT_FOUND));
+    } finally {
+      adminStub.dropDatabase(DropDatabaseRequest.newBuilder().setCredentials(credentials()).setName(testDbName).build());
+    }
   }
 
   @Test

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7407InsertStreamUpsertMetricsIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7407InsertStreamUpsertMetricsIT.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.stub.ServerCallStreamObserver;
+import io.grpc.stub.StreamObserver;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7407: the upsert and ignore lookups of {@code insertStream} and {@code insertBidirectional} are real
+ * SQL, run from observer callbacks on a thread that is not the one the RPC arrived on. They were metered and
+ * traced as {@code protocol="internal"}; they belong to {@code grpc}, as {@code bulkInsert}'s already were.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue7407InsertStreamUpsertMetricsIT extends BaseGraphServerTest {
+  private static final int ROWS = 20;
+
+  private String              typeName;
+  private ArcadeDbGrpcService service;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void createKeyedType() {
+    typeName = "Issue7407Keyed_" + System.currentTimeMillis();
+    final Database database = getServer(0).getDatabase(getDatabaseName());
+    database.command("sql", "CREATE DOCUMENT TYPE " + typeName);
+    database.command("sql", "CREATE PROPERTY " + typeName + ".name STRING");
+    database.command("sql", "CREATE INDEX ON " + typeName + " (name) UNIQUE");
+    database.transaction(() -> {
+      for (int i = 0; i < ROWS; i++)
+        database.newDocument(typeName).set("name", "k" + i).set("v", 0).save();
+    });
+    service = new ArcadeDbGrpcService(getDatabaseName(), getServer(0));
+  }
+
+  @AfterEach
+  void dropKeyedType() {
+    service.close();
+    getServer(0).getDatabase(getDatabaseName()).command("sql", "DROP TYPE " + typeName + " IF EXISTS UNSAFE");
+  }
+
+  @Test
+  void insertStreamUpsertLookupsAreMeteredAsGrpc() throws Exception {
+    final long grpcBefore = timerCount("grpc");
+    final long internalBefore = timerCount("internal");
+
+    final AtomicReference<InsertSummary> summaryRef = new AtomicReference<>();
+    final CountDownLatch done = new CountDownLatch(1);
+    final StreamObserver<InsertChunk> req = service.insertStream(new RecordingSummaryObserver(summaryRef, done));
+
+    final InsertChunk.Builder chunk = InsertChunk.newBuilder().setSessionId("issue-7407-stream").setChunkSeq(0)
+        .setLast(true).setOptions(upsertOptions());
+    for (int i = 0; i < ROWS; i++)
+      chunk.addRows(row(i));
+    req.onNext(chunk.build());
+    req.onCompleted();
+
+    assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+    assertThat(summaryRef.get().getUpdated()).isEqualTo(ROWS);
+    assertThat(summaryRef.get().getFailed()).isZero();
+
+    assertThat(timerCount("grpc") - grpcBefore).as("one metered lookup per upserted row").isGreaterThanOrEqualTo(ROWS);
+    assertThat(timerCount("internal") - internalBefore).as("none of them attributed to internal").isZero();
+  }
+
+  @Test
+  void insertBidirectionalUpsertLookupsAreMeteredAsGrpc() throws Exception {
+    final long grpcBefore = timerCount("grpc");
+    final long internalBefore = timerCount("internal");
+
+    final RecordingInsertResponseObserver resp = new RecordingInsertResponseObserver();
+    final StreamObserver<InsertRequest> req = service.insertBidirectional(resp);
+
+    req.onNext(InsertRequest.newBuilder().setStart(Start.newBuilder().setDatabase(getDatabaseName())
+        .setCredentials(credentials()).setOptions(upsertOptions()).build()).build());
+    final Started started = resp.await(resp.started);
+
+    final InsertChunk.Builder chunk = InsertChunk.newBuilder().setSessionId(started.getSessionId()).setChunkSeq(1);
+    for (int i = 0; i < ROWS; i++)
+      chunk.addRows(row(i));
+    req.onNext(InsertRequest.newBuilder().setChunk(chunk.build()).build());
+    final BatchAck ack = resp.await(resp.batchAck);
+    assertThat(ack.getUpdated()).isEqualTo(ROWS);
+    assertThat(ack.getFailed()).isZero();
+
+    req.onNext(InsertRequest.newBuilder().setCommit(Commit.newBuilder().setSessionId(started.getSessionId())
+        .setCommit(true).build()).build());
+    resp.await(resp.committed);
+    req.onCompleted();
+
+    assertThat(timerCount("grpc") - grpcBefore).as("one metered lookup per upserted row").isGreaterThanOrEqualTo(ROWS);
+    assertThat(timerCount("internal") - internalBefore).as("none of them attributed to internal").isZero();
+  }
+
+  private InsertOptions upsertOptions() {
+    return InsertOptions.newBuilder().setDatabase(getDatabaseName()).setCredentials(credentials())
+        .setTargetClass(typeName).setConflictMode(InsertOptions.ConflictMode.CONFLICT_UPDATE).addKeyColumns("name")
+        .setTransactionMode(InsertOptions.TransactionMode.PER_STREAM).build();
+  }
+
+  private GrpcRecord row(final int i) {
+    return GrpcRecord.newBuilder().setType(typeName)
+        .putProperties("name", GrpcValue.newBuilder().setStringValue("k" + i).build())
+        .putProperties("v", GrpcValue.newBuilder().setInt32Value(1).build()).build();
+  }
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  /** Total count of the {@code arcadedb.query.duration} timers carrying this {@code protocol} tag. */
+  private static long timerCount(final String protocol) {
+    return Metrics.globalRegistry.find("arcadedb.query.duration").tag("protocol", protocol).timers().stream()
+        .mapToLong(Timer::count).sum();
+  }
+
+  private static final class RecordingSummaryObserver extends ServerCallStreamObserver<InsertSummary> {
+    private final AtomicReference<InsertSummary> summaryRef;
+    private final CountDownLatch                 done;
+
+    private RecordingSummaryObserver(final AtomicReference<InsertSummary> summaryRef, final CountDownLatch done) {
+      this.summaryRef = summaryRef;
+      this.done = done;
+    }
+
+    @Override public void onNext(final InsertSummary value) { summaryRef.set(value); }
+    @Override public void onError(final Throwable t) { done.countDown(); }
+    @Override public void onCompleted() { done.countDown(); }
+    @Override public boolean isCancelled() { return false; }
+    @Override public void setOnCancelHandler(final Runnable onCancelHandler) { }
+    @Override public void setCompression(final String compression) { }
+    @Override public boolean isReady() { return true; }
+    @Override public void setOnReadyHandler(final Runnable onReadyHandler) { }
+    @Override public void request(final int count) { }
+    @Override public void setMessageCompression(final boolean enable) { }
+    @Override public void disableAutoInboundFlowControl() { }
+  }
+
+  private static final class RecordingInsertResponseObserver extends ServerCallStreamObserver<InsertResponse> {
+    private final Slot<Started>   started   = new Slot<>();
+    private final Slot<BatchAck>  batchAck  = new Slot<>();
+    private final Slot<Committed> committed = new Slot<>();
+    private final AtomicReference<Throwable> error = new AtomicReference<>();
+
+    private static final class Slot<T> {
+      private final AtomicReference<T> value = new AtomicReference<>();
+      private final CountDownLatch     latch = new CountDownLatch(1);
+    }
+
+    private <T> T await(final Slot<T> slot) throws InterruptedException {
+      assertThat(slot.latch.await(30, TimeUnit.SECONDS)).as("timed out waiting for the frame").isTrue();
+      if (error.get() != null)
+        throw new AssertionError("insertBidirectional errored", error.get());
+      return slot.value.get();
+    }
+
+    @Override
+    public void onNext(final InsertResponse value) {
+      switch (value.getMsgCase()) {
+      case STARTED -> { started.value.set(value.getStarted()); started.latch.countDown(); }
+      case BATCH_ACK -> { batchAck.value.set(value.getBatchAck()); batchAck.latch.countDown(); }
+      case COMMITTED -> { committed.value.set(value.getCommitted()); committed.latch.countDown(); }
+      default -> { }
+      }
+    }
+
+    @Override
+    public void onError(final Throwable t) {
+      error.set(t);
+      started.latch.countDown();
+      batchAck.latch.countDown();
+      committed.latch.countDown();
+    }
+
+    @Override public void onCompleted() { }
+    @Override public boolean isCancelled() { return false; }
+    @Override public void setOnCancelHandler(final Runnable onCancelHandler) { }
+    @Override public void setCompression(final String compression) { }
+    @Override public boolean isReady() { return true; }
+    @Override public void setOnReadyHandler(final Runnable onReadyHandler) { }
+    @Override public void request(final int count) { }
+    @Override public void setMessageCompression(final boolean enable) { }
+    @Override public void disableAutoInboundFlowControl() { }
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/HttpServer.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpServer.java
@@ -75,6 +75,8 @@ import com.arcadedb.server.http.ssl.SslUtils;
 import com.arcadedb.server.http.ssl.TlsProtocol;
 import com.arcadedb.server.http.ws.WebSocketConnectionHandler;
 import com.arcadedb.server.http.ws.WebSocketEventBus;
+import com.arcadedb.server.http.ws.insert.WebSocketInsertProtocol;
+import com.arcadedb.server.http.ws.insert.WebSocketInsertSessionManager;
 import com.arcadedb.server.ai.AiActivateHandler;
 import com.arcadedb.server.ai.AiAnalyzeProfilerHandler;
 import com.arcadedb.server.ai.AiChatHandler;
@@ -123,6 +125,8 @@ public class HttpServer implements ServerPlugin {
   private final    HttpSessionManager     sessionManager;
   private final    HttpAuthSessionManager authSessionManager;
   private final    WebSocketEventBus      webSocketEventBus;
+  private final    WebSocketInsertSessionManager  insertSessionManager;
+  private final    WebSocketInsertProtocol        insertProtocol;
   private final    IdempotencyCache       idempotencyCache;
   private          ScheduledExecutorService idempotencyCleanupExecutor;
   private          Undertow               undertow;
@@ -141,6 +145,12 @@ public class HttpServer implements ServerPlugin {
         server.getConfiguration().getValueAsInteger(GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_MAX),
         server.getConfiguration().getValueAsInteger(GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_MAX_PER_USER));
     this.webSocketEventBus = new WebSocketEventBus(this.server);
+    // A /ws insert session holds a transaction between frames, so an abandoned one has to expire the way an
+    // 'arcadedb-session-id' transaction does - on its own budget, because a bulk loader pauses between chunks
+    // for reasons an HTTP command never does (issue #7382).
+    this.insertSessionManager = new WebSocketInsertSessionManager(this.server,
+        server.getConfiguration().getValueAsLong(GlobalConfiguration.SERVER_WS_INSERT_SESSION_EXPIRE_TIMEOUT) * 1_000L);
+    this.insertProtocol = new WebSocketInsertProtocol(this.insertSessionManager);
     final long ttlMs = server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_IDEMPOTENCY_CACHE_TTL_MS);
     final int maxEntries = server.getConfiguration().getValueAsInteger(GlobalConfiguration.HA_IDEMPOTENCY_CACHE_MAX_ENTRIES);
     final long maxBytes = server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_IDEMPOTENCY_CACHE_MAX_BYTES);
@@ -154,6 +164,7 @@ public class HttpServer implements ServerPlugin {
   @Override
   public void stopService() {
     webSocketEventBus.stop();
+    insertSessionManager.close();
 
     if (idempotencyCleanupExecutor != null) {
       idempotencyCleanupExecutor.shutdown();
@@ -450,6 +461,14 @@ public class HttpServer implements ServerPlugin {
    */
   public int getHttpsPort() {
     return httpsPortListening;
+  }
+
+  public WebSocketInsertSessionManager getInsertSessionManager() {
+    return insertSessionManager;
+  }
+
+  public WebSocketInsertProtocol getInsertProtocol() {
+    return insertProtocol;
   }
 
   public WebSocketEventBus getWebSocketEventBus() {

--- a/server/src/main/java/com/arcadedb/server/http/handler/OpenApiSpecGenerator.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/OpenApiSpecGenerator.java
@@ -107,7 +107,12 @@ public class OpenApiSpecGenerator {
     //   generated client no capability it does not already have by construction.
     // GET /api/v1/docs serves the Swagger UI page. It is HTML for a human, not an API operation.
     // /ws is a WebSocket upgrade. OpenAPI 3.0 cannot express a bidirectional stream under any
-    //   encoding; AsyncAPI is the IDL that would, and adopting it is not in scope here.
+    //   encoding; AsyncAPI is the IDL that would, and adopting it is not in scope here. That is also
+    //   why the duplex insert session of issue #7382 (start / chunk / commit / rollback) lives there
+    //   rather than behind an HTTP route: its control frames need the client to react to what the
+    //   server said and change what it sends next INSIDE the same session, which is the half of the
+    //   gRPC InsertBidirectional shape a request/response exchange cannot carry. See
+    //   com.arcadedb.server.http.ws.insert.WebSocketInsertProtocol for the frame reference.
     // / is the Studio static-content fallback, registered only outside production mode or when
     //   STUDIO_ENABLED is set. Assets, not an API.
     //

--- a/server/src/main/java/com/arcadedb/server/http/ws/WebSocketEventBus.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/WebSocketEventBus.java
@@ -25,7 +25,6 @@ import com.arcadedb.server.security.ServerSecurity;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.websockets.core.WebSocketCallback;
 import io.undertow.websockets.core.WebSocketChannel;
-import io.undertow.websockets.core.WebSockets;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -178,7 +177,7 @@ public class WebSocketEventBus {
         }
 
         try {
-          WebSockets.sendText(json, subscription.getChannel(), callback);
+          WebSocketFrameSender.send(subscription.getChannel(), json, callback);
         } catch (final Exception e) {
           // The frame never reached Undertow, so nothing is outstanding: give the reservation back rather than let
           // a channel that fails synchronously look like a slow consumer.

--- a/server/src/main/java/com/arcadedb/server/http/ws/WebSocketFrameSender.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/WebSocketFrameSender.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.ws;
+
+import io.undertow.websockets.core.WebSocketCallback;
+import io.undertow.websockets.core.WebSocketChannel;
+import io.undertow.websockets.core.WebSockets;
+
+/**
+ * The one place a {@code /ws} text frame is written from, so what the connection's several senders rely on is
+ * written down once (issue #7423).
+ * <p>
+ * A {@code /ws} connection has more than one writer and nothing of ours serializing them: the change-stream
+ * fan-out of {@link WebSocketEventBus} runs on the per-database watcher thread, the subscription acknowledgements
+ * of {@code WebSocketReceiveListener} on the I/O thread that read the frame, the insert-session answers of
+ * {@code WebSocketInsertProtocol} on an Undertow worker thread, and the idle sweep's unsolicited {@code error}
+ * on whichever thread expired the session. That is safe because of how Undertow 2.4.3.Final builds a frame,
+ * established from its source rather than assumed:
+ * <ul>
+ * <li>{@link WebSockets#sendText(String, WebSocketChannel, WebSocketCallback)} calls {@code WebSocketChannel.send(TEXT)},
+ *     which creates a NEW {@code StreamSinkFrameChannel} per call and appends it to the channel's
+ *     {@code WebSocketFramePriority.strictOrderQueue}, a {@code ConcurrentLinkedDeque}. The whole payload is
+ *     then attached to that sink as its single body and {@code AbstractFramedChannel.queueFrame} adds the sink
+ *     to {@code newFrames}, a {@code LinkedBlockingDeque}. Both queues take concurrent adds.</li>
+ * <li>Bytes reach the socket only from {@code AbstractFramedChannel.flushSenders()}, which is
+ *     {@code synchronized} and runs on the channel's I/O thread ({@code runNowOrInIoThread}). It drains
+ *     {@code newFrames} in order and the frame priority releases the next sink only when the one ahead of it in
+ *     {@code strictOrderQueue} has been written to the end, so one frame's bytes are never split around
+ *     another's.</li>
+ * </ul>
+ * So concurrent callers each get a complete frame on the wire, in the order their {@code send(TEXT)} calls
+ * happened. What they do NOT get is an ordering between senders - a change event and a {@code batchAck} may
+ * arrive in either order - which the protocols on {@code /ws} already tolerate: every frame carries its own
+ * {@code action}. The one plain read in the path is the {@code closeFrameSent} / {@code closeFrameReceived} pair
+ * in {@code WebSocketChannel.send()}: a sender racing a close can be refused with an {@code IOException} from
+ * {@code queueFrame} instead of the "channel closed" message, and that is handed to the callback, or closes the
+ * channel when there is none, exactly as any other send failure is.
+ * <p>
+ * Every sender goes through here so the next one added inherits the note above instead of re-deriving it, and
+ * so that if a future Undertow changes the guarantee there is one method to put a lock in.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class WebSocketFrameSender {
+  private WebSocketFrameSender() {
+  }
+
+  /**
+   * Queues one complete text frame on the channel. Returns as soon as the frame is queued: the write itself
+   * happens on the channel's I/O thread.
+   *
+   * @param callback notified when the frame has been written or has failed, or {@code null} to let Undertow close
+   *                 the channel on a failed write
+   */
+  public static void send(final WebSocketChannel channel, final String text, final WebSocketCallback<Void> callback) {
+    WebSockets.sendText(text, channel, callback);
+  }
+
+  /** {@link #send(WebSocketChannel, String, WebSocketCallback)} with no callback, skipped when the channel is gone. */
+  public static void sendIfOpen(final WebSocketChannel channel, final String text) {
+    if (channel.isOpen())
+      WebSockets.sendText(text, channel, null);
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/ws/WebSocketReceiveListener.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/WebSocketReceiveListener.java
@@ -30,7 +30,6 @@ import io.undertow.websockets.core.AbstractReceiveListener;
 import io.undertow.websockets.core.BufferedTextMessage;
 import io.undertow.websockets.core.StreamSourceFrameChannel;
 import io.undertow.websockets.core.WebSocketChannel;
-import io.undertow.websockets.core.WebSockets;
 
 import java.io.IOException;
 import java.util.Locale;
@@ -120,7 +119,7 @@ public class WebSocketReceiveListener extends AbstractReceiveListener {
   private void sendAck(final WebSocketChannel channel, final ACTION action) {
     final var json = new JSONObject("{\"result\": \"ok\"}");
     json.put("action", action.toString().toLowerCase(Locale.ENGLISH));
-    WebSockets.sendText(json.toString(), channel, null);
+    WebSocketFrameSender.send(channel, json.toString(), null);
   }
 
   private void sendError(final WebSocketChannel channel, final String error, final String detail, final Throwable exception) {
@@ -130,7 +129,7 @@ public class WebSocketReceiveListener extends AbstractReceiveListener {
       json.put("detail", encodeError(detail));
     if (exception != null)
       json.put("exception", exception.getClass().getName());
-    WebSockets.sendText(json.toString(), channel, null);
+    WebSocketFrameSender.send(channel, json.toString(), null);
   }
 
   private String encodeError(final String message) {

--- a/server/src/main/java/com/arcadedb/server/http/ws/WebSocketReceiveListener.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/WebSocketReceiveListener.java
@@ -24,6 +24,7 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.HttpServer;
+import com.arcadedb.server.http.ws.insert.WebSocketInsertProtocol;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.websockets.core.AbstractReceiveListener;
 import io.undertow.websockets.core.BufferedTextMessage;
@@ -39,14 +40,16 @@ import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 public class WebSocketReceiveListener extends AbstractReceiveListener {
-  private final HttpServer        httpServer;
-  private final WebSocketEventBus webSocketEventBus;
+  private final HttpServer              httpServer;
+  private final WebSocketEventBus       webSocketEventBus;
+  private final WebSocketInsertProtocol insertProtocol;
 
   public enum ACTION {UNKNOWN, SUBSCRIBE, UNSUBSCRIBE}
 
   public WebSocketReceiveListener(final HttpServer httpServer, final WebSocketEventBus webSocketEventBus) {
     this.httpServer = httpServer;
     this.webSocketEventBus = webSocketEventBus;
+    this.insertProtocol = httpServer.getInsertProtocol();
   }
 
   @Override
@@ -54,6 +57,15 @@ public class WebSocketReceiveListener extends AbstractReceiveListener {
     try {
       final var message = new JSONObject(textMessage.getData());
       final var rawAction = message.getString("action", "");
+
+      // The duplex insert-session frames (issue #7382) run off this I/O thread: they touch the database, and a
+      // commit taken here would stall every other connection this thread serves.
+      final var insertAction = rawAction.toLowerCase(Locale.ENGLISH);
+      if (WebSocketInsertProtocol.handles(insertAction)) {
+        insertProtocol.dispatch(channel, insertAction, message);
+        return;
+      }
+
       var action = ACTION.UNKNOWN;
       try {
         action = ACTION.valueOf(rawAction.toUpperCase(Locale.ENGLISH));
@@ -101,6 +113,8 @@ public class WebSocketReceiveListener extends AbstractReceiveListener {
   protected void onClose(final WebSocketChannel channel, final StreamSourceFrameChannel frameChannel) throws IOException {
     final var channelId = (UUID) channel.getAttribute(WebSocketEventBus.CHANNEL_ID);
     this.webSocketEventBus.unsubscribeAll(channelId);
+    // An insert session the client walked away from without committing is rolled back, never left open.
+    this.insertProtocol.onChannelClosed(channel, channelId);
   }
 
   private void sendAck(final WebSocketChannel channel, final ACTION action) {

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/InsertSessionOptions.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/InsertSessionOptions.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.ws.insert;
+
+import com.arcadedb.serializer.json.JSONObject;
+
+import java.util.Locale;
+
+/**
+ * The subset of the gRPC {@code InsertOptions} message a {@code /ws} insert session understands, parsed from the
+ * {@code options} object of a {@code start} frame (issue #7382).
+ * <p>
+ * Only the fields whose behaviour the control frames change are here. {@code conflictMode}, {@code keyColumns},
+ * {@code updateColumnsOnConflict} and {@code validateOnly} are gRPC-only for now and are rejected rather than
+ * ignored, so a client porting a working {@code InsertBidirectional} loader is told what is missing instead of
+ * silently getting plain inserts where it asked for upserts - see issue #7404.
+ *
+ * @author Arcade Data Ltd
+ */
+public class InsertSessionOptions {
+  /**
+   * When each transaction the session writes through is committed. Mirrors {@code InsertOptions.TransactionMode},
+   * which is the part of the gRPC shape that most needs the control frames: over {@code POST /api/v1/batch} the
+   * commit policy is fixed by query parameters before the load starts and cannot be changed once it is running.
+   */
+  public enum TransactionMode {
+    /**
+     * One transaction for the whole session, committed or rolled back when the CLIENT says so. The only mode in
+     * which a {@code rollback} frame can still undo a chunk the client has already been acknowledged for.
+     * {@code PER_REQUEST} is accepted as an alias: a {@code /ws} session IS the request, so gRPC's distinction
+     * between "the RPC" and "the stream" has no counterpart here.
+     */
+    PER_STREAM,
+    /** One transaction per {@code chunk} frame, committed before its {@code batchAck} is written. */
+    PER_BATCH,
+    /** One transaction per row. */
+    PER_ROW,
+    /**
+     * The caller manages the transaction externally. Refused at {@code start}: a {@code /ws} session has no way to
+     * name an existing transaction yet, which is issue #7403.
+     */
+    NONE
+  }
+
+  /** Default type of the records of every chunk, overridable per record with {@code @class}. */
+  public final String          targetType;
+  public final TransactionMode transactionMode;
+
+  private InsertSessionOptions(final String targetType, final TransactionMode transactionMode) {
+    this.targetType = targetType;
+    this.transactionMode = transactionMode;
+  }
+
+  /**
+   * @param options the {@code options} object of a {@code start} frame, or {@code null} when the frame carried none
+   *
+   * @throws IllegalArgumentException when a value is not one this server implements. Thrown rather than defaulted:
+   *                                  a load that silently ran under a different commit policy than the one asked
+   *                                  for is exactly the failure the control frames exist to prevent
+   */
+  public static InsertSessionOptions parse(final JSONObject options) {
+    if (options == null)
+      return new InsertSessionOptions(null, TransactionMode.PER_STREAM);
+
+    for (final String unsupported : new String[] { "conflictMode", "keyColumns", "updateColumnsOnConflict",
+        "validateOnly" })
+      if (options.has(unsupported) && !options.isNull(unsupported))
+        throw new IllegalArgumentException(
+            "Option '" + unsupported + "' is not supported by a /ws insert session yet (issue #7404)");
+
+    final String targetType = options.getString("targetType", null);
+
+    final String rawMode = options.getString("transactionMode", null);
+    final TransactionMode mode;
+    if (rawMode == null || rawMode.isBlank())
+      mode = TransactionMode.PER_STREAM;
+    else {
+      final String normalized = rawMode.trim().toUpperCase(Locale.ENGLISH);
+      if ("PER_REQUEST".equals(normalized))
+        mode = TransactionMode.PER_STREAM;
+      else
+        try {
+          mode = TransactionMode.valueOf(normalized);
+        } catch (final IllegalArgumentException e) {
+          throw new IllegalArgumentException("Unknown transactionMode '" + rawMode
+              + "'. Expected one of: per_stream, per_request, per_batch, per_row, none");
+        }
+    }
+
+    if (mode == TransactionMode.NONE)
+      throw new IllegalArgumentException(
+          "transactionMode 'none' needs an externally-managed transaction, which a /ws insert session cannot name yet (issue #7403)");
+
+    return new InsertSessionOptions(targetType, mode);
+  }
+
+  /** The name this mode is spelled with on the wire, i.e. what a {@code started} frame echoes back. */
+  public String transactionModeName() {
+    return transactionMode.name().toLowerCase(Locale.ENGLISH);
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/InsertSessionOptions.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/InsertSessionOptions.java
@@ -18,18 +18,23 @@
  */
 package com.arcadedb.server.http.ws.insert;
 
+import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 
+import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 /**
- * The subset of the gRPC {@code InsertOptions} message a {@code /ws} insert session understands, parsed from the
+ * The gRPC {@code InsertOptions} message as a {@code /ws} insert session understands it, parsed from the
  * {@code options} object of a {@code start} frame (issue #7382).
  * <p>
- * Only the fields whose behaviour the control frames change are here. {@code conflictMode}, {@code keyColumns},
- * {@code updateColumnsOnConflict} and {@code validateOnly} are gRPC-only for now and are rejected rather than
- * ignored, so a client porting a working {@code InsertBidirectional} loader is told what is missing instead of
- * silently getting plain inserts where it asked for upserts - see issue #7404.
+ * The control frames decide WHEN a transaction commits ({@code transactionMode}); the conflict options decide
+ * WHAT HAPPENS TO A ROW THAT ALREADY EXISTS ({@code conflictMode}, {@code keyColumns},
+ * {@code updateColumnsOnConflict}) and {@code validateOnly} whether anything is written at all. All of them are
+ * honoured with the semantics gRPC gives them (issue #7404), so a loader ported from {@code InsertBidirectional}
+ * keeps its behaviour. The gRPC spellings of the enum values ({@code CONFLICT_UPDATE}, {@code PER_BATCH}) are
+ * accepted next to the short ones.
  *
  * @author Arcade Data Ltd
  */
@@ -58,13 +63,52 @@ public class InsertSessionOptions {
     NONE
   }
 
+  /**
+   * What to do with a row whose key is already taken. Mirrors {@code InsertOptions.ConflictMode}, and like it a
+   * "key" is either the {@link #keyColumns} the session names or, when it names none, whatever unique index the
+   * insert trips over.
+   */
+  public enum ConflictMode {
+    /** The row is counted in {@code failed} and described in {@code errors} with the code {@code CONFLICT}. */
+    ERROR,
+    /**
+     * The matching record is updated in place with the incoming values - {@link #updateColumnsOnConflict} when
+     * given, every non-key property of the record otherwise - and the row is counted in {@code updated}. Needs
+     * {@link #keyColumns}: with nothing to look the existing record up by, there is nothing to update.
+     */
+    UPDATE,
+    /** The row is dropped and counted in {@code ignored}. */
+    IGNORE,
+    /**
+     * Accepted for parity with gRPC, where it is answered exactly as {@link #ERROR} is: the row is reported as a
+     * {@code CONFLICT} and the rest of the chunk still goes in.
+     */
+    ABORT
+  }
+
   /** Default type of the records of every chunk, overridable per record with {@code @class}. */
   public final String          targetType;
   public final TransactionMode transactionMode;
+  public final ConflictMode    conflictMode;
+  /** The properties a row is matched on for {@link ConflictMode#UPDATE} and {@link ConflictMode#IGNORE}. */
+  public final List<String>    keyColumns;
+  /** {@link #keyColumns} as a set, for the per-property "is this a key" check of a merge. */
+  public final Set<String>     keyColumnSet;
+  /** The properties an {@link ConflictMode#UPDATE} overwrites; empty means every non-key property sent. */
+  public final List<String>    updateColumnsOnConflict;
+  /** Rows are received, parsed and counted but nothing is written. */
+  public final boolean         validateOnly;
 
-  private InsertSessionOptions(final String targetType, final TransactionMode transactionMode) {
+  private InsertSessionOptions(final String targetType, final TransactionMode transactionMode,
+      final ConflictMode conflictMode, final List<String> keyColumns, final List<String> updateColumnsOnConflict,
+      final boolean validateOnly) {
     this.targetType = targetType;
     this.transactionMode = transactionMode;
+    this.conflictMode = conflictMode;
+    this.keyColumns = keyColumns;
+    this.keyColumnSet = Set.copyOf(keyColumns);
+    this.updateColumnsOnConflict = updateColumnsOnConflict;
+    this.validateOnly = validateOnly;
   }
 
   /**
@@ -76,42 +120,91 @@ public class InsertSessionOptions {
    */
   public static InsertSessionOptions parse(final JSONObject options) {
     if (options == null)
-      return new InsertSessionOptions(null, TransactionMode.PER_STREAM);
-
-    for (final String unsupported : new String[] { "conflictMode", "keyColumns", "updateColumnsOnConflict",
-        "validateOnly" })
-      if (options.has(unsupported) && !options.isNull(unsupported))
-        throw new IllegalArgumentException(
-            "Option '" + unsupported + "' is not supported by a /ws insert session yet (issue #7404)");
+      return new InsertSessionOptions(null, TransactionMode.PER_STREAM, ConflictMode.ERROR, List.of(), List.of(), false);
 
     final String targetType = options.getString("targetType", null);
+    final TransactionMode mode = parseTransactionMode(options.getString("transactionMode", null));
+    final ConflictMode conflictMode = parseConflictMode(options.getString("conflictMode", null));
+    final List<String> keyColumns = parseColumns(options, "keyColumns");
+    final List<String> updateColumns = parseColumns(options, "updateColumnsOnConflict");
+    final boolean validateOnly = options.getBoolean("validateOnly", false);
 
-    final String rawMode = options.getString("transactionMode", null);
-    final TransactionMode mode;
+    // gRPC accepts this combination and then reports every conflicting row as a CONFLICT, because with no key
+    // to look the existing record up by tryUpsertByRecord never matches. A session that asked for updates and
+    // can never perform one is better refused at start than discovered chunk by chunk.
+    if (conflictMode == ConflictMode.UPDATE && keyColumns.isEmpty())
+      throw new IllegalArgumentException(
+          "conflictMode 'update' needs 'keyColumns': the properties an existing record is matched on before it is updated");
+
+    return new InsertSessionOptions(targetType, mode, conflictMode, keyColumns, updateColumns, validateOnly);
+  }
+
+  private static TransactionMode parseTransactionMode(final String rawMode) {
     if (rawMode == null || rawMode.isBlank())
-      mode = TransactionMode.PER_STREAM;
-    else {
-      final String normalized = rawMode.trim().toUpperCase(Locale.ENGLISH);
-      if ("PER_REQUEST".equals(normalized))
-        mode = TransactionMode.PER_STREAM;
-      else
-        try {
-          mode = TransactionMode.valueOf(normalized);
-        } catch (final IllegalArgumentException e) {
-          throw new IllegalArgumentException("Unknown transactionMode '" + rawMode
-              + "'. Expected one of: per_stream, per_request, per_batch, per_row, none");
-        }
+      return TransactionMode.PER_STREAM;
+
+    final String normalized = rawMode.trim().toUpperCase(Locale.ENGLISH);
+    if ("PER_REQUEST".equals(normalized))
+      return TransactionMode.PER_STREAM;
+
+    final TransactionMode mode;
+    try {
+      mode = TransactionMode.valueOf(normalized);
+    } catch (final IllegalArgumentException e) {
+      throw new IllegalArgumentException("Unknown transactionMode '" + rawMode
+          + "'. Expected one of: per_stream, per_request, per_batch, per_row, none");
     }
 
     if (mode == TransactionMode.NONE)
       throw new IllegalArgumentException(
           "transactionMode 'none' needs an externally-managed transaction, which a /ws insert session cannot name yet (issue #7403)");
 
-    return new InsertSessionOptions(targetType, mode);
+    return mode;
+  }
+
+  private static ConflictMode parseConflictMode(final String rawMode) {
+    if (rawMode == null || rawMode.isBlank())
+      return ConflictMode.ERROR;
+
+    // "CONFLICT_UPDATE" is how the gRPC enum spells it; a ported loader may well send that.
+    String normalized = rawMode.trim().toUpperCase(Locale.ENGLISH);
+    if (normalized.startsWith("CONFLICT_"))
+      normalized = normalized.substring("CONFLICT_".length());
+
+    try {
+      return ConflictMode.valueOf(normalized);
+    } catch (final IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Unknown conflictMode '" + rawMode + "'. Expected one of: error, update, ignore, abort");
+    }
+  }
+
+  /**
+   * A list of property names. Refuses a blank name up front, the way gRPC's {@code INVALID_KEY_COLUMN} does,
+   * rather than letting every row fail on the quoting of an empty identifier.
+   */
+  private static List<String> parseColumns(final JSONObject options, final String key) {
+    if (!options.has(key) || options.isNull(key))
+      return List.of();
+
+    final JSONArray array = options.getJSONArray(key);
+    final String[] columns = new String[array.length()];
+    for (int i = 0; i < columns.length; i++) {
+      final Object column = array.isNull(i) ? null : array.get(i);
+      if (!(column instanceof String name) || name.isBlank())
+        throw new IllegalArgumentException("Option '" + key + "' must not contain empty names");
+      columns[i] = name;
+    }
+    return List.of(columns);
   }
 
   /** The name this mode is spelled with on the wire, i.e. what a {@code started} frame echoes back. */
   public String transactionModeName() {
     return transactionMode.name().toLowerCase(Locale.ENGLISH);
+  }
+
+  /** The name this mode is spelled with on the wire, i.e. what a {@code started} frame echoes back. */
+  public String conflictModeName() {
+    return conflictMode.name().toLowerCase(Locale.ENGLISH);
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertProtocol.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertProtocol.java
@@ -20,6 +20,7 @@ package com.arcadedb.server.http.ws.insert;
 
 import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.ws.WebSocketEventBus;
 import com.arcadedb.server.security.ServerSecurityUser;
@@ -180,7 +181,11 @@ public class WebSocketInsertProtocol {
       }
     } catch (final SecurityException e) {
       send(channel, error("Security error", e.getMessage(), message.getString("sessionId", null), e));
-    } catch (final IllegalArgumentException | IllegalStateException e) {
+    } catch (final JSONException | IllegalArgumentException | IllegalStateException e) {
+      // JSONException joins them because a frame whose 'options' carries a value of the wrong JSON TYPE is the
+      // same class of mistake as one carrying a value of the wrong content, and answering the first with
+      // "Internal error" and the second with "Insert session error" told a client the server had broken when it
+      // had not.
       send(channel, error("Insert session error", e.getMessage(), message.getString("sessionId", null), e));
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.FINE, "Error on /ws insert session action '%s'", e, action);

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertProtocol.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertProtocol.java
@@ -149,9 +149,9 @@ public class WebSocketInsertProtocol {
     try {
       switch (action) {
       case "start" -> {
-        final WebSocketInsertSession session = sessionManager.start(user, channelId, message.getString("database", null),
-            message.getString("sessionId", null), message.getJSONObject("options", null));
-        session.setChannel(channel);
+        final WebSocketInsertSession session = sessionManager.start(user, channel, channelId,
+            message.getString("database", null), message.getString("sessionId", null),
+            message.getJSONObject("options", null));
 
         final JSONObject started = new JSONObject();
         started.put("result", "ok");

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertProtocol.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertProtocol.java
@@ -18,14 +18,15 @@
  */
 package com.arcadedb.server.http.ws.insert;
 
+import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.ws.WebSocketEventBus;
+import com.arcadedb.server.http.ws.WebSocketFrameSender;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.websockets.core.WebSocketChannel;
-import io.undertow.websockets.core.WebSockets;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -47,8 +48,9 @@ import java.util.logging.Level;
  * Client to server, on the existing {@code /ws} connection, as the {@code action} of a JSON text frame:
  * <ul>
  * <li>{@code start} - {@code database} (required), {@code sessionId} (optional; the server generates one when it
- *     is absent) and {@code options} ({@code targetType}, {@code transactionMode}). Answered with
- *     {@code started}. A client-chosen id lives in ONE server-wide namespace, not one per user or per database -
+ *     is absent) and {@code options} ({@code targetType}, {@code transactionMode}, and the conflict options of
+ *     issue #7404: {@code conflictMode}, {@code keyColumns}, {@code updateColumnsOnConflict},
+ *     {@code validateOnly}). Answered with {@code started}, which echoes the modes the session runs under. A client-chosen id lives in ONE server-wide namespace, not one per user or per database -
  *     that is what makes "the same session id is refused to a second concurrent {@code start}" true whichever
  *     connection the second one arrives on. Two unrelated clients that both pick a house convention like
  *     {@code batch-1} will therefore collide; a client that does not need to name its own session should leave
@@ -159,6 +161,8 @@ public class WebSocketInsertProtocol {
         started.put("sessionId", session.id);
         started.put("database", session.databaseName);
         started.put("transactionMode", session.options.transactionModeName());
+        started.put("conflictMode", session.options.conflictModeName());
+        started.put("validateOnly", session.options.validateOnly);
         send(channel, started);
       }
       case "chunk" -> {
@@ -189,11 +193,12 @@ public class WebSocketInsertProtocol {
       }
     } catch (final SecurityException e) {
       send(channel, error("Security error", e.getMessage(), message.getString("sessionId", null), e));
-    } catch (final JSONException | IllegalArgumentException | IllegalStateException e) {
+    } catch (final JSONException | IllegalArgumentException | IllegalStateException | DuplicatedKeyException e) {
       // JSONException joins them because a frame whose 'options' carries a value of the wrong JSON TYPE is the
       // same class of mistake as one carrying a value of the wrong content, and answering the first with
       // "Internal error" and the second with "Insert session error" told a client the server had broken when it
-      // had not.
+      // had not. DuplicatedKeyException is the per_stream commit refusing a key the client sent twice (issue
+      // #7404): the client's data, not the server's fault.
       send(channel, error("Insert session error", e.getMessage(), message.getString("sessionId", null), e));
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.FINE, "Error on /ws insert session action '%s'", e, action);
@@ -218,9 +223,12 @@ public class WebSocketInsertProtocol {
     return json;
   }
 
+  /**
+   * One of several independent senders on a {@code /ws} channel; see {@link WebSocketFrameSender} for why they
+   * need no lock between them (issue #7423).
+   */
   private static void send(final WebSocketChannel channel, final JSONObject message) {
-    if (channel.isOpen())
-      WebSockets.sendText(message.toString(), channel, null);
+    WebSocketFrameSender.sendIfOpen(channel, message.toString());
   }
 
   private void registerCloseHook(final WebSocketChannel channel, final UUID channelId) {

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertProtocol.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertProtocol.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.ws.insert;
+
+import com.arcadedb.log.LogManager;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.http.ws.WebSocketEventBus;
+import com.arcadedb.server.security.ServerSecurityUser;
+import io.undertow.websockets.core.WebSocketChannel;
+import io.undertow.websockets.core.WebSockets;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.UUID;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.logging.Level;
+
+/**
+ * The {@code /ws} half of the gRPC {@code InsertBidirectional} shape: the control frames issue #7382 was opened
+ * about.
+ * <p>
+ * {@code POST /api/v1/batch} with {@code Accept: application/x-ndjson} (issue #7311) already carries the
+ * acknowledgement half - chunk <i>n</i>'s outcome reaching the client while chunk <i>n+1</i> is still being sent.
+ * What a request/response exchange cannot express is the other half: the client reacting to what the server said
+ * and changing what it sends next INSIDE the same session. That is what these frames are for, and it is why
+ * {@code /ws} is where they live rather than behind another HTTP route.
+ *
+ * <h2>Frames</h2>
+ * Client to server, on the existing {@code /ws} connection, as the {@code action} of a JSON text frame:
+ * <ul>
+ * <li>{@code start} - {@code database} (required), {@code sessionId} (optional; the server generates one when it
+ *     is absent) and {@code options} ({@code targetType}, {@code transactionMode}). Answered with
+ *     {@code started}.</li>
+ * <li>{@code chunk} - {@code sessionId}, {@code chunkSeq} and {@code records}, an array of JSON objects. A record
+ *     takes its type from its own {@code @class} or from the session's {@code targetType}; an edge record names
+ *     its endpoints with {@code @from} / {@code @to} (gRPC's {@code out} / {@code in} are accepted too). Answered
+ *     with {@code batchAck}.</li>
+ * <li>{@code commit} / {@code rollback} - {@code sessionId}. Answered with {@code committed}, whose
+ *     {@code outcome} says which of the two it was and whose {@code summary} carries the full-session totals.</li>
+ * </ul>
+ * Server to client: {@code started}, {@code batchAck}, {@code committed}, and an {@code error} the server is free
+ * to push unsolicited - which is what the idle sweep does when it rolls back a session the client walked away
+ * from.
+ *
+ * <h2>Ordering and threads</h2>
+ * Undertow delivers the frames of one connection serially, on an I/O thread that must not be blocked with
+ * database work. Each frame is therefore handed to the Undertow worker pool through a per-connection queue that
+ * runs one frame at a time in arrival order: a client may pipeline {@code start} and its first chunks without
+ * waiting for {@code started}, and no session ever has two of its frames in flight at once. No thread is
+ * dedicated to a session - the session's transaction is bound to whichever worker thread is running its current
+ * frame, exactly as an {@code arcadedb-session-id} transaction is bound to whichever thread is running its
+ * current HTTP request.
+ *
+ * @author Arcade Data Ltd
+ */
+public class WebSocketInsertProtocol {
+  /**
+   * How many frames one connection may have waiting to run. The acknowledgements ARE the flow control of this
+   * protocol - a client is meant to look at {@code batchAck} before deciding what to send next - so a client
+   * this far ahead of them is not being served, it is filling the server's heap with parsed chunks. Refused
+   * with an {@code error} frame naming the limit rather than queued; the session itself stays open, so a client
+   * that catches up can carry on. Bounding the SIZE of one frame is issue #7405.
+   */
+  private static final int    MAX_PENDING_FRAMES = 64;
+  /** Channel attribute holding this connection's serial frame queue. */
+  private static final String FRAME_QUEUE = "arcadedb.ws.insert.frameQueue";
+  /** Channel attribute recording that the connection-close hook is already registered. */
+  private static final String CLOSE_HOOK  = "arcadedb.ws.insert.closeHook";
+
+  private final WebSocketInsertSessionManager sessionManager;
+
+  public WebSocketInsertProtocol(final WebSocketInsertSessionManager sessionManager) {
+    this.sessionManager = sessionManager;
+    sessionManager.setExpiryListener((session, reason) -> {
+      final WebSocketChannel channel = session.getChannel();
+      if (channel != null && channel.isOpen())
+        send(channel, error("Insert session expired", reason, session.id, null));
+    });
+  }
+
+  /** The actions this protocol owns. Anything else is left to the subscription actions of {@code /ws}. */
+  public static boolean handles(final String action) {
+    return switch (action) {
+    case "start", "chunk", "commit", "rollback" -> true;
+    default -> false;
+    };
+  }
+
+  /**
+   * Queues one frame for execution on the Undertow worker pool. Returns immediately: the caller is the I/O thread
+   * and must stay free to read the next frame.
+   */
+  public void dispatch(final WebSocketChannel channel, final String action, final JSONObject message) {
+    final ServerSecurityUser user = (ServerSecurityUser) channel.getAttribute(WebSocketEventBus.USER);
+    final UUID channelId = (UUID) channel.getAttribute(WebSocketEventBus.CHANNEL_ID);
+
+    registerCloseHook(channel, channelId);
+
+    if (!frameQueue(channel).submit(() -> execute(channel, channelId, user, action, message)))
+      send(channel, error("Too many frames in flight",
+          "This connection already has " + MAX_PENDING_FRAMES + " frames waiting to be applied. Wait for the"
+              + " acknowledgements of the frames already sent before sending more", message.getString("sessionId", null),
+          null));
+  }
+
+  /**
+   * Rolls back whatever the connection left open. Idempotent, so both close paths may call it.
+   * <p>
+   * Runs on the worker rather than on the caller's thread: rolling a session back waits for the frame it may
+   * still be applying, and both close paths (the receive listener's {@code onClose} and the channel's close
+   * task) arrive on an I/O thread that other connections are waiting on.
+   */
+  public void onChannelClosed(final WebSocketChannel channel, final UUID channelId) {
+    if (channelId == null)
+      return;
+    try {
+      channel.getWorker().execute(() -> sessionManager.closeChannelSessions(channelId));
+    } catch (final RejectedExecutionException e) {
+      // The worker is going away with the connection; roll back here rather than not at all.
+      sessionManager.closeChannelSessions(channelId);
+    }
+  }
+
+  private void execute(final WebSocketChannel channel, final UUID channelId, final ServerSecurityUser user,
+      final String action, final JSONObject message) {
+    try {
+      switch (action) {
+      case "start" -> {
+        final WebSocketInsertSession session = sessionManager.start(user, channelId, message.getString("database", null),
+            message.getString("sessionId", null), message.getJSONObject("options", null));
+        session.setChannel(channel);
+
+        final JSONObject started = new JSONObject();
+        started.put("result", "ok");
+        started.put("action", "started");
+        started.put("sessionId", session.id);
+        started.put("database", session.databaseName);
+        started.put("transactionMode", session.options.transactionModeName());
+        send(channel, started);
+      }
+      case "chunk" -> {
+        final WebSocketInsertSession session = sessionManager.resolve(user, channelId,
+            message.getString("sessionId", null));
+        final JSONArray records = message.getJSONArray("records", null);
+        if (records == null)
+          throw new IllegalArgumentException("Property 'records' is required and must be an array");
+
+        // Refused rather than defaulted: the sequence is what makes a replayed chunk idempotent, and a missing
+        // one would land on the initial watermark and be acknowledged as a duplicate - silently dropping every
+        // record the frame carried.
+        final long chunkSeq = message.getLong("chunkSeq", 0);
+        if (chunkSeq < 1)
+          throw new IllegalArgumentException("Property 'chunkSeq' is required and must be 1 or greater");
+
+        send(channel, session.applyChunk(chunkSeq, records));
+      }
+      case "commit", "rollback" -> {
+        final WebSocketInsertSession session = sessionManager.resolve(user, channelId,
+            message.getString("sessionId", null));
+        send(channel, sessionManager.finish(session, "commit".equals(action)));
+      }
+      default -> send(channel, error("Unknown action", "%s is not a valid action.".formatted(action), null, null));
+      }
+    } catch (final SecurityException e) {
+      send(channel, error("Security error", e.getMessage(), message.getString("sessionId", null), e));
+    } catch (final IllegalArgumentException | IllegalStateException e) {
+      send(channel, error("Insert session error", e.getMessage(), message.getString("sessionId", null), e));
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.FINE, "Error on /ws insert session action '%s'", e, action);
+      send(channel, error("Internal error", e.getMessage(), message.getString("sessionId", null), e));
+    }
+  }
+
+  private static JSONObject error(final String error, final String detail, final String sessionId, final Throwable e) {
+    final JSONObject json = new JSONObject();
+    json.put("result", "error");
+    json.put("action", "error");
+    json.put("error", error);
+    if (detail != null)
+      json.put("detail", detail.replace("\\\\", " ").replace("\n", " "));
+    if (sessionId != null)
+      json.put("sessionId", sessionId);
+    if (e != null)
+      json.put("exception", e.getClass().getName());
+    return json;
+  }
+
+  private static void send(final WebSocketChannel channel, final JSONObject message) {
+    if (channel.isOpen())
+      WebSockets.sendText(message.toString(), channel, null);
+  }
+
+  private void registerCloseHook(final WebSocketChannel channel, final UUID channelId) {
+    // The receive listener's onClose only fires on a courteous close frame. A connection that simply goes away
+    // has to reach the same rollback, or its transaction is held until the idle sweep notices.
+    if (channel.getAttribute(CLOSE_HOOK) != null)
+      return;
+    channel.setAttribute(CLOSE_HOOK, Boolean.TRUE);
+    channel.addCloseTask(ch -> onChannelClosed(ch, channelId));
+  }
+
+  private static FrameQueue frameQueue(final WebSocketChannel channel) {
+    FrameQueue queue = (FrameQueue) channel.getAttribute(FRAME_QUEUE);
+    if (queue == null) {
+      // Created on the I/O thread, which Undertow runs one frame at a time per connection, so no two threads
+      // can reach this branch for the same channel.
+      queue = new FrameQueue(channel);
+      channel.setAttribute(FRAME_QUEUE, queue);
+    }
+    return queue;
+  }
+
+  /**
+   * Runs a connection's frames one at a time, in arrival order, on the Undertow worker pool. Adds no thread of
+   * its own: it holds a worker only while it has frames to run, and hands it back the moment it runs dry.
+   */
+  private static final class FrameQueue {
+    private final WebSocketChannel channel;
+    private final Deque<Runnable>  pending = new ArrayDeque<>();
+    private       boolean          draining;
+
+    private FrameQueue(final WebSocketChannel channel) {
+      this.channel = channel;
+    }
+
+    /**
+     * @return {@code false} when the connection is already {@link #MAX_PENDING_FRAMES} frames behind, in which
+     * case the frame was NOT queued and the caller answers with an error
+     */
+    private boolean submit(final Runnable frame) {
+      synchronized (this) {
+        if (pending.size() >= MAX_PENDING_FRAMES)
+          return false;
+        pending.addLast(frame);
+        if (draining)
+          return true;
+        draining = true;
+      }
+      try {
+        channel.getWorker().execute(this::drain);
+      } catch (final RejectedExecutionException e) {
+        // The worker is shutting down: drop the queue rather than throwing out of the I/O callback. The
+        // connection is going away with it, and the close hook rolls the session back.
+        synchronized (this) {
+          pending.clear();
+          draining = false;
+        }
+      }
+      return true;
+    }
+
+    private void drain() {
+      while (true) {
+        final Runnable next;
+        synchronized (this) {
+          next = pending.pollFirst();
+          if (next == null) {
+            draining = false;
+            return;
+          }
+        }
+        try {
+          next.run();
+        } catch (final Exception e) {
+          LogManager.instance().log(this, Level.FINE, "Error on running a /ws insert frame", e);
+        }
+      }
+    }
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertProtocol.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertProtocol.java
@@ -48,11 +48,16 @@ import java.util.logging.Level;
  * <ul>
  * <li>{@code start} - {@code database} (required), {@code sessionId} (optional; the server generates one when it
  *     is absent) and {@code options} ({@code targetType}, {@code transactionMode}). Answered with
- *     {@code started}.</li>
- * <li>{@code chunk} - {@code sessionId}, {@code chunkSeq} and {@code records}, an array of JSON objects. A record
- *     takes its type from its own {@code @class} or from the session's {@code targetType}; an edge record names
- *     its endpoints with {@code @from} / {@code @to} (gRPC's {@code out} / {@code in} are accepted too). Answered
- *     with {@code batchAck}.</li>
+ *     {@code started}. A client-chosen id lives in ONE server-wide namespace, not one per user or per database -
+ *     that is what makes "the same session id is refused to a second concurrent {@code start}" true whichever
+ *     connection the second one arrives on. Two unrelated clients that both pick a house convention like
+ *     {@code batch-1} will therefore collide; a client that does not need to name its own session should leave
+ *     the field out and use the id the server generates.</li>
+ * <li>{@code chunk} - {@code sessionId}, {@code chunkSeq} and {@code records}, an array of JSON objects. The
+ *     sequence starts at 1 and is contiguous: re-sending one already applied is acknowledged as a replay,
+ *     skipping ahead of the next one due is refused. A record takes its type from its own {@code @class} or from
+ *     the session's {@code targetType}; an edge record names its endpoints with {@code @from} / {@code @to}
+ *     (gRPC's {@code out} / {@code in} are accepted too). Answered with {@code batchAck}.</li>
  * <li>{@code commit} / {@code rollback} - {@code sessionId}. Answered with {@code committed}, whose
  *     {@code outcome} says which of the two it was and whose {@code summary} carries the full-session totals.</li>
  * </ul>
@@ -177,6 +182,9 @@ public class WebSocketInsertProtocol {
             message.getString("sessionId", null));
         send(channel, sessionManager.finish(session, "commit".equals(action)));
       }
+      // Unreachable through dispatch(), which only ever passes an action handles() claimed. It is here for the
+      // next action added to handles() without a case of its own: answering an error frame is a great deal
+      // easier to diagnose than falling through and silently acknowledging nothing.
       default -> send(channel, error("Unknown action", "%s is not a valid action.".formatted(action), null, null));
       }
     } catch (final SecurityException e) {
@@ -198,8 +206,11 @@ public class WebSocketInsertProtocol {
     json.put("result", "error");
     json.put("action", "error");
     json.put("error", error);
+    // Flattened to one line so an error stays greppable next to the log entry that describes it. Only the line
+    // breaks: the sibling encodeError() in WebSocketReceiveListener also collapses a literal double backslash,
+    // which JSONObject.toString() already escapes on its own, so there is nothing left for that to fix here.
     if (detail != null)
-      json.put("detail", detail.replace("\\\\", " ").replace("\n", " "));
+      json.put("detail", detail.replace("\r", " ").replace("\n", " "));
     if (sessionId != null)
       json.put("sessionId", sessionId);
     if (e != null)

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSession.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSession.java
@@ -137,6 +137,12 @@ public class WebSocketInsertSession {
    * mirroring the gRPC path. A row that fails is counted in {@code failed} and described in {@code errors}; the
    * rest of the chunk still goes in, because a duplex session exists so the client can decide what to do about a
    * partial chunk rather than have the server decide by aborting.
+   * <p>
+   * Anything else - a sequence that skips ahead of the next one due - is REFUSED. A watermark that simply
+   * follows whatever arrives would jump to 5 when a client sent chunk 5 before chunk 2, and chunk 2 would then
+   * be acknowledged as a replay of something that never happened: every row it carried silently dropped, with a
+   * successful-looking answer. Chunks are therefore contiguous from 1, which a client sending them in order
+   * satisfies without doing anything, and a gap is an error rather than an undocumented hazard.
    */
   JSONObject applyChunk(final long chunkSeq, final JSONArray records) {
     lock.lock();
@@ -149,6 +155,11 @@ public class WebSocketInsertSession {
       ack.put("action", "batchAck");
       ack.put("sessionId", id);
       ack.put("chunkSeq", chunkSeq);
+
+      if (chunkSeq > watermark + 1)
+        throw new IllegalArgumentException(
+            "Chunk " + chunkSeq + " skips ahead: session '" + id + "' has applied up to chunk " + watermark
+                + " and expects " + (watermark + 1) + " next. Chunk sequences must be contiguous from 1");
 
       if (chunkSeq <= watermark) {
         ack.put("received", 0L);

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSession.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSession.java
@@ -501,9 +501,10 @@ public class WebSocketInsertSession {
       case ERROR, ABORT -> {
         // With key columns the conflict is found on the row that caused it rather than left to the engine,
         // which reports it only where the transaction commits.
+        // The "index" the exception names is the session's key, which reads as such: "Keyed on [name]".
         final RID taken = findByKey(typeName, properties);
         if (taken != null)
-          throw new DuplicatedKeyException(typeName + options.keyColumns, keyValues(properties), taken);
+          throw new DuplicatedKeyException(typeName + " on " + options.keyColumns, keyValues(properties), taken);
       }
       }
 

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSession.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSession.java
@@ -1,0 +1,432 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.ws.insert;
+
+import com.arcadedb.database.DatabaseContext;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.TransactionContext;
+import com.arcadedb.graph.MutableEdge;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.EdgeType;
+import com.arcadedb.schema.VertexType;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.security.ServerSecurityUser;
+import io.undertow.websockets.core.WebSocketChannel;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * One duplex insert session opened on {@code /ws} by a {@code start} frame (issue #7382). Mirrors the state the
+ * gRPC {@code InsertBidirectional} RPC keeps for the lifetime of its stream: the transaction, the running totals,
+ * and the chunk watermark that makes a replayed chunk idempotent.
+ * <p>
+ * <b>Threading.</b> The session's {@link TransactionContext} is bound to whichever thread is currently running one
+ * of its frames and detached again when that frame finishes - the same borrow-per-request lifecycle
+ * {@code DatabaseAbstractHandler} gives an {@code arcadedb-session-id} transaction, and the reason no thread has to
+ * be dedicated to a session. {@link WebSocketInsertSessionManager} guarantees the frames of one channel do not
+ * overlap; {@link #lock} guards against the idle sweep and the connection-close hook, which do not come through
+ * that ordering.
+ *
+ * @author Arcade Data Ltd
+ */
+public class WebSocketInsertSession {
+  /** Record keys that name the record itself rather than one of its properties. */
+  private static final String CLASS_KEY = "@class";
+  private static final String FROM_KEY  = "@from";
+  private static final String TO_KEY    = "@to";
+  /** gRPC spells an edge's endpoints {@code out} / {@code in}; accepted so a ported loader keeps working. */
+  private static final String OUT_KEY   = "out";
+  private static final String IN_KEY    = "in";
+
+  public final  String                        id;
+  public final  String                        databaseName;
+  public final  ServerSecurityUser            user;
+  public final  UUID                          channelId;
+  public final  InsertSessionOptions          options;
+  private final DatabaseInternal              database;
+  private final ReentrantLock                 lock       = new ReentrantLock();
+  private final long                          startedAt  = System.currentTimeMillis();
+  /** Null in every mode but {@code PER_STREAM}, where it is the transaction the client's frames decide. */
+  private       TransactionContext            transaction;
+  private       long                          received;
+  private       long                          inserted;
+  private       long                          updated;
+  private       long                          ignored;
+  private       long                          failed;
+  /** Highest chunk sequence already applied. A chunk at or below it is acknowledged without being applied again. */
+  private       long                          watermark;
+  private volatile boolean                    closed;
+  private volatile long                       lastUsed   = System.currentTimeMillis();
+  /** The connection this session was opened on, so the idle sweep can tell its client it gave up on it. */
+  private volatile WebSocketChannel            channel;
+
+  WebSocketInsertSession(final String id, final DatabaseInternal database, final ServerSecurityUser user,
+      final UUID channelId, final InsertSessionOptions options) {
+    this.id = id;
+    this.database = database;
+    this.databaseName = database.getName();
+    this.user = user;
+    this.channelId = channelId;
+    this.options = options;
+  }
+
+  /**
+   * Begins the session's own transaction. Only {@code PER_STREAM} has one: the other modes open and commit a
+   * transaction inside {@link #applyChunk}, which is what makes their acknowledged chunks durable before the
+   * client has said anything.
+   */
+  void begin() {
+    if (options.transactionMode != InsertSessionOptions.TransactionMode.PER_STREAM)
+      return;
+
+    DatabaseContext.INSTANCE.init(database);
+    try {
+      database.begin();
+      transaction = database.getTransaction();
+      // The requester is what lets a lock taken on this thread be released from another one, which is exactly
+      // what a session whose frames land on different worker threads needs. Same reason PostBeginHandler sets it.
+      transaction.setRequester(id);
+    } finally {
+      DatabaseContext.INSTANCE.removeContext(database.getDatabasePath());
+    }
+  }
+
+  public void setChannel(final WebSocketChannel channel) {
+    this.channel = channel;
+  }
+
+  public WebSocketChannel getChannel() {
+    return channel;
+  }
+
+  public long elapsedFromLastUse() {
+    return System.currentTimeMillis() - lastUsed;
+  }
+
+  public boolean isClosed() {
+    return closed;
+  }
+
+  /**
+   * Applies one {@code chunk} frame and returns the {@code batchAck} to answer it with.
+   * <p>
+   * A chunk at or below the watermark is a replay: it is acknowledged with zero tallies and NOT applied again,
+   * mirroring the gRPC path. A row that fails is counted in {@code failed} and described in {@code errors}; the
+   * rest of the chunk still goes in, because a duplex session exists so the client can decide what to do about a
+   * partial chunk rather than have the server decide by aborting.
+   */
+  JSONObject applyChunk(final long chunkSeq, final JSONArray records) {
+    lock.lock();
+    try {
+      requireOpen();
+      lastUsed = System.currentTimeMillis();
+
+      final JSONObject ack = new JSONObject();
+      ack.put("result", "ok");
+      ack.put("action", "batchAck");
+      ack.put("sessionId", id);
+      ack.put("chunkSeq", chunkSeq);
+
+      if (chunkSeq <= watermark) {
+        ack.put("received", 0L);
+        ack.put("inserted", 0L);
+        ack.put("updated", 0L);
+        ack.put("ignored", 0L);
+        ack.put("failed", 0L);
+        ack.put("replay", true);
+        return ack;
+      }
+
+      final ChunkCounts counts = new ChunkCounts();
+      final int rows = records == null ? 0 : records.length();
+
+      DatabaseContext.INSTANCE.init(database, transaction);
+      try {
+        DatabaseContext.INSTANCE.getContext(database.getDatabasePath()).setCurrentUser(user.getDatabaseUser(database));
+
+        switch (options.transactionMode) {
+        case PER_STREAM -> applyRows(records, rows, counts);
+        case PER_BATCH -> {
+          try {
+            database.transaction(() -> applyRows(records, rows, counts));
+          } catch (final Exception e) {
+            // The chunk's own transaction failed to commit, so nothing in it is durable. Report the whole chunk
+            // as failed - the per-row tallies applyRows produced describe a transaction that no longer exists.
+            counts.resetToWholeChunkFailure(rows, e);
+          }
+        }
+        case PER_ROW -> {
+          for (int i = 0; i < rows; i++) {
+            final int row = i;
+            try {
+              database.transaction(() -> applyRow(records.getJSONObject(row), row, counts));
+            } catch (final Exception e) {
+              counts.fail(row, e);
+            }
+          }
+        }
+        default -> throw new IllegalStateException("Unsupported transaction mode " + options.transactionMode);
+        }
+      } finally {
+        DatabaseContext.INSTANCE.removeContext(database.getDatabasePath());
+      }
+
+      received += rows;
+      inserted += counts.inserted;
+      updated += counts.updated;
+      ignored += counts.ignored;
+      failed += counts.failed;
+      // The watermark advances only on a chunk that was applied without a whole-chunk failure, so a client that
+      // replays a chunk whose transaction never committed gets it applied rather than acknowledged as a duplicate.
+      if (!counts.wholeChunkFailed)
+        watermark = chunkSeq;
+
+      ack.put("received", (long) rows);
+      ack.put("inserted", counts.inserted);
+      ack.put("updated", counts.updated);
+      ack.put("ignored", counts.ignored);
+      ack.put("failed", counts.failed);
+      if (!counts.errors.isEmpty())
+        ack.put("errors", counts.errors);
+
+      lastUsed = System.currentTimeMillis();
+      return ack;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /**
+   * Ends the session, committing or discarding what it wrote, and returns the {@code committed} frame carrying the
+   * full-session totals.
+   *
+   * @param commit {@code true} for a {@code commit} frame, {@code false} for a {@code rollback} one
+   */
+  JSONObject finish(final boolean commit) {
+    lock.lock();
+    try {
+      requireOpen();
+
+      if (transaction != null) {
+        DatabaseContext.INSTANCE.init(database, transaction);
+        try {
+          if (commit)
+            database.commit();
+          else
+            database.rollback();
+        } finally {
+          DatabaseContext.INSTANCE.removeContext(database.getDatabasePath());
+          transaction = null;
+        }
+      }
+
+      closed = true;
+
+      final JSONObject summary = new JSONObject();
+      summary.put("received", received);
+      summary.put("inserted", inserted);
+      summary.put("updated", updated);
+      summary.put("ignored", ignored);
+      summary.put("failed", failed);
+      summary.put("executionTimeMs", System.currentTimeMillis() - startedAt);
+      // PER_BATCH and PER_ROW commit as they go, so a rollback frame cannot take back a chunk the client has
+      // already been acknowledged for. Say so in the answer rather than letting the outcome imply otherwise.
+      summary.put("partialCommit", options.transactionMode != InsertSessionOptions.TransactionMode.PER_STREAM);
+
+      final JSONObject response = new JSONObject();
+      response.put("result", "ok");
+      response.put("action", "committed");
+      response.put("sessionId", id);
+      response.put("outcome", commit ? "commit" : "rollback");
+      response.put("summary", summary);
+      return response;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /**
+   * What {@link #cancelIfIdle()} did, so the idle sweep can tell "leave it registered and look again next tick"
+   * from "it is gone".
+   */
+  enum CancelOutcome {
+    /** A frame is being applied right now: the session is NOT idle and must be left alone this sweep. */
+    BUSY,
+    /** This call is the one that closed the session. */
+    CANCELLED,
+    /** Somebody else had already closed it. */
+    ALREADY_CLOSED
+  }
+
+  /**
+   * Discards whatever the session wrote and marks it closed. Called by the connection-close hook and by server
+   * shutdown - paths that end a session WITHOUT the client having said what to do with it, which is why the
+   * answer is always rollback. Waits for a frame in flight rather than tearing its transaction down underneath
+   * it, which is the race issue #4857 fixed for the HTTP sessions; callers therefore run it off the I/O thread.
+   *
+   * @return {@code true} when this call is the one that closed the session
+   */
+  boolean cancel() {
+    lock.lock();
+    try {
+      return rollbackAndClose();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /**
+   * The idle sweep's version: gives up rather than waiting. A session with a frame in flight is not idle at all -
+   * its {@code lastUsed} was stamped when that frame STARTED, so a chunk that takes longer than the timeout looks
+   * abandoned from outside - and rolling its transaction back from the timer thread while a worker thread is
+   * still writing into it is the same defect issue #4857 closed for {@code HttpSession}.
+   */
+  CancelOutcome cancelIfIdle() {
+    if (!lock.tryLock())
+      return CancelOutcome.BUSY;
+    try {
+      return rollbackAndClose() ? CancelOutcome.CANCELLED : CancelOutcome.ALREADY_CLOSED;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /** Must be called holding {@link #lock}. */
+  private boolean rollbackAndClose() {
+    if (closed)
+      return false;
+    closed = true;
+
+    if (transaction != null) {
+      DatabaseContext.INSTANCE.init(database, transaction);
+      try {
+        database.rollback();
+      } catch (final Exception e) {
+        // The session is being torn down; a rollback that cannot run leaves nothing further to do here.
+      } finally {
+        DatabaseContext.INSTANCE.removeContext(database.getDatabasePath());
+        transaction = null;
+      }
+    }
+    return true;
+  }
+
+  private void requireOpen() {
+    if (closed)
+      throw new IllegalStateException("Insert session '" + id + "' is closed");
+  }
+
+  private void applyRows(final JSONArray records, final int rows, final ChunkCounts counts) {
+    for (int i = 0; i < rows; i++)
+      try {
+        applyRow(records.getJSONObject(i), i, counts);
+      } catch (final Exception e) {
+        counts.fail(i, e);
+      }
+  }
+
+  private void applyRow(final JSONObject record, final int rowIndex, final ChunkCounts counts) {
+    final String typeName = record.getString(CLASS_KEY, options.targetType);
+    if (typeName == null || typeName.isBlank())
+      throw new IllegalArgumentException(
+          "Record " + rowIndex + " has no type: set '@class' on it or 'targetType' in the start frame options");
+
+    final DocumentType type = database.getSchema().getType(typeName);
+    final Map<String, Object> properties = record.toMap();
+    properties.remove(CLASS_KEY);
+
+    if (type instanceof EdgeType) {
+      final String from = firstNonBlank(record.getString(FROM_KEY, null), record.getString(OUT_KEY, null));
+      final String to = firstNonBlank(record.getString(TO_KEY, null), record.getString(IN_KEY, null));
+      if (from == null || to == null)
+        throw new IllegalArgumentException(
+            "Edge record " + rowIndex + " of type '" + typeName + "' needs both '@from' and '@to' (or 'out' and 'in')");
+
+      properties.remove(FROM_KEY);
+      properties.remove(TO_KEY);
+      properties.remove(OUT_KEY);
+      properties.remove(IN_KEY);
+
+      final Vertex fromVertex = database.lookupByRID(database.newRID(from), false).asVertex(false);
+      final MutableEdge edge = fromVertex.newEdge(typeName, database.newRID(to));
+      edge.set(properties);
+      edge.save();
+    } else if (type instanceof VertexType) {
+      final MutableVertex vertex = database.newVertex(typeName);
+      vertex.set(properties);
+      vertex.save();
+    } else {
+      final MutableDocument document = database.newDocument(typeName);
+      document.set(properties);
+      document.save();
+    }
+    counts.inserted++;
+  }
+
+  private static String firstNonBlank(final String first, final String second) {
+    if (first != null && !first.isBlank())
+      return first;
+    return second != null && !second.isBlank() ? second : null;
+  }
+
+  /** Per-chunk tallies, the shape of the gRPC {@code BatchAck} counters. */
+  private static final class ChunkCounts {
+    private       JSONArray errors = new JSONArray();
+    private       long      inserted;
+    private       long      updated;
+    private       long      ignored;
+    private       long      failed;
+    private       boolean   wholeChunkFailed;
+
+    private void fail(final int rowIndex, final Exception e) {
+      failed++;
+      errors.put(error(rowIndex, "DB_ERROR", e));
+    }
+
+    /**
+     * A failure that belongs to the chunk's transaction rather than to any one row: nothing in the chunk is
+     * durable, so the per-row tallies are replaced instead of added to. Reported with {@code rowIndex} -1, the
+     * "not applicable" value the gRPC {@code InsertError} contract uses for the same case.
+     */
+    private void resetToWholeChunkFailure(final int rows, final Exception e) {
+      inserted = 0;
+      updated = 0;
+      ignored = 0;
+      failed = rows;
+      wholeChunkFailed = true;
+      errors = new JSONArray();
+      errors.put(error(-1, "DB_ERROR", e));
+    }
+
+    private static JSONObject error(final int rowIndex, final String code, final Exception e) {
+      final JSONObject error = new JSONObject();
+      error.put("rowIndex", rowIndex);
+      error.put("code", code);
+      error.put("message", e.getMessage() != null ? e.getMessage() : e.toString());
+      error.put("exception", e.getClass().getName());
+      return error;
+    }
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSession.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSession.java
@@ -21,10 +21,17 @@ package com.arcadedb.server.http.ws.insert;
 import com.arcadedb.database.DatabaseContext;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.ProtocolContext;
+import com.arcadedb.database.RID;
 import com.arcadedb.database.TransactionContext;
+import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.graph.MutableEdge;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.query.sql.parser.Identifier;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.EdgeType;
 import com.arcadedb.schema.VertexType;
@@ -33,15 +40,29 @@ import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.websockets.core.WebSocketChannel;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
+import java.util.logging.Level;
 
 /**
  * One duplex insert session opened on {@code /ws} by a {@code start} frame (issue #7382). Mirrors the state the
  * gRPC {@code InsertBidirectional} RPC keeps for the lifetime of its stream: the transaction, the running totals,
  * and the chunk watermark that makes a replayed chunk idempotent.
+ * <p>
+ * <b>Conflicts.</b> The {@code conflictMode} / {@code keyColumns} / {@code updateColumnsOnConflict} /
+ * {@code validateOnly} options are honoured the way {@code ArcadeDbGrpcService.insertRows} honours them (issue
+ * #7404): a row is first matched on its {@code keyColumns} with a {@code SELECT} against its type, and the mode
+ * decides whether a match is updated in place, dropped, or reported as a {@code CONFLICT}. A duplicate the engine
+ * itself detects - a unique index the session named no key columns for - is answered by the same mode, wherever
+ * it surfaces: at the row's own {@code save()} when the twin was written by this same transaction, at the chunk's
+ * commit under {@code per_batch}, at the row's commit under {@code per_row}, and at the session's {@code commit}
+ * frame under {@code per_stream}. That last case is the engine's contract, not this session's: a unique index is
+ * checked against durable state when the transaction commits, so a session that wants a conflict reported on
+ * the row that caused it names its {@code keyColumns}.
  * <p>
  * <b>Threading.</b> The session's {@link TransactionContext} is bound to whichever thread is currently running one
  * of its frames and detached again when that frame finishes - the same borrow-per-request lifecycle
@@ -79,6 +100,8 @@ public class WebSocketInsertSession {
   /** Highest chunk sequence already applied. A chunk at or below it is acknowledged without being applied again. */
   private       long                          watermark;
   private volatile boolean                    closed;
+  /** Set once the "out/in in updateColumnsOnConflict are ignored" warning has been logged for this session. */
+  private          boolean                    warnedEdgeEndpointUpdateColumns;
   private volatile long                       lastUsed   = System.currentTimeMillis();
   /** The connection this session was opened on, so the idle sweep can tell its client it gave up on it. */
   private volatile WebSocketChannel            channel;
@@ -175,6 +198,9 @@ public class WebSocketInsertSession {
       final int rows = records == null ? 0 : records.length();
 
       DatabaseContext.INSTANCE.init(database, transaction);
+      // The key lookups below are real SQL: tagged with the transport they serve so they are metered as such,
+      // which is the misattribution issue #7407 found on the gRPC streaming inserts.
+      ProtocolContext.set("ws");
       try {
         DatabaseContext.INSTANCE.getContext(database.getDatabasePath()).setCurrentUser(user.getDatabaseUser(database));
 
@@ -193,8 +219,17 @@ public class WebSocketInsertSession {
           for (int i = 0; i < rows; i++) {
             final int row = i;
             try {
-              counts.absorb(inOwnTransaction(attempt -> applyRow(records.getJSONObject(row), row, attempt)));
+              counts.absorb(inOwnTransaction(attempt -> applyRowCounting(records, row, attempt)));
+            } catch (final DuplicatedKeyException e) {
+              // The row's own commit hit a unique index the session named no key columns for. The row IS the
+              // transaction here, so the mode can still answer per row: dropped under ignore, a CONFLICT
+              // otherwise.
+              if (options.conflictMode == InsertSessionOptions.ConflictMode.IGNORE)
+                counts.ignored++;
+              else
+                counts.conflict(row, e);
             } catch (final Exception e) {
+              // Anything else that stops the row's commit is reported on the row, since the row is the transaction.
               counts.fail(row, e);
             }
           }
@@ -202,6 +237,7 @@ public class WebSocketInsertSession {
         default -> throw new IllegalStateException("Unsupported transaction mode " + options.transactionMode);
         }
       } finally {
+        ProtocolContext.clear();
         DatabaseContext.INSTANCE.removeContext(database.getDatabasePath());
       }
 
@@ -241,6 +277,11 @@ public class WebSocketInsertSession {
     try {
       requireOpen();
 
+      // Closed BEFORE the commit is attempted: a commit the engine refuses - a unique index it checks only now,
+      // see the class comment - rolls the transaction back, and a session whose transaction is gone must not
+      // stay open to take more chunks.
+      closed = true;
+
       if (transaction != null) {
         DatabaseContext.INSTANCE.init(database, transaction);
         try {
@@ -253,8 +294,6 @@ public class WebSocketInsertSession {
           transaction = null;
         }
       }
-
-      closed = true;
 
       final JSONObject summary = new JSONObject();
       summary.put("received", received);
@@ -374,13 +413,26 @@ public class WebSocketInsertSession {
 
   private void applyRows(final JSONArray records, final int rows, final ChunkCounts counts) {
     for (int i = 0; i < rows; i++)
-      try {
-        applyRow(records.getJSONObject(i), i, counts);
-      } catch (final Exception e) {
-        counts.fail(i, e);
-      }
+      applyRowCounting(records, i, counts);
   }
 
+  /** {@link #applyRow} with its outcome tallied: a row that cannot be applied is counted, never thrown. */
+  private void applyRowCounting(final JSONArray records, final int rowIndex, final ChunkCounts counts) {
+    try {
+      applyRow(records.getJSONObject(rowIndex), rowIndex, counts);
+    } catch (final DuplicatedKeyException e) {
+      // Reaches here only from the modes that report a duplicate rather than absorb it.
+      counts.conflict(rowIndex, e);
+    } catch (final Exception e) {
+      counts.fail(rowIndex, e);
+    }
+  }
+
+  /**
+   * Applies one record under the session's conflict mode. Throws for a row that could not be applied; the
+   * caller decides how that is tallied. A {@link DuplicatedKeyException} that escapes is one the mode wants
+   * reported as a {@code CONFLICT}.
+   */
   private void applyRow(final JSONObject record, final int rowIndex, final ChunkCounts counts) {
     final String typeName = record.getString(CLASS_KEY, options.targetType);
     if (typeName == null || typeName.isBlank())
@@ -388,12 +440,15 @@ public class WebSocketInsertSession {
           "Record " + rowIndex + " has no type: set '@class' on it or 'targetType' in the start frame options");
 
     final DocumentType type = database.getSchema().getType(typeName);
+    final boolean isEdge = type instanceof EdgeType;
     final Map<String, Object> properties = record.toMap();
     properties.remove(CLASS_KEY);
 
-    if (type instanceof EdgeType) {
-      final String from = firstNonBlank(record.getString(FROM_KEY, null), record.getString(OUT_KEY, null));
-      final String to = firstNonBlank(record.getString(TO_KEY, null), record.getString(IN_KEY, null));
+    String from = null;
+    String to = null;
+    if (isEdge) {
+      from = firstNonBlank(record.getString(FROM_KEY, null), record.getString(OUT_KEY, null));
+      to = firstNonBlank(record.getString(TO_KEY, null), record.getString(IN_KEY, null));
       if (from == null || to == null)
         throw new IllegalArgumentException(
             "Edge record " + rowIndex + " of type '" + typeName + "' needs both '@from' and '@to' (or 'out' and 'in')");
@@ -403,6 +458,59 @@ public class WebSocketInsertSession {
       properties.remove(OUT_KEY);
       properties.remove(IN_KEY);
 
+      warnAboutEdgeEndpointUpdateColumns(typeName);
+    }
+
+    // A dry run parses and validates the row - the type, the endpoints - and stops here, so `received` counts it
+    // and nothing else does. Same as gRPC's validate_only.
+    if (options.validateOnly)
+      return;
+
+    try {
+      switch (options.conflictMode) {
+      case UPDATE -> {
+        if (updateExisting(typeName, properties, isEdge)) {
+          counts.updated++;
+          return;
+        }
+      }
+      case IGNORE -> {
+        if (findByKey(typeName, properties) != null) {
+          counts.ignored++;
+          return;
+        }
+      }
+      case ERROR, ABORT -> {
+        // With key columns the conflict is found on the row that caused it rather than left to the engine,
+        // which reports it only where the transaction commits.
+        final RID taken = findByKey(typeName, properties);
+        if (taken != null)
+          throw new DuplicatedKeyException(typeName + options.keyColumns, keyValues(properties), taken);
+      }
+      }
+
+      insert(type, typeName, properties, from, to);
+      counts.inserted++;
+    } catch (final DuplicatedKeyException dup) {
+      switch (options.conflictMode) {
+      case IGNORE -> counts.ignored++;
+      // A concurrent writer landed this key after the lookup above; the index proves it exists now, so update
+      // it rather than lose the row. If the match is gone again (a transient window), or a third writer races
+      // the retry too, it is a retriable CONFLICT. Anything else is a real failure, not a conflict.
+      case UPDATE -> {
+        if (updateExisting(typeName, properties, isEdge))
+          counts.updated++;
+        else
+          throw dup;
+      }
+      case ERROR, ABORT -> throw dup;
+      }
+    }
+  }
+
+  private void insert(final DocumentType type, final String typeName, final Map<String, Object> properties,
+      final String from, final String to) {
+    if (type instanceof EdgeType) {
       final Vertex fromVertex = database.lookupByRID(database.newRID(from), false).asVertex(false);
       final MutableEdge edge = fromVertex.newEdge(typeName, database.newRID(to));
       edge.set(properties);
@@ -416,7 +524,94 @@ public class WebSocketInsertSession {
       document.set(properties);
       document.save();
     }
-    counts.inserted++;
+  }
+
+  /**
+   * Matches an existing record of {@code typeName} on the session's key columns and merges the incoming values
+   * onto it: the {@code updateColumnsOnConflict} when the session names some, every non-key property sent
+   * otherwise. A property whose incoming value is absent or null is left as it is, so nothing can be nulled
+   * through this path; an edge's endpoints are never rewritten, because {@code set()} would bypass the graph
+   * engine's edge-list bookkeeping. The same rules as gRPC's {@code applyConflictUpdates}.
+   *
+   * @return {@code false} when no record matched, in which case the caller inserts
+   */
+  private boolean updateExisting(final String typeName, final Map<String, Object> properties, final boolean isEdge) {
+    try (final ResultSet rs = lookupByKey(typeName, properties)) {
+      if (!rs.hasNext())
+        return false;
+
+      final Result match = rs.next();
+      if (!match.isElement())
+        return false;
+
+      final MutableDocument existing = match.getElement().get().asDocument().modify();
+
+      final boolean mergeAll = options.updateColumnsOnConflict.isEmpty();
+      final Iterable<String> columns = mergeAll ? properties.keySet() : options.updateColumnsOnConflict;
+      for (final String column : columns) {
+        if (column.startsWith("@"))
+          continue;
+        if (mergeAll && options.keyColumnSet.contains(column))
+          continue;
+        if (isEdge && (OUT_KEY.equals(column) || IN_KEY.equals(column)))
+          continue;
+        final Object value = properties.get(column);
+        if (value == null)
+          continue;
+        existing.set(column, value);
+      }
+      existing.save();
+      return true;
+    }
+  }
+
+  /** @return the record of {@code typeName} carrying this row's key values, or {@code null} when there is none */
+  private RID findByKey(final String typeName, final Map<String, Object> properties) {
+    if (options.keyColumns.isEmpty())
+      return null;
+    try (final ResultSet rs = lookupByKey(typeName, properties)) {
+      return rs.hasNext() ? rs.next().getIdentity().orElse(null) : null;
+    }
+  }
+
+  /**
+   * {@code SELECT FROM type WHERE k1 = ? AND k2 = ?} on the session's key columns. Identifiers are
+   * backtick-quoted so a client-supplied name cannot inject SQL; the values stay parameters.
+   */
+  private ResultSet lookupByKey(final String typeName, final Map<String, Object> properties) {
+    final List<String> keys = options.keyColumns;
+    final StringBuilder sql = new StringBuilder("SELECT FROM ").append(Identifier.quote(typeName)).append(" WHERE ");
+    final Object[] params = new Object[keys.size()];
+    for (int i = 0; i < params.length; i++) {
+      if (i > 0)
+        sql.append(" AND ");
+      sql.append(Identifier.quote(keys.get(i))).append(" = ?");
+      params[i] = properties.get(keys.get(i));
+    }
+    return database.query("sql", sql.toString(), params);
+  }
+
+  private String keyValues(final Map<String, Object> properties) {
+    final List<String> keys = options.keyColumns;
+    final Object[] values = new Object[keys.size()];
+    for (int i = 0; i < values.length; i++)
+      values[i] = properties.get(keys.get(i));
+    return Arrays.toString(values);
+  }
+
+  /**
+   * Tells the operator, once per session, that the endpoints named in {@code updateColumnsOnConflict} are not
+   * going to be rewritten, rather than dropping them silently. Same warning gRPC logs for an edge target.
+   */
+  private void warnAboutEdgeEndpointUpdateColumns(final String typeName) {
+    if (warnedEdgeEndpointUpdateColumns || options.conflictMode != InsertSessionOptions.ConflictMode.UPDATE)
+      return;
+    if (!options.updateColumnsOnConflict.contains(OUT_KEY) && !options.updateColumnsOnConflict.contains(IN_KEY))
+      return;
+    warnedEdgeEndpointUpdateColumns = true;
+    LogManager.instance().log(this, Level.WARNING,
+        "/ws insert session %s: upsert on edge type '%s' ignores 'out'/'in' in updateColumnsOnConflict (edge endpoints cannot be re-pointed by an upsert)",
+        id, typeName);
   }
 
   private static String firstNonBlank(final String first, final String second) {
@@ -446,7 +641,18 @@ public class WebSocketInsertSession {
 
     private void fail(final int rowIndex, final Exception e) {
       failed++;
-      errors.put(error(rowIndex, "DB_ERROR", e));
+      errors.put(error(rowIndex, codeOf(e), e));
+    }
+
+    /** A row refused because its key is already taken: the {@code CONFLICT} code of the gRPC {@code InsertError}. */
+    private void conflict(final int rowIndex, final DuplicatedKeyException e) {
+      failed++;
+      errors.put(error(rowIndex, "CONFLICT", e));
+    }
+
+    /** A duplicate the engine reported on a commit rather than on a row is still a conflict, not a server fault. */
+    private static String codeOf(final Exception e) {
+      return e instanceof DuplicatedKeyException ? "CONFLICT" : "DB_ERROR";
     }
 
     /**
@@ -461,7 +667,7 @@ public class WebSocketInsertSession {
       failed = rows;
       wholeChunkFailed = true;
       errors = new JSONArray();
-      errors.put(error(-1, "DB_ERROR", e));
+      errors.put(error(-1, codeOf(e), e));
     }
 
     private static JSONObject error(final int rowIndex, final String code, final Exception e) {

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSession.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSession.java
@@ -114,7 +114,12 @@ public class WebSocketInsertSession {
     }
   }
 
-  public void setChannel(final WebSocketChannel channel) {
+  /**
+   * Attaches the connection the session belongs to. Called by {@link WebSocketInsertSessionManager#start} BEFORE
+   * the session is registered, so the idle sweep can never find a registered session with no channel to dispatch
+   * its expiry to - and therefore never has to run a rollback on the one sweep thread for the whole server.
+   */
+  void setChannel(final WebSocketChannel channel) {
     this.channel = channel;
   }
 
@@ -138,6 +143,14 @@ public class WebSocketInsertSession {
    * rest of the chunk still goes in, because a duplex session exists so the client can decide what to do about a
    * partial chunk rather than have the server decide by aborting.
    * <p>
+   * What "applied" means differs by transaction mode, and the difference is visible to a client that replays.
+   * Under {@code PER_STREAM} and {@code PER_BATCH} the chunk is all-or-nothing, so a chunk whose transaction failed
+   * leaves the watermark where it was and replaying that sequence applies it. Under {@code PER_ROW} every row
+   * commits on its own, so no chunk is all-or-nothing and the watermark advances on any chunk that was tried -
+   * including one whose rows ALL failed. Resending that sequence is answered as a replay rather than retried; a
+   * client that wants a failed row in resends it under a new sequence, reading which rows off {@code errors[]}.
+   * Retrying the whole chunk instead would double-apply the rows of it that had succeeded.
+   * <p>
    * Anything else - a sequence that skips ahead of the next one due - is REFUSED. A watermark that simply
    * follows whatever arrives would jump to 5 when a client sent chunk 5 before chunk 2, and chunk 2 would then
    * be acknowledged as a replay of something that never happened: every row it carried silently dropped, with a
@@ -148,6 +161,9 @@ public class WebSocketInsertSession {
     lock.lock();
     try {
       requireOpen();
+      // Stamped on entry as well as on the way out: a frame that throws - a skipped sequence, a malformed record -
+      // never reaches the closing stamp, and a client whose chunks are being refused is still a client using the
+      // session. Without this, a run of refusals would let the idle sweep roll the session back underneath it.
       lastUsed = System.currentTimeMillis();
 
       final JSONObject ack = new JSONObject();
@@ -212,6 +228,8 @@ public class WebSocketInsertSession {
       failed += counts.failed;
       // The watermark advances only on a chunk that was applied without a whole-chunk failure, so a client that
       // replays a chunk whose transaction never committed gets it applied rather than acknowledged as a duplicate.
+      // Only PER_STREAM and PER_BATCH can report a whole-chunk failure: PER_ROW commits row by row, so it advances
+      // even when every row failed, and the client resends those rows under a new sequence. See the javadoc.
       if (!counts.wholeChunkFailed)
         watermark = chunkSeq;
 

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSession.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSession.java
@@ -36,6 +36,7 @@ import io.undertow.websockets.core.WebSocketChannel;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 
 /**
  * One duplex insert session opened on {@code /ws} by a {@code start} frame (issue #7382). Mirrors the state the
@@ -170,10 +171,10 @@ public class WebSocketInsertSession {
         case PER_STREAM -> applyRows(records, rows, counts);
         case PER_BATCH -> {
           try {
-            database.transaction(() -> applyRows(records, rows, counts));
+            counts.absorb(inOwnTransaction(attempt -> applyRows(records, rows, attempt)));
           } catch (final Exception e) {
             // The chunk's own transaction failed to commit, so nothing in it is durable. Report the whole chunk
-            // as failed - the per-row tallies applyRows produced describe a transaction that no longer exists.
+            // as failed - the per-row tallies the attempts produced describe transactions that no longer exist.
             counts.resetToWholeChunkFailure(rows, e);
           }
         }
@@ -181,7 +182,7 @@ public class WebSocketInsertSession {
           for (int i = 0; i < rows; i++) {
             final int row = i;
             try {
-              database.transaction(() -> applyRow(records.getJSONObject(row), row, counts));
+              counts.absorb(inOwnTransaction(attempt -> applyRow(records.getJSONObject(row), row, attempt)));
             } catch (final Exception e) {
               counts.fail(row, e);
             }
@@ -338,6 +339,28 @@ public class WebSocketInsertSession {
       throw new IllegalStateException("Insert session '" + id + "' is closed");
   }
 
+  /**
+   * Runs {@code work} inside a transaction of its own and returns the tallies of the attempt that COMMITTED.
+   * <p>
+   * {@link com.arcadedb.database.Database#transaction(com.arcadedb.database.Database.TransactionScope)} re-runs
+   * its block up to {@code arcadedb.txRetries} times when the commit hits a transient conflict, and this engine
+   * conflicts at page granularity, so under concurrent load that is an ordinary outcome rather than an exotic
+   * one. Every attempt therefore gets a FRESH {@link ChunkCounts}: a single accumulator shared across attempts
+   * counts every row of every attempt, so a chunk that landed once, correctly, on the second try would be
+   * acknowledged with twice its true {@code inserted} and a duplicate entry per {@code errors} row - and a
+   * bulk-load protocol whose whole value is a trustworthy acknowledgement cannot afford that. The tallies of the
+   * abandoned attempts are dropped with the transaction that produced them.
+   */
+  private ChunkCounts inOwnTransaction(final Consumer<ChunkCounts> work) {
+    final ChunkCounts[] committed = new ChunkCounts[1];
+    database.transaction(() -> {
+      final ChunkCounts attempt = new ChunkCounts();
+      committed[0] = attempt;
+      work.accept(attempt);
+    });
+    return committed[0];
+  }
+
   private void applyRows(final JSONArray records, final int rows, final ChunkCounts counts) {
     for (int i = 0; i < rows; i++)
       try {
@@ -399,6 +422,16 @@ public class WebSocketInsertSession {
     private       long      ignored;
     private       long      failed;
     private       boolean   wholeChunkFailed;
+
+    /** Adds the tallies of a committed attempt to the chunk's running totals. */
+    private void absorb(final ChunkCounts other) {
+      inserted += other.inserted;
+      updated += other.updated;
+      ignored += other.ignored;
+      failed += other.failed;
+      for (final Object error : other.errors)
+        errors.put(error);
+    }
 
     private void fail(final int rowIndex, final Exception e) {
       failed++;

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSession.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSession.java
@@ -469,7 +469,7 @@ public class WebSocketInsertSession {
     try {
       switch (options.conflictMode) {
       case UPDATE -> {
-        if (updateExisting(typeName, properties, isEdge)) {
+        if (updateExisting(typeName, properties)) {
           counts.updated++;
           return;
         }
@@ -498,7 +498,7 @@ public class WebSocketInsertSession {
       // it rather than lose the row. If the match is gone again (a transient window), or a third writer races
       // the retry too, it is a retriable CONFLICT. Anything else is a real failure, not a conflict.
       case UPDATE -> {
-        if (updateExisting(typeName, properties, isEdge))
+        if (updateExisting(typeName, properties))
           counts.updated++;
         else
           throw dup;
@@ -530,12 +530,15 @@ public class WebSocketInsertSession {
    * Matches an existing record of {@code typeName} on the session's key columns and merges the incoming values
    * onto it: the {@code updateColumnsOnConflict} when the session names some, every non-key property sent
    * otherwise. A property whose incoming value is absent or null is left as it is, so nothing can be nulled
-   * through this path; an edge's endpoints are never rewritten, because {@code set()} would bypass the graph
-   * engine's edge-list bookkeeping. The same rules as gRPC's {@code applyConflictUpdates}.
+   * through this path. An edge's endpoints are never rewritten - {@code set()} would bypass the graph engine's
+   * edge-list bookkeeping - which needs no check here: {@link #applyRow} strips {@code @from}/{@code @to} and
+   * {@code out}/{@code in} out of {@code properties} before this runs, so naming them in
+   * {@code updateColumnsOnConflict} finds no value and is skipped like any absent column. The same rules as
+   * gRPC's {@code applyConflictUpdates}.
    *
    * @return {@code false} when no record matched, in which case the caller inserts
    */
-  private boolean updateExisting(final String typeName, final Map<String, Object> properties, final boolean isEdge) {
+  private boolean updateExisting(final String typeName, final Map<String, Object> properties) {
     try (final ResultSet rs = lookupByKey(typeName, properties)) {
       if (!rs.hasNext())
         return false;
@@ -552,8 +555,6 @@ public class WebSocketInsertSession {
         if (column.startsWith("@"))
           continue;
         if (mergeAll && options.keyColumnSet.contains(column))
-          continue;
-        if (isEdge && (OUT_KEY.equals(column) || IN_KEY.equals(column)))
           continue;
         final Object value = properties.get(column);
         if (value == null)

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSessionManager.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSessionManager.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.ws.insert;
+
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.security.ServerSecurityUser;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+
+/**
+ * Registry of the duplex insert sessions open on {@code /ws} (issue #7382).
+ * <p>
+ * A session is identified by an id the client may choose or leave to the server, and lives until the client ends
+ * it with a {@code commit} or {@code rollback} frame. Every other way it can end - the connection dropping, the
+ * idle sweep, the server stopping - rolls it back, because none of them is the client saying what it wanted.
+ * <p>
+ * At most ONE session is open per WebSocket channel at a time, which is the constraint gRPC gets for free (a
+ * session there IS a stream). It bounds the number of live transactions by the number of connections instead of
+ * leaving it to whatever a client chooses to open, and it makes "the same session id is rejected by a second
+ * concurrent start" true for both shapes of the race: a second {@code start} on the same channel, and one on a
+ * different channel naming an id that is already taken.
+ *
+ * @author Arcade Data Ltd
+ */
+public class WebSocketInsertSessionManager {
+  private final ArcadeDBServer                          server;
+  private final Map<String, WebSocketInsertSession>     sessions = new ConcurrentHashMap<>();
+  /** One session per channel, so a channel that opens a second one is refused rather than tracked. */
+  private final Map<UUID, String>                       byChannel = new ConcurrentHashMap<>();
+  private final long                                    idleTimeoutMs;
+  private final Timer                                   timer;
+  /** Set by {@link #close()}, so a frame racing the shutdown cannot open a session nothing will ever roll back. */
+  private volatile boolean                              closed;
+  /** Notified when a session is rolled back by something other than its own client, so the client can be told. */
+  private volatile ExpiryListener                       expiryListener = (session, reason) -> {
+  };
+
+  /** Called with a session the server ended on its own, so the protocol layer can push an unsolicited error. */
+  public interface ExpiryListener {
+    void onSessionCancelled(WebSocketInsertSession session, String reason);
+  }
+
+  public WebSocketInsertSessionManager(final ArcadeDBServer server, final long idleTimeoutMs) {
+    this.server = server;
+    this.idleTimeoutMs = idleTimeoutMs;
+
+    this.timer = new Timer("arcadedb-ws-insert-session-sweep", true);
+    this.timer.schedule(new TimerTask() {
+      @Override
+      public void run() {
+        try {
+          checkSessionsValidity();
+        } catch (final Exception e) {
+          LogManager.instance().log(this, Level.FINE, "Error on sweeping /ws insert sessions", e);
+        }
+      }
+    }, idleTimeoutMs, idleTimeoutMs);
+  }
+
+  public void setExpiryListener(final ExpiryListener expiryListener) {
+    this.expiryListener = expiryListener;
+  }
+
+  /**
+   * Opens a session and begins its transaction.
+   *
+   * @param requestedId the id the client asked for, or {@code null}/blank to have the server generate one
+   *
+   * @throws IllegalStateException    when the channel already has a session, or the requested id is taken
+   * @throws SecurityException        when the principal cannot access the database
+   * @throws IllegalArgumentException when the options are not ones this server implements
+   */
+  public WebSocketInsertSession start(final ServerSecurityUser user, final UUID channelId, final String databaseName,
+      final String requestedId, final JSONObject rawOptions) {
+    if (closed)
+      throw new IllegalStateException("The server is shutting down and is not opening new insert sessions");
+
+    if (databaseName == null || databaseName.isBlank())
+      throw new IllegalArgumentException("Property 'database' is required to start an insert session");
+
+    if (user == null || !user.canAccessToDatabase(databaseName))
+      throw new SecurityException("User does not have access to database '" + databaseName + "'.");
+
+    final InsertSessionOptions options = InsertSessionOptions.parse(rawOptions);
+
+    final String id = requestedId == null || requestedId.isBlank() ? UUID.randomUUID().toString() : requestedId;
+
+    // Claim the channel BEFORE the id: a client that pipelines two starts must be refused on the second one
+    // whichever id it chose, and claiming the id first would leave it registered to a session that is refused.
+    final String alreadyOnChannel = byChannel.putIfAbsent(channelId, id);
+    if (alreadyOnChannel != null)
+      throw new IllegalStateException(
+          "This connection already has insert session '" + alreadyOnChannel + "' open. Commit or roll it back first");
+
+    final DatabaseInternal database;
+    final WebSocketInsertSession session;
+    try {
+      database = server.getDatabase(databaseName, false, false);
+      session = new WebSocketInsertSession(id, database, user, channelId, options);
+
+      if (sessions.putIfAbsent(id, session) != null)
+        throw new IllegalStateException("Insert session '" + id + "' already exists");
+    } catch (final RuntimeException e) {
+      byChannel.remove(channelId, id);
+      throw e;
+    }
+
+    try {
+      session.begin();
+    } catch (final RuntimeException e) {
+      sessions.remove(id, session);
+      byChannel.remove(channelId, id);
+      throw e;
+    }
+
+    return session;
+  }
+
+  /**
+   * Resolves a session for a frame that claims to belong to it. A session is only reachable from the connection
+   * that opened it and by the principal that opened it: a frame that names someone else's session is refused
+   * rather than served, the same rule {@code HttpSessionManager.getSessionById} enforces for {@code /begin}
+   * transactions.
+   */
+  public WebSocketInsertSession resolve(final ServerSecurityUser user, final UUID channelId, final String sessionId) {
+    if (sessionId == null || sessionId.isBlank())
+      throw new IllegalArgumentException("Property 'sessionId' is required");
+
+    final WebSocketInsertSession session = sessions.get(sessionId);
+    if (session == null || session.isClosed())
+      throw new IllegalStateException("Insert session '" + sessionId + "' not found or expired");
+
+    if (!session.channelId.equals(channelId))
+      throw new SecurityException("Insert session '" + sessionId + "' belongs to another connection");
+
+    if (user == null || !user.equals(session.user))
+      throw new SecurityException("Insert session '" + sessionId + "' belongs to another user");
+
+    return session;
+  }
+
+  /** Ends a session the client itself terminated, and answers with the {@code committed} frame. */
+  public JSONObject finish(final WebSocketInsertSession session, final boolean commit) {
+    try {
+      return session.finish(commit);
+    } finally {
+      unregister(session);
+    }
+  }
+
+  /**
+   * Rolls back and forgets every session opened on a channel. Called when the connection closes, whether the
+   * client said goodbye or the socket simply went away.
+   */
+  public void closeChannelSessions(final UUID channelId) {
+    final String sessionId = byChannel.remove(channelId);
+    if (sessionId == null)
+      return;
+
+    final WebSocketInsertSession session = sessions.remove(sessionId);
+    if (session != null && session.cancel())
+      LogManager.instance().log(this, Level.FINE,
+          "Rolled back /ws insert session %s: its connection closed before it was committed", sessionId);
+  }
+
+  /**
+   * Rolls back every session idle for longer than the configured timeout, notifying the client of each. Package
+   * visibility is deliberate: the sweep is also the unit-testable seam for "an abandoned session does not hold a
+   * transaction open forever".
+   *
+   * @return how many sessions were expired
+   */
+  public int checkSessionsValidity() {
+    if (sessions.isEmpty())
+      return 0;
+
+    final List<WebSocketInsertSession> expired = new ArrayList<>();
+    for (final WebSocketInsertSession session : sessions.values())
+      if (session.elapsedFromLastUse() > idleTimeoutMs)
+        expired.add(session);
+
+    int count = 0;
+    for (final WebSocketInsertSession session : expired) {
+      // Roll it back BEFORE forgetting it, and only if it is genuinely idle: a session whose frame is still
+      // running is left registered so the next tick can look again. Removing it first and then finding it busy
+      // would untrack a live transaction that nothing else would ever roll back.
+      final WebSocketInsertSession.CancelOutcome outcome = session.cancelIfIdle();
+      if (outcome == WebSocketInsertSession.CancelOutcome.BUSY)
+        continue;
+
+      sessions.remove(session.id, session);
+      byChannel.remove(session.channelId, session.id);
+
+      if (outcome == WebSocketInsertSession.CancelOutcome.CANCELLED) {
+        count++;
+        LogManager.instance().log(this, Level.FINE, "Rolled back /ws insert session %s after %dms of inactivity",
+            session.id, idleTimeoutMs);
+        try {
+          expiryListener.onSessionCancelled(session,
+              "Insert session '" + session.id + "' was rolled back after " + idleTimeoutMs + "ms of inactivity");
+        } catch (final Exception e) {
+          // Best effort: the connection this session belonged to may already be gone.
+        }
+      }
+    }
+    return count;
+  }
+
+  /** Rolls back every open session. The server is stopping, so no client is going to say what it wanted. */
+  public void close() {
+    closed = true;
+    timer.cancel();
+    for (final WebSocketInsertSession session : new ArrayList<>(sessions.values())) {
+      sessions.remove(session.id, session);
+      byChannel.remove(session.channelId, session.id);
+      session.cancel();
+    }
+  }
+
+  public int getOpenSessionCount() {
+    return sessions.size();
+  }
+
+  private void unregister(final WebSocketInsertSession session) {
+    sessions.remove(session.id, session);
+    byChannel.remove(session.channelId, session.id);
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSessionManager.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSessionManager.java
@@ -94,14 +94,16 @@ public class WebSocketInsertSessionManager {
   /**
    * Opens a session and begins its transaction.
    *
+   * @param channel     the connection the session belongs to, attached before the session is registered so the
+   *                    idle sweep always has a worker to dispatch an expiry to
    * @param requestedId the id the client asked for, or {@code null}/blank to have the server generate one
    *
    * @throws IllegalStateException    when the channel already has a session, or the requested id is taken
    * @throws SecurityException        when the principal cannot access the database
    * @throws IllegalArgumentException when the options are not ones this server implements
    */
-  public WebSocketInsertSession start(final ServerSecurityUser user, final UUID channelId, final String databaseName,
-      final String requestedId, final JSONObject rawOptions) {
+  public WebSocketInsertSession start(final ServerSecurityUser user, final WebSocketChannel channel,
+      final UUID channelId, final String databaseName, final String requestedId, final JSONObject rawOptions) {
     if (closed)
       throw new IllegalStateException("The server is shutting down and is not opening new insert sessions");
 
@@ -127,6 +129,9 @@ public class WebSocketInsertSessionManager {
     try {
       database = server.getDatabase(databaseName, false, false);
       session = new WebSocketInsertSession(id, database, user, channelId, options);
+      // Before it is registered, not after: a session the sweep can see must already know where to send its
+      // expiry, or the sweep would have nothing to dispatch to and would roll it back on its own thread.
+      session.setChannel(channel);
 
       if (sessions.putIfAbsent(id, session) != null)
         throw new IllegalStateException("Insert session '" + id + "' already exists");
@@ -218,14 +223,19 @@ public class WebSocketInsertSessionManager {
 
   private void dispatchExpiry(final WebSocketInsertSession session) {
     final WebSocketChannel channel = session.getChannel();
-    if (channel != null)
-      try {
-        channel.getWorker().execute(() -> expire(session));
-        return;
-      } catch (final RejectedExecutionException e) {
-        // The worker is going away: expire here rather than not at all.
-      }
-    expire(session);
+    if (channel == null)
+      // Not reachable: start() attaches the channel before registering the session. Left as a skip rather than a
+      // fallback because the fallback would be to expire on the sweep thread, which is the one thing this class
+      // promises not to do; a session somehow without a channel is left for the next tick instead.
+      return;
+
+    try {
+      channel.getWorker().execute(() -> expire(session));
+    } catch (final RejectedExecutionException e) {
+      // The worker is going away with the connection: expire here rather than not at all. Bounded by that
+      // connection dying, unlike the missing-channel case above, which would repeat every tick.
+      expire(session);
+    }
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSessionManager.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSessionManager.java
@@ -60,7 +60,8 @@ public class WebSocketInsertSessionManager {
   private volatile boolean                              closed;
   /**
    * Notified when a session is rolled back by something other than its own client, so the client can be told.
-   * Its write is one of several independent senders on a {@code /ws} channel, which is issue #7423.
+   * Its write is one of several independent senders on a {@code /ws} channel; {@code WebSocketFrameSender}
+   * records why they need no lock between them (issue #7423).
    */
   private volatile ExpiryListener                       expiryListener = (session, reason) -> {
   };

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSessionManager.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSessionManager.java
@@ -23,14 +23,15 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.security.ServerSecurityUser;
+import io.undertow.websockets.core.WebSocketChannel;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.logging.Level;
 
 /**
@@ -57,7 +58,10 @@ public class WebSocketInsertSessionManager {
   private final Timer                                   timer;
   /** Set by {@link #close()}, so a frame racing the shutdown cannot open a session nothing will ever roll back. */
   private volatile boolean                              closed;
-  /** Notified when a session is rolled back by something other than its own client, so the client can be told. */
+  /**
+   * Notified when a session is rolled back by something other than its own client, so the client can be told.
+   * Its write is one of several independent senders on a {@code /ws} channel, which is issue #7423.
+   */
   private volatile ExpiryListener                       expiryListener = (session, reason) -> {
   };
 
@@ -190,46 +194,65 @@ public class WebSocketInsertSessionManager {
   }
 
   /**
-   * Rolls back every session idle for longer than the configured timeout, notifying the client of each. Package
-   * visibility is deliberate: the sweep is also the unit-testable seam for "an abandoned session does not hold a
-   * transaction open forever".
+   * Hands every session idle for longer than the configured timeout to the worker pool to be rolled back and its
+   * client told. The sweep itself decides and dispatches only: rolling back a large {@code PER_STREAM}
+   * transaction and writing to a socket both take as long as they take, and there is one sweep thread for the
+   * whole server, so doing either here would delay every other session's expiry behind the slowest one. Same
+   * reason no frame is applied on the I/O thread.
    *
-   * @return how many sessions were expired
+   * @return how many sessions this tick handed over. A session that turns out to be busy is handed over and then
+   * left registered, so this counts decisions, not rollbacks
    */
   public int checkSessionsValidity() {
     if (sessions.isEmpty())
       return 0;
 
-    final List<WebSocketInsertSession> expired = new ArrayList<>();
-    for (final WebSocketInsertSession session : sessions.values())
-      if (session.elapsedFromLastUse() > idleTimeoutMs)
-        expired.add(session);
+    int dispatched = 0;
+    for (final WebSocketInsertSession session : new ArrayList<>(sessions.values()))
+      if (session.elapsedFromLastUse() > idleTimeoutMs) {
+        dispatched++;
+        dispatchExpiry(session);
+      }
+    return dispatched;
+  }
 
-    int count = 0;
-    for (final WebSocketInsertSession session : expired) {
-      // Roll it back BEFORE forgetting it, and only if it is genuinely idle: a session whose frame is still
-      // running is left registered so the next tick can look again. Removing it first and then finding it busy
-      // would untrack a live transaction that nothing else would ever roll back.
-      final WebSocketInsertSession.CancelOutcome outcome = session.cancelIfIdle();
-      if (outcome == WebSocketInsertSession.CancelOutcome.BUSY)
-        continue;
+  private void dispatchExpiry(final WebSocketInsertSession session) {
+    final WebSocketChannel channel = session.getChannel();
+    if (channel != null)
+      try {
+        channel.getWorker().execute(() -> expire(session));
+        return;
+      } catch (final RejectedExecutionException e) {
+        // The worker is going away: expire here rather than not at all.
+      }
+    expire(session);
+  }
 
-      sessions.remove(session.id, session);
-      byChannel.remove(session.channelId, session.id);
+  /**
+   * Rolls a session back BEFORE forgetting it, and only if it is genuinely idle: a session whose frame is still
+   * running is left registered so the next tick can look again. Removing it first and then finding it busy would
+   * untrack a live transaction that nothing else would ever roll back. Safe to run twice for the same session -
+   * a later tick can dispatch one that an earlier tick is still expiring - because only the call that actually
+   * closes it reports anything.
+   */
+  private void expire(final WebSocketInsertSession session) {
+    final WebSocketInsertSession.CancelOutcome outcome = session.cancelIfIdle();
+    if (outcome == WebSocketInsertSession.CancelOutcome.BUSY)
+      return;
 
-      if (outcome == WebSocketInsertSession.CancelOutcome.CANCELLED) {
-        count++;
-        LogManager.instance().log(this, Level.FINE, "Rolled back /ws insert session %s after %dms of inactivity",
-            session.id, idleTimeoutMs);
-        try {
-          expiryListener.onSessionCancelled(session,
-              "Insert session '" + session.id + "' was rolled back after " + idleTimeoutMs + "ms of inactivity");
-        } catch (final Exception e) {
-          // Best effort: the connection this session belonged to may already be gone.
-        }
+    sessions.remove(session.id, session);
+    byChannel.remove(session.channelId, session.id);
+
+    if (outcome == WebSocketInsertSession.CancelOutcome.CANCELLED) {
+      LogManager.instance().log(this, Level.FINE, "Rolled back /ws insert session %s after %dms of inactivity",
+          session.id, idleTimeoutMs);
+      try {
+        expiryListener.onSessionCancelled(session,
+            "Insert session '" + session.id + "' was rolled back after " + idleTimeoutMs + "ms of inactivity");
+      } catch (final Exception e) {
+        // Best effort: the connection this session belonged to may already be gone.
       }
     }
-    return count;
   }
 
   /** Rolls back every open session. The server is stopping, so no client is going to say what it wanted. */

--- a/server/src/test/java/com/arcadedb/server/http/ws/insert/InsertSessionOptionsTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/ws/insert/InsertSessionOptionsTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.ws.insert;
+
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The {@code options} of a {@code /ws} {@code start} frame (issue #7382), tested directly rather than through a
+ * live server: every branch here is a decision about what the session will DO with the load, and one that
+ * defaulted quietly where it should have refused would be answered with a perfectly successful-looking load run
+ * under a policy the client did not ask for. It also stays cheap to extend as more of {@code InsertOptions}
+ * arrives (issue #7404).
+ */
+class InsertSessionOptionsTest {
+
+  @Test
+  void noOptionsAtAllMeansOneTransactionForTheWholeSession() {
+    final InsertSessionOptions options = InsertSessionOptions.parse(null);
+    assertThat(options.transactionMode).isEqualTo(InsertSessionOptions.TransactionMode.PER_STREAM);
+    assertThat(options.transactionModeName()).isEqualTo("per_stream");
+    assertThat(options.targetType).isNull();
+  }
+
+  @Test
+  void anEmptyOptionsObjectMeansTheSameThing() {
+    assertThat(InsertSessionOptions.parse(new JSONObject()).transactionMode)
+        .isEqualTo(InsertSessionOptions.TransactionMode.PER_STREAM);
+  }
+
+  @Test
+  void theTargetTypeIsCarried() {
+    assertThat(InsertSessionOptions.parse(new JSONObject().put("targetType", "Person")).targetType).isEqualTo("Person");
+  }
+
+  @Test
+  void everyTransactionModeIsAcceptedInAnyCase() {
+    assertThat(InsertSessionOptions.parse(new JSONObject().put("transactionMode", "per_batch")).transactionMode)
+        .isEqualTo(InsertSessionOptions.TransactionMode.PER_BATCH);
+    assertThat(InsertSessionOptions.parse(new JSONObject().put("transactionMode", "PER_ROW")).transactionMode)
+        .isEqualTo(InsertSessionOptions.TransactionMode.PER_ROW);
+    assertThat(InsertSessionOptions.parse(new JSONObject().put("transactionMode", "  Per_Stream  ")).transactionMode)
+        .isEqualTo(InsertSessionOptions.TransactionMode.PER_STREAM);
+  }
+
+  /** gRPC's name for the same thing: a {@code /ws} session IS the request, so the two cannot differ here. */
+  @Test
+  void perRequestIsAnAliasOfPerStreamAndEchoesBackAsPerStream() {
+    final InsertSessionOptions options = InsertSessionOptions.parse(new JSONObject().put("transactionMode", "per_request"));
+    assertThat(options.transactionMode).isEqualTo(InsertSessionOptions.TransactionMode.PER_STREAM);
+    assertThat(options.transactionModeName()).isEqualTo("per_stream");
+  }
+
+  @Test
+  void aBlankTransactionModeFallsBackToTheDefaultRatherThanFailing() {
+    assertThat(InsertSessionOptions.parse(new JSONObject().put("transactionMode", "   ")).transactionMode)
+        .isEqualTo(InsertSessionOptions.TransactionMode.PER_STREAM);
+  }
+
+  @Test
+  void anUnknownTransactionModeIsRefusedAndTheMessageListsTheRealOnes() {
+    assertThatThrownBy(() -> InsertSessionOptions.parse(new JSONObject().put("transactionMode", "whenever")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("whenever")
+        .hasMessageContaining("per_stream")
+        .hasMessageContaining("per_batch")
+        .hasMessageContaining("per_row");
+  }
+
+  /** {@code none} means "the caller manages the transaction", which a /ws session cannot name yet (#7403). */
+  @Test
+  void transactionModeNoneIsRefusedWithThePointerToItsIssue() {
+    assertThatThrownBy(() -> InsertSessionOptions.parse(new JSONObject().put("transactionMode", "none")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("#7403");
+  }
+
+  /**
+   * The four gRPC-only options are refused, not ignored: a loader ported from {@code InsertBidirectional} that
+   * asked for upserts must not silently get plain inserts (#7404).
+   */
+  @Test
+  void everyOptionThisServerDoesNotImplementIsRefusedByName() {
+    assertThatThrownBy(() -> InsertSessionOptions.parse(new JSONObject().put("conflictMode", "update")))
+        .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("conflictMode").hasMessageContaining("#7404");
+    assertThatThrownBy(() -> InsertSessionOptions.parse(new JSONObject().put("keyColumns", new JSONArray().put("id"))))
+        .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("keyColumns");
+    assertThatThrownBy(
+        () -> InsertSessionOptions.parse(new JSONObject().put("updateColumnsOnConflict", new JSONArray().put("name"))))
+        .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("updateColumnsOnConflict");
+    assertThatThrownBy(() -> InsertSessionOptions.parse(new JSONObject().put("validateOnly", true)))
+        .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("validateOnly");
+  }
+
+  /** An explicit JSON null is "not set", not "set to something unsupported". */
+  @Test
+  void anExplicitNullForAnUnsupportedOptionIsNotTreatedAsAskingForIt() {
+    final JSONObject options = new JSONObject().put("targetType", "Person");
+    options.put("conflictMode", (Object) null);
+    assertThat(InsertSessionOptions.parse(options).targetType).isEqualTo("Person");
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/ws/insert/InsertSessionOptionsTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/ws/insert/InsertSessionOptionsTest.java
@@ -101,23 +101,82 @@ class InsertSessionOptionsTest {
    * asked for upserts must not silently get plain inserts (#7404).
    */
   @Test
-  void everyOptionThisServerDoesNotImplementIsRefusedByName() {
-    assertThatThrownBy(() -> InsertSessionOptions.parse(new JSONObject().put("conflictMode", "update")))
-        .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("conflictMode").hasMessageContaining("#7404");
-    assertThatThrownBy(() -> InsertSessionOptions.parse(new JSONObject().put("keyColumns", new JSONArray().put("id"))))
-        .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("keyColumns");
-    assertThatThrownBy(
-        () -> InsertSessionOptions.parse(new JSONObject().put("updateColumnsOnConflict", new JSONArray().put("name"))))
-        .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("updateColumnsOnConflict");
-    assertThatThrownBy(() -> InsertSessionOptions.parse(new JSONObject().put("validateOnly", true)))
-        .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("validateOnly");
+  void noConflictOptionsMeansErrorOnADuplicateWithNoKeyColumnsAndNoDryRun() {
+    final InsertSessionOptions options = InsertSessionOptions.parse(new JSONObject().put("targetType", "Person"));
+    assertThat(options.conflictMode).isEqualTo(InsertSessionOptions.ConflictMode.ERROR);
+    assertThat(options.conflictModeName()).isEqualTo("error");
+    assertThat(options.keyColumns).isEmpty();
+    assertThat(options.updateColumnsOnConflict).isEmpty();
+    assertThat(options.validateOnly).isFalse();
   }
 
-  /** An explicit JSON null is "not set", not "set to something unsupported". */
+  /** Issue #7404: the four gRPC conflict options are honoured, in either the short or the gRPC spelling. */
   @Test
-  void anExplicitNullForAnUnsupportedOptionIsNotTreatedAsAskingForIt() {
+  void everyConflictModeIsAcceptedInEitherSpelling() {
+    final JSONArray key = new JSONArray().put("id");
+    assertThat(InsertSessionOptions.parse(new JSONObject().put("conflictMode", "update").put("keyColumns", key)).conflictMode)
+        .isEqualTo(InsertSessionOptions.ConflictMode.UPDATE);
+    assertThat(InsertSessionOptions.parse(new JSONObject().put("conflictMode", "CONFLICT_UPDATE").put("keyColumns", key)).conflictMode)
+        .isEqualTo(InsertSessionOptions.ConflictMode.UPDATE);
+    assertThat(InsertSessionOptions.parse(new JSONObject().put("conflictMode", " Ignore ")).conflictMode)
+        .isEqualTo(InsertSessionOptions.ConflictMode.IGNORE);
+    assertThat(InsertSessionOptions.parse(new JSONObject().put("conflictMode", "conflict_abort")).conflictMode)
+        .isEqualTo(InsertSessionOptions.ConflictMode.ABORT);
+    assertThat(InsertSessionOptions.parse(new JSONObject().put("conflictMode", "error")).conflictMode)
+        .isEqualTo(InsertSessionOptions.ConflictMode.ERROR);
+  }
+
+  @Test
+  void keyColumnsUpdateColumnsAndValidateOnlyAreCarried() {
+    final InsertSessionOptions options = InsertSessionOptions.parse(new JSONObject().put("conflictMode", "update")
+        .put("keyColumns", new JSONArray().put("id").put("tenant"))
+        .put("updateColumnsOnConflict", new JSONArray().put("name"))
+        .put("validateOnly", true));
+    assertThat(options.keyColumns).containsExactly("id", "tenant");
+    assertThat(options.keyColumnSet).containsExactlyInAnyOrder("id", "tenant");
+    assertThat(options.updateColumnsOnConflict).containsExactly("name");
+    assertThat(options.validateOnly).isTrue();
+  }
+
+  @Test
+  void anUnknownConflictModeIsRefusedAndTheMessageListsTheRealOnes() {
+    assertThatThrownBy(() -> InsertSessionOptions.parse(new JSONObject().put("conflictMode", "merge")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("merge")
+        .hasMessageContaining("update")
+        .hasMessageContaining("ignore");
+  }
+
+  /**
+   * gRPC accepts an update mode with no key columns and then reports every duplicate as a CONFLICT, because it
+   * has nothing to match the existing record on. A session that can never perform the update it asked for is
+   * refused up front instead.
+   */
+  @Test
+  void updateWithoutKeyColumnsIsRefusedAtStart() {
+    assertThatThrownBy(() -> InsertSessionOptions.parse(new JSONObject().put("conflictMode", "update")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("keyColumns");
+  }
+
+  @Test
+  void aBlankOrNonStringKeyColumnIsRefusedByName() {
+    assertThatThrownBy(() -> InsertSessionOptions.parse(new JSONObject().put("keyColumns", new JSONArray().put("id").put(" "))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("keyColumns");
+    assertThatThrownBy(() -> InsertSessionOptions.parse(new JSONObject().put("updateColumnsOnConflict", new JSONArray().put(42))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("updateColumnsOnConflict");
+  }
+
+  @Test
+  void anExplicitNullForAConflictOptionMeansItsDefault() {
     final JSONObject options = new JSONObject().put("targetType", "Person");
     options.put("conflictMode", (Object) null);
-    assertThat(InsertSessionOptions.parse(options).targetType).isEqualTo("Person");
+    options.put("keyColumns", (Object) null);
+    final InsertSessionOptions parsed = InsertSessionOptions.parse(options);
+    assertThat(parsed.targetType).isEqualTo("Person");
+    assertThat(parsed.conflictMode).isEqualTo(InsertSessionOptions.ConflictMode.ERROR);
+    assertThat(parsed.keyColumns).isEmpty();
   }
 }

--- a/server/src/test/java/com/arcadedb/server/ws/WebSocketClientHelper.java
+++ b/server/src/test/java/com/arcadedb/server/ws/WebSocketClientHelper.java
@@ -56,11 +56,22 @@ public class WebSocketClientHelper implements AutoCloseable {
   private final XnioWorker                 worker;
   private final ByteBufferPool             pool         = new DefaultByteBufferPool(true, BUFFER_SIZE, 1000, 10, 100);
   private final WebSocketChannel           channel;
-  private final ArrayBlockingQueue<String> messageQueue = new ArrayBlockingQueue<>(20);
+  private final ArrayBlockingQueue<String> messageQueue;
 
   private static final int DEFAULT_DELAY = 5_000;
 
   public WebSocketClientHelper(final String uri, final String user, final String pass) throws URISyntaxException, IOException {
+    this(uri, user, pass, 20);
+  }
+
+  /**
+   * @param queueCapacity how many frames the client keeps before dropping the next one on the floor. The default
+   *                      of 20 fits a request/answer exchange; a test that has the server push a change stream
+   *                      at the client while it drives its own frames needs room for all of them
+   */
+  public WebSocketClientHelper(final String uri, final String user, final String pass, final int queueCapacity)
+      throws URISyntaxException, IOException {
+    this.messageQueue = new ArrayBlockingQueue<>(queueCapacity);
     final Xnio xnio = Xnio.getInstance(BaseGraphServerTest.class.getClassLoader());
     worker = xnio.createWorker(OptionMap.builder()//
         .set(Options.WORKER_IO_THREADS, 4)//
@@ -115,9 +126,14 @@ public class WebSocketClientHelper implements AutoCloseable {
   }
 
   public String send(final String payload) throws URISyntaxException, IOException {
+    sendWithoutWaiting(payload);
+    return this.popMessage(DEFAULT_DELAY);
+  }
+
+  /** Queues a frame and returns at once, for a test that pipelines frames or reads the answers separately. */
+  public void sendWithoutWaiting(final String payload) throws IOException {
     final var sendChannel = this.channel.send(WebSocketFrameType.TEXT);
     new StringWriteChannelListener(payload).setup(sendChannel);
-    return this.popMessage(DEFAULT_DELAY);
   }
 
   public String popMessage() {

--- a/server/src/test/java/com/arcadedb/server/ws/WebSocketConcurrentSendersIT.java
+++ b/server/src/test/java/com/arcadedb/server/ws/WebSocketConcurrentSendersIT.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ws;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.http.ws.WebSocketFrameSender;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7423: one {@code /ws} connection with three independent senders - the change-stream fan-out on the
+ * database watcher thread, the insert session's answers on an Undertow worker thread, and the subscription
+ * acknowledgement on the I/O thread - and nothing of ours serializing them. Every frame the client receives
+ * must still be one complete JSON object; {@link WebSocketFrameSender} records why Undertow guarantees that.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class WebSocketConcurrentSendersIT extends BaseGraphServerTest {
+  private static final int CHUNKS          = 40;
+  private static final int ROWS_PER_CHUNK  = 5;
+  private static final int BACKGROUND_ROWS = 300;
+
+  @Test
+  void changeEventsAndBatchAcksInterleaveOnOneConnectionAsWholeFrames() throws Throwable {
+    final Database database = getServerDatabase(0, getDatabaseName());
+    final int expectedEvents = BACKGROUND_ROWS + CHUNKS * ROWS_PER_CHUNK;
+
+    final String url = "ws://localhost:" + getServer(0).getHttpServer().getPort() + "/ws";
+    try (final var client = new WebSocketClientHelper(url, "root", DEFAULT_PASSWORD_FOR_TESTS, expectedEvents + CHUNKS + 16)) {
+      final JSONObject subscribed = new JSONObject(client.send(new JSONObject().put("action", "subscribe")
+          .put("database", getDatabaseName()).put("type", "Person").toString()));
+      assertThat(subscribed.getString("result", "")).isEqualTo("ok");
+
+      final JSONObject started = new JSONObject(client.send(new JSONObject().put("action", "start")
+          .put("database", getDatabaseName())
+          .put("options", new JSONObject().put("targetType", "Person").put("transactionMode", "per_batch")).toString()));
+      assertThat(started.getString("action", "")).isEqualTo("started");
+      final String sessionId = started.getString("sessionId");
+
+      // A writer that is not this connection at all, so the watcher thread pushes events while the worker thread
+      // answers chunks. The session's own per_batch inserts feed the same watcher, so both senders are busy on
+      // this one channel for the whole run.
+      final CountDownLatch writerDone = new CountDownLatch(1);
+      final AtomicReference<Throwable> writerFailure = new AtomicReference<>();
+      final Thread writer = new Thread(() -> {
+        try {
+          for (int i = 0; i < BACKGROUND_ROWS; i++)
+            database.transaction(() -> database.newDocument("Person").set("name", "background").save());
+        } catch (final Throwable t) {
+          writerFailure.set(t);
+        } finally {
+          writerDone.countDown();
+        }
+      }, "issue-7423-writer");
+      writer.start();
+
+      // The chunks are pipelined without waiting for their acknowledgements: the point is to have as many frames
+      // in flight from as many senders as possible, not to drive the session politely.
+      for (int seq = 1; seq <= CHUNKS; seq++) {
+        final JSONArray records = new JSONArray();
+        for (int r = 0; r < ROWS_PER_CHUNK; r++)
+          records.put(new JSONObject().put("name", "chunk-" + seq + "-" + r));
+        client.sendWithoutWaiting(new JSONObject().put("action", "chunk").put("sessionId", sessionId)
+            .put("chunkSeq", seq).put("records", records).toString());
+      }
+
+      assertThat(writerDone.await(60, TimeUnit.SECONDS)).isTrue();
+      assertThat(writerFailure.get()).isNull();
+
+      // Every frame received, whatever thread sent it, parses as one complete JSON object with an action or a
+      // changeType of its own: a torn or interleaved frame would fail the parse or carry neither.
+      final List<JSONObject> acks = new ArrayList<>();
+      int events = 0;
+      String frame;
+      while ((frame = client.popMessage(5_000)) != null) {
+        final JSONObject json = new JSONObject(frame);
+        if (json.has("changeType")) {
+          assertThat(json.getString("changeType", "")).isEqualTo("create");
+          assertThat(json.getJSONObject("record").getString("@type", "")).isEqualTo("Person");
+          events++;
+        } else {
+          assertThat(json.getString("action", "")).as(frame).isEqualTo("batchAck");
+          assertThat(json.getLong("inserted", -1)).isEqualTo(ROWS_PER_CHUNK);
+          acks.add(json);
+        }
+        if (acks.size() == CHUNKS && events >= expectedEvents)
+          break;
+      }
+
+      assertThat(acks).hasSize(CHUNKS);
+      // At least: a per_batch chunk whose commit is retried on a page conflict with the background writer fires
+      // its create events again, so the stream may carry more than the rows that ended up durable.
+      assertThat(events).isGreaterThanOrEqualTo(expectedEvents);
+
+      final JSONObject committed = new JSONObject(client.send(new JSONObject().put("action", "commit")
+          .put("sessionId", sessionId).toString()));
+      assertThat(committed.getString("action", "")).isEqualTo("committed");
+      assertThat(committed.getJSONObject("summary").getLong("inserted", -1)).isEqualTo(CHUNKS * ROWS_PER_CHUNK);
+    }
+
+    assertThat(database.countType("Person", false)).isEqualTo(expectedEvents);
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/ws/WebSocketInsertSessionConflictIT.java
+++ b/server/src/test/java/com/arcadedb/server/ws/WebSocketInsertSessionConflictIT.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ws;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The conflict half of the gRPC {@code InsertOptions} on a {@code /ws} insert session (issue #7404):
+ * {@code conflictMode}, {@code keyColumns}, {@code updateColumnsOnConflict} and {@code validateOnly}, with the
+ * semantics {@code ArcadeDbGrpcService.insertRows} gives them.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class WebSocketInsertSessionConflictIT extends BaseGraphServerTest {
+  private static final String TYPE      = "Keyed7404";
+  private static final String EDGE_TYPE = "KeyedEdge7404";
+
+  private Database database;
+
+  @BeforeEach
+  void createKeyedType() {
+    database = getServerDatabase(0, getDatabaseName());
+    database.command("sql", "CREATE DOCUMENT TYPE " + TYPE);
+    database.command("sql", "CREATE PROPERTY " + TYPE + ".name STRING");
+    database.command("sql", "CREATE INDEX ON " + TYPE + " (name) UNIQUE");
+    database.command("sql", "CREATE EDGE TYPE " + EDGE_TYPE);
+    database.command("sql", "CREATE PROPERTY " + EDGE_TYPE + ".name STRING");
+    database.command("sql", "CREATE INDEX ON " + EDGE_TYPE + " (name) UNIQUE");
+    database.transaction(() -> {
+      database.newDocument(TYPE).set("name", "a").set("role", "old-a").save();
+      database.newDocument(TYPE).set("name", "b").set("role", "old-b").save();
+    });
+  }
+
+  @AfterEach
+  void dropKeyedType() {
+    database.command("sql", "DROP TYPE " + EDGE_TYPE + " IF EXISTS UNSAFE");
+    database.command("sql", "DROP TYPE " + TYPE + " IF EXISTS UNSAFE");
+  }
+
+  /** Verification 1: the duplicate chunk under {@code update} is acknowledged as updated, and nothing new is created. */
+  @Test
+  void updateMatchesOnTheKeyColumnsAndRewritesTheExistingRecords() throws Throwable {
+    try (final var client = newClient()) {
+      final JSONObject started = new JSONObject(client.send(start(options("update", "name"))));
+      assertThat(started.getString("action", "")).isEqualTo("started");
+      assertThat(started.getString("conflictMode", "")).isEqualTo("update");
+      final String sessionId = started.getString("sessionId");
+
+      final JSONObject ack = new JSONObject(client.send(chunk(sessionId, 1,
+          record("a", "new-a").put("extra", 1), record("b", "new-b"), record("c", "new-c"))));
+      assertThat(ack.getString("action", "")).isEqualTo("batchAck");
+      assertThat(ack.getLong("received", -1)).isEqualTo(3);
+      assertThat(ack.getLong("updated", -1)).isEqualTo(2);
+      assertThat(ack.getLong("inserted", -1)).isEqualTo(1);
+      assertThat(ack.getLong("failed", -1)).isZero();
+      assertThat(ack.has("errors")).isFalse();
+
+      final JSONObject committed = new JSONObject(client.send(control("commit", sessionId)));
+      assertThat(committed.getJSONObject("summary").getLong("updated", -1)).isEqualTo(2);
+    }
+
+    assertThat(database.countType(TYPE, false)).isEqualTo(3);
+    assertThat(roleOf("a")).isEqualTo("new-a");
+    assertThat(roleOf("b")).isEqualTo("new-b");
+    assertThat(propertyOf("a", "extra")).isEqualTo(1);
+  }
+
+  /** {@code updateColumnsOnConflict} narrows the merge to the columns it names; the others keep their values. */
+  @Test
+  void updateColumnsOnConflictLimitsWhatAnUpdateOverwrites() throws Throwable {
+    try (final var client = newClient()) {
+      final JSONObject options = options("update", "name").put("updateColumnsOnConflict", new JSONArray().put("extra"));
+      final String sessionId = new JSONObject(client.send(start(options))).getString("sessionId");
+
+      final JSONObject ack = new JSONObject(client.send(chunk(sessionId, 1, record("a", "should-not-land").put("extra", 7))));
+      assertThat(ack.getLong("updated", -1)).isEqualTo(1);
+      new JSONObject(client.send(control("commit", sessionId)));
+    }
+
+    assertThat(roleOf("a")).isEqualTo("old-a");
+    assertThat(propertyOf("a", "extra")).isEqualTo(7);
+  }
+
+  /** Verification 2: the same chunk under {@code ignore} is acknowledged as ignored. */
+  @Test
+  void ignoreDropsTheRowsWhoseKeyIsTaken() throws Throwable {
+    try (final var client = newClient()) {
+      final String sessionId = new JSONObject(client.send(start(options("ignore", "name")))).getString("sessionId");
+
+      final JSONObject ack = new JSONObject(client.send(chunk(sessionId, 1, record("a", "x"), record("b", "x"), record("c", "x"))));
+      assertThat(ack.getLong("ignored", -1)).isEqualTo(2);
+      assertThat(ack.getLong("inserted", -1)).isEqualTo(1);
+      assertThat(ack.getLong("failed", -1)).isZero();
+      new JSONObject(client.send(control("commit", sessionId)));
+    }
+
+    assertThat(database.countType(TYPE, false)).isEqualTo(3);
+    assertThat(roleOf("a")).isEqualTo("old-a");
+  }
+
+  /** Verification 3: under the default, each duplicate is a failed row with a {@code CONFLICT}-coded error. */
+  @Test
+  void theDefaultReportsEachDuplicateAsAConflictAndStillAppliesTheRest() throws Throwable {
+    try (final var client = newClient()) {
+      final String sessionId = new JSONObject(client.send(start(options(null, "name")))).getString("sessionId");
+
+      final JSONObject ack = new JSONObject(client.send(chunk(sessionId, 1, record("a", "x"), record("c", "x"), record("b", "x"))));
+      assertThat(ack.getLong("failed", -1)).isEqualTo(2);
+      assertThat(ack.getLong("inserted", -1)).isEqualTo(1);
+      final JSONArray errors = ack.getJSONArray("errors");
+      assertThat(errors.length()).isEqualTo(2);
+      assertThat(errors.getJSONObject(0).getInt("rowIndex", -1)).isZero();
+      assertThat(errors.getJSONObject(0).getString("code", "")).isEqualTo("CONFLICT");
+      assertThat(errors.getJSONObject(1).getInt("rowIndex", -1)).isEqualTo(2);
+      assertThat(errors.getJSONObject(1).getString("code", "")).isEqualTo("CONFLICT");
+      new JSONObject(client.send(control("commit", sessionId)));
+    }
+
+    assertThat(database.countType(TYPE, false)).isEqualTo(3);
+  }
+
+  /** {@code abort} is accepted for parity with gRPC and answered exactly as {@code error} is there. */
+  @Test
+  void abortIsAnsweredLikeError() throws Throwable {
+    try (final var client = newClient()) {
+      final String sessionId = new JSONObject(client.send(start(options("abort", "name")))).getString("sessionId");
+      final JSONObject ack = new JSONObject(client.send(chunk(sessionId, 1, record("a", "x"))));
+      assertThat(ack.getLong("failed", -1)).isEqualTo(1);
+      assertThat(ack.getJSONArray("errors").getJSONObject(0).getString("code", "")).isEqualTo("CONFLICT");
+      new JSONObject(client.send(control("rollback", sessionId)));
+    }
+  }
+
+  /** Verification 4: a dry run acknowledges every row as received while the database stays as it was. */
+  @Test
+  void validateOnlyReceivesEveryRowAndWritesNothing() throws Throwable {
+    try (final var client = newClient()) {
+      final JSONObject options = new JSONObject().put("targetType", TYPE).put("validateOnly", true);
+      final String sessionId = new JSONObject(client.send(start(options))).getString("sessionId");
+
+      final JSONObject ack = new JSONObject(client.send(chunk(sessionId, 1, record("a", "x"), record("z", "x"))));
+      assertThat(ack.getLong("received", -1)).isEqualTo(2);
+      assertThat(ack.getLong("inserted", -1)).isZero();
+      assertThat(ack.getLong("failed", -1)).isZero();
+
+      // Validation still validates: a row with no type is reported even though nothing would be written.
+      final JSONArray untyped = new JSONArray().put(new JSONObject().put("@class", "NoSuchType7404").put("name", "q"));
+      final JSONObject bad = new JSONObject(client.send(chunkOf(sessionId, 2, untyped)));
+      assertThat(bad.getLong("failed", -1)).isEqualTo(1);
+
+      final JSONObject committed = new JSONObject(client.send(control("commit", sessionId)));
+      assertThat(committed.getJSONObject("summary").getLong("received", -1)).isEqualTo(3);
+      assertThat(committed.getJSONObject("summary").getLong("inserted", -1)).isZero();
+    }
+
+    assertThat(database.countType(TYPE, false)).isEqualTo(2);
+  }
+
+  /** {@code update} with nothing to match on can never update anything, so it is refused at {@code start}. */
+  @Test
+  void updateWithoutKeyColumnsIsRefusedAtStart() throws Throwable {
+    try (final var client = newClient()) {
+      final JSONObject refused = new JSONObject(client.send(start(new JSONObject().put("conflictMode", "update"))));
+      assertThat(refused.getString("result", "")).isEqualTo("error");
+      assertThat(refused.getString("detail", "")).contains("keyColumns");
+    }
+    assertThat(getServer(0).getHttpServer().getInsertSessionManager().getOpenSessionCount()).isZero();
+  }
+
+  /**
+   * With no key columns the duplicate is the engine's to find, and it finds it where the transaction commits:
+   * under {@code per_row} that is the row itself, so the mode still gets to answer per row.
+   */
+  @Test
+  void withoutKeyColumnsPerRowStillAnswersPerRow() throws Throwable {
+    try (final var client = newClient()) {
+      final JSONObject ignoring = new JSONObject().put("targetType", TYPE).put("transactionMode", "per_row")
+          .put("conflictMode", "ignore");
+      final String ignoringSession = new JSONObject(client.send(start(ignoring))).getString("sessionId");
+      final JSONObject ignoredAck = new JSONObject(client.send(chunk(ignoringSession, 1, record("a", "x"), record("d", "x"))));
+      assertThat(ignoredAck.getLong("ignored", -1)).isEqualTo(1);
+      assertThat(ignoredAck.getLong("inserted", -1)).isEqualTo(1);
+      assertThat(ignoredAck.getLong("failed", -1)).isZero();
+      new JSONObject(client.send(control("commit", ignoringSession)));
+
+      final JSONObject erroring = new JSONObject().put("targetType", TYPE).put("transactionMode", "per_row");
+      final String erroringSession = new JSONObject(client.send(start(erroring))).getString("sessionId");
+      final JSONObject failedAck = new JSONObject(client.send(chunk(erroringSession, 1, record("b", "x"), record("e", "x"))));
+      assertThat(failedAck.getLong("failed", -1)).isEqualTo(1);
+      assertThat(failedAck.getLong("inserted", -1)).isEqualTo(1);
+      assertThat(failedAck.getJSONArray("errors").getJSONObject(0).getInt("rowIndex", -1)).isZero();
+      assertThat(failedAck.getJSONArray("errors").getJSONObject(0).getString("code", "")).isEqualTo("CONFLICT");
+      new JSONObject(client.send(control("commit", erroringSession)));
+    }
+
+    assertThat(database.countType(TYPE, false)).isEqualTo(4);
+    assertThat(roleOf("a")).isEqualTo("old-a");
+  }
+
+  /**
+   * And under {@code per_stream} the engine finds it at the session's commit: the {@code commit} frame is
+   * answered with a client error naming the duplicate, the session is closed, and nothing of it is durable.
+   */
+  @Test
+  void withoutKeyColumnsPerStreamRefusesTheCommit() throws Throwable {
+    try (final var client = newClient()) {
+      final String sessionId = new JSONObject(client.send(start(new JSONObject().put("targetType", TYPE)))).getString("sessionId");
+      final JSONObject ack = new JSONObject(client.send(chunk(sessionId, 1, record("a", "x"), record("f", "x"))));
+      assertThat(ack.getLong("inserted", -1)).isEqualTo(2);
+
+      final JSONObject refused = new JSONObject(client.send(control("commit", sessionId)));
+      assertThat(refused.getString("result", "")).isEqualTo("error");
+      assertThat(refused.getString("error", "")).isEqualTo("Insert session error");
+      assertThat(refused.getString("exception", "")).endsWith("DuplicatedKeyException");
+
+      final JSONObject gone = new JSONObject(client.send(chunk(sessionId, 2, record("g", "x"))));
+      assertThat(gone.getString("result", "")).isEqualTo("error");
+      assertThat(gone.getString("detail", "")).contains("not found or expired");
+    }
+
+    assertThat(database.countType(TYPE, false)).isEqualTo(2);
+    assertThat(getServer(0).getHttpServer().getInsertSessionManager().getOpenSessionCount()).isZero();
+  }
+
+  /** An edge upsert rewrites the edge's own properties and never its endpoints, even when asked to. */
+  @Test
+  void anEdgeUpsertKeepsItsEndpoints() throws Throwable {
+    final String fromRid = ridOfFirst("select from " + VERTEX1_TYPE_NAME + " limit 1");
+    final String toRid = ridOfFirst("select from " + VERTEX2_TYPE_NAME + " limit 1");
+    final String[] otherRid = new String[1];
+    database.transaction(() -> {
+      otherRid[0] = database.newVertex(VERTEX1_TYPE_NAME).set("id", 7404).set("name", "other").save().getIdentity().toString();
+      database.lookupByRID(database.newRID(fromRid), false).asVertex()
+          .newEdge(EDGE_TYPE, database.newRID(toRid)).set("name", "e1").set("weight", 1).save();
+    });
+
+    try (final var client = newClient()) {
+      final JSONObject options = new JSONObject().put("targetType", EDGE_TYPE).put("conflictMode", "update")
+          .put("keyColumns", new JSONArray().put("name"))
+          .put("updateColumnsOnConflict", new JSONArray().put("weight").put("out"));
+      final String sessionId = new JSONObject(client.send(start(options))).getString("sessionId");
+
+      final JSONArray records = new JSONArray().put(new JSONObject().put("name", "e1").put("weight", 2)
+          .put("@from", otherRid[0]).put("@to", toRid));
+      final JSONObject ack = new JSONObject(client.send(chunkOf(sessionId, 1, records)));
+      assertThat(ack.getLong("updated", -1)).isEqualTo(1);
+      assertThat(ack.getLong("inserted", -1)).isZero();
+      new JSONObject(client.send(control("commit", sessionId)));
+    }
+
+    try (final ResultSet rs = database.query("sql", "select from " + EDGE_TYPE + " where name = 'e1'")) {
+      final var edge = rs.next().getEdge().orElseThrow();
+      assertThat(edge.<Integer>get("weight")).isEqualTo(2);
+      assertThat(edge.getOut().toString()).isEqualTo(fromRid);
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  private WebSocketClientHelper newClient() throws Exception {
+    return new WebSocketClientHelper("ws://localhost:" + getServer(0).getHttpServer().getPort() + "/ws", "root",
+        BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
+  }
+
+  private static JSONObject options(final String conflictMode, final String... keyColumns) {
+    final JSONObject options = new JSONObject().put("targetType", TYPE);
+    if (conflictMode != null)
+      options.put("conflictMode", conflictMode);
+    options.put("keyColumns", new JSONArray(keyColumns));
+    return options;
+  }
+
+  private String start(final JSONObject options) {
+    final JSONObject message = new JSONObject();
+    message.put("action", "start");
+    message.put("database", getDatabaseName());
+    message.put("options", options);
+    return message.toString();
+  }
+
+  private static JSONObject record(final String name, final String role) {
+    return new JSONObject().put("name", name).put("role", role);
+  }
+
+  private static String chunk(final String sessionId, final long chunkSeq, final JSONObject... records) {
+    return chunkOf(sessionId, chunkSeq, new JSONArray(records));
+  }
+
+  private static String chunkOf(final String sessionId, final long chunkSeq, final JSONArray records) {
+    final JSONObject message = new JSONObject();
+    message.put("action", "chunk");
+    message.put("sessionId", sessionId);
+    message.put("chunkSeq", chunkSeq);
+    message.put("records", records);
+    return message.toString();
+  }
+
+  private static String control(final String action, final String sessionId) {
+    final JSONObject message = new JSONObject();
+    message.put("action", action);
+    message.put("sessionId", sessionId);
+    return message.toString();
+  }
+
+  private String roleOf(final String name) {
+    return (String) propertyOf(name, "role");
+  }
+
+  private Object propertyOf(final String name, final String property) {
+    try (final ResultSet rs = database.query("sql", "select from " + TYPE + " where name = ?", name)) {
+      return rs.next().getProperty(property);
+    }
+  }
+
+  private String ridOfFirst(final String query) {
+    try (final ResultSet rs = database.query("sql", query)) {
+      return rs.next().getIdentity().orElseThrow().toString();
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/ws/WebSocketInsertSessionExpiryIT.java
+++ b/server/src/test/java/com/arcadedb/server/ws/WebSocketInsertSessionExpiryIT.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ws;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A {@code /ws} insert session holds a transaction open between frames, so a client that opens one and walks away
+ * would hold it for as long as its connection stays up. The idle sweep rolls it back on the same budget an
+ * {@code arcadedb-session-id} transaction gets, and tells the client it did (issue #7382).
+ * <p>
+ * Its own class because the expiry budget is a server setting: the class lowers it to one second, which every
+ * other insert session in the same server would then also be measured against.
+ */
+class WebSocketInsertSessionExpiryIT extends BaseGraphServerTest {
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    config.setValue(GlobalConfiguration.SERVER_WS_INSERT_SESSION_EXPIRE_TIMEOUT, 1);
+  }
+
+  @Test
+  void anAbandonedSessionIsRolledBackAndItsClientToldSo() throws Throwable {
+    final Database database = getServerDatabase(0, getDatabaseName());
+
+    try (final var client = new WebSocketClientHelper(
+        "ws://localhost:" + getServer(0).getHttpServer().getPort() + "/ws", "root",
+        BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS)) {
+
+      final JSONObject started = new JSONObject(client.send(new JSONObject().put("action", "start")
+          .put("database", getDatabaseName()).put("options", new JSONObject().put("targetType", "Person")).toString()));
+      final String sessionId = started.getString("sessionId");
+
+      final JSONObject ack = new JSONObject(client.send(new JSONObject().put("action", "chunk")
+          .put("sessionId", sessionId).put("chunkSeq", 1)
+          .put("records", new JSONArray().put(new JSONObject().put("name", "abandoned"))).toString()));
+      assertThat(ack.getLong("inserted", -1)).isEqualTo(1);
+
+      // The client now says nothing at all. The sweep is what has to notice.
+      final JSONObject unsolicited = new JSONObject(client.popMessage(15_000));
+      assertThat(unsolicited.getString("result", "")).isEqualTo("error");
+      assertThat(unsolicited.getString("sessionId", "")).isEqualTo(sessionId);
+      assertThat(unsolicited.getString("detail", "")).contains("inactivity");
+
+      Awaitility.await().atMost(10, TimeUnit.SECONDS).pollInterval(100, TimeUnit.MILLISECONDS)
+          .until(() -> getServer(0).getHttpServer().getInsertSessionManager().getOpenSessionCount() == 0);
+
+      assertThat(database.countType("Person", false)).isZero();
+
+      // And the id no longer resolves, so a late frame is refused rather than served.
+      final JSONObject late = new JSONObject(client.send(new JSONObject().put("action", "commit")
+          .put("sessionId", sessionId).toString()));
+      assertThat(late.getString("result", "")).isEqualTo("error");
+      assertThat(late.getString("detail", "")).contains("not found or expired");
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/ws/WebSocketInsertSessionIT.java
+++ b/server/src/test/java/com/arcadedb/server/ws/WebSocketInsertSessionIT.java
@@ -256,17 +256,13 @@ class WebSocketInsertSessionIT extends BaseGraphServerTest {
 
   /**
    * The options a {@code /ws} session does not implement are refused at {@code start}, not ignored: a loader
-   * ported from {@code InsertBidirectional} must not silently get plain inserts where it asked for upserts
-   * (issues #7403, #7404).
+   * ported from {@code InsertBidirectional} must not silently run under a different policy than the one it
+   * asked for (issue #7403). The conflict options are honoured since issue #7404; see
+   * {@link WebSocketInsertSessionConflictIT}.
    */
   @Test
   void optionsThisServerDoesNotImplementAreRefusedRatherThanIgnored() throws Throwable {
     try (final var client = newClient()) {
-      final JSONObject options = new JSONObject().put("targetType", "Person").put("conflictMode", "update");
-      final JSONObject refused = new JSONObject(client.send(startWithOptions(null, options)));
-      assertThat(refused.getString("result", "")).isEqualTo("error");
-      assertThat(refused.getString("detail", "")).contains("conflictMode").contains("#7404");
-
       final JSONObject noneMode = new JSONObject(
           client.send(startWithOptions(null, new JSONObject().put("targetType", "Person").put("transactionMode", "none"))));
       assertThat(noneMode.getString("result", "")).isEqualTo("error");

--- a/server/src/test/java/com/arcadedb/server/ws/WebSocketInsertSessionIT.java
+++ b/server/src/test/java/com/arcadedb/server/ws/WebSocketInsertSessionIT.java
@@ -1,0 +1,539 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ws;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.security.ServerSecurity;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The duplex insert session on {@code /ws} (issue #7382): the {@code start} / {@code chunk} /
+ * {@code commit} / {@code rollback} control frames that the gRPC {@code InsertBidirectional} RPC has and that
+ * {@code POST /api/v1/batch} - even with the per-chunk acknowledgements of issue #7311 - structurally cannot
+ * offer, because they need the client to react to what the server said and change what it sends next inside the
+ * same session.
+ */
+class WebSocketInsertSessionIT extends BaseGraphServerTest {
+
+  /**
+   * The verification issue #7382 asks for first: a session that sends two chunks and, AFTER seeing the
+   * acknowledgement of the first, rolls the session back - the records of neither chunk are in the database.
+   * That "after seeing the ack" ordering is the whole point: over {@code /batch} the commit policy is fixed by
+   * query parameters before the load starts.
+   */
+  @Test
+  void rollbackAfterSeeingAnAckDiscardsEveryChunk() throws Throwable {
+    final Database database = getServerDatabase(0, getDatabaseName());
+    assertThat(database.countType("Person", false)).isZero();
+
+    try (final var client = newClient()) {
+      final JSONObject started = new JSONObject(client.send(start(null, "Person", null)));
+      assertThat(started.getString("action", "")).isEqualTo("started");
+      assertThat(started.getString("transactionMode", "")).isEqualTo("per_stream");
+      final String sessionId = started.getString("sessionId");
+      assertThat(sessionId).isNotBlank();
+
+      final JSONObject firstAck = new JSONObject(client.send(chunk(sessionId, 1, "a", "b")));
+      assertThat(firstAck.getString("action", "")).isEqualTo("batchAck");
+      assertThat(firstAck.getLong("chunkSeq", -1)).isEqualTo(1);
+      assertThat(firstAck.getLong("inserted", -1)).isEqualTo(2);
+      assertThat(firstAck.getLong("failed", -1)).isZero();
+
+      // Only now, having seen the first acknowledgement, does the client send the second chunk.
+      final JSONObject secondAck = new JSONObject(client.send(chunk(sessionId, 2, "c", "d")));
+      assertThat(secondAck.getLong("inserted", -1)).isEqualTo(2);
+
+      final JSONObject committed = new JSONObject(client.send(control("rollback", sessionId)));
+      assertThat(committed.getString("action", "")).isEqualTo("committed");
+      assertThat(committed.getString("outcome", "")).isEqualTo("rollback");
+
+      final JSONObject summary = committed.getJSONObject("summary");
+      assertThat(summary.getLong("received", -1)).isEqualTo(4);
+      assertThat(summary.getLong("inserted", -1)).isEqualTo(4);
+      assertThat(summary.getBoolean("partialCommit", true)).isFalse();
+    }
+
+    assertThat(database.countType("Person", false)).isZero();
+  }
+
+  /** The companion verification: a session that commits after the last acknowledgement keeps every record. */
+  @Test
+  void commitAfterTheLastAckPersistsEveryRecord() throws Throwable {
+    final Database database = getServerDatabase(0, getDatabaseName());
+
+    try (final var client = newClient()) {
+      final JSONObject started = new JSONObject(client.send(start(null, "Person", null)));
+      final String sessionId = started.getString("sessionId");
+
+      assertThat(new JSONObject(client.send(chunk(sessionId, 1, "a", "b"))).getLong("inserted", -1)).isEqualTo(2);
+      assertThat(new JSONObject(client.send(chunk(sessionId, 2, "c", "d"))).getLong("inserted", -1)).isEqualTo(2);
+
+      final JSONObject committed = new JSONObject(client.send(control("commit", sessionId)));
+      assertThat(committed.getString("outcome", "")).isEqualTo("commit");
+      assertThat(committed.getJSONObject("summary").getLong("inserted", -1)).isEqualTo(4);
+    }
+
+    assertThat(database.countType("Person", false)).isEqualTo(4);
+  }
+
+  /**
+   * The third verification: the same session id is rejected by a second concurrent {@code start} - both when the
+   * second one arrives on a different connection and when it arrives on the one that already owns a session.
+   */
+  @Test
+  void aSecondStartWithTheSameSessionIdIsRejected() throws Throwable {
+    try (final var first = newClient(); final var second = newClient()) {
+      final JSONObject started = new JSONObject(first.send(start("shared-session-id", "Person", null)));
+      assertThat(started.getString("action", "")).isEqualTo("started");
+      assertThat(started.getString("sessionId", "")).isEqualTo("shared-session-id");
+
+      final JSONObject fromAnotherConnection = new JSONObject(second.send(start("shared-session-id", "Person", null)));
+      assertThat(fromAnotherConnection.getString("result", "")).isEqualTo("error");
+      assertThat(fromAnotherConnection.getString("detail", "")).contains("already exists");
+
+      final JSONObject onTheSameConnection = new JSONObject(first.send(start("shared-session-id", "Person", null)));
+      assertThat(onTheSameConnection.getString("result", "")).isEqualTo("error");
+      assertThat(onTheSameConnection.getString("detail", "")).contains("already has insert session");
+
+      new JSONObject(first.send(control("rollback", "shared-session-id")));
+    }
+  }
+
+  /** A frame naming a session the server does not know is refused, never served against a fresh transaction. */
+  @Test
+  void aChunkForAnUnknownSessionIsRefused() throws Throwable {
+    try (final var client = newClient()) {
+      final JSONObject error = new JSONObject(client.send(chunk("no-such-session", 1, "a")));
+      assertThat(error.getString("result", "")).isEqualTo("error");
+      assertThat(error.getString("detail", "")).contains("not found or expired");
+    }
+
+    assertThat(getServerDatabase(0, getDatabaseName()).countType("Person", false)).isZero();
+  }
+
+  /** A session is reachable only from the connection that opened it, even by the very same principal. */
+  @Test
+  void anotherConnectionCannotDriveTheSession() throws Throwable {
+    try (final var owner = newClient(); final var intruder = newClient()) {
+      final String sessionId = new JSONObject(owner.send(start(null, "Person", null))).getString("sessionId");
+
+      final JSONObject error = new JSONObject(intruder.send(chunk(sessionId, 1, "stolen")));
+      assertThat(error.getString("result", "")).isEqualTo("error");
+      assertThat(error.getString("detail", "")).contains("another connection");
+
+      new JSONObject(owner.send(control("rollback", sessionId)));
+    }
+
+    assertThat(getServerDatabase(0, getDatabaseName()).countType("Person", false)).isZero();
+  }
+
+  /** And only by the principal that opened it: a second user's connection cannot adopt someone else's session. */
+  @Test
+  void anotherUserCannotDriveTheSession() throws Throwable {
+    final ServerSecurity security = getServer(0).getSecurity();
+    final String otherUser = "mallory";
+    final String password = "mallorypassword";
+    security.createUser(new JSONObject().put("name", otherUser).put("password", security.encodePassword(password))
+        .put("databases", new JSONObject().put(getDatabaseName(), new JSONArray(new String[] { "admin" }))));
+    try {
+      try (final var owner = newClient();
+          final var other = new WebSocketClientHelper(wsUrl(), otherUser, password)) {
+        final String sessionId = new JSONObject(owner.send(start(null, "Person", null))).getString("sessionId");
+
+        // Reaches the ownership check only because the intruder is on its own connection; the connection check
+        // fires first, so this asserts the pair of them rather than the user check alone.
+        final JSONObject error = new JSONObject(other.send(chunk(sessionId, 1, "stolen")));
+        assertThat(error.getString("result", "")).isEqualTo("error");
+        assertThat(error.getString("detail", "")).contains("another connection");
+
+        new JSONObject(owner.send(control("rollback", sessionId)));
+      }
+    } finally {
+      security.dropUser(otherUser);
+    }
+  }
+
+  /** A user with no rights on the database cannot open a session on it at all. */
+  @Test
+  void startOnAnUnauthorizedDatabaseIsRejected() throws Throwable {
+    final ServerSecurity security = getServer(0).getSecurity();
+    final String otherUser = "eve7382";
+    final String password = "evepassword";
+    security.createUser(new JSONObject().put("name", otherUser).put("password", security.encodePassword(password))
+        .put("databases", new JSONObject().put("otherdb", new JSONArray(new String[] { "admin" }))));
+    try {
+      try (final var client = new WebSocketClientHelper(wsUrl(), otherUser, password)) {
+        final JSONObject error = new JSONObject(client.send(start(null, "Person", null)));
+        assertThat(error.getString("result", "")).isEqualTo("error");
+        assertThat(error.getString("error", "")).contains("Security");
+      }
+    } finally {
+      security.dropUser(otherUser);
+    }
+
+    assertThat(getServer(0).getHttpServer().getInsertSessionManager().getOpenSessionCount()).isZero();
+  }
+
+  /**
+   * {@code per_batch} commits each chunk before acknowledging it, so a later {@code rollback} frame cannot take
+   * one back. The answer says so with {@code partialCommit} rather than letting {@code outcome: rollback} imply
+   * an undo that did not happen.
+   */
+  @Test
+  void perBatchCommitsEachChunkSoARollbackCannotTakeItBack() throws Throwable {
+    final Database database = getServerDatabase(0, getDatabaseName());
+
+    try (final var client = newClient()) {
+      final JSONObject started = new JSONObject(client.send(start(null, "Person", "per_batch")));
+      assertThat(started.getString("transactionMode", "")).isEqualTo("per_batch");
+      final String sessionId = started.getString("sessionId");
+
+      assertThat(new JSONObject(client.send(chunk(sessionId, 1, "a", "b"))).getLong("inserted", -1)).isEqualTo(2);
+
+      // Durable already, before the client has said anything about committing.
+      assertThat(database.countType("Person", false)).isEqualTo(2);
+
+      final JSONObject committed = new JSONObject(client.send(control("rollback", sessionId)));
+      assertThat(committed.getString("outcome", "")).isEqualTo("rollback");
+      assertThat(committed.getJSONObject("summary").getBoolean("partialCommit", false)).isTrue();
+    }
+
+    assertThat(database.countType("Person", false)).isEqualTo(2);
+  }
+
+  /** {@code per_row} commits every row on its own, which the same {@code partialCommit} flag reports. */
+  @Test
+  void perRowCommitsEveryRowOnItsOwn() throws Throwable {
+    final Database database = getServerDatabase(0, getDatabaseName());
+
+    try (final var client = newClient()) {
+      final String sessionId = new JSONObject(client.send(start(null, "Person", "per_row"))).getString("sessionId");
+      assertThat(new JSONObject(client.send(chunk(sessionId, 1, "a", "b", "c"))).getLong("inserted", -1)).isEqualTo(3);
+      assertThat(database.countType("Person", false)).isEqualTo(3);
+
+      final JSONObject committed = new JSONObject(client.send(control("commit", sessionId)));
+      assertThat(committed.getJSONObject("summary").getBoolean("partialCommit", false)).isTrue();
+    }
+
+    assertThat(database.countType("Person", false)).isEqualTo(3);
+  }
+
+  /** {@code per_request} is gRPC's name for the same thing a {@code /ws} session calls {@code per_stream}. */
+  @Test
+  void perRequestIsAnAliasOfPerStream() throws Throwable {
+    try (final var client = newClient()) {
+      final JSONObject started = new JSONObject(client.send(start(null, "Person", "per_request")));
+      assertThat(started.getString("transactionMode", "")).isEqualTo("per_stream");
+      new JSONObject(client.send(control("rollback", started.getString("sessionId"))));
+    }
+  }
+
+  /**
+   * The options a {@code /ws} session does not implement are refused at {@code start}, not ignored: a loader
+   * ported from {@code InsertBidirectional} must not silently get plain inserts where it asked for upserts
+   * (issues #7403, #7404).
+   */
+  @Test
+  void optionsThisServerDoesNotImplementAreRefusedRatherThanIgnored() throws Throwable {
+    try (final var client = newClient()) {
+      final JSONObject options = new JSONObject().put("targetType", "Person").put("conflictMode", "update");
+      final JSONObject refused = new JSONObject(client.send(startWithOptions(null, options)));
+      assertThat(refused.getString("result", "")).isEqualTo("error");
+      assertThat(refused.getString("detail", "")).contains("conflictMode").contains("#7404");
+
+      final JSONObject noneMode = new JSONObject(
+          client.send(startWithOptions(null, new JSONObject().put("targetType", "Person").put("transactionMode", "none"))));
+      assertThat(noneMode.getString("result", "")).isEqualTo("error");
+      assertThat(noneMode.getString("detail", "")).contains("#7403");
+
+      final JSONObject unknownMode = new JSONObject(
+          client.send(startWithOptions(null, new JSONObject().put("targetType", "Person").put("transactionMode", "whenever"))));
+      assertThat(unknownMode.getString("result", "")).isEqualTo("error");
+      assertThat(unknownMode.getString("detail", "")).contains("Unknown transactionMode");
+    }
+
+    assertThat(getServer(0).getHttpServer().getInsertSessionManager().getOpenSessionCount()).isZero();
+  }
+
+  /**
+   * A row that cannot be applied is counted and described, and the rest of the chunk still goes in. The client
+   * gets to decide what to do about a partial chunk - which is what having a duplex session is for.
+   */
+  @Test
+  void aRowThatFailsIsReportedWhileTheRestOfTheChunkStillGoesIn() throws Throwable {
+    final Database database = getServerDatabase(0, getDatabaseName());
+
+    try (final var client = newClient()) {
+      final String sessionId = new JSONObject(client.send(start(null, "Person", null))).getString("sessionId");
+
+      final JSONArray records = new JSONArray();
+      records.put(new JSONObject().put("name", "good-1"));
+      records.put(new JSONObject().put("@class", "NoSuchTypeAnywhere").put("name", "bad"));
+      records.put(new JSONObject().put("name", "good-2"));
+
+      final JSONObject ack = new JSONObject(client.send(chunkOf(sessionId, 1, records)));
+      assertThat(ack.getLong("received", -1)).isEqualTo(3);
+      assertThat(ack.getLong("inserted", -1)).isEqualTo(2);
+      assertThat(ack.getLong("failed", -1)).isEqualTo(1);
+      assertThat(ack.getJSONArray("errors").length()).isEqualTo(1);
+      assertThat(ack.getJSONArray("errors").getJSONObject(0).getInt("rowIndex", -1)).isEqualTo(1);
+
+      new JSONObject(client.send(control("commit", sessionId)));
+    }
+
+    assertThat(database.countType("Person", false)).isEqualTo(2);
+  }
+
+  /** A chunk sequence at or below the watermark is acknowledged as a replay, not applied a second time. */
+  @Test
+  void aReplayedChunkIsAcknowledgedWithoutBeingAppliedAgain() throws Throwable {
+    final Database database = getServerDatabase(0, getDatabaseName());
+
+    try (final var client = newClient()) {
+      final String sessionId = new JSONObject(client.send(start(null, "Person", null))).getString("sessionId");
+
+      assertThat(new JSONObject(client.send(chunk(sessionId, 1, "a", "b"))).getLong("inserted", -1)).isEqualTo(2);
+
+      final JSONObject replay = new JSONObject(client.send(chunk(sessionId, 1, "a", "b")));
+      assertThat(replay.getBoolean("replay", false)).isTrue();
+      assertThat(replay.getLong("inserted", -1)).isZero();
+
+      new JSONObject(client.send(control("commit", sessionId)));
+    }
+
+    assertThat(database.countType("Person", false)).isEqualTo(2);
+  }
+
+  /** Vertices and edges travel through the same session; an edge names its endpoints with {@code @from}/{@code @to}. */
+  @Test
+  void verticesAndEdgesGoInThroughTheSameSession() throws Throwable {
+    final Database database = getServerDatabase(0, getDatabaseName());
+    final String fromRid = ridOfFirst(database, "select from " + VERTEX1_TYPE_NAME + " limit 1");
+    final String toRid = ridOfFirst(database, "select from " + VERTEX2_TYPE_NAME + " limit 1");
+    final long edgesBefore = database.countType(EDGE1_TYPE_NAME, false);
+
+    try (final var client = newClient()) {
+      final String sessionId = new JSONObject(client.send(start(null, null, null))).getString("sessionId");
+
+      final JSONArray records = new JSONArray();
+      records.put(new JSONObject().put("@class", VERTEX2_TYPE_NAME).put("name", "ws-vertex"));
+      records.put(new JSONObject().put("@class", EDGE1_TYPE_NAME).put("@from", fromRid).put("@to", toRid)
+          .put("name", "ws-edge"));
+
+      final JSONObject ack = new JSONObject(client.send(chunkOf(sessionId, 1, records)));
+      assertThat(ack.getLong("failed", -1)).isZero();
+      assertThat(ack.getLong("inserted", -1)).isEqualTo(2);
+
+      new JSONObject(client.send(control("commit", sessionId)));
+    }
+
+    assertThat(database.countType(EDGE1_TYPE_NAME, false)).isEqualTo(edgesBefore + 1);
+    assertThat(database.query("sql", "select from " + EDGE1_TYPE_NAME + " where name = 'ws-edge'").hasNext()).isTrue();
+  }
+
+  /** gRPC spells an edge's endpoints {@code out}/{@code in}; a loader ported from it keeps working. */
+  @Test
+  void anEdgeCanNameItsEndpointsTheWayGrpcDoes() throws Throwable {
+    final Database database = getServerDatabase(0, getDatabaseName());
+    final String fromRid = ridOfFirst(database, "select from " + VERTEX1_TYPE_NAME + " limit 1");
+    final String toRid = ridOfFirst(database, "select from " + VERTEX2_TYPE_NAME + " limit 1");
+    final long edgesBefore = database.countType(EDGE1_TYPE_NAME, false);
+
+    try (final var client = newClient()) {
+      final String sessionId = new JSONObject(client.send(start(null, EDGE1_TYPE_NAME, null))).getString("sessionId");
+
+      final JSONArray records = new JSONArray();
+      records.put(new JSONObject().put("out", fromRid).put("in", toRid).put("name", "grpc-shaped-edge"));
+
+      assertThat(new JSONObject(client.send(chunkOf(sessionId, 1, records))).getLong("inserted", -1)).isEqualTo(1);
+      new JSONObject(client.send(control("commit", sessionId)));
+    }
+
+    assertThat(database.countType(EDGE1_TYPE_NAME, false)).isEqualTo(edgesBefore + 1);
+  }
+
+  /** An edge record with no endpoints is a client error, reported per row rather than aborting the chunk. */
+  @Test
+  void anEdgeWithoutEndpointsIsReportedPerRow() throws Throwable {
+    try (final var client = newClient()) {
+      final String sessionId = new JSONObject(client.send(start(null, EDGE1_TYPE_NAME, null))).getString("sessionId");
+
+      final JSONArray records = new JSONArray();
+      records.put(new JSONObject().put("name", "dangling"));
+
+      final JSONObject ack = new JSONObject(client.send(chunkOf(sessionId, 1, records)));
+      assertThat(ack.getLong("failed", -1)).isEqualTo(1);
+      assertThat(ack.getJSONArray("errors").getJSONObject(0).getString("message", "")).contains("@from");
+
+      new JSONObject(client.send(control("rollback", sessionId)));
+    }
+  }
+
+  /** A record with neither {@code @class} nor a session {@code targetType} has no type to go into. */
+  @Test
+  void aRecordWithNoTypeIsReported() throws Throwable {
+    try (final var client = newClient()) {
+      final String sessionId = new JSONObject(client.send(start(null, null, null))).getString("sessionId");
+
+      final JSONArray records = new JSONArray();
+      records.put(new JSONObject().put("name", "homeless"));
+
+      final JSONObject ack = new JSONObject(client.send(chunkOf(sessionId, 1, records)));
+      assertThat(ack.getLong("failed", -1)).isEqualTo(1);
+      assertThat(ack.getJSONArray("errors").getJSONObject(0).getString("message", "")).contains("targetType");
+
+      new JSONObject(client.send(control("rollback", sessionId)));
+    }
+  }
+
+  /**
+   * A connection that goes away with an open session rolls it back. Nothing else would: the client is gone, so
+   * it is never going to say what it wanted, and the transaction would otherwise be held until the idle sweep.
+   */
+  @Test
+  void closingTheConnectionRollsTheSessionBack() throws Throwable {
+    final Database database = getServerDatabase(0, getDatabaseName());
+
+    final var client = newClient();
+    final String sessionId = new JSONObject(client.send(start(null, "Person", null))).getString("sessionId");
+    assertThat(new JSONObject(client.send(chunk(sessionId, 1, "a", "b"))).getLong("inserted", -1)).isEqualTo(2);
+    assertThat(getServer(0).getHttpServer().getInsertSessionManager().getOpenSessionCount()).isEqualTo(1);
+
+    client.breakConnection();
+
+    Awaitility.await().atMost(10, TimeUnit.SECONDS).pollInterval(100, TimeUnit.MILLISECONDS)
+        .until(() -> getServer(0).getHttpServer().getInsertSessionManager().getOpenSessionCount() == 0);
+
+    assertThat(database.countType("Person", false)).isZero();
+  }
+
+  /**
+   * A chunk with no sequence is refused, not defaulted. Defaulting it to 0 would land on the initial watermark
+   * and be acknowledged as a duplicate, which silently drops every record the frame carried - the worst possible
+   * answer for a load.
+   */
+  @Test
+  void aChunkWithNoSequenceIsRefusedRatherThanTreatedAsAReplay() throws Throwable {
+    try (final var client = newClient()) {
+      final String sessionId = new JSONObject(client.send(start(null, "Person", null))).getString("sessionId");
+
+      final JSONObject message = new JSONObject();
+      message.put("action", "chunk");
+      message.put("sessionId", sessionId);
+      message.put("records", new JSONArray().put(new JSONObject().put("name", "unsequenced")));
+
+      final JSONObject error = new JSONObject(client.send(message.toString()));
+      assertThat(error.getString("result", "")).isEqualTo("error");
+      assertThat(error.getString("detail", "")).contains("chunkSeq");
+
+      new JSONObject(client.send(control("rollback", sessionId)));
+    }
+
+    assertThat(getServerDatabase(0, getDatabaseName()).countType("Person", false)).isZero();
+  }
+
+  /** A finished session releases its connection, which can then open another one. */
+  @Test
+  void aConnectionCanOpenANewSessionOnceTheFirstIsFinished() throws Throwable {
+    final Database database = getServerDatabase(0, getDatabaseName());
+
+    try (final var client = newClient()) {
+      final String first = new JSONObject(client.send(start(null, "Person", null))).getString("sessionId");
+      assertThat(new JSONObject(client.send(chunk(first, 1, "first"))).getLong("inserted", -1)).isEqualTo(1);
+      new JSONObject(client.send(control("commit", first)));
+
+      final JSONObject startedAgain = new JSONObject(client.send(start(null, "Person", null)));
+      assertThat(startedAgain.getString("action", "")).isEqualTo("started");
+      final String second = startedAgain.getString("sessionId");
+      assertThat(second).isNotEqualTo(first);
+
+      assertThat(new JSONObject(client.send(chunk(second, 1, "second"))).getLong("inserted", -1)).isEqualTo(1);
+      new JSONObject(client.send(control("commit", second)));
+    }
+
+    assertThat(database.countType("Person", false)).isEqualTo(2);
+    assertThat(getServer(0).getHttpServer().getInsertSessionManager().getOpenSessionCount()).isZero();
+  }
+
+  private WebSocketClientHelper newClient() throws Exception {
+    return new WebSocketClientHelper(wsUrl(), "root", BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
+  }
+
+  private String wsUrl() {
+    return "ws://localhost:" + getServer(0).getHttpServer().getPort() + "/ws";
+  }
+
+  private String start(final String sessionId, final String targetType, final String transactionMode) {
+    final JSONObject options = new JSONObject();
+    if (targetType != null)
+      options.put("targetType", targetType);
+    if (transactionMode != null)
+      options.put("transactionMode", transactionMode);
+    return startWithOptions(sessionId, options);
+  }
+
+  private String startWithOptions(final String sessionId, final JSONObject options) {
+    final JSONObject message = new JSONObject();
+    message.put("action", "start");
+    message.put("database", getDatabaseName());
+    if (sessionId != null)
+      message.put("sessionId", sessionId);
+    message.put("options", options);
+    return message.toString();
+  }
+
+  private static String chunk(final String sessionId, final long chunkSeq, final String... names) {
+    final JSONArray records = new JSONArray();
+    for (final String name : names)
+      records.put(new JSONObject().put("name", name));
+    return chunkOf(sessionId, chunkSeq, records);
+  }
+
+  private static String chunkOf(final String sessionId, final long chunkSeq, final JSONArray records) {
+    final JSONObject message = new JSONObject();
+    message.put("action", "chunk");
+    message.put("sessionId", sessionId);
+    message.put("chunkSeq", chunkSeq);
+    message.put("records", records);
+    return message.toString();
+  }
+
+  private static String control(final String action, final String sessionId) {
+    final JSONObject message = new JSONObject();
+    message.put("action", action);
+    message.put("sessionId", sessionId);
+    return message.toString();
+  }
+
+  private static String ridOfFirst(final Database database, final String query) {
+    try (final ResultSet rs = database.query("sql", query)) {
+      return rs.next().getIdentity().orElseThrow().toString();
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/ws/WebSocketInsertSessionIT.java
+++ b/server/src/test/java/com/arcadedb/server/ws/WebSocketInsertSessionIT.java
@@ -310,6 +310,44 @@ class WebSocketInsertSessionIT extends BaseGraphServerTest {
     assertThat(database.countType("Person", false)).isEqualTo(2);
   }
 
+  /**
+   * PER_ROW advances the watermark even when every row of the chunk failed, so resending that chunk is answered as
+   * a replay rather than retried. That is the mode's contract and not an oversight: each row commits on its own, so
+   * a chunk is never all-or-nothing, and replaying one whose rows partly succeeded would double-apply the rows that
+   * did. A client that wants a failed row retried resends it under a NEW sequence, reading which rows to resend off
+   * the ack's {@code errors[]}. Pinned here because the guarantee PER_BATCH gets - a chunk whose transaction failed
+   * is applied on replay rather than acknowledged - deliberately does not hold in this mode.
+   */
+  @Test
+  void perRowAdvancesTheWatermarkEvenWhenEveryRowFailed() throws Throwable {
+    final Database database = getServerDatabase(0, getDatabaseName());
+
+    try (final var client = newClient()) {
+      final String sessionId = new JSONObject(client.send(start(null, "Person", "per_row"))).getString("sessionId");
+
+      final JSONArray records = new JSONArray();
+      records.put(new JSONObject().put("@class", "NoSuchTypeAnywhere").put("name", "bad-1"));
+      records.put(new JSONObject().put("@class", "NoSuchTypeAnywhere").put("name", "bad-2"));
+
+      final JSONObject ack = new JSONObject(client.send(chunkOf(sessionId, 1, records)));
+      assertThat(ack.getLong("failed", -1)).isEqualTo(2);
+      assertThat(ack.getLong("inserted", -1)).isZero();
+      assertThat(ack.getBoolean("replay", false)).isFalse();
+
+      // The same sequence again: acknowledged as already seen, NOT retried, even though nothing of it was durable.
+      final JSONObject replay = new JSONObject(client.send(chunkOf(sessionId, 1, records)));
+      assertThat(replay.getBoolean("replay", false)).isTrue();
+      assertThat(replay.getLong("failed", -1)).isZero();
+
+      // The way to get those rows in is a new sequence, which the session accepts as the next one due.
+      assertThat(new JSONObject(client.send(chunk(sessionId, 2, "good"))).getLong("inserted", -1)).isEqualTo(1);
+
+      new JSONObject(client.send(control("commit", sessionId)));
+    }
+
+    assertThat(database.countType("Person", false)).isEqualTo(1);
+  }
+
   /** A chunk sequence at or below the watermark is acknowledged as a replay, not applied a second time. */
   @Test
   void aReplayedChunkIsAcknowledgedWithoutBeingAppliedAgain() throws Throwable {

--- a/server/src/test/java/com/arcadedb/server/ws/WebSocketInsertSessionIT.java
+++ b/server/src/test/java/com/arcadedb/server/ws/WebSocketInsertSessionIT.java
@@ -458,6 +458,40 @@ class WebSocketInsertSessionIT extends BaseGraphServerTest {
     assertThat(getServerDatabase(0, getDatabaseName()).countType("Person", false)).isZero();
   }
 
+  /**
+   * A frame whose fields carry the wrong JSON TYPE is a client mistake, and is answered as one. It used to reach
+   * the catch-all and come back as "Internal error", telling a client the server had broken when it had not.
+   */
+  @Test
+  void aFrameWithAWronglyTypedFieldIsAClientErrorNotAnInternalOne() throws Throwable {
+    try (final var client = newClient()) {
+      final JSONObject badOptions = new JSONObject();
+      badOptions.put("action", "start");
+      badOptions.put("database", getDatabaseName());
+      badOptions.put("options", "not-an-object");
+
+      final JSONObject refused = new JSONObject(client.send(badOptions.toString()));
+      assertThat(refused.getString("result", "")).isEqualTo("error");
+      assertThat(refused.getString("error", "")).isEqualTo("Insert session error");
+
+      final String sessionId = new JSONObject(client.send(start(null, "Person", null))).getString("sessionId");
+
+      final JSONObject badRecords = new JSONObject();
+      badRecords.put("action", "chunk");
+      badRecords.put("sessionId", sessionId);
+      badRecords.put("chunkSeq", 1);
+      badRecords.put("records", "not-an-array");
+
+      final JSONObject refusedChunk = new JSONObject(client.send(badRecords.toString()));
+      assertThat(refusedChunk.getString("result", "")).isEqualTo("error");
+      assertThat(refusedChunk.getString("error", "")).isEqualTo("Insert session error");
+
+      new JSONObject(client.send(control("rollback", sessionId)));
+    }
+
+    assertThat(getServer(0).getHttpServer().getInsertSessionManager().getOpenSessionCount()).isZero();
+  }
+
   /** A finished session releases its connection, which can then open another one. */
   @Test
   void aConnectionCanOpenANewSessionOnceTheFirstIsFinished() throws Throwable {

--- a/server/src/test/java/com/arcadedb/server/ws/WebSocketInsertSessionIT.java
+++ b/server/src/test/java/com/arcadedb/server/ws/WebSocketInsertSessionIT.java
@@ -330,6 +330,36 @@ class WebSocketInsertSessionIT extends BaseGraphServerTest {
     assertThat(database.countType("Person", false)).isEqualTo(2);
   }
 
+  /**
+   * A chunk that skips ahead of the next sequence due is refused. Letting the watermark follow whatever arrived
+   * would make the skipped chunk, when it finally lands, look like a replay of something that never happened -
+   * every row in it dropped, under a successful-looking answer.
+   */
+  @Test
+  void aChunkThatSkipsAheadIsRefusedAndTheSkippedOneStillLands() throws Throwable {
+    final Database database = getServerDatabase(0, getDatabaseName());
+
+    try (final var client = newClient()) {
+      final String sessionId = new JSONObject(client.send(start(null, "Person", null))).getString("sessionId");
+
+      assertThat(new JSONObject(client.send(chunk(sessionId, 1, "one"))).getLong("inserted", -1)).isEqualTo(1);
+
+      final JSONObject skipped = new JSONObject(client.send(chunk(sessionId, 5, "five")));
+      assertThat(skipped.getString("result", "")).isEqualTo("error");
+      assertThat(skipped.getString("detail", "")).contains("skips ahead").contains("expects 2");
+
+      // The refusal left the watermark alone, so the chunk that was actually next still goes in rather than
+      // being acknowledged as a replay of the jump.
+      final JSONObject second = new JSONObject(client.send(chunk(sessionId, 2, "two")));
+      assertThat(second.getBoolean("replay", false)).isFalse();
+      assertThat(second.getLong("inserted", -1)).isEqualTo(1);
+
+      new JSONObject(client.send(control("commit", sessionId)));
+    }
+
+    assertThat(database.countType("Person", false)).isEqualTo(2);
+  }
+
   /** Vertices and edges travel through the same session; an edge names its endpoints with {@code @from}/{@code @to}. */
   @Test
   void verticesAndEdgesGoInThroughTheSameSession() throws Throwable {


### PR DESCRIPTION
Closes #7382

## What this does

`InsertBidirectional (stream InsertRequest) returns (stream InsertResponse)` carries two things. #7311 shipped the first over HTTP: `POST /api/v1/batch` with `Accept: application/x-ndjson` writes a `progress` line for chunk *n* while chunk *n+1* is still being uploaded. The second - `Start`, `Commit`/`Rollback`, and a server free to push an unsolicited error mid-stream - needs the client to react to what the server said and change what it sends next **inside the same session**, which HTTP/1.1 cannot express under any encoding. That is why OpenAPI 3.0 cannot describe it and why `/ws` is deliberately absent from the generated document.

This adds that session to `/ws`, mirroring the gRPC frames:

| client → server | server → client |
|---|---|
| `start` (`database`, optional `sessionId`, `options`) | `started` (`sessionId`, `database`, `transactionMode`) |
| `chunk` (`sessionId`, `chunkSeq`, `records[]`) | `batchAck` (`received`/`inserted`/`updated`/`ignored`/`failed`, `errors[]`) |
| `commit` / `rollback` (`sessionId`) | `committed` (`outcome`, full-session `summary`) |
| | `error` - including unsolicited, which is what the idle sweep sends |

`InsertOptions.TransactionMode` is the part that most needed the control frames, because over `/batch` the commit policy is fixed by query parameters before the load starts:

- **`per_stream`** (default; `per_request` is accepted as an alias, since a `/ws` session *is* the request) - one transaction for the whole session, decided by the client's `commit` / `rollback` frame. The only mode in which a rollback can still undo a chunk the client has already been acknowledged for.
- **`per_batch`** - one transaction per chunk, committed before its `batchAck`.
- **`per_row`** - one transaction per row.
- **`none`** - refused at `start` rather than silently begun as a server-managed transaction. It means "the caller manages it externally", and a `/ws` session has no way to name an existing transaction yet: #7403.

`per_batch` and `per_row` commit as they go, so a later `rollback` cannot take a chunk back. The `committed` frame says so with `summary.partialCommit` rather than letting `outcome: rollback` imply an undo that did not happen.

A record takes its type from its own `@class` or from the session's `options.targetType`; the kind (document / vertex / edge) is read from the schema the way `ArcadeDbGrpcService.insertRows` reads it. An edge names its endpoints with `@from` / `@to` - the `/api/v1/batch` JSONL convention - and gRPC's `out` / `in` are accepted as aliases so a ported loader keeps working.

### Session lifetime, ownership and shutdown

The issue calls out that a new duplex surface is a separate protocol "with its own authentication, session lifetime, backpressure and shutdown semantics". Concretely:

- **One session per connection.** gRPC gets this for free (a session there *is* a stream). It bounds the number of live transactions by the number of connections, and it makes "the same session id is rejected by a second concurrent `start`" true for both shapes of the race: a second `start` on the same connection, and one on a different connection naming an id already taken.
- **Authentication** is the `/ws` handshake's; **authorization** is `canAccessToDatabase` on `start`, before the channel is claimed. A frame is served only to the connection AND the principal that opened the session.
- **Lifetime.** The session's `TransactionContext` is bound to whichever worker thread is running its current frame and detached again when that frame finishes - the same borrow-per-request lifecycle `DatabaseAbstractHandler` gives an `arcadedb-session-id` transaction, and the reason no thread has to be dedicated to a session.
- **Expiry.** New `arcadedb.server.wsInsertSessionExpireTimeout` (60s, `SCOPE.SERVER`). Deliberately not `httpSessionExpireTimeout`'s 5 seconds: a bulk loader legitimately pauses between chunks while it reads its source. The sweep uses `tryLock` and skips a session with a frame in flight - a chunk that outruns the timeout looks abandoned from outside, and rolling its transaction back from the timer thread while a worker is still writing into it is the defect #4857 closed for `HttpSession`.
- **Shutdown / disconnect.** Every path that ends a session *without* the client saying what it wanted rolls it back: the receive listener's `onClose`, the channel's own close task (which is what catches a socket that simply went away), and `HttpServer.stopService`. After `close()` the manager refuses new sessions, so a frame racing the shutdown cannot open one nothing would roll back.
- **Ordering and threads.** Frames touch the database, so they run on the Undertow worker pool, never on the I/O thread. A per-connection queue runs them one at a time in arrival order, so a client may pipeline `start` and its first chunks without waiting for `started` and no session ever has two frames in flight. No pool is added - the queue holds a worker only while it has frames and hands it back when it runs dry - so nothing in `.claude/skills/engine-concurrency` applies.
- **Backpressure.** The acknowledgements *are* the flow control. A connection more than 64 frames ahead of them is refused with an `error` frame naming the limit, and the session stays open so a client that catches up carries on. Bounding the *size* of one frame is #7405.

### Replay

`chunkSeq` is required and must be ≥ 1. A chunk at or below the session's watermark is acknowledged with zero tallies and `replay: true` instead of being applied again, mirroring the gRPC path; the watermark does not advance past a chunk whose own transaction failed, so replaying that one applies it rather than acknowledging it as a duplicate. Defaulting a missing `chunkSeq` to 0 would land on the initial watermark and silently drop every record the frame carried, so it is refused instead.

## Test plan

`mvn -pl server verify -DskipITs=false -DskipTests=true -Dit.test='WebSocketInsertSessionIT,WebSocketInsertSessionExpiryIT'` → **21 tests, 0 failures**.

The three verifications the issue asks for:

- [x] a session that sends two chunks and, after seeing the ack of the first, rolls back - neither chunk's records are in the database (`rollbackAfterSeeingAnAckDiscardsEveryChunk`)
- [x] a session that commits after the last ack - every record is (`commitAfterTheLastAckPersistsEveryRecord`)
- [x] the same session id rejected by a second concurrent `start`, on another connection and on the same one (`aSecondStartWithTheSameSessionIdIsRejected`)

and the rest of the surface:

- [x] `perBatchCommitsEachChunkSoARollbackCannotTakeItBack`, `perRowCommitsEveryRowOnItsOwn`, `perRequestIsAnAliasOfPerStream`
- [x] `optionsThisServerDoesNotImplementAreRefusedRatherThanIgnored` (`conflictMode` → #7404, `transactionMode: none` → #7403, an unknown mode)
- [x] `aChunkForAnUnknownSessionIsRefused`, `anotherConnectionCannotDriveTheSession`, `anotherUserCannotDriveTheSession`, `startOnAnUnauthorizedDatabaseIsRejected`
- [x] `aRowThatFailsIsReportedWhileTheRestOfTheChunkStillGoesIn`, `aReplayedChunkIsAcknowledgedWithoutBeingAppliedAgain`, `aChunkWithNoSequenceIsRefusedRatherThanTreatedAsAReplay`
- [x] `verticesAndEdgesGoInThroughTheSameSession`, `anEdgeCanNameItsEndpointsTheWayGrpcDoes`, `anEdgeWithoutEndpointsIsReportedPerRow`, `aRecordWithNoTypeIsReported`
- [x] `closingTheConnectionRollsTheSessionBack`, `aConnectionCanOpenANewSessionOnceTheFirstIsFinished`
- [x] `WebSocketInsertSessionExpiryIT.anAbandonedSessionIsRolledBackAndItsClientToldSo` - its own class because the expiry budget is a server setting, lowered to 1s there

**Proved the tests can fail**, not just pass:
- making `rollback` commit → `rollbackAfterSeeingAnAckDiscardsEveryChunk` FAILS.
- disabling the connection-close hook → `closingTheConnectionRollsTheSessionBack` FAILS (it passed against an earlier draft only because the sweep's budget was 5s and covered for it, which is part of why the budget is now its own 60s setting).

No regressions in the neighbourhood: `ChangeEventTest`, `Issue5024WebSocketEventBusConcurrencyTest`, `Issue6762WebSocketEventBusTest` → 14/14; `Issue7124BooleanSettingStrictCoercionTest`, `Issue7163DatabaseScopeCallbackTest` (they walk every `GlobalConfiguration` value, so they are the ones the new setting could break) → 19/19. Full reactor `mvn compile` green.

`WebSocketEventBusIT` and several `server` unit tests fail on this machine for an unrelated environment reason: they hardcode `localhost:2480`, and a foreign ArcadeDB process holds that port (`lsof -nP -iTCP:2480 -sTCP:LISTEN` shows two), so the requests are answered by it - `UpgradeFailedException: Invalid response code 403`, `401` where `200` was expected. The new ITs derive their URL from `getServer(0).getHttpServer().getPort()` and are immune.

## Coverage

| Entry point | Covered by fix? | Covered by a test? |
|---|---|---|
| `/ws` `start` → new session, generated or client-supplied id | yes | yes |
| `/ws` `chunk` → rows applied, `batchAck` written | yes | yes |
| `/ws` `commit` → durable | yes | yes |
| `/ws` `rollback` → nothing durable (`per_stream`) | yes | yes |
| duplicate `start`: same id, other connection | yes | yes |
| duplicate `start`: same connection, any id | yes | yes |
| `chunk`/`commit` naming an unknown or expired session | yes | yes |
| session driven from another connection / another principal | yes | yes |
| `start` on a database the principal cannot access | yes | yes |
| transaction modes `per_stream` / `per_request` / `per_batch` / `per_row` | yes | yes |
| transaction mode `none`, unknown mode, unimplemented option | refused with a pointer | yes |
| per-row failure inside a chunk | yes | yes |
| replayed `chunkSeq`; missing `chunkSeq` | yes | yes |
| document / vertex / edge records, `@from`/`@to` and `out`/`in` | yes | yes |
| connection closed with an open session | yes | yes |
| idle session swept | yes | yes (own IT class) |
| server shutdown with open sessions | yes | argued: `HttpServer.stopService` → `WebSocketInsertSessionManager.close()` cancels every session and then refuses new ones. Driving a real shutdown mid-session from an IT would race the fixture's own teardown for no additional signal |
| connection more than 64 frames ahead of its acks | yes | argued: the cap is a guard, not the feature. Filling it needs 64 frames queued faster than a worker drains them, which is a race no test client can win deterministically; a test that only goes red on a loaded machine is worse than none. Every other test drives the accepting path of the same `submit()` |
| `/ws` frames described in OpenAPI | argued: OpenAPI 3.0 cannot express a bidirectional stream under any encoding - the reason the issue gives for these frames not being an HTTP route. `OpenApiSpecGenerator`'s standing note about `/ws` now says so for the insert session specifically and points at the frame reference |
| a session on an HA follower | argued: the session commits through the ordinary `TransactionContext.commit()`, which on a replicated database is `RaftReplicatedDatabase`'s - the same path `POST /api/v1/command` uses. It does not go near `PostBatchHandler`'s bespoke leader-forwarding, which exists for the schema-dictionary race of the `GraphBatch` bulk path (#4122), so it inherits whatever ordinary transactional writes do and adds no new HA behaviour |

### Known gaps

Every one filed before this PR opened:

- **#7403** - a `/ws` session cannot join an externally-managed transaction, so `InsertOptions.NONE` (and gRPC's `Start.transaction`, which #6795 made `insertBidirectional` honour) has no counterpart. `transactionMode: "none"` is refused with a message pointing there.
- **#7404** - `conflictMode`, `keyColumns`, `updateColumnsOnConflict` and `validateOnly` are still gRPC-only, so `batchAck`'s `updated` / `ignored` can only ever be 0. Passing any of them to `start` is refused rather than ignored.
- **#7405** - `/ws` text frames are buffered whole with no size cap (`AbstractReceiveListener.getMaxTextBufferSize()` is `-1`). Pre-existing for the subscription frames; a `chunk` frame gives clients a reason to send large ones, so this PR makes the hole bulk-sized without opening it. The per-connection frame-*count* cap above is in this PR; the per-frame *size* cap is there.
- **#7406** - no client: `RemoteDatabase` cannot open a `/ws` insert session, so only a hand-written WebSocket client can use this. The gRPC side has `RemoteGrpcDatabase.insertBidirectional*`; a "decide commit or rollback after seeing the acks" callback is the part `RemoteGraphBatch`'s progress callback structurally cannot offer.

## Adversarial pass

The skill's Phase 1.5 spawns an isolated subagent to write the follow-up issue it would file against the patch. **No `Task` tool is available in this build**, so that pass was run by hand against the diff instead - noted here because a self-review is exactly the thing the isolated agent exists to avoid. Four findings survived reading the tree, all fixed in this branch before the PR opened:

1. **A missing `chunkSeq` was silently a replay.** `getLong("chunkSeq", 0)` defaulted to 0, which is `<= watermark` on a fresh session, so the frame was acknowledged as a duplicate and every record in it dropped. Now refused; `aChunkWithNoSequenceIsRefusedRatherThanTreatedAsAReplay`.
2. **The per-connection frame queue was unbounded.** The I/O thread returns immediately after enqueuing, so a client that never reads its acks could queue parsed chunks without limit. Capped at 64 with an `error` frame naming the limit.
3. **The idle sweep could tear down a busy session.** `lastUsed` is stamped when a frame *starts*, so a chunk slower than the timeout looks abandoned; the sweep rolled its transaction back from the timer thread while a worker was still writing into it - #4857's defect, in a new place. `cancelIfIdle()` now `tryLock`s and leaves a busy session registered for the next tick.
4. **The connection-close hook rolled back on the I/O thread.** Cancelling waits for the frame in flight, so a disconnect mid-chunk parked an I/O thread that other connections share. Now dispatched to the worker, with an inline fallback if the worker is already going away.

Two more were considered and deliberately not acted on:

- **`error` frames echo `e.getMessage()` and the exception class name.** They do - and so does the `sendError` that has always answered `subscribe`/`unsubscribe` on this endpoint. Diverging from the neighbouring code's policy in one new branch would be worse than matching it; if `/ws` should redact in production mode, that is a change to the whole endpoint.
- **A whole-chunk failure in `per_stream` leaves the session's transaction alive.** Intentional, and what gRPC does: the client is holding the control frames precisely so it can decide whether to retry the chunk or roll the session back.

## Notes for review

- New files are `server/src/main/java/com/arcadedb/server/http/ws/insert/` (4 classes). `WebSocketInsertProtocol`'s class javadoc is the frame reference.
- `WebSocketReceiveListener` gains a branch that hands the four insert actions off before its own `ACTION` parse; nothing about `subscribe`/`unsubscribe` changes.
- No existing test was modified and none was deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Raa9V6fPZda6yQkn3kvRZf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added duplex WebSocket insert sessions through the `/ws` endpoint, including document, vertex, and edge inserts.
  * Supports transaction modes, acknowledgements, per-row errors, duplicate-chunk replay, session ownership, and automatic rollback after disconnects or inactivity.
  * Added conflict handling options: update, ignore, error, abort, selective updates, and validation-only mode.
  * gRPC clients now recover across server restarts.
  * Database creation and deletion support idempotent operations with outcome reporting.

* **Bug Fixes**
  * Improved handling of expired, unknown, out-of-order, and invalid sessions and insert operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->