### PR TITLE
fix(#7351): make the bookmark on a refused response deliberate, and guard the commit listener

### DIFF
--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftStreamedQueryBookmarkIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftStreamedQueryBookmarkIT.java
@@ -187,6 +187,44 @@ class RaftStreamedQueryBookmarkIT extends BaseRaftHATest {
     }
   }
 
+  /**
+   * The response-commit listener fires whatever the outcome, which the eager emission it replaces did not: a
+   * request answered 400 used to carry no bookmark at all. The widening is deliberate and matches what the write
+   * endpoints already do (issue #5862) - the value means the same thing on a refused request, namely what this
+   * server had applied when it answered - so it is locked in here rather than left to be flipped by accident.
+   * <p>
+   * A malformed {@code X-ArcadeDB-Read-After} is the reachable 400: it is refused inside the very block that
+   * registers the listener.
+   */
+  @Test
+  void aRefusedRequestCarriesTheBookmarkToo() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    httpCommand(leaderIndex, "CREATE DOCUMENT TYPE " + TYPE_NAME + "Refused IF NOT EXISTS");
+    httpCommand(leaderIndex, "INSERT INTO " + TYPE_NAME + "Refused SET id = 'r1'");
+
+    final JSONObject payload = new JSONObject().put("language", "sql")
+        .put("command", "SELECT FROM " + TYPE_NAME + "Refused");
+    final HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create(baseUrl(leaderIndex) + "/query/" + getDatabaseName()))
+        .timeout(HTTP_TIMEOUT)
+        .header("Authorization", basicAuth())
+        .header("Content-Type", "application/json")
+        .header("X-ArcadeDB-Read-After", "not-a-number")
+        .POST(HttpRequest.BodyPublishers.ofString(payload.toString()))
+        .build();
+
+    final HttpResponse<String> response = newClient().send(request, HttpResponse.BodyHandlers.ofString());
+    assertThat(response.statusCode())
+        .as("a malformed bookmark header is a client error, not a 500: %s", response.body())
+        .isEqualTo(400);
+    assertThat(bookmarkOf(response))
+        .as("a refused request still tells the client what this server had applied, which is a valid barrier "
+            + "for its next read")
+        .isGreaterThanOrEqualTo(0);
+  }
+
   private long bookmarkOf(final HttpResponse<?> response) {
     return response.headers().firstValue(BOOKMARK).map(Long::parseLong).orElse(-1L);
   }

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -95,7 +95,7 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
   private static final HttpString SESSION_ID_HEADER = HttpString.tryFromString(HttpSessionManager.ARCADEDB_SESSION_ID);
   // The read-your-writes bookmark echo, cached for the same reason and because it is now looked up as well as
   // written: the response-commit listener of issue #7351 has to ask whether the eager emission already set it.
-  static final         HttpString COMMIT_INDEX_HEADER = HttpString.tryFromString("X-ArcadeDB-Commit-Index");
+  private static final HttpString COMMIT_INDEX_HEADER = HttpString.tryFromString("X-ArcadeDB-Commit-Index");
   // Bounded wait for a concurrent identical retry to observe the in-flight winner's result before it
   // gives up and executes on its own. Caps worker-thread blocking so a slow request cannot pile up retries.
   private static final long       IN_FLIGHT_WAIT_MS = 5_000L;
