### PR TITLE
feat(#7353): stream the temporary-id mapping back one committed chunk at a time

### DIFF
--- a/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
@@ -1263,16 +1263,51 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
     return getUrl(command) + "/" + databaseName;
   }
 
+  /**
+   * Convenience form for a caller with nothing to listen to. Delegates, and never sends: there is exactly one
+   * method on this class that puts a batch on the wire, and it is {@link #sendBatch(String, Map, Consumer)}.
+   */
   JSONObject sendBatch(final String content, final Map<String, String> queryParams) {
+    return sendBatch(content, queryParams, null);
+  }
+
+  /**
+   * Sends one bulk-load payload to {@code POST /api/v1/batch} and returns the load's summary object.
+   * <p>
+   * <b>The single place a batch request is sent</b>, and therefore the method a subclass overrides to intercept
+   * every flush this client makes. It used to be the two-argument overload, with this one delegating to it for a
+   * {@code null} listener and duplicating it otherwise - which meant a subclass intercepting flushes saw only
+   * the ones that asked for no progress, silently, since the compiler is perfectly happy to call the sibling
+   * method nobody overrode. Now that {@code RemoteGraphBatch} always negotiates the streaming encoding
+   * (issue #7353) that split would have hidden every flush it makes, so the two paths were folded into one:
+   * there is no second method to forget.
+   * <p>
+   * With an {@code onProgress} listener the request negotiates the streaming encoding of issue #7311
+   * ({@code Accept: application/x-ndjson}) and the listener is handed every {@code progress} line as it arrives,
+   * so a caller learns what the server has committed - and, since issue #7353, which temporary ids it resolved -
+   * while the rest of its payload is still being read. The object returned is the terminal {@code summary} line,
+   * which carries exactly the fields the buffered encoding returns, so nothing downstream of this method has to
+   * know which encoding was used.
+   *
+   * @param onProgress notified once per chunk acknowledgement, or {@code null} to send an unnegotiated request
+   *                   answered by the single buffered object
+   */
+  JSONObject sendBatch(final String content, final Map<String, String> queryParams,
+      final Consumer<JSONObject> onProgress) {
     checkDatabaseIsOpen();
 
     try {
-      final HttpRequest request = createRequestBuilder("POST", batchUrl(queryParams))
+      final HttpRequest.Builder builder = createRequestBuilder("POST", batchUrl(queryParams))
           .POST(HttpRequest.BodyPublishers.ofString(content))
-          .header("Content-Type", NDJSON_CONTENT_TYPE)
-          .build();
+          .header("Content-Type", NDJSON_CONTENT_TYPE);
 
-      final HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+      if (onProgress != null)
+        return readStreamedBatch(
+            httpClient.send(builder.header("Accept", NDJSON_CONTENT_TYPE).build(),
+                HttpResponse.BodyHandlers.ofInputStream()),
+            onProgress);
+
+      final HttpResponse<String> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
 
       // GraphBatch commits internally every commitEvery records (issue #5862), so unlike a single
       // begin/commit/rollback a non-200 response here can still carry chunks the server already made
@@ -1286,48 +1321,6 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
       }
 
       return new JSONObject(response.body());
-    } catch (final DatabaseOperationException e) {
-      throw e;
-    } catch (final Exception e) {
-      throw new DatabaseOperationException("Error on batch import", e);
-    }
-  }
-
-  /**
-   * Sends one bulk-load payload to {@code POST /api/v1/batch} and returns the load's summary object.
-   * <p>
-   * With a {@code onProgress} listener the request negotiates the streaming encoding of issue #7311
-   * ({@code Accept: application/x-ndjson}) and the listener is handed every {@code progress} line as it arrives,
-   * so a caller learns what the server has committed while the rest of its payload is still being read. The
-   * object returned is the terminal {@code summary} line, which carries exactly the fields the buffered
-   * encoding returns - so nothing downstream of this method has to know which encoding was used.
-   * <p>
-   * With a {@code null} listener this delegates to {@link #sendBatch(String, Map)}, so a subclass that overrode
-   * that method to intercept every flush still sees it. A subclass that wants to intercept a load WITH a
-   * listener has to override this method too - there is no third place the two paths meet.
-   *
-   * @param onProgress notified once per chunk acknowledgement, or {@code null} to send an unnegotiated request
-   */
-  JSONObject sendBatch(final String content, final Map<String, String> queryParams,
-      final Consumer<JSONObject> onProgress) {
-    // Delegates rather than duplicates, and in this direction on purpose: sendBatch(content, queryParams) is an
-    // overridable extension point that a subclass replaces to intercept every flush - Issue7031RemoteClientIT
-    // does exactly that to simulate a failed request. Routing the no-listener case through the new overload
-    // instead would have walked straight past those overrides, silently, since the compiler is perfectly happy
-    // to call the sibling method nobody overrode.
-    if (onProgress == null)
-      return sendBatch(content, queryParams);
-
-    checkDatabaseIsOpen();
-
-    try {
-      final HttpRequest request = createRequestBuilder("POST", batchUrl(queryParams))
-          .POST(HttpRequest.BodyPublishers.ofString(content))
-          .header("Content-Type", NDJSON_CONTENT_TYPE)
-          .header("Accept", NDJSON_CONTENT_TYPE)
-          .build();
-
-      return readStreamedBatch(httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream()), onProgress);
     } catch (final DatabaseOperationException e) {
       throw e;
     } catch (final Exception e) {

--- a/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteGraphBatch.java
@@ -73,8 +73,10 @@ public class RemoteGraphBatch implements AutoCloseable {
   private final   Map<String, String> queryParams;
   private final   int                 flushEvery;
   /**
-   * Notified once per server-side chunk acknowledgement while a flush is still uploading, or {@code null} when
-   * the caller did not ask for progress and the flush uses the buffered request it always used (issue #7311).
+   * The caller's own progress listener, notified once per server-side chunk acknowledgement while a flush is
+   * still uploading (issue #7311), or {@code null} when it asked for none. It no longer decides the encoding:
+   * every flush negotiates the streaming one, because that is how the temporary-id mapping comes back a chunk
+   * at a time instead of as one object per flush (issue #7353).
    */
   private final   Consumer<JSONObject> progressListener;
   private final   StringBuilder       buffer;
@@ -244,7 +246,13 @@ public class RemoteGraphBatch implements AutoCloseable {
 
     queryParams.put("ordinalBase", Integer.toString(bufferOrdinalBase));
 
-    final JSONObject response = database.sendBatch(buffer.toString(), queryParams, progressListener);
+    // Always the streaming encoding, whether or not the caller asked for progress (issue #7353). It is the
+    // mapping that makes it non-optional: with the buffered one the server has to build the temporary-id map of
+    // the entire flush as a single JSON object, and this client has to read that object back in one piece -
+    // 50,000 entries per flush by default, and every vertex of the load when flushEvery is 0. Streamed, the
+    // mapping arrives one committed chunk at a time and neither end ever holds more than one chunk of it. The
+    // caller's own listener, when it set one, is notified from inside this one.
+    final JSONObject response = database.sendBatch(buffer.toString(), queryParams, this::onFlushProgress);
 
     totalVerticesCreated += response.getLong("verticesCreated");
     totalEdgesCreated += response.getLong("edgesCreated");
@@ -252,33 +260,70 @@ public class RemoteGraphBatch implements AutoCloseable {
 
     if (response.getBoolean("idMappingOmitted", false))
       // Never resolve edges against a mapping that is not there: it would silently drop every cross-flush edge.
+      // Only reachable against a server that predates issue #7311 and answered the buffered object: one that
+      // streams says 'idMappingStreamed' instead, and has no size at which it stops sending.
       throw new IllegalStateException(
           "The server did not return the temporary-id mapping of the last flush (" + response.getInt("idMappingSize", 0)
-              + " ids). Lower flushEvery so each request stays within what the server echoes back");
+              + " ids). Lower flushEvery so each request stays within what the server echoes back, or upgrade the "
+              + "server to one that streams the mapping back as it resolves it");
 
-    // Store resolved temp ID → RID mapping for cross-flush edge references
-    if (response.has("idMapping")) {
-      final JSONObject idMapping = response.getJSONObject("idMapping");
-      for (final String key : idMapping.keySet()) {
-        // "123" in ordinal mode, "v123" when the server resolves by temporary id.
-        final int idx = Integer.parseInt(key.charAt(0) == 'v' ? key.substring(1) : key);
-        final String ridStr = idMapping.getString(key);      // "#3:456"
-        final int colonPos = ridStr.indexOf(':');
-        final int bucketId = Integer.parseInt(ridStr.substring(1, colonPos));
-        final long position = Long.parseLong(ridStr.substring(colonPos + 1));
+    // The residual mapping of the last chunk, when the server streamed it, or the whole mapping of the flush
+    // when it answered the buffered object - which a server predating issue #7353 still does.
+    applyIdMapping(response);
 
-        ensureMappingCapacity(idx + 1);
-        resolvedBucketIds[idx] = bucketId;
-        resolvedPositions[idx] = position;
-        if (idx >= resolvedCount)
-          resolvedCount = idx + 1;
-      }
-    }
+    if (response.getBoolean("idMappingStreamed", false) && resolvedCount < vertexCounter)
+      // The count the terminal line reports is what makes an incomplete stream detectable at all: a mapping
+      // that arrives in pieces can lose a piece to a truncated response without any single piece looking wrong,
+      // and an edge resolved against the gap would silently point at the wrong vertex.
+      throw new IllegalStateException("The server resolved " + response.getInt("idMappingSize", 0)
+          + " temporary ids for the last flush but only " + (resolvedCount - bufferOrdinalBase)
+          + " of them arrived, so the mapping this batch resolves its cross-flush edges against is incomplete");
 
     buffer.setLength(0);
     itemsInBuffer = 0;
     bufferOrdinalBase = vertexCounter;
     failed = false;
+  }
+
+  /**
+   * Handed every {@code progress} line of a flush. It applies the temporary ids that line reports as resolved -
+   * which is why this client negotiates the streaming encoding at all (issue #7353) - and then passes the line
+   * on to the caller's own listener, if it set one.
+   * <p>
+   * Applying a mapping before the flush that produced it has returned is safe here for the same reason the
+   * counters on the same line are: a batch is not atomic, so the chunks acknowledged before a failure are
+   * durable, and a flush that does not complete leaves this batch permanently {@code failed} and unusable
+   * (issue #7031) - so a partially applied mapping is never resolved against.
+   */
+  private void onFlushProgress(final JSONObject progress) {
+    applyIdMapping(progress);
+    if (progressListener != null)
+      progressListener.accept(progress);
+  }
+
+  /**
+   * Folds one {@code idMapping} object - a whole flush's worth from the buffered encoding, or one committed
+   * chunk's worth from a streamed line - into the flat arrays that resolve cross-flush edge references.
+   */
+  private void applyIdMapping(final JSONObject event) {
+    if (!event.has("idMapping"))
+      return;
+
+    final JSONObject idMapping = event.getJSONObject("idMapping");
+    for (final String key : idMapping.keySet()) {
+      // "123" in ordinal mode, "v123" when the server resolves by temporary id.
+      final int idx = Integer.parseInt(key.charAt(0) == 'v' ? key.substring(1) : key);
+      final String ridStr = idMapping.getString(key);      // "#3:456"
+      final int colonPos = ridStr.indexOf(':');
+      final int bucketId = Integer.parseInt(ridStr.substring(1, colonPos));
+      final long position = Long.parseLong(ridStr.substring(colonPos + 1));
+
+      ensureMappingCapacity(idx + 1);
+      resolvedBucketIds[idx] = bucketId;
+      resolvedPositions[idx] = position;
+      if (idx >= resolvedCount)
+        resolvedCount = idx + 1;
+    }
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
@@ -88,7 +88,10 @@ import java.util.logging.Level;
  * <p>
  * Response: {@code verticesCreated}, {@code edgesCreated}, {@code elapsedMs}, {@code bytesRead} and, when temporary
  * ids were used, {@code idMapping} - replaced by {@code idMappingOmitted} / {@code idMappingSize} past
- * {@link #MAX_ID_MAPPING_IN_RESPONSE} entries, unless {@code idMapping=true} demands it.
+ * {@link #MAX_ID_MAPPING_IN_RESPONSE} entries, unless {@code idMapping=true} demands it. On the streaming
+ * encoding the mapping is not in this object at all: it travelled in the acknowledgements, and the terminal line
+ * says {@code idMappingStreamed} with the {@code idMappingSize} to check the received pieces against
+ * (issue #7353).
  * <p>
  * Streaming response ({@code Accept: application/x-ndjson}): the answer above is a single object written after the
  * whole body has been consumed, so a caller learns nothing about chunk <i>n</i> until chunk <i>n+1</i> and every
@@ -97,9 +100,14 @@ import java.util.logging.Level;
  * newline-delimited stream, written while its own upload is still being read:
  * <ul>
  * <li>{@code {"progress": {...}}} - emitted at every vertex commit and every {@code commitEvery} edges, carrying
- *     the same counters the final answer carries, plus {@code phase} ({@code vertices} or {@code edges});</li>
- * <li>{@code {"summary": {...}}} - the last line of a successful load. Byte-for-byte the object the buffered
- *     encoding would have sent, produced by the same code, plus {@code commitIndex} on a replicated database;</li>
+ *     the same counters the final answer carries, plus {@code phase} ({@code vertices} or {@code edges}) and
+ *     {@code idMapping}: the temporary ids THIS chunk resolved, and only those. Concatenating them yields what
+ *     the buffered encoding returns in one object, which is the point - neither end ever holds the mapping of
+ *     the whole load, and the {@link #MAX_ID_MAPPING_IN_RESPONSE} cap that exists because the buffered encoding
+ *     does has no counterpart here (issue #7353);</li>
+ * <li>{@code {"summary": {...}}} - the last line of a successful load. The object the buffered encoding would
+ *     have sent, produced by the same code, plus {@code commitIndex} on a replicated database, and with
+ *     {@code idMappingStreamed} / {@code idMappingSize} where that object carries the mapping itself;</li>
  * <li>{@code {"error": {...}}} - the last line of a failed one: the object the buffered encoding would have sent,
  *     plus the {@code status} it would have sent it under. A 200 is already on the wire by then and cannot be
  *     taken back, so the status travels in band and the line is the only terminator a consumer gets - a stream
@@ -180,8 +188,10 @@ import java.util.logging.Level;
  *   one transaction. On a replicated database that transaction becomes a single Raft entry, so this is the
  *   knob to lower when the server warns that a replicated entry approaches the maximum entry size
  *   (issue #5470); on an embedded/standalone database it only trades memory for throughput
- * - idMapping (auto|true|false, default auto): whether the response echoes the temporary-id to RID mapping. See
- *   {@link #echoIdMapping}
+ * - idMapping (auto|true|false, default auto): whether the response returns the temporary-id to RID mapping. On
+ *   the buffered encoding it is echoed in the terminal object under a size cap - see {@link #echoIdMapping}; on
+ *   the streaming one it is handed back one committed chunk at a time and there is no cap, because nothing is
+ *   ever built that a cap would protect - see {@link #streamIdMapping} (issue #7353)
  * - refMode (id|ordinal, default id): how edges name the vertices they connect. {@code id} resolves the
  *   {@code @from} / {@code @to} against the {@code @id} each vertex declared, which costs the id itself plus a hash
  *   slot for every vertex of the request; {@code ordinal} resolves them against the 0-based POSITION of the vertex
@@ -332,8 +342,10 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
             vertexBatchSize, expectedRecords, haDb);
 
       try {
+        // No mapping sink: the buffered encoding has nowhere to put a chunk of it before the end, so it keeps
+        // echoing the whole mapping in the terminal object under the MAX_ID_MAPPING_IN_RESPONSE cap.
         return streamRecords(exchange, databaseName, isCsv, builder, inputStream, vertexRefs,
-            System.currentTimeMillis(), vertexBatchSize, expectedRecords, BatchProgressSink.NONE);
+            System.currentTimeMillis(), vertexBatchSize, expectedRecords, BatchProgressSink.NONE, null);
       } finally {
         emitCommitIndexBookmark(exchange, haDb);
       }
@@ -355,7 +367,8 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
   private ExecutionResponse streamRecords(final HttpServerExchange exchange, final String databaseName,
       final boolean isCsv, final GraphBatch.Builder builder, final CountingInputStream inputStream,
       final VertexRefResolver vertexRefs, final long startTime, final int vertexBatchSize,
-      final long expectedRecords, final BatchProgressSink progress) throws Exception {
+      final long expectedRecords, final BatchProgressSink progress,
+      final VertexRefResolver.EntryConsumer mappingSink) throws Exception {
 
     long verticesCreated = 0;
     long edgesCreated = 0;
@@ -396,7 +409,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
           // Transition to edge phase: flush remaining vertices
           if (!vertexPropsBatch.isEmpty()) {
             verticesCreated += flushVertexBatch(batch, currentTypeName, vertexPropsBatch, vertexTempIds, vertexRefs,
-                verticesCreated);
+                verticesCreated, mappingSink);
             progress.chunk(VERTEX_PHASE, verticesCreated, edgesCreated, stream, vertexRefs, inputStream);
           }
 
@@ -413,7 +426,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
         // Accumulate vertex — flush when type changes or batch is full
         if (currentTypeName != null && !currentTypeName.equals(rec.typeName)) {
           verticesCreated += flushVertexBatch(batch, currentTypeName, vertexPropsBatch, vertexTempIds, vertexRefs,
-              verticesCreated);
+              verticesCreated, mappingSink);
           progress.chunk(VERTEX_PHASE, verticesCreated, edgesCreated, stream, vertexRefs, inputStream);
         }
         currentTypeName = rec.typeName;
@@ -422,7 +435,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
 
         if (vertexPropsBatch.size() >= vertexBatchSize) {
           verticesCreated += flushVertexBatch(batch, currentTypeName, vertexPropsBatch, vertexTempIds, vertexRefs,
-              verticesCreated);
+              verticesCreated, mappingSink);
           progress.chunk(VERTEX_PHASE, verticesCreated, edgesCreated, stream, vertexRefs, inputStream);
         }
       }
@@ -430,7 +443,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
       // Flush remaining vertices (e.g., vertex-only import or last batch before EOF)
       if (!vertexPropsBatch.isEmpty()) {
         verticesCreated += flushVertexBatch(batch, currentTypeName, vertexPropsBatch, vertexTempIds, vertexRefs,
-            verticesCreated);
+            verticesCreated, mappingSink);
         progress.chunk(VERTEX_PHASE, verticesCreated, edgesCreated, stream, vertexRefs, inputStream);
       }
 
@@ -560,7 +573,13 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     // Include temp ID mapping if any temp IDs were used, unless the load was too big for the mapping to be worth
     // (or even possible to) send back - see MAX_ID_MAPPING_IN_RESPONSE and the 'idMapping' parameter.
     if (!vertexRefs.isEmpty()) {
-      if (echoIdMapping(exchange, vertexRefs.size())) {
+      if (mappingSink != null) {
+        // The mapping has been travelling one committed chunk at a time since the load started, so putting it
+        // here as well would rebuild in this single object the very thing streaming it was for. What the
+        // terminal line owes the client is the count, so it can check it received all of it (issue #7353).
+        result.put("idMappingStreamed", true);
+        result.put("idMappingSize", vertexRefs.size());
+      } else if (echoIdMapping(exchange, vertexRefs.size())) {
         final JSONObject mapping = new JSONObject();
         vertexRefs.forEach((ref, rid) -> mapping.put(ref, rid.toString()));
         result.put("idMapping", mapping);
@@ -634,6 +653,16 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     // Counters as of the last acknowledgement, so a failure that cannot reach streamRecords' own counters -
     // an engine exception raised after the stream started - still has something honest to report.
     final long[] lastProgress = new long[2];
+
+    // The temporary-id mapping of the vertices committed since the last acknowledgement, and never more than
+    // that: it is drained into every progress line and into the terminal one, so no line - and no server-side
+    // object - ever holds the mapping of the whole load (issue #7353). Null when the client asked not to
+    // receive the mapping at all, which is the only way to switch the accumulation off.
+    final JSONObject[] pendingMapping = { streamIdMapping(exchange) ? new JSONObject() : null };
+    final VertexRefResolver.EntryConsumer mappingSink = pendingMapping[0] == null
+        ? null
+        : (ref, rid) -> pendingMapping[0].put(ref, rid.toString());
+
     try {
       final ExecutionResponse unary = streamRecords(exchange, databaseName, isCsv, builder, inputStream, vertexRefs,
           System.currentTimeMillis(), vertexBatchSize, expectedRecords,
@@ -643,6 +672,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
             event.put("verticesCreated", verticesCreated);
             event.put("edgesCreated", edgesCreated);
             addLineAccounting(event, stream, refs, in);
+            drainPendingMapping(pendingMapping, event);
             lastProgress[0] = verticesCreated;
             lastProgress[1] = edgesCreated;
             try {
@@ -655,7 +685,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
               // and completely wrong diagnosis: the body arrived, it is the RESPONSE that could not be written.
               throw new BatchResponseWriteException(e);
             }
-          });
+          }, mappingSink);
 
       if (unary.getCode() != 200 && !response.hasStarted()) {
         // A failure streamRecords REPORTS BY RETURNING - a malformed record, an unknown temporary id, a
@@ -670,6 +700,10 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
       }
 
       final JSONObject terminal = new JSONObject(unary.getResponse());
+      // Whatever the last flush resolved after the final acknowledgement, so the client's mapping is complete
+      // when it reads 'idMappingStreamed' and can check it against 'idMappingSize' (issue #7353). Normally
+      // empty - every vertex flush is followed by an acknowledgement - and bounded by one flush when it is not.
+      drainPendingMapping(pendingMapping, terminal);
       // The bookmark of issue #5862 cannot be a header on this encoding: by the time the commit index is known
       // the response has usually started, and a header set then is dropped without a word. It carries the same
       // meaning in band, on the same line as the counters a READ_YOUR_WRITES client is reconciling against.
@@ -877,6 +911,42 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     if (value == null || value.isEmpty() || "auto".equalsIgnoreCase(value))
       return size <= MAX_ID_MAPPING_IN_RESPONSE;
     return Boolean.parseBoolean(value);
+  }
+
+  /**
+   * Whether the streaming encoding hands the mapping back one committed chunk at a time (issue #7353).
+   * <p>
+   * {@code auto} streams it, with no cap: {@link #MAX_ID_MAPPING_IN_RESPONSE} exists because the buffered
+   * encoding has to build the whole mapping as one JSON object and one string before it can send anything, and
+   * that is what turns the last step of a successful 17-million-vertex import into an OutOfMemoryError. Here
+   * neither ever exists - each line carries the vertices of one {@code vertexBatchSize} flush and is dropped
+   * after it is written - so the reason to refuse a large mapping is gone, and refusing one anyway would leave
+   * the streaming encoding delivering strictly less than the buffered one it is supposed to supersede.
+   * <p>
+   * {@code idMapping=false} still means never: a client loading vertices nothing will reference has no use for
+   * the mapping, and not sending it saves both ends the bytes.
+   */
+  private boolean streamIdMapping(final HttpServerExchange exchange) {
+    final String value = getQueryParameter(exchange, "idMapping");
+    if (value == null || value.isEmpty() || "auto".equalsIgnoreCase(value))
+      return true;
+    return Boolean.parseBoolean(value);
+  }
+
+  /**
+   * Moves whatever the mapping sink has collected since the previous line onto {@code event} and empties it, so
+   * the accumulator never grows past one committed chunk (issue #7353). A no-op when the client asked for no
+   * mapping, and when a chunk resolved nothing nameable - an edge-phase acknowledgement, or a vertex flush in
+   * which every vertex declared no {@code @id} under {@code refMode=tempId}.
+   */
+  private static void drainPendingMapping(final JSONObject[] pending, final JSONObject event) {
+    final JSONObject mapping = pending[0];
+    if (mapping == null || mapping.isEmpty())
+      return;
+    event.put("idMapping", mapping);
+    // A fresh object rather than a clear(): the one just attached belongs to the event being written, and
+    // clearing it in place would empty the line that is about to be serialized.
+    pending[0] = new JSONObject();
   }
 
   /**
@@ -1337,16 +1407,28 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     }
   }
 
+  /**
+   * @param mappingSink notified of every reference this flush resolved, or {@code null} when the mapping is not
+   *                    being streamed back. It is fed here rather than read off the resolver afterwards because
+   *                    neither resolver keeps insertion order - and the point of streaming it is to never build
+   *                    a structure that does (issue #7353).
+   */
   private int flushVertexBatch(final GraphBatch batch, final String typeName,
       final List<Object[]> propsBatch, final List<String> tempIds, final VertexRefResolver vertexRefs,
-      final long firstOrdinal) {
+      final long firstOrdinal, final VertexRefResolver.EntryConsumer mappingSink) {
 
     final int count = propsBatch.size();
     final Object[][] propsArray = propsBatch.toArray(new Object[count][]);
     final RID[] rids = batch.createVertices(typeName, propsArray);
 
-    for (int i = 0; i < count; i++)
+    for (int i = 0; i < count; i++) {
       vertexRefs.put(tempIds.get(i), (int) (firstOrdinal + i), rids[i]);
+      if (mappingSink != null) {
+        final String ref = vertexRefs.refOf(tempIds.get(i), firstOrdinal + i);
+        if (ref != null)
+          mappingSink.accept(ref, rids[i]);
+      }
+    }
 
     propsBatch.clear();
     tempIds.clear();

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
@@ -751,6 +751,13 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
         error.put("verticesCreated", lastProgress[0]);
         error.put("edgesCreated", lastProgress[1]);
         error.put("partialCommit", lastProgress[0] > 0 || lastProgress[1] > 0);
+        // pendingMapping is deliberately NOT drained onto this line (issue #7353, PR #7429 review). Anything it
+        // could still hold was resolved AFTER the last acknowledgement, while the counters just above are as OF
+        // that acknowledgement - so emitting it here would hand back ids for vertices this very line says were
+        // never reached. The client already holds every entry up to those counters, which is exactly the prefix
+        // it can reconcile against; the rest belongs to a chunk whose fate this response cannot state. The
+        // window is empty in practice anyway: every vertex flush is followed immediately by its own
+        // acknowledgement, so nothing accumulates between the two.
         if (haDb != null) {
           final long lastApplied = haDb.getLastAppliedIndex();
           if (lastApplied >= 0)

--- a/server/src/main/java/com/arcadedb/server/http/handler/batch/OrdinalVertexRefResolver.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/batch/OrdinalVertexRefResolver.java
@@ -138,6 +138,15 @@ public class OrdinalVertexRefResolver implements VertexRefResolver {
   }
 
   /**
+   * The absolute position of the vertex in the load, which is what {@link #forEach} keys by. Never {@code null}:
+   * the position IS the key here, so every vertex this resolver stores can be named.
+   */
+  @Override
+  public String refOf(final String tempId, final long ordinal) {
+    return Long.toString(ordinalBase + ordinal);
+  }
+
+  /**
    * Parses a vertex position, accepting both the bare number and the {@code v<number>} form that
    * {@code RemoteGraphBatch} generates.
    */

--- a/server/src/main/java/com/arcadedb/server/http/handler/batch/TempIdVertexRefResolver.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/batch/TempIdVertexRefResolver.java
@@ -104,4 +104,13 @@ public class TempIdVertexRefResolver implements VertexRefResolver {
   public void forEach(final EntryConsumer consumer) {
     map.forEach(consumer::accept);
   }
+
+  /**
+   * The temporary id itself, which is what {@link #forEach} keys by. {@code null} for a vertex that declared
+   * none: nothing was stored for it, so there is nothing to hand back.
+   */
+  @Override
+  public String refOf(final String tempId, final long ordinal) {
+    return tempId;
+  }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/batch/VertexRefResolver.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/batch/VertexRefResolver.java
@@ -85,6 +85,17 @@ public interface VertexRefResolver {
    */
   void forEach(EntryConsumer consumer);
 
+  /**
+   * The reference by which the payload names the vertex just recorded at {@code ordinal}, keyed exactly as
+   * {@link #forEach} keys it, or {@code null} when this resolver cannot name that vertex - a vertex that
+   * declared no {@code @id} under {@code refMode=tempId}.
+   * <p>
+   * Exists so the mapping can be handed to the client one committed chunk at a time instead of being
+   * accumulated into a single terminal object (issue #7353). Keying it here rather than at the call site is
+   * what keeps the streamed mapping and the echoed one from ever disagreeing about how a vertex is named.
+   */
+  String refOf(String tempId, long ordinal);
+
   @FunctionalInterface
   interface EntryConsumer {
     void accept(String ref, RID rid);

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -844,6 +844,13 @@ public class CoreApiSpec implements OpenApiContributor {
     progress.addProperty("phase", SpecBuilders.string("'vertices' or 'edges'"));
     progress.addProperty("verticesCreated", SpecBuilders.integer("Vertices attempted so far"));
     progress.addProperty("edgesCreated", SpecBuilders.integer("Edges attempted so far"));
+    progress.addProperty("idMapping", SpecBuilders.object("""
+        Temporary id to RID mapping of the vertices this chunk resolved, and only of those: the mapping is \
+        handed back one committed chunk at a time so neither end ever holds the whole load's worth of it \
+        (issue #7353). Concatenate the 'idMapping' of every line, in order, to obtain what the buffered \
+        encoding returns in one object, and check the total against 'idMappingSize' on the terminal line. \
+        Absent on an edge-phase acknowledgement, on a chunk whose vertices declared no @id under \
+        refMode=tempId, and when the request sent idMapping=false."""));
     addLoadAccounting(progress);
     schema.addProperty("progress", progress);
 
@@ -853,6 +860,16 @@ public class CoreApiSpec implements OpenApiContributor {
         header here because the response has already started when its value becomes known.""");
     summary.addProperty("commitIndex", SpecBuilders.integer(
         "Last applied Raft index, the value the X-ArcadeDB-Commit-Index header carries on the buffered encoding"));
+    summary.addProperty("idMappingStreamed", SpecBuilders.bool("""
+        Always true on this encoding when the load resolved any temporary id: the mapping travelled in the \
+        'idMapping' of the progress lines rather than in this object, so 'idMapping' here is only whatever the \
+        last chunk resolved after the final acknowledgement - usually nothing. 'idMappingOmitted' is never sent \
+        on this encoding: the size cap it reports exists because the buffered encoding has to build the whole \
+        mapping before it can send anything, which streaming removes (issue #7353)."""));
+    summary.addProperty("idMappingSize", SpecBuilders.integer("""
+        Total number of temporary ids the load resolved. Check the number of mapping entries received across \
+        all the lines against it: a mapping that arrives in pieces can lose one to a truncated response \
+        without any single piece looking wrong."""));
     schema.addProperty("summary", summary);
 
     final Schema<Object> error = SpecBuilders.object("""

--- a/server/src/test/java/com/arcadedb/remote/Issue7031RemoteClientIT.java
+++ b/server/src/test/java/com/arcadedb/remote/Issue7031RemoteClientIT.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -181,12 +182,18 @@ class Issue7031RemoteClientIT extends BaseGraphServerTest {
       super(server, port, databaseName, userName, userPassword);
     }
 
+    /**
+     * The single method that puts a batch on the wire, whatever encoding it negotiates, so overriding it here
+     * intercepts every flush - which is the whole point of this stub (issue #7353 folded the two overloads
+     * into one precisely so a subclass could not miss half of them).
+     */
     @Override
-    JSONObject sendBatch(final String content, final Map<String, String> queryParams) {
+    JSONObject sendBatch(final String content, final Map<String, String> queryParams,
+        final Consumer<JSONObject> onProgress) {
       sentPayloads.add(content);
       if (failNextSend)
         throw new ArcadeDBException("simulated failure of the batch request");
-      return super.sendBatch(content, queryParams);
+      return super.sendBatch(content, queryParams, onProgress);
     }
   }
 }

--- a/server/src/test/java/com/arcadedb/remote/RemoteGraphBatchProgressIT.java
+++ b/server/src/test/java/com/arcadedb/remote/RemoteGraphBatchProgressIT.java
@@ -31,13 +31,17 @@ import org.junit.jupiter.api.Timeout;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Issue #7311: the Java driver can be acknowledged per chunk instead of only at the end of a flush. Without a
- * listener the flush sends the request it always sent, so the server-side encoding is opt-in from here too.
+ * Issue #7311: the Java driver can be acknowledged per chunk instead of only at the end of a flush.
+ * <p>
+ * Issue #7353 made the streaming encoding unconditional here: the temporary-id mapping this client needs to
+ * resolve cross-flush edges also arrives on those lines, one committed chunk at a time, so a flush negotiates
+ * the stream whether or not the caller asked to see the progress. The listener is now only about who gets told.
  *
  * @author Roberto Franchini (r.franchini@arcadedata.com)
  */
@@ -145,9 +149,9 @@ class RemoteGraphBatchProgressIT extends BaseGraphServerTest {
 
   /**
    * A listener must not change what the flush does with the server's answer. The temporary-id mapping a batch
-   * needs to resolve an edge against a vertex sent in an EARLIER request travels in the terminal line on this
-   * encoding, and a driver that read the progress lines and stopped there would drop every cross-flush edge -
-   * silently, since nothing else in the load would fail.
+   * needs to resolve an edge against a vertex sent in an EARLIER request arrives on the progress lines since
+   * issue #7353, and a driver that handed those lines to the caller without folding the mapping into its own
+   * resolver would drop every cross-flush edge - silently, since nothing else in the load would fail.
    */
   @Test
   @Timeout(120)
@@ -182,12 +186,90 @@ class RemoteGraphBatchProgressIT extends BaseGraphServerTest {
   }
 
   /**
-   * The progress listener is an overload, and an overload is a second path: a flush that asks for no progress
-   * has to keep going through {@code sendBatch(content, queryParams)}, which is the method a subclass replaces
-   * to intercept every request this client makes. Routing it through the new three-argument sibling instead
-   * walks past those overrides in silence - the compiler is perfectly happy to call the method nobody
-   * overrode - and the only symptom is a stub that never fires, which reads as a test that stopped reproducing
-   * its own bug rather than as a broken client.
+   * Issue #7353: the mapping this client resolves its cross-flush edges against arrives on the progress lines,
+   * not in the terminal object. That is the whole point - with the buffered encoding the server has to build
+   * the temporary-id map of an entire flush as one JSON object before it can answer, and this client has to
+   * read that object back in one piece: 50,000 entries per flush by default, and every vertex of the load when
+   * flushEvery is 0.
+   * <p>
+   * A load of more than one flush, with an edge crossing them, is what proves the mapping was not merely
+   * REPORTED on those lines but actually applied: the edge cannot resolve from anywhere else.
+   */
+  @Test
+  @Timeout(120)
+  void theCrossFlushMappingArrivesOnTheProgressLines() {
+    final RemoteDatabase database = remoteDatabase();
+    database.command("sql", "CREATE VERTEX TYPE Person");
+    database.command("sql", "CREATE EDGE TYPE KNOWS");
+
+    final List<JSONObject> progress = new ArrayList<>();
+    final List<String> ids = new ArrayList<>();
+    try (final RemoteGraphBatch batch = database.batch()
+        .withFlushEvery(4)
+        .withVertexBatchSize(2)
+        .withProgressListener(progress::add)
+        .build()) {
+      for (int i = 0; i < 10; i++)
+        ids.add(batch.createVertex("Person", "name", "p" + i));
+      batch.createEdge("KNOWS", ids.getFirst(), ids.getLast());
+    }
+
+    assertThat(progress.stream().filter(p -> p.has("idMapping")).count())
+        .as("the mapping must reach the client on the acknowledgements, in more than one piece - one piece "
+            + "would be the buffered object with a newline after it")
+        .isGreaterThan(1);
+    assertThat(progress.stream().filter(p -> p.has("idMapping"))
+        .mapToInt(p -> p.getJSONObject("idMapping").length()).max().orElse(0))
+        .as("no acknowledgement may carry more than the vertex flush that produced it")
+        .isLessThanOrEqualTo(2);
+
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) as cnt FROM KNOWS")) {
+      assertThat(((Number) rs.nextIfAvailable().getProperty("cnt")).longValue())
+          .as("the edge spanning two flushes can only resolve through a mapping that was actually applied")
+          .isEqualTo(1);
+    }
+  }
+
+  /**
+   * The same, with no listener at all. The encoding is no longer the caller's choice (issue #7353): the mapping
+   * has to stream whether or not anybody asked to watch it, or the default configuration of this client would
+   * keep the buffering the streaming encoding exists to remove.
+   */
+  @Test
+  @Timeout(120)
+  void aBatchWithNoListenerStreamsTheMappingAndStillResolvesCrossFlushEdges() {
+    final RemoteDatabase database = remoteDatabase();
+    database.command("sql", "CREATE VERTEX TYPE Person");
+    database.command("sql", "CREATE EDGE TYPE KNOWS");
+
+    final List<String> ids = new ArrayList<>();
+    try (final RemoteGraphBatch batch = database.batch()
+        .withFlushEvery(4)
+        .withVertexBatchSize(2)
+        .build()) {
+      for (int i = 0; i < 10; i++)
+        ids.add(batch.createVertex("Person", "name", "p" + i));
+      batch.createEdge("KNOWS", ids.getFirst(), ids.getLast());
+    }
+
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) as cnt FROM KNOWS")) {
+      assertThat(((Number) rs.nextIfAvailable().getProperty("cnt")).longValue()).isEqualTo(1);
+    }
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) as cnt FROM Person")) {
+      assertThat(((Number) rs.nextIfAvailable().getProperty("cnt")).longValue()).isEqualTo(10);
+    }
+  }
+
+  /**
+   * There must be exactly ONE method on {@code RemoteDatabase} that puts a batch on the wire, because a subclass
+   * replaces it to intercept every request this client makes. It used to be two overloads, and an overload is a
+   * second path: whichever one a stub did not override walked past it in silence - the compiler is perfectly
+   * happy to call the method nobody overrode - and the only symptom was a stub that never fired, which reads as
+   * a test that stopped reproducing its own bug rather than as a broken client. Since {@code RemoteGraphBatch}
+   * always negotiates the streaming encoding (issue #7353), the split would have hidden every flush it makes,
+   * so the two were folded into {@code sendBatch(content, queryParams, onProgress)}.
+   * <p>
+   * Asserted with NO listener on purpose: that is the case the old split routed down the other method.
    */
   @Test
   @Timeout(120)
@@ -196,9 +278,10 @@ class RemoteGraphBatchProgressIT extends BaseGraphServerTest {
     try (final RemoteDatabase database = new RemoteDatabase("127.0.0.1", httpPort(), DATABASE_NAME, "root",
         BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS) {
       @Override
-      JSONObject sendBatch(final String content, final Map<String, String> queryParams) {
+      JSONObject sendBatch(final String content, final Map<String, String> queryParams,
+          final Consumer<JSONObject> onProgress) {
         intercepted.add(content);
-        return super.sendBatch(content, queryParams);
+        return super.sendBatch(content, queryParams, onProgress);
       }
     }) {
       database.command("sql", "CREATE VERTEX TYPE Person");

--- a/server/src/test/java/com/arcadedb/server/PostBatchStreamingIT.java
+++ b/server/src/test/java/com/arcadedb/server/PostBatchStreamingIT.java
@@ -182,6 +182,52 @@ class PostBatchStreamingIT extends BaseGraphServerTest {
   }
 
   /**
+   * The tripwire for an invariant that is currently held by adjacency alone (PR #7429 review).
+   * <p>
+   * When a load fails after the response has started, the error line reports its counters as of the LAST
+   * acknowledgement, and {@code streamRecordsAsNdJson} deliberately does not drain whatever the mapping sink
+   * may still hold onto that line - those entries were resolved after that acknowledgement, so sending them
+   * would hand back ids for vertices the same line says were never reached. Today nothing can accumulate there
+   * at all, because every vertex flush is followed immediately by its own acknowledgement.
+   * <p>
+   * What that adds up to, and what is asserted here rather than left to a comment, is one property a client can
+   * rely on: <b>the mapping it received is exactly the mapping for the vertices the failure reports as
+   * attempted</b> - no more, no less. A refactor that opened a window between the flush and its acknowledgement
+   * would break this loudly instead of silently changing what a failed load hands back.
+   */
+  @Test
+  @Timeout(60)
+  void aFailedLoadsMappingMatchesTheCountersItReports() throws Exception {
+    // V1.id is unique, so this id is already taken when the payload below reaches its second batch.
+    postStreamed(ndjsonVertices(1_200_010, 1), "?vertexBatchSize=1", NDJSON);
+
+    final StringBuilder body = new StringBuilder();
+    for (int i = 0; i < 2; i++)
+      body.append("{\"@type\":\"vertex\",\"@class\":\"V1\",\"@id\":\"m").append(i).append("\",\"id\":")
+          .append(1_200_000 + i).append("}\n");
+    body.append("{\"@type\":\"vertex\",\"@class\":\"V1\",\"@id\":\"m9\",\"id\":1200010}\n");
+
+    final List<JSONObject> events = postStreamed(body.toString().getBytes(StandardCharsets.UTF_8),
+        "?vertexBatchSize=2", NDJSON);
+
+    assertThat(countEvents(events, "progress"))
+        .as("the failure has to come after an acknowledgement, or this test proves nothing")
+        .isGreaterThan(0);
+
+    final JSONObject error = terminal(events, "error");
+    final JSONObject received = collectStreamedMapping(events);
+
+    assertThat((long) received.length())
+        .as("a client must be handed the mapping of exactly the vertices the failure reports as attempted: "
+            + "fewer would leave it unable to reference records that are durable, more would name records "
+            + "this same line says were never reached")
+        .isEqualTo(error.getLong("verticesCreated"));
+    assertThat(received.keySet())
+        .as("and those entries are the ids the payload actually declared before it failed")
+        .containsExactlyInAnyOrder("m0", "m1");
+  }
+
+  /**
    * The memory property, which is the reason the mapping is streamed at all. Past
    * {@code MAX_ID_MAPPING_IN_RESPONSE} (10,000) the buffered encoding stops sending the mapping altogether,
    * because building it as one object and one string is what turns the last step of an otherwise successful

--- a/server/src/test/java/com/arcadedb/server/PostBatchStreamingIT.java
+++ b/server/src/test/java/com/arcadedb/server/PostBatchStreamingIT.java
@@ -19,6 +19,7 @@
 package com.arcadedb.server;
 
 import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -37,6 +38,8 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -113,6 +116,10 @@ class PostBatchStreamingIT extends BaseGraphServerTest {
   /**
    * The terminal line is not a second, parallel shape of the answer: it is the very object the buffered encoding
    * would have sent, produced by the same code. A client can therefore apply one piece of logic to both.
+   * <p>
+   * The one field that differs is the temporary-id mapping, and it differs on purpose: since issue #7353 it
+   * travels in the progress lines, so the summary reports how much of it was sent rather than carrying it. That
+   * is asserted separately below - here it is excluded so this test keeps checking the property it is about.
    */
   @Test
   @Timeout(60)
@@ -121,15 +128,127 @@ class PostBatchStreamingIT extends BaseGraphServerTest {
     final JSONObject streamed = terminal(postStreamed(ndjsonVertices(200_010, 6), "?vertexBatchSize=2", NDJSON),
         "summary");
 
-    assertThat(streamed.keySet())
-        .as("the summary must carry the same fields as the buffered body, so a client parses one shape")
-        .isEqualTo(buffered.keySet());
+    assertThat(withoutMappingFields(streamed))
+        .as("apart from where the mapping lives, the summary must carry the same fields as the buffered body, "
+            + "so a client parses one shape")
+        .isEqualTo(withoutMappingFields(buffered));
     assertThat(streamed.getLong("verticesCreated")).isEqualTo(buffered.getLong("verticesCreated"));
     assertThat(streamed.getLong("linesRead")).isEqualTo(buffered.getLong("linesRead"));
     assertThat(streamed.getLong("linesSkipped")).isEqualTo(buffered.getLong("linesSkipped"));
     assertThat(streamed.getLong("bytesRead")).isEqualTo(buffered.getLong("bytesRead"));
-    assertThat(streamed.getJSONObject("idMapping").length())
+    assertThat(streamed.getInt("idMappingSize", -1))
+        .as("the summary accounts for the mapping it streamed")
         .isEqualTo(buffered.getJSONObject("idMapping").length());
+  }
+
+  /**
+   * Issue #7353: the temporary-id mapping is handed back one committed chunk at a time instead of accumulating
+   * into the terminal object. The union of the chunks has to be exactly what the buffered encoding returns -
+   * anything less and a client resolving edges across requests silently points them at the wrong vertex.
+   */
+  @Test
+  @Timeout(60)
+  void theIdMappingTravelsInTheProgressLinesInsteadOfTheTerminalOne() throws Exception {
+    // Distinct id ranges because V1.id is unique: the same payload cannot be loaded twice. What is compared is
+    // therefore the SHAPE of the mapping - which keys, and how many - not the RIDs, which two separate loads
+    // necessarily assign differently.
+    final JSONObject buffered = postBuffered(ndjsonVertices(210_000, 6), "?vertexBatchSize=2", NDJSON, 200);
+    final List<JSONObject> events = postStreamed(ndjsonVertices(210_010, 6), "?vertexBatchSize=2", NDJSON);
+
+    assertThat(events.stream().filter(e -> e.has("progress"))
+        .filter(e -> e.getJSONObject("progress").has("idMapping")).count())
+        .as("a mapping delivered in one line would be the very thing streaming it is for")
+        .isGreaterThan(1);
+
+    final JSONObject summary = terminal(events, "summary");
+    assertThat(summary.has("idMapping"))
+        .as("the vertex flush is acknowledged, so nothing is left over for the terminal line to carry")
+        .isFalse();
+    assertThat(summary.getBoolean("idMappingStreamed", false))
+        .as("the client has to be told the mapping went somewhere rather than being omitted")
+        .isTrue();
+    assertThat(summary.getInt("idMappingSize", -1)).isEqualTo(6);
+
+    final JSONObject streamedMapping = collectStreamedMapping(events);
+    assertThat(streamedMapping.keySet())
+        .as("the chunks must reassemble into every temporary id the payload declared, and nothing else")
+        .containsExactlyInAnyOrder("t210010", "t210011", "t210012", "t210013", "t210014", "t210015");
+    assertThat(streamedMapping.length())
+        .as("and into as many entries as the buffered encoding returns for the same payload shape")
+        .isEqualTo(buffered.getJSONObject("idMapping").length());
+    assertThat(streamedMapping.getString("t210010"))
+        .as("each entry names a real record, not a placeholder")
+        .matches("#-?\\d+:\\d+");
+  }
+
+  /**
+   * The memory property, which is the reason the mapping is streamed at all. Past
+   * {@code MAX_ID_MAPPING_IN_RESPONSE} (10,000) the buffered encoding stops sending the mapping altogether,
+   * because building it as one object and one string is what turns the last step of an otherwise successful
+   * import into an OutOfMemoryError. The streamed encoding has no such ceiling: it delivers the whole mapping,
+   * and no single line ever carries more than one {@code vertexBatchSize} flush of it.
+   */
+  @Test
+  @Tag("slow")
+  @Timeout(180)
+  void aLoadPastTheEchoCapStreamsTheWholeMappingWithoutEverHoldingIt() throws Exception {
+    final int vertices = 12_000;
+    final int batch = 1_000;
+
+    final JSONObject buffered = postBuffered(ndjsonVertices(2_000_000, vertices), "?vertexBatchSize=" + batch,
+        NDJSON, 200);
+    assertThat(buffered.getBoolean("idMappingOmitted", false))
+        .as("the premise of this test: the buffered encoding refuses a mapping of this size")
+        .isTrue();
+
+    final List<JSONObject> events = postStreamed(ndjsonVertices(2_100_000, vertices), "?vertexBatchSize=" + batch,
+        NDJSON);
+    final JSONObject summary = terminal(events, "summary");
+
+    assertThat(summary.has("idMappingOmitted"))
+        .as("the size cap has no counterpart here: nothing is ever built that a cap would protect")
+        .isFalse();
+    assertThat(summary.getInt("idMappingSize", -1)).isEqualTo(vertices);
+    assertThat(collectStreamedMapping(events).length())
+        .as("every one of the %d ids must reach the client, which the buffered encoding cannot do at all",
+            vertices)
+        .isEqualTo(vertices);
+
+    final int largestChunk = events.stream()
+        .filter(e -> e.has("progress"))
+        .map(e -> e.getJSONObject("progress"))
+        .filter(p -> p.has("idMapping"))
+        .mapToInt(p -> p.getJSONObject("idMapping").length())
+        .max().orElse(0);
+    assertThat(largestChunk)
+        .as("no line may carry more than the flush that produced it - that bound IS the memory property, and "
+            + "without it this encoding would just be the buffered one with newlines in it")
+        .isLessThanOrEqualTo(batch);
+  }
+
+  /**
+   * {@code idMapping=false} still means never, on this encoding as on the other: a load whose vertices nothing
+   * will reference has no use for the mapping, and not sending it saves both ends the bytes.
+   */
+  @Test
+  @Timeout(60)
+  void idMappingFalseSuppressesTheStreamedMappingToo() throws Exception {
+    final List<JSONObject> events = postStreamed(ndjsonVertices(220_000, 6),
+        "?vertexBatchSize=2&idMapping=false", NDJSON);
+
+    assertThat(collectStreamedMapping(events).isEmpty())
+        .as("no progress line may carry a mapping the client asked not to receive")
+        .isTrue();
+
+    final JSONObject summary = terminal(events, "summary");
+    assertThat(summary.has("idMapping")).isFalse();
+    assertThat(summary.getBoolean("idMappingStreamed", false))
+        .as("nothing was streamed, so nothing may claim to have been")
+        .isFalse();
+    assertThat(summary.getBoolean("idMappingOmitted", false))
+        .as("this is the buffered encoding's answer for a refused mapping, which is what a client sees when it "
+            + "declined one")
+        .isTrue();
   }
 
   /**
@@ -497,6 +616,37 @@ class PostBatchStreamingIT extends BaseGraphServerTest {
     } finally {
       conn.disconnect();
     }
+  }
+
+  /**
+   * The field names identical for both encodings, i.e. everything but where the temporary-id mapping lives:
+   * the buffered answer carries it (or says it refused to), the streamed one says it sent it in the lines
+   * before (issue #7353).
+   */
+  private static Set<String> withoutMappingFields(final JSONObject object) {
+    final Set<String> keys = new TreeSet<>(object.keySet());
+    keys.removeAll(Set.of("idMapping", "idMappingOmitted", "idMappingSize", "idMappingStreamed"));
+    return keys;
+  }
+
+  /**
+   * Reassembles the mapping a streamed load delivered, from every line that carried a piece of it. A duplicated
+   * key would be silently absorbed here, which is why the caller checks the total against 'idMappingSize'.
+   */
+  private static JSONObject collectStreamedMapping(final List<JSONObject> events) {
+    final JSONObject mapping = new JSONObject();
+    for (final JSONObject event : events)
+      for (final String kind : List.of("progress", "summary", "error")) {
+        if (!event.has(kind))
+          continue;
+        final JSONObject line = event.getJSONObject(kind);
+        if (line.has("idMapping")) {
+          final JSONObject chunk = line.getJSONObject("idMapping");
+          for (final String key : chunk.keySet())
+            mapping.put(key, chunk.getString(key));
+        }
+      }
+    return mapping;
   }
 
   private static String readAll(final InputStream in) throws Exception {

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/BatchStreamingApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/BatchStreamingApiSpecTest.java
@@ -27,6 +27,8 @@ import io.swagger.v3.oas.models.parameters.Parameter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -84,6 +86,30 @@ class BatchStreamingApiSpecTest {
     assertThat(((Schema<?>) event.getProperties().get("summary")).getProperties())
         .as("so does the read-your-writes bookmark, which can no longer be a response header")
         .containsKey("commitIndex");
+  }
+
+  /**
+   * Issue #7353: the temporary-id mapping is a property of the progress lines on this encoding, not of the
+   * terminal object. A client generated from a document that still put it only on the summary would read
+   * 'idMappingStreamed' and have nowhere to look for what was streamed.
+   */
+  @Test
+  void theStreamedMappingIsDeclaredOnTheAcknowledgementsAndAccountedForOnTheSummary() {
+    final Schema<?> event = openAPI.getComponents().getSchemas().get("NdJsonBatchEvent");
+
+    assertThat(((Schema<?>) event.getProperties().get("progress")).getProperties())
+        .as("the mapping travels one committed chunk at a time, on the acknowledgements")
+        .containsKey("idMapping");
+    assertThat(((Schema<?>) ((Schema<?>) event.getProperties().get("progress")).getProperties().get("idMapping"))
+        .getDescription())
+        .as("and the document has to say it is a CHUNK, or a client will treat the first one as the whole thing")
+        .contains("this chunk resolved");
+
+    final Map<String, Schema> summary = ((Schema<?>) event.getProperties().get("summary")).getProperties();
+    assertThat(summary)
+        .as("the summary says where the mapping went and how much of it there was, so an incomplete stream is "
+            + "detectable")
+        .containsKeys("idMappingStreamed", "idMappingSize");
   }
 
   @Test


### PR DESCRIPTION
Closes #7353.

## What was actually left

#7353 tracks the three gRPC ingestion capabilities HTTP had no counterpart for. Two of them were closed by #7311 while this issue was deferred behind #7306, so the first thing this PR does is establish what genuinely remains:

| Capability | Status before this PR |
|---|---|
| `InsertStream` | **done** - `POST /batch` already applies an `application/x-ndjson` body incrementally |
| `InsertBidirectional` | **done** (#7311) - under `Accept: application/x-ndjson` each chunk is acknowledged while the client is still uploading |
| `GraphBatchLoad` | **the mapping half was not** |

The issue's own table describes that last row as "the same, for the vertices-then-edges graph shape, **with the temporary-id mapping streamed back**". That is what was missing, and it is the one place where the issue's central claim - "an HTTP bulk load currently buffers what the gRPC path does not" - was still true.

## The problem

The temporary-id to RID mapping was buffered on both ends. The server built the whole flush's map as one `JSONObject` and then as one `String` before it could answer, and `RemoteGraphBatch` read that object back in one piece. With its defaults that is **50,000 entries per flush**, and with `flushEvery=0` it is every vertex of the load.

This is the same memory characteristic on the write side that #7306 removed on the read side, and it is the reason `MAX_ID_MAPPING_IN_RESPONSE` exists at all: past 10,000 entries the buffered encoding gives up and sends `idMappingOmitted` rather than risk turning the last step of an otherwise successful 17-million-vertex import into an `OutOfMemoryError`.

## The change

On the streaming encoding each `progress` line now carries the mapping of the vertices **its own flush** resolved, and nothing else. The terminal line reports `idMappingStreamed` plus `idMappingSize` - the total, so a client can check what it received - instead of carrying the mapping itself.

Because neither end ever holds more than one chunk, the size cap has no counterpart here: `idMapping=auto` streams the whole mapping however large it is, which is strictly more than the buffered encoding can deliver. `idMapping=false` still means never.

Two details worth the review's attention:

- **The delta is fed from `flushVertexBatch`**, not read off the resolver afterwards. Neither resolver keeps insertion order, and building one that did would recreate exactly the structure this removes. `VertexRefResolver.refOf` keys an entry exactly as `forEach` keys it, so the streamed mapping and the echoed one cannot disagree about how a vertex is named.
- **`RemoteGraphBatch` now negotiates the stream on every flush**, whether or not the caller set a progress listener, and folds the deltas into the arrays it resolves cross-flush edges against. Otherwise the default configuration of this client would keep the buffering the change exists to remove.

## One design decision worth flagging

That last point made the two `RemoteDatabase.sendBatch` overloads dangerous rather than merely redundant.

The three-argument form used to delegate to the two-argument one for a `null` listener, with a comment warning that a subclass overriding the two-argument method to intercept every flush would otherwise be walked past in silence. Now that `RemoteGraphBatch` always passes a listener, that split would have hidden **every** flush it makes from the two test stubs that depend on it (`Issue7031RemoteClientIT` and `RemoteGraphBatchProgressIT`) - the failure mode the comment predicted, and one whose only symptom is a stub that never fires.

So the two paths are folded into a single send method and both `@Override`s move onto it. `aFlushWithNoListenerStillGoesThroughTheOverridableSend` is retargeted to assert the stronger property: there is exactly one method that puts a batch on the wire.

The buffered `application/json` answer is unchanged.

## Verification

New, in `PostBatchStreamingIT`:

- `theIdMappingTravelsInTheProgressLinesInsteadOfTheTerminalOne` - the mapping arrives in more than one piece, the summary carries `idMappingStreamed`/`idMappingSize` and no mapping, and the reassembled chunks are exactly the temporary ids the payload declared.
- `aLoadPastTheEchoCapStreamsTheWholeMappingWithoutEverHoldingIt` (`@Tag("slow")`) - the memory test the issue asks for. 12,000 vertices: the buffered encoding refuses the mapping outright (`idMappingOmitted`), the streamed one delivers all 12,000, and **no single line carries more than one `vertexBatchSize` flush of it**. That bound is the memory property - without it this encoding would just be the buffered one with newlines in it.
- `idMappingFalseSuppressesTheStreamedMappingToo`.
- `theSummaryLineCarriesTheSameObjectTheUnaryEncodingWouldHaveSent` updated: it compares every field except where the mapping lives, so it keeps testing the property it is about.

New, in `RemoteGraphBatchProgressIT`:

- `theCrossFlushMappingArrivesOnTheProgressLines` - a load spanning several flushes with an edge crossing them. The edge cannot resolve from anywhere but an applied mapping, so this proves the deltas were used and not merely reported.
- `aBatchWithNoListenerStreamsTheMappingAndStillResolvesCrossFlushEdges` - the same with no listener, which is the case the old overload split routed elsewhere.

Plus `BatchStreamingApiSpecTest.theStreamedMappingIsDeclaredOnTheAcknowledgementsAndAccountedForOnTheSummary` for the OpenAPI contract.

**Local results:** `RemoteGraphBatchProgressIT` 7/7, `PostBatchStreamingIT` 15/16, `CoreApiSpecTest` + `BatchStreamingApiSpecTest` 30/30.

The one `PostBatchStreamingIT` failure is environmental and pre-existing, not from this change: `progressReachesTheClientBeforeTheBodyHasBeenFullySent` calls `countVertices`, which goes through `BaseGraphServerTest.executeCommand` and its hardcoded port 2480. Another process on this machine holds that port, so the query is answered by something else. Every test in these classes that resolves the server's actually-bound port passes. CI runs on clean ports and covers it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch uploads now provide temporary ID-to-record mappings incrementally in streaming progress responses.
  * Mappings are available even without a progress listener and can exceed buffered response limits.
  * Stream summaries report whether mappings were streamed and their total size.
  * Mapping output can be disabled with `idMapping=false`.

* **Bug Fixes**
  * Improved temporary ID resolution across multiple batch flushes.
  * Added validation to detect incomplete streamed mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Behaviour change worth knowing when benchmarking

`RemoteGraphBatch` now negotiates `Accept: application/x-ndjson` on **every** flush, including a vertex-only load with no listener and no cross-flush edges, and reads the response line by line instead of as a single buffered `HttpResponse<String>`. That is deliberate - the mapping has to come back somehow, and the buffered path is the thing being removed - but it means a pure-vertex-load throughput comparison against the previous version is measuring a different response path, so this is the first place to look if one moves.