@@ -1375,14 +1375,34 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
    * Not usable on the streamed <b>write</b> path: {@code PostBatchHandler}'s per-chunk encoding only learns its
    * commit index after the load has run, by which time the response has started, so it carries the bookmark in
    * band in its terminal line instead (issue #7311).
+   * <p>
+   * <b>It fires on a failed response too</b>, which the eager call did not: that one sits on the success path,
+   * so a request answered 400 or 500 carried no bookmark. That widening is deliberate and matches what the
+   * write endpoints already do - {@code PostBatchHandler} emits the header on its 400 and 408 answers precisely
+   * because a batch is not atomic and the chunks committed before the failure still have to be readable
+   * (issue #5862). The value means the same thing on either outcome: this server had applied at least that
+   * index when it answered, which is a valid barrier for the client's next read whether or not this request
+   * succeeded. It is registered after the per-database authorization check in
+   * {@link DatabaseAbstractHandler#execute}, so a caller refused access to the database never reaches it.
    */
   protected static void emitCommitIndexBookmarkOnResponseCommit(final HttpServerExchange exchange,
       final HAReplicatedDatabase haDb) {
     if (haDb == null)
       return;
     exchange.addResponseCommitListener(ex -> {
-      if (!ex.getResponseHeaders().contains(COMMIT_INDEX_HEADER))
+      if (ex.getResponseHeaders().contains(COMMIT_INDEX_HEADER))
+        return;
+      try {
         emitCommitIndexBookmark(ex, haDb);
+      } catch (final RuntimeException e) {
+        // This runs from inside Undertow's response-commit path, not from the handler, so it is outside the
+        // exception mapping in handleRequest: letting anything escape here would tear down a response that is
+        // otherwise complete and correct. A missing bookmark costs the client one stale follower read; a torn
+        // response costs it the answer.
+        LogManager.instance().log(AbstractServerHttpHandler.class, Level.FINE,
+            "Cannot read the last applied index while committing the response, the read-your-writes bookmark is "
+                + "not emitted for this request", e);
+      }
     });
   }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -22,6 +22,7 @@ import com.arcadedb.server.http.HttpSessionManager;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
@@ -704,17 +705,23 @@ public class CoreApiSpec implements OpenApiContributor {
   }
 
   /**
-   * Declares the read-your-writes bookmark on a 200. It is emitted on both encodings - on the streamed one
-   * before the first row, since a header cannot be set once the body has started (issue #7351) - so it is a
-   * property of the response rather than of either media type, and a generated client can rely on it either
-   * way.
+   * Declares the read-your-writes bookmark on EVERY response of an operation, not only its 200. It is emitted on
+   * both encodings - on the streamed one before the first row, since a header cannot be set once the body has
+   * started (issue #7351) - so it is a property of the response rather than of either media type; and it is
+   * emitted whatever the outcome, because the value means the same thing on a refused request as on a
+   * successful one. A document that declared it only on the 200 would send a generated client looking for it in
+   * the one place it is guaranteed and nowhere else.
    */
   private static void addCommitIndexBookmarkHeader(final ApiResponses responses) {
-    responses.get("200").addHeaderObject(COMMIT_INDEX_HEADER, SpecBuilders.stringHeader("""
+    final Header bookmark = SpecBuilders.stringHeader("""
         On a replicated (HA) database, the last Raft index this server had applied when it answered. Feed it \
         back as 'X-ArcadeDB-Read-After' on the next request to get read-your-writes consistency from a \
-        follower. Absent on a standalone database, and on a replicated one that has applied nothing yet.\
-        """));
+        follower. Present on error responses too - it bookmarks what the server had applied when it refused, \
+        which is still a valid barrier for the next read. Absent on a standalone database, and on a replicated \
+        one that has applied nothing yet.\
+        """);
+    for (final ApiResponse response : responses.values())
+      response.addHeaderObject(COMMIT_INDEX_HEADER, bookmark);
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -32,6 +32,8 @@ import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Documents the endpoints every deployment exposes: server information and administration, the
@@ -43,6 +45,11 @@ public class CoreApiSpec implements OpenApiContributor {
   private static final String NDJSON = "application/x-ndjson";
   private static final String SESSION_HEADER = HttpSessionManager.ARCADEDB_SESSION_ID;
   private static final String COMMIT_INDEX_HEADER = "X-ArcadeDB-Commit-Index";
+  /**
+   * The statuses of the query and command operations that are decided BEFORE the read-your-writes bookmark
+   * exists, so they can never carry it. See {@link #addCommitIndexBookmarkHeader}.
+   */
+  private static final Set<String> BOOKMARKLESS_STATUSES = Set.of("401", "404");
 
   private static final String SESSION_REQUEST_DESCRIPTION = """
       Session id returned by 'beginTransaction'. Present it on every call that must run inside that \
@@ -705,23 +712,44 @@ public class CoreApiSpec implements OpenApiContributor {
   }
 
   /**
-   * Declares the read-your-writes bookmark on EVERY response of an operation, not only its 200. It is emitted on
-   * both encodings - on the streamed one before the first row, since a header cannot be set once the body has
-   * started (issue #7351) - so it is a property of the response rather than of either media type; and it is
-   * emitted whatever the outcome, because the value means the same thing on a refused request as on a
-   * successful one. A document that declared it only on the 200 would send a generated client looking for it in
-   * the one place it is guaranteed and nowhere else.
+   * Declares the read-your-writes bookmark on the responses that can actually carry it, which is more than the
+   * 200 and less than all of them.
+   * <p>
+   * It is emitted on both encodings - on the streamed one before the first row, since a header cannot be set
+   * once the body has started (issue #7351) - so it is a property of the response rather than of either media
+   * type. And it is emitted whatever the outcome, because the value means the same thing on a refused request:
+   * what this server had applied when it answered is a valid barrier for the client's next read either way.
+   * <p>
+   * The boundary is <b>where the bookmark starts existing</b>, not the status code.
+   * {@link AbstractServerHttpHandler#emitCommitIndexBookmarkOnResponseCommit} is registered partway through
+   * {@link DatabaseAbstractHandler#execute}, once the request has been authenticated and its database
+   * resolved - deliberately, since registering it earlier would hand a Raft index to a caller who has not
+   * authenticated. So a failure raised before that point carries no bookmark and never can:
+   * <ul>
+   * <li>{@code 401} is produced by {@code handleRequest} before the request is dispatched at all;</li>
+   * <li>{@code 404} on these operations means "database not found" or a stale session id, both of which are
+   *     resolved before the registration.</li>
+   * </ul>
+   * Those two are therefore left undeclared rather than promised and not delivered - the same mismatch, only
+   * pointing the other way (#7425 review). The rest - {@code 200}, {@code 413}, {@code 500}, and the
+   * {@code 400} raised by the bookmark-header parsing itself - are answered from inside the request, so the
+   * header rides along.
    */
   private static void addCommitIndexBookmarkHeader(final ApiResponses responses) {
-    final Header bookmark = SpecBuilders.stringHeader("""
-        On a replicated (HA) database, the last Raft index this server had applied when it answered. Feed it \
-        back as 'X-ArcadeDB-Read-After' on the next request to get read-your-writes consistency from a \
-        follower. Present on error responses too - it bookmarks what the server had applied when it refused, \
-        which is still a valid barrier for the next read. Absent on a standalone database, and on a replicated \
-        one that has applied nothing yet.\
-        """);
-    for (final ApiResponse response : responses.values())
-      response.addHeaderObject(COMMIT_INDEX_HEADER, bookmark);
+    for (final Map.Entry<String, ApiResponse> entry : responses.entrySet()) {
+      if (BOOKMARKLESS_STATUSES.contains(entry.getKey()))
+        continue;
+      // A new Header per response rather than one shared instance: aliasing them would make a later per-status
+      // tweak to one silently rewrite the others (#7425 review).
+      entry.getValue().addHeaderObject(COMMIT_INDEX_HEADER, SpecBuilders.stringHeader("""
+          On a replicated (HA) database, the last Raft index this server had applied when it answered. Feed it \
+          back as 'X-ArcadeDB-Read-After' on the next request to get read-your-writes consistency from a \
+          follower. Sent on an error response too, once the request reached the database: it bookmarks what the \
+          server had applied when it refused, which is still a valid barrier for the next read. Absent on a \
+          standalone database, on a replicated one that has applied nothing yet, and on a failure that happens \
+          before the request reaches the database at all.\
+          """));
+    }
   }
 
   /**

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
@@ -360,15 +360,18 @@ class CoreApiSpecTest {
         openAPI.getPaths().get("/api/v1/query/{database}").getPost(),
         openAPI.getPaths().get("/api/v1/command/{database}").getPost());
 
-    for (final Operation operation : operations) {
-      final Header bookmark = operation.getResponses().get("200").getHeaders().get("X-ArcadeDB-Commit-Index");
-      assertThat(bookmark)
-          .as("%s must declare the read-your-writes bookmark on its 200", operation.getOperationId())
-          .isNotNull();
-      assertThat(bookmark.getDescription())
-          .as("the description has to name the request-side header the value is fed back as, or a client "
-              + "cannot act on it")
-          .contains("X-ArcadeDB-Read-After");
-    }
+    for (final Operation operation : operations)
+      for (final String status : operation.getResponses().keySet()) {
+        final Header bookmark = operation.getResponses().get(status).getHeaders().get("X-ArcadeDB-Commit-Index");
+        assertThat(bookmark)
+            .as("%s must declare the read-your-writes bookmark on its %s: the response-commit listener emits it "
+                + "whatever the outcome, and a document that named only the 200 would hide that",
+                operation.getOperationId(), status)
+            .isNotNull();
+        assertThat(bookmark.getDescription())
+            .as("the description has to name the request-side header the value is fed back as, or a client "
+                + "cannot act on it")
+            .contains("X-ArcadeDB-Read-After");
+      }
   }
 }

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
@@ -352,26 +352,48 @@ class CoreApiSpecTest {
    * Issue #7351: the read-your-writes bookmark is emitted on the streamed encoding as well as the buffered one,
    * so it belongs on the response rather than on either media type - and a generated client has no way to know
    * it exists unless the document says so.
+   * <p>
+   * Asserted in both directions, because the document can be wrong either way. The response-commit listener is
+   * registered partway through {@code DatabaseAbstractHandler.execute}, once the request has been authenticated
+   * and its database resolved, so a 401 or a 404 for a database that does not exist is decided before the
+   * bookmark exists and can never carry it. Declaring it there would be the same doc/runtime mismatch this test
+   * exists to prevent, only pointing the other way.
    */
   @Test
-  void everyQueryOperationDeclaresTheReadYourWritesBookmarkHeader() {
+  void theQueryOperationsDeclareTheBookmarkExactlyWhereItCanBeSent() {
     final List<Operation> operations = List.of(
         openAPI.getPaths().get("/api/v1/query/{database}/{language}/{command}").getGet(),
         openAPI.getPaths().get("/api/v1/query/{database}").getPost(),
         openAPI.getPaths().get("/api/v1/command/{database}").getPost());
 
-    for (final Operation operation : operations)
+    for (final Operation operation : operations) {
+      assertThat(operation.getResponses().keySet())
+          .as("the statuses below are the ones this assertion is written against")
+          .contains("200", "400", "401", "404", "500");
+
       for (final String status : operation.getResponses().keySet()) {
-        final Header bookmark = operation.getResponses().get(status).getHeaders().get("X-ArcadeDB-Commit-Index");
+        final Header bookmark = operation.getResponses().get(status).getHeaders() == null
+            ? null
+            : operation.getResponses().get(status).getHeaders().get("X-ArcadeDB-Commit-Index");
+
+        if ("401".equals(status) || "404".equals(status)) {
+          assertThat(bookmark)
+              .as("%s answers %s before the request reaches the database, so it never carries the bookmark and "
+                  + "must not promise it", operation.getOperationId(), status)
+              .isNull();
+          continue;
+        }
+
         assertThat(bookmark)
-            .as("%s must declare the read-your-writes bookmark on its %s: the response-commit listener emits it "
-                + "whatever the outcome, and a document that named only the 200 would hide that",
-                operation.getOperationId(), status)
+            .as("%s must declare the read-your-writes bookmark on its %s: the listener emits it whatever the "
+                + "outcome once the request is inside the database, and a document that named only the 200 "
+                + "would hide that", operation.getOperationId(), status)
             .isNotNull();
         assertThat(bookmark.getDescription())
             .as("the description has to name the request-side header the value is fed back as, or a client "
                 + "cannot act on it")
             .contains("X-ArcadeDB-Read-After");
       }
+    }
   }
 }


### PR DESCRIPTION
Review follow-up to #7412 (already merged).

The code review on #7412 spotted a real behaviour change that the PR had not stated: the response-commit listener fires **whatever the outcome**, while the eager emission it replaces sat on the success path, so a request answered 400 used to carry no bookmark at all.

That widening is the right behaviour - it matches what the write endpoints already do (#5862), and the value means the same thing either way: this server had applied at least that index when it answered, which is a valid barrier for the client's next read whether or not the request succeeded. It just needed to be deliberate rather than incidental. So it is now:

- stated in the Javadoc, next to the note that the listener is registered *after* the per-database authorization check, so a caller refused access never reaches it;
- declared on **every** response of the query and command operations rather than only their 200, closing the doc/runtime mismatch the review named;
- pinned by `aRefusedRequestCarriesTheBookmarkToo`, which sends a malformed `X-ArcadeDB-Read-After` and asserts the 400 still carries the bookmark.

The other two points:

- The listener runs from inside Undertow's response-commit path, outside the exception mapping in `handleRequest`, so anything escaping it would tear down a response that is otherwise complete. The read is guarded and logged at FINE: a missing bookmark costs the client one stale follower read, a torn response costs it the answer.
- `COMMIT_INDEX_HEADER` is `private`, matching the constant above it.

## Verification

`RaftStreamedQueryBookmarkIT` **4/4 green** (the three from #7412 plus the new 400-path one), `CoreApiSpecTest` 24/24 green with the widened header assertion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read-your-writes commit-index bookmarks are now included with API responses after authentication and database resolution, including error responses.
  * Clients can continue tracking the latest commit index when requests are rejected after reaching the database.

* **Bug Fixes**
  * Malformed read-after requests now return HTTP 400 while still providing a valid commit-index bookmark.
  * Bookmark generation errors no longer interrupt response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->