### PR TITLE
fix(#7424): honour a login token on every node of the cluster

### DIFF
--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAuthSessionQuery.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAuthSessionQuery.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.HAServerPlugin;
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.protocol.RaftPeerId;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
+
+/**
+ * Asks the node that issued an authentication token whether it still holds the session, and tells every node to
+ * drop its copy on logout, through {@code POST /api/v1/cluster/auth-session} (issue #7424).
+ * <p>
+ * Transport and authentication are {@link PeerCapabilityQuery}'s: the {@code X-ArcadeDB-Cluster-Token} +
+ * {@code X-ArcadeDB-Forwarded-User} pair every peer-to-peer RPC uses, the peer's HTTPS endpoint preferred when
+ * {@code arcadedb.ssl.enabled} is set, and the dial guarded by {@link PeerDialAddress} so a question about a
+ * token is never put to a node that was not asked - which matters more here than for a capability probe, because
+ * the answer decides whether a client is authenticated.
+ * <p>
+ * <b>A node that predates this route answers 404</b>, the same status as "I do not hold this token". A cluster in
+ * the middle of a rolling upgrade therefore refuses the tokens its old nodes issued on its new ones, exactly as it
+ * did before the route existed; nothing is granted on a guess.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+final class PeerAuthSessionQuery {
+  static final String ROUTE = "/api/v1/cluster/auth-session";
+
+  private static final HttpClient HTTP = HttpClient.newBuilder()
+      .connectTimeout(Duration.ofSeconds(5))
+      .build();
+
+  private PeerAuthSessionQuery() {
+  }
+
+  /**
+   * Asks {@code issuer} about {@code token}.
+   *
+   * @return the session as the issuer holds it, or {@code null} when the issuer answered that it does not hold
+   * it (404)
+   *
+   * @throws IOException when the issuer could not be asked: no address identifies it on its own, transport
+   *                     failure, timeout, or any status other than 200 and 404
+   */
+  static HAServerPlugin.PeerAuthSession validate(final RaftHAServer raft, final RaftPeerId issuer, final String token,
+      final long timeoutMs) throws IOException {
+    final PeerDialAddress dial = PeerDialAddress.resolve(raft, issuer, "issuer of the authentication token");
+    if (dial.refused())
+      throw new IOException(dial.refusal());
+    final HttpRequest request = request(raft, dial, token, "validate", timeoutMs);
+    final HttpResponse<String> response;
+    try {
+      response = client(raft, request).send(request, HttpResponse.BodyHandlers.ofString());
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("interrupted while asking " + issuer + " about an authentication token", e);
+    }
+    if (response.statusCode() == 404)
+      return null;
+    if (response.statusCode() != 200)
+      throw new IOException("authentication-session query to " + request.uri() + " returned HTTP " + response.statusCode());
+    final JSONObject body = new JSONObject(response.body());
+    final String userName = body.getString("user", null);
+    if (userName == null || userName.isBlank())
+      throw new IOException("authentication-session query to " + request.uri() + " answered without a user");
+    return new HAServerPlugin.PeerAuthSession(userName, body.getLong("createdAt", 0L));
+  }
+
+  /**
+   * Tells every other peer of the configured group to drop its copy of {@code token}. All peers are dialled at
+   * once and the call returns when they have answered or {@code timeoutMs} has passed, whichever is first: a
+   * peer that is down must not hold a logout hostage, and it drops the copy on its own at the next renewal.
+   */
+  static void revokeEverywhere(final RaftHAServer raft, final String token, final long timeoutMs) {
+    final List<CompletableFuture<HttpResponse<Void>>> pending = new ArrayList<>();
+    for (final RaftPeer peer : raft.getRaftGroup().getPeers()) {
+      final RaftPeerId peerId = peer.getId();
+      if (peerId.equals(raft.getLocalPeerId()))
+        continue;
+      final PeerDialAddress dial = PeerDialAddress.resolve(raft, peerId, "holder of an authentication session copy");
+      if (dial.refused()) {
+        LogManager.instance().log(PeerAuthSessionQuery.class, Level.FINE,
+            "Not asking %s to drop an authentication session copy: %s", peerId, dial.refusal());
+        continue;
+      }
+      try {
+        final HttpRequest request = request(raft, dial, token, "revoke", timeoutMs);
+        pending.add(client(raft, request).sendAsync(request, HttpResponse.BodyHandlers.discarding()));
+      } catch (final IOException e) {
+        LogManager.instance().log(PeerAuthSessionQuery.class, Level.FINE,
+            "Cannot ask %s to drop an authentication session copy: %s", peerId, e.getMessage());
+      }
+    }
+    if (pending.isEmpty())
+      return;
+    try {
+      CompletableFuture.allOf(pending.toArray(new CompletableFuture[0])).get(timeoutMs, TimeUnit.MILLISECONDS);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+    } catch (final ExecutionException | TimeoutException e) {
+      // Best effort: the peers that did not answer drop the copy at their next renewal with the issuer.
+      LogManager.instance().log(PeerAuthSessionQuery.class, Level.FINE,
+          "Not every peer confirmed dropping an authentication session copy within %d ms: %s", timeoutMs,
+          e.getMessage());
+    }
+  }
+
+  private static HttpRequest request(final RaftHAServer raft, final PeerDialAddress dial, final String token,
+      final String action, final long timeoutMs) {
+    final boolean useSSL = raft.getServer().getConfiguration().getValueAsBoolean(GlobalConfiguration.NETWORK_USE_SSL);
+    final String url = useSSL && dial.httpsAddress() != null ? "https://" + dial.httpsAddress() + ROUTE
+        : "http://" + dial.httpAddress() + ROUTE;
+    final HttpRequest.Builder builder = HttpRequest.newBuilder()
+        .uri(URI.create(url))
+        .timeout(Duration.ofMillis(timeoutMs))
+        .header("Content-Type", "application/json")
+        .header("X-ArcadeDB-Forwarded-User", RaftHAServer.FORWARDED_ROOT_USER)
+        .POST(HttpRequest.BodyPublishers.ofString(
+            new JSONObject().put("action", action).put("token", token).toString()));
+    final String clusterToken = raft.getClusterToken();
+    if (clusterToken != null && !clusterToken.isBlank())
+      builder.header("X-ArcadeDB-Cluster-Token", clusterToken);
+    return builder.build();
+  }
+
+  private static HttpClient client(final RaftHAServer raft, final HttpRequest request) throws IOException {
+    return "https".equals(request.uri().getScheme()) ? raft.getHttpsClients().clientFor(raft.getServer()) : HTTP;
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -29,6 +29,7 @@ import com.arcadedb.server.monitor.HAReplicationStatsProvider;
 import com.arcadedb.server.http.HttpServer;
 
 import io.undertow.server.handlers.PathHandler;
+import org.apache.ratis.protocol.RaftPeerId;
 
 import com.arcadedb.database.DatabaseInternal;
 
@@ -314,6 +315,35 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
   @Override
   public String getClusterName() {
     return raftHAServer != null ? raftHAServer.getClusterName() : null;
+  }
+
+  @Override
+  public HAServerPlugin.PeerAuthSession lookupAuthSession(final String issuerServerName, final String token)
+      throws IOException {
+    final RaftHAServer raft = raftHAServer;
+    if (raft == null)
+      throw new IOException("Raft HA is not started");
+    final RaftPeerId issuer = raft.resolvePeerIdByServerName(issuerServerName);
+    // Not a member, or this node itself (which does not hold the token, or it would not be asking): definitive.
+    if (issuer == null || issuer.equals(raft.getLocalPeerId()))
+      return null;
+    return PeerAuthSessionQuery.validate(raft, issuer, token, authSessionRpcTimeoutMs());
+  }
+
+  @Override
+  public void revokeAuthSession(final String token) {
+    final RaftHAServer raft = raftHAServer;
+    if (raft == null)
+      return;
+    PeerAuthSessionQuery.revokeEverywhere(raft, token, authSessionRpcTimeoutMs());
+  }
+
+  /**
+   * Budget for one authentication-session RPC to a peer: the leader proxy's connect timeout, because the RPC is
+   * one small request on a LAN and the caller is a client waiting on a 401-or-200 decision.
+   */
+  private long authSessionRpcTimeoutMs() {
+    return server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_PROXY_CONNECT_TIMEOUT);
   }
 
   @Override

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -194,6 +194,10 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   // not advertised. Re-reported whenever the verdict changes, see {@code isNewAmbiguityVerdict} (issue #6297).
   private final    Map<HAServerPlugin.ROUTING_PROTOCOL, AtomicReference<String>> routingAmbiguityReported = createRoutingProtocolVerdicts();
   private final    Map<RaftPeerId, String> peerDisplayNames   = new ConcurrentHashMap<>();
+  // The server list as configured, in order, and the names the operator gave its entries: what
+  // resolvePeerIdByServerName() applies the local-peer resolution rules to (issue #7424).
+  private final    List<RaftPeer>          configuredPeerList;
+  private final    Map<RaftPeerId, String> configuredPeerNames;
   private final    String                  clusterName;
 
   // volatile: reassigned by the recovery path (restartRatis) and cleared by stop(), while background
@@ -356,6 +360,8 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
           serverName, configuredPeers, synthesized.getId());
     }
     this.localPeerId = resolvedLocalPeerId;
+    this.configuredPeerList = peers;
+    this.configuredPeerNames = configuredPeerNames;
 
     // If this node is configured as a replica, override its Raft peer priority to 0
     // so Ratis never elects it as leader (useful for read-scale or witness nodes).
@@ -954,6 +960,31 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * Returns a human-readable display name for a peer, e.g. "arcadedb-0 (localhost:2480)".
    * Falls back to the raw peer ID string if the peer is unknown.
    */
+  /**
+   * The peer whose {@code arcadedb.server.name} is {@code serverName}, or {@code null} when no peer of the
+   * configured server list answers to it (issue #7424). Applies the rules a node uses to find ITSELF in the list
+   * ({@link RaftPeerAddressResolver#findLocalPeerId}) to another node's name: a configured {@code name@host}
+   * entry, a host equal to the name, or a {@code -N}/{@code _N} suffix naming the position in the list. Those
+   * rules hold on every node because every node reads the same list, so the answer here is the peer that node
+   * resolved itself to.
+   */
+  public RaftPeerId resolvePeerIdByServerName(final String serverName) {
+    if (serverName == null || serverName.isBlank())
+      return null;
+    try {
+      return RaftPeerAddressResolver.findLocalPeerId(configuredPeerList, configuredPeerNames, serverName, arcadeServer);
+    } catch (final IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  /**
+   * The HTTPS clients this node uses for its peer-to-peer RPCs, built once per server and reused (issue #7301).
+   */
+  TrustedHttpClientCache getHttpsClients() {
+    return capabilityHttpsClients;
+  }
+
   public String getPeerDisplayName(final RaftPeerId peerId) {
     final String name = peerDisplayNames.get(peerId);
     return name != null ? name : peerId.toString();

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -957,10 +957,6 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   }
 
   /**
-   * Returns a human-readable display name for a peer, e.g. "arcadedb-0 (localhost:2480)".
-   * Falls back to the raw peer ID string if the peer is unknown.
-   */
-  /**
    * The peer whose {@code arcadedb.server.name} is {@code serverName}, or {@code null} when no peer of the
    * configured server list answers to it (issue #7424). Applies the rules a node uses to find ITSELF in the list
    * ({@link RaftPeerAddressResolver#findLocalPeerId}) to another node's name: a configured {@code name@host}
@@ -985,6 +981,10 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     return capabilityHttpsClients;
   }
 
+  /**
+   * Returns a human-readable display name for a peer, e.g. "arcadedb-0 (localhost:2480)".
+   * Falls back to the raw peer ID string if the peer is unknown.
+   */
   public String getPeerDisplayName(final RaftPeerId peerId) {
     final String name = peerDisplayNames.get(peerId);
     return name != null ? name : peerId.toString();

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ClusterAuthSessionTokenIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ClusterAuthSessionTokenIT.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.http.HttpAuthSession;
+import com.arcadedb.server.http.HttpAuthSessionManager;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A login token issued by one node is honoured by every node of the cluster (issue #7424): the token names its
+ * issuer, a node that has never seen it asks that issuer once and keeps a copy, a logout anywhere drops every
+ * copy, and a copy dies when the issuer no longer holds the session. This is the Studio-behind-a-load-balancer
+ * scenario: without it two requests out of three landed on a node that answered 401.
+ */
+class ClusterAuthSessionTokenIT extends BaseRaftHATest {
+  /** Short, so the lease renewal (a third of it) is observable; every test finishes well inside it. */
+  private static final long AUTH_SESSION_TIMEOUT_SECONDS = 6;
+
+  private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+      .version(HttpClient.Version.HTTP_1_1)
+      .connectTimeout(Duration.ofSeconds(10))
+      .build();
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    config.setValue(GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_EXPIRE_TIMEOUT, AUTH_SESSION_TIMEOUT_SECONDS);
+  }
+
+  @Test
+  void tokenIssuedByOneNodeIsHonouredByTheOthers() throws Exception {
+    final String token = loginAndGetToken(0);
+    assertThat(HttpAuthSessionManager.issuerOf(token)).isEqualTo(getServer(0).getServerName());
+
+    for (int node = 1; node < getServerCount(); node++) {
+      final HttpResponse<String> response = query(node, token);
+      assertThat(response.statusCode()).as("node %d must honour a token node 0 issued", node).isEqualTo(200);
+      assertThat(response.body()).contains("result");
+
+      final HttpAuthSession copy = authSessions(node).getSessionByToken(token);
+      assertThat(copy).as("node %d keeps a copy for the next request", node).isNotNull();
+      assertThat(copy.isRemote()).isTrue();
+      assertThat(copy.getIssuer()).isEqualTo(getServer(0).getServerName());
+      assertThat(copy.getUser().getName()).isEqualTo("root");
+    }
+    assertThat(authSessions(0).getSessionByToken(token).isRemote()).as("the issuer holds the original").isFalse();
+    // Second round: served from the copies, still 200.
+    for (int node = 1; node < getServerCount(); node++)
+      assertThat(query(node, token).statusCode()).isEqualTo(200);
+  }
+
+  @Test
+  void logoutOnAnyNodeRevokesTheTokenEverywhere() throws Exception {
+    final String token = loginAndGetToken(0);
+    for (int node = 1; node < getServerCount(); node++)
+      assertThat(query(node, token).statusCode()).isEqualTo(200);
+
+    assertThat(logout(2, token).statusCode()).isEqualTo(204);
+
+    for (int node = 0; node < getServerCount(); node++) {
+      assertThat(authSessions(node).getSessionByToken(token)).as("node %d dropped the session", node).isNull();
+      assertThat(query(node, token).statusCode()).as("node %d after logout", node).isEqualTo(401);
+    }
+  }
+
+  @Test
+  void copyDiesWhenTheIssuerNoLongerHoldsTheSession() throws Exception {
+    final String token = loginAndGetToken(0);
+    assertThat(query(1, token).statusCode()).isEqualTo(200);
+
+    // The issuer forgets the session on its own (an idle expiry, a restart) - nobody tells node 1.
+    authSessions(0).removeSession(token);
+    assertThat(query(1, token).statusCode()).as("the lease is still current").isEqualTo(200);
+
+    Thread.sleep(authSessions(1).getRemoteRenewalIntervalMs() + 200);
+    assertThat(query(1, token).statusCode()).as("renewal with the issuer fails, the copy is dropped").isEqualTo(401);
+    assertThat(authSessions(1).getSessionByToken(token)).isNull();
+  }
+
+  @Test
+  void copyInUseKeepsTheSessionAliveOnTheIssuer() throws Exception {
+    final String token = loginAndGetToken(0);
+    assertThat(query(1, token).statusCode()).isEqualTo(200);
+    final long lastUpdateOnIssuer = authSessions(0).getSessionByToken(token).getLastUpdate();
+
+    Thread.sleep(authSessions(1).getRemoteRenewalIntervalMs() + 200);
+    assertThat(query(1, token).statusCode()).isEqualTo(200);
+
+    assertThat(authSessions(0).getSessionByToken(token).getLastUpdate())
+        .as("the renewal counted as activity on the issuer, so the session does not idle out there")
+        .isGreaterThan(lastUpdateOnIssuer);
+  }
+
+  @Test
+  void tokenNamingNoMemberOrNoIssuerIsRefusedWithoutAskingAnyone() throws Exception {
+    final String uuid = "2af64e60-8455-423a-bc64-ed0e19729f04";
+    assertThat(query(1, "AU-no-such-node-" + uuid).statusCode()).isEqualTo(401);
+    assertThat(query(1, "AU-" + uuid).statusCode()).as("legacy form").isEqualTo(401);
+    assertThat(query(1, "AU-" + getServer(1).getServerName() + "-" + uuid).statusCode())
+        .as("names this very node, which does not hold it").isEqualTo(401);
+  }
+
+  // --------------------------------------------------------------------------
+  // Helpers
+  // --------------------------------------------------------------------------
+
+  private HttpAuthSessionManager authSessions(final int node) {
+    return getServer(node).getHttpServer().getAuthSessionManager();
+  }
+
+  private String loginAndGetToken(final int node) throws Exception {
+    final HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create(baseUrl(node) + "/api/v1/login"))
+        .timeout(Duration.ofSeconds(30))
+        .header("Authorization", basicRoot())
+        .header("Content-Type", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString("{}", StandardCharsets.UTF_8))
+        .build();
+    final HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+    assertThat(response.statusCode()).as("login on node %d", node).isEqualTo(200);
+    final String token = new JSONObject(response.body()).getString("token");
+    assertThat(token).startsWith("AU-");
+    return token;
+  }
+
+  private HttpResponse<String> query(final int node, final String token) throws Exception {
+    final String body = new JSONObject().put("language", "sql").put("command", "SELECT FROM V1 LIMIT 1").toString();
+    final HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create(baseUrl(node) + "/api/v1/query/" + getDatabaseName()))
+        .timeout(Duration.ofSeconds(30))
+        .header("Authorization", "Bearer " + token)
+        .header("Content-Type", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+        .build();
+    return HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+  }
+
+  private HttpResponse<String> logout(final int node, final String token) throws Exception {
+    final HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create(baseUrl(node) + "/api/v1/logout"))
+        .timeout(Duration.ofSeconds(30))
+        .header("Authorization", "Bearer " + token)
+        .POST(HttpRequest.BodyPublishers.noBody())
+        .build();
+    return HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  private String baseUrl(final int node) {
+    return "http://127.0.0.1:" + getServer(node).getHttpServer().getPort();
+  }
+
+  private static String basicRoot() {
+    return "Basic " + Base64.getEncoder()
+        .encodeToString(("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
+++ b/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -259,6 +260,36 @@ public interface HAServerPlugin extends ServerPlugin {
    *
    * @param usersJsonArray a JSON array string representing the full current users list
    */
+  /**
+   * What the node that issued an authentication token says about it when asked (issue #7424): the principal it
+   * belongs to and when it was created.
+   */
+  record PeerAuthSession(String userName, long createdAt) {
+  }
+
+  /**
+   * Asks the node named {@code issuerServerName} whether it still holds the authentication session {@code token}
+   * (issue #7424). A login token lives on the node that answered {@code /api/v1/login}; behind a load balancer the
+   * next request lands elsewhere, and this is how that node finds out whether the token is good.
+   *
+   * @return the session as the issuer describes it, or {@code null} when the answer is definitive: the issuer is
+   * not a member of this cluster, is this node itself, or does not know the token
+   *
+   * @throws IOException when the issuer could not be asked (unreachable, timed out, no usable address); the caller
+   *                     treats it as "unknown for now", not as a revocation
+   */
+  default PeerAuthSession lookupAuthSession(final String issuerServerName, final String token) throws IOException {
+    return null;
+  }
+
+  /**
+   * Tells every other node of the cluster to drop its copy of the authentication session {@code token} (issue
+   * #7424). Best effort and bounded in time: a peer that cannot be reached drops the copy on its own at its next
+   * renewal with the issuer, which no longer holds it.
+   */
+  default void revokeAuthSession(final String token) {
+  }
+
   default void replicateSecurityUsers(final String usersJsonArray) {
     // No-op by default; Raft implementation overrides.
   }

--- a/server/src/main/java/com/arcadedb/server/http/ClusterAuthSessionResolver.java
+++ b/server/src/main/java/com/arcadedb/server/http/ClusterAuthSessionResolver.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http;
+
+import com.arcadedb.log.LogManager;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.HAServerPlugin;
+import com.arcadedb.server.security.ServerSecurityUser;
+import io.micrometer.core.instrument.Metrics;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
+import java.util.logging.Level;
+
+/**
+ * Resolves, renews and revokes authentication sessions across the nodes of a cluster (issue #7424).
+ * <p>
+ * A login token lives on the node that answered {@code /api/v1/login}. Behind a load balancer the next request
+ * lands on another node, which has never seen the token and used to answer 401. The token now names its issuer
+ * ({@code AU-<server name>-<uuid>}), so that node can ask exactly one peer - through the same cluster-token channel
+ * every peer-to-peer RPC uses - and install a local copy of the session. The copy is a lease: it is confirmed with
+ * the issuer every {@link HttpAuthSessionManager#getRemoteRenewalIntervalMs()}, which also counts as activity on
+ * the issuer, so a session in use anywhere never idles out at its source. An issuer that no longer holds the
+ * session (logout, restart) revokes the copy at the next renewal; an issuer that cannot be reached keeps the copy
+ * alive for at most the idle timeout, after which the copy is dropped rather than served on trust.
+ * <p>
+ * Bounded on purpose: an unauthenticated caller can make this node dial a peer by presenting a made-up token, so
+ * at most {@link #MAX_CONCURRENT_LOOKUPS} lookups are in flight at once (past that a miss is refused without
+ * dialling), and a token a peer refused is remembered for {@link #REFUSAL_CACHE_TTL_MS} so a repeat costs nothing.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class ClusterAuthSessionResolver {
+  static final int  MAX_CONCURRENT_LOOKUPS = 16;
+  static final long REFUSAL_CACHE_TTL_MS   = 5_000L;
+  static final int  REFUSAL_CACHE_MAX      = 4_096;
+
+  private final ArcadeDBServer                server;
+  private final HttpAuthSessionManager        sessions;
+  private final Semaphore                     inFlight = new Semaphore(MAX_CONCURRENT_LOOKUPS);
+  private final ConcurrentHashMap<String, Long> refused  = new ConcurrentHashMap<>();
+
+  public ClusterAuthSessionResolver(final ArcadeDBServer server, final HttpAuthSessionManager sessions) {
+    this.server = server;
+    this.sessions = sessions;
+  }
+
+  /**
+   * Called on a token this node does not hold. Asks the issuer the token names and, when it vouches for the
+   * session, installs a local copy.
+   *
+   * @return the local copy, or {@code null} when the token is not honoured here: it names no issuer, names this
+   * node (which does not hold it, so it expired), names a node that is not a member, the issuer refused it or
+   * could not be asked, or this node has no room for a copy
+   */
+  public HttpAuthSession resolve(final String token) {
+    final String issuer = HttpAuthSessionManager.issuerOf(token);
+    if (issuer == null || issuer.equals(sessions.getIssuerName()))
+      return null;
+    final HAServerPlugin ha = server.getHA();
+    if (ha == null)
+      return null;
+
+    final long now = System.currentTimeMillis();
+    final Long refusedUntil = refused.get(token);
+    if (refusedUntil != null && refusedUntil > now) {
+      count("refused_cached");
+      return null;
+    }
+
+    if (!inFlight.tryAcquire()) {
+      count("saturated");
+      LogManager.instance().log(this, Level.FINE,
+          "Refused to resolve authentication token issued by '%s': %d lookups already in flight", issuer,
+          MAX_CONCURRENT_LOOKUPS);
+      return null;
+    }
+    final HAServerPlugin.PeerAuthSession peerSession;
+    try {
+      peerSession = ha.lookupAuthSession(issuer, token);
+    } catch (final IOException e) {
+      count("unreachable");
+      recordRefusal(token, now);
+      LogManager.instance().log(this, Level.FINE, "Cannot ask node '%s' about an authentication token: %s", issuer,
+          e.getMessage());
+      return null;
+    } finally {
+      inFlight.release();
+    }
+
+    if (peerSession == null) {
+      count("refused");
+      recordRefusal(token, now);
+      return null;
+    }
+    // Re-resolved from the live users map, like the bearer branch does for a local session: the issuer vouches
+    // for the principal's name, this node decides what that principal may do today.
+    final ServerSecurityUser user = server.getSecurity().getUser(peerSession.userName());
+    if (user == null) {
+      count("refused");
+      recordRefusal(token, now);
+      return null;
+    }
+    count("resolved");
+    return sessions.addRemoteSession(token, user, peerSession.createdAt(), issuer);
+  }
+
+  /**
+   * Called on every hit. A local session is always kept. A remote copy is kept while its lease holds; once the
+   * renewal interval has passed the issuer is asked again, and the copy is dropped when the issuer no longer
+   * holds the session or has been unreachable for a whole idle timeout.
+   *
+   * @return {@code true} to serve the request with this session, {@code false} after the copy has been dropped
+   */
+  public boolean renew(final HttpAuthSession session) {
+    if (!session.isRemote() || session.elapsedFromConfirmation() < sessions.getRemoteRenewalIntervalMs())
+      return true;
+    final HAServerPlugin ha = server.getHA();
+    if (ha == null)
+      return true;
+    if (!inFlight.tryAcquire())
+      // Saturated: the lease is served as it stands and the next request tries again. Renewal is a background
+      // concern of a session already vouched for, unlike a first lookup, which is the abuse surface.
+      return true;
+    final HAServerPlugin.PeerAuthSession peerSession;
+    try {
+      peerSession = ha.lookupAuthSession(session.getIssuer(), session.token);
+    } catch (final IOException e) {
+      if (session.elapsedFromConfirmation() <= sessions.getSessionTimeoutInMs())
+        return true;
+      count("lease_expired");
+      LogManager.instance().log(this, Level.FINE,
+          "Dropping the copy of authentication session %s: node '%s' has not confirmed it for %d ms (%s)",
+          session.token, session.getIssuer(), session.elapsedFromConfirmation(), e.getMessage());
+      sessions.removeSession(session.token);
+      return false;
+    } finally {
+      inFlight.release();
+    }
+    if (peerSession == null) {
+      count("revoked");
+      sessions.removeSession(session.token);
+      return false;
+    }
+    session.confirm();
+    return true;
+  }
+
+  /**
+   * Called on logout, after the local session is gone: tells every other node to drop its copy.
+   */
+  public void revoke(final String token) {
+    final HAServerPlugin ha = server.getHA();
+    if (ha != null && HttpAuthSessionManager.issuerOf(token) != null)
+      ha.revokeAuthSession(token);
+  }
+
+  private void recordRefusal(final String token, final long now) {
+    if (refused.size() >= REFUSAL_CACHE_MAX)
+      // Flooded with distinct made-up tokens: forget them all rather than grow. The in-flight cap, not this
+      // cache, is what bounds the cost of a flood; the cache only makes a REPEATED token free.
+      refused.clear();
+    refused.put(token, now + REFUSAL_CACHE_TTL_MS);
+  }
+
+  private static void count(final String result) {
+    Metrics.counter("http.authSession.peerLookup", "result", result).increment();
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/ClusterAuthSessionResolver.java
+++ b/server/src/main/java/com/arcadedb/server/http/ClusterAuthSessionResolver.java
@@ -97,7 +97,7 @@ public class ClusterAuthSessionResolver {
       peerSession = ha.lookupAuthSession(issuer, token);
     } catch (final IOException e) {
       count("unreachable");
-      recordRefusal(token, now);
+      recordRefusal(token);
       LogManager.instance().log(this, Level.FINE, "Cannot ask node '%s' about an authentication token: %s", issuer,
           e.getMessage());
       return null;
@@ -107,7 +107,7 @@ public class ClusterAuthSessionResolver {
 
     if (peerSession == null) {
       count("refused");
-      recordRefusal(token, now);
+      recordRefusal(token);
       return null;
     }
     // Re-resolved from the live users map, like the bearer branch does for a local session: the issuer vouches
@@ -115,7 +115,7 @@ public class ClusterAuthSessionResolver {
     final ServerSecurityUser user = server.getSecurity().getUser(peerSession.userName());
     if (user == null) {
       count("refused");
-      recordRefusal(token, now);
+      recordRefusal(token);
       return null;
     }
     count("resolved");
@@ -172,12 +172,16 @@ public class ClusterAuthSessionResolver {
       ha.revokeAuthSession(token);
   }
 
-  private void recordRefusal(final String token, final long now) {
+  /**
+   * Stamped when the refusal is recorded, not when the lookup began: a lookup that ran to its timeout would
+   * otherwise insert an entry that is already expired, and the next request would dial the peer again.
+   */
+  private void recordRefusal(final String token) {
     if (refused.size() >= REFUSAL_CACHE_MAX)
       // Flooded with distinct made-up tokens: forget them all rather than grow. The in-flight cap, not this
       // cache, is what bounds the cost of a flood; the cache only makes a REPEATED token free.
       refused.clear();
-    refused.put(token, now + REFUSAL_CACHE_TTL_MS);
+    refused.put(token, System.currentTimeMillis() + REFUSAL_CACHE_TTL_MS);
   }
 
   private static void count(final String result) {

--- a/server/src/main/java/com/arcadedb/server/http/HttpAuthSession.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpAuthSession.java
@@ -51,6 +51,13 @@ public class HttpAuthSession {
   private final String             userAgent;
   private final String             country;
   private final String             city;
+  /**
+   * Name of the cluster node that minted the token, or {@code null} for a session this node created itself. Set only
+   * on the local copy of a session resolved from a peer (issue #7424): that copy is a lease the issuer renews, see
+   * {@link #elapsedFromConfirmation()}.
+   */
+  private final String             issuer;
+  private volatile long            confirmedAt;
 
   public HttpAuthSession(final ServerSecurityUser user, final String token) {
     this(user, token, null, null, null, null);
@@ -67,11 +74,28 @@ public class HttpAuthSession {
    */
   HttpAuthSession(final ServerSecurityUser user, final String token, final String sourceIp,
       final String userAgent, final String country, final String city, final LongSupplier clock) {
+    this(user, token, sourceIp, userAgent, country, city, clock, null, clock.getAsLong());
+  }
+
+  /**
+   * The local copy of a session another node issued. {@code createdAt} is the issuer's, so the absolute timeout
+   * keeps counting from the original login rather than restarting on every node the token reaches.
+   */
+  HttpAuthSession(final ServerSecurityUser user, final String token, final String issuer, final long createdAt,
+      final LongSupplier clock) {
+    this(user, token, null, null, null, null, clock, issuer, createdAt);
+  }
+
+  private HttpAuthSession(final ServerSecurityUser user, final String token, final String sourceIp,
+      final String userAgent, final String country, final String city, final LongSupplier clock, final String issuer,
+      final long createdAt) {
     this.user = user;
     this.token = token;
     this.clock = clock;
-    this.createdAt = clock.getAsLong();
-    this.lastUpdate = this.createdAt;
+    this.issuer = issuer;
+    this.createdAt = createdAt;
+    this.lastUpdate = clock.getAsLong();
+    this.confirmedAt = this.lastUpdate;
     // Truncated here rather than at each call site so no future caller can reintroduce the unbounded
     // retention: this constructor is the only way a client-supplied string enters a session (issue #6809).
     this.sourceIp = truncate(sourceIp);
@@ -107,6 +131,34 @@ public class HttpAuthSession {
 
   public void touch() {
     this.lastUpdate = clock.getAsLong();
+  }
+
+  /**
+   * True when this is the local copy of a session another node issued, i.e. {@link #getIssuer()} is set.
+   */
+  public boolean isRemote() {
+    return issuer != null;
+  }
+
+  /**
+   * The node that minted the token, or {@code null} for a session this node created.
+   */
+  public String getIssuer() {
+    return issuer;
+  }
+
+  /**
+   * Milliseconds since the issuer last confirmed this copy is still valid. Always 0 for a local session.
+   */
+  public long elapsedFromConfirmation() {
+    return issuer == null ? 0 : clock.getAsLong() - confirmedAt;
+  }
+
+  /**
+   * Records that the issuer has just confirmed the session.
+   */
+  public void confirm() {
+    this.confirmedAt = clock.getAsLong();
   }
 
   public ServerSecurityUser getUser() {

--- a/server/src/main/java/com/arcadedb/server/http/HttpAuthSessionManager.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpAuthSessionManager.java
@@ -26,6 +26,7 @@ import com.arcadedb.utility.RWLockContext;
 
 import java.util.*;
 import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 
 /**
@@ -39,6 +40,14 @@ import java.util.logging.Level;
  * @see <a href="https://github.com/ArcadeData/arcadedb/issues/1691">GitHub Issue #1691</a>
  */
 public class HttpAuthSessionManager extends RWLockContext {
+  public static final  String TOKEN_PREFIX            = "AU-";
+  /** Length of the random part of a token: a {@link UUID} in its canonical text form. */
+  static final         int    TOKEN_RANDOM_LENGTH     = 36;
+  /** Upper bound on the issuer segment of a token, see {@link #sanitizeIssuerName(String)}. */
+  static final         int    MAX_ISSUER_NAME_LENGTH  = 64;
+  /** Cap on how often a remote copy is confirmed with its issuer, whatever the idle timeout says. */
+  static final         long   MAX_RENEWAL_INTERVAL_MS = 60_000L;
+
   private final Map<String, HttpAuthSession> sessions = new HashMap<>();
   // Per-principal index of the tokens above, in insertion order. A LinkedHashSet (not a Deque) so both the
   // "which is the oldest session of this user" lookup the per-user cap needs and the arbitrary removal an
@@ -52,6 +61,12 @@ public class HttpAuthSessionManager extends RWLockContext {
   private final       int                          maxSessionsPerUser;
   private final       LongSupplier                 clock;
   private final       Timer                        timer;
+  /**
+   * Written into every token this node mints, between the prefix and the random part, so a peer that has never
+   * seen the token can tell which node to ask about it (issue #7424). {@code null} keeps the legacy
+   * {@code AU-<uuid>} form, which no peer can resolve.
+   */
+  private final       String                       issuerName;
   /**
    * Stands in for a server that was not supplied - the test-only constructors below; reads through to each
    * setting's process-wide value. Shared rather than built per read: it holds nothing per instance.
@@ -89,10 +104,25 @@ public class HttpAuthSessionManager extends RWLockContext {
 
   HttpAuthSessionManager(final long sessionTimeoutInMs, final long absoluteTimeoutInMs, final int maxSessions,
       final int maxSessionsPerUser, final LongSupplier clock) {
+    this(sessionTimeoutInMs, absoluteTimeoutInMs, maxSessions, maxSessionsPerUser, null, clock);
+  }
+
+  /**
+   * The form {@code HttpServer} uses: {@code issuerName} is this node's {@code arcadedb.server.name}, written into
+   * every token so the other nodes of a cluster can resolve it (issue #7424).
+   */
+  public HttpAuthSessionManager(final long sessionTimeoutInMs, final long absoluteTimeoutInMs, final int maxSessions,
+      final int maxSessionsPerUser, final String issuerName) {
+    this(sessionTimeoutInMs, absoluteTimeoutInMs, maxSessions, maxSessionsPerUser, issuerName, System::currentTimeMillis);
+  }
+
+  HttpAuthSessionManager(final long sessionTimeoutInMs, final long absoluteTimeoutInMs, final int maxSessions,
+      final int maxSessionsPerUser, final String issuerName, final LongSupplier clock) {
     this.sessionTimeoutInMs = sessionTimeoutInMs;
     this.absoluteTimeoutInMs = absoluteTimeoutInMs;
     this.maxSessions = maxSessions;
     this.maxSessionsPerUser = maxSessionsPerUser;
+    this.issuerName = sanitizeIssuerName(issuerName);
     this.clock = clock;
 
     timer = new Timer("HttpAuthSessionManager-Cleanup", true);
@@ -197,6 +227,78 @@ public class HttpAuthSessionManager extends RWLockContext {
    */
   public HttpAuthSession createSession(final ServerSecurityUser user, final String sourceIp,
       final String userAgent, final String country, final String city) {
+    final String token = issuerName != null ? TOKEN_PREFIX + issuerName + "-" + UUID.randomUUID()
+        : TOKEN_PREFIX + UUID.randomUUID();
+    return insert(user, () -> new HttpAuthSession(user, token, sourceIp, userAgent, country, city, clock));
+  }
+
+  /**
+   * Installs the local copy of a session another node of the cluster issued (issue #7424), once that node has
+   * confirmed the token. The copy is subject to the same caps and timeouts as a local session: it counts against
+   * the principal's and the server's limits, idles out when unused HERE, and inherits the issuer's creation time
+   * so the absolute timeout is measured from the original login.
+   *
+   * @return the installed copy, or {@code null} when the global cap refused it (the caller answers 401: the token
+   * is valid, but this node has no room to honour it)
+   */
+  public HttpAuthSession addRemoteSession(final String token, final ServerSecurityUser user, final long createdAt,
+      final String issuer) {
+    return insert(user, () -> new HttpAuthSession(user, token, issuer, createdAt, clock));
+  }
+
+  /**
+   * Which node minted {@code token}, read from the {@code AU-<issuer>-<uuid>} form; {@code null} for the legacy
+   * {@code AU-<uuid>} form, for anything that is not a session token, or for an issuer segment that is not a
+   * sanitized name. Parsed from the END, because the issuer is a server name and server names carry dashes
+   * ({@code arcadedb-0}), while the random part has a fixed length.
+   */
+  public static String issuerOf(final String token) {
+    if (token == null || !token.startsWith(TOKEN_PREFIX))
+      return null;
+    final int issuerEnd = token.length() - TOKEN_RANDOM_LENGTH - 1;
+    if (issuerEnd <= TOKEN_PREFIX.length() || token.charAt(issuerEnd) != '-')
+      return null;
+    final String issuer = token.substring(TOKEN_PREFIX.length(), issuerEnd);
+    return issuer.equals(sanitizeIssuerName(issuer)) ? issuer : null;
+  }
+
+  /**
+   * The issuer segment a server name becomes inside a token: any character outside {@code [A-Za-z0-9._-]} is
+   * replaced with {@code _} and the result is capped at {@link #MAX_ISSUER_NAME_LENGTH}, so the token stays a
+   * plain header value whatever the operator called the node. Applied on BOTH sides - when minting and when a
+   * peer maps the segment back to a node - so the mapping is stable. {@code null} and blank stay {@code null}.
+   */
+  public static String sanitizeIssuerName(final String name) {
+    if (name == null || name.isBlank())
+      return null;
+    final StringBuilder out = new StringBuilder(Math.min(name.length(), MAX_ISSUER_NAME_LENGTH));
+    for (int i = 0; i < name.length() && out.length() < MAX_ISSUER_NAME_LENGTH; i++) {
+      final char c = name.charAt(i);
+      final boolean allowed = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+          || c == '.' || c == '_' || c == '-';
+      out.append(allowed ? c : '_');
+    }
+    return out.toString();
+  }
+
+  /**
+   * How long a remote copy is served before it is confirmed with its issuer again: a third of the idle timeout,
+   * capped at {@link #MAX_RENEWAL_INTERVAL_MS}. The confirmation touches the session on the issuer, so a token in
+   * use anywhere in the cluster never idles out at its source; a third leaves two attempts before it would.
+   */
+  public long getRemoteRenewalIntervalMs() {
+    return Math.max(1, Math.min(sessionTimeoutInMs / 3, MAX_RENEWAL_INTERVAL_MS));
+  }
+
+  public long getSessionTimeoutInMs() {
+    return sessionTimeoutInMs;
+  }
+
+  public String getIssuerName() {
+    return issuerName;
+  }
+
+  private HttpAuthSession insert(final ServerSecurityUser user, final Supplier<HttpAuthSession> factory) {
     if (maxSessions > 0 && getActiveSessionCount() >= maxSessions)
       // Reclaim first: a map full of idle-expired sessions must not refuse a legitimate login just because
       // the background sweep has not fired yet. Done outside the write lock below (it takes its own).
@@ -234,12 +336,12 @@ public class HttpAuthSessionManager extends RWLockContext {
             userName, maxSessionsPerUser);
       }
 
-      final String token = "AU-" + UUID.randomUUID();
-      final HttpAuthSession session = new HttpAuthSession(user, token, sourceIp, userAgent, country, city, clock);
+      final HttpAuthSession session = factory.get();
+      final String token = session.token;
       sessions.put(token, session);
       userTokens.add(token);
       LogManager.instance().log(this, Level.FINE, "Created authentication session %s for user %s from %s", token,
-          user.getName(), sourceIp);
+          user.getName(), session.isRemote() ? "peer " + session.getIssuer() : session.getSourceIp());
       return session;
     });
   }

--- a/server/src/main/java/com/arcadedb/server/http/HttpServer.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpServer.java
@@ -54,6 +54,7 @@ import com.arcadedb.server.http.handler.PutUserHandler;
 import com.arcadedb.server.http.handler.PostCommandHandler;
 import com.arcadedb.server.http.handler.PostCommitHandler;
 import com.arcadedb.server.http.handler.PostLoginHandler;
+import com.arcadedb.server.http.handler.PostClusterAuthSessionHandler;
 import com.arcadedb.server.http.handler.PostLogoutHandler;
 import com.arcadedb.server.http.handler.PostQueryHandler;
 import com.arcadedb.server.http.handler.PostRollbackHandler;
@@ -122,6 +123,7 @@ public class HttpServer implements ServerPlugin {
   private final    ArcadeDBServer         server;
   private final    HttpSessionManager     sessionManager;
   private final    HttpAuthSessionManager authSessionManager;
+  private final    ClusterAuthSessionResolver clusterAuthSessionResolver;
   private final    WebSocketEventBus      webSocketEventBus;
   private final    IdempotencyCache       idempotencyCache;
   private          ScheduledExecutorService idempotencyCleanupExecutor;
@@ -139,7 +141,9 @@ public class HttpServer implements ServerPlugin {
         server.getConfiguration().getValueAsLong(GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_EXPIRE_TIMEOUT) * 1_000L,
         server.getConfiguration().getValueAsLong(GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_ABSOLUTE_TIMEOUT) * 1_000L,
         server.getConfiguration().getValueAsInteger(GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_MAX),
-        server.getConfiguration().getValueAsInteger(GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_MAX_PER_USER));
+        server.getConfiguration().getValueAsInteger(GlobalConfiguration.SERVER_HTTP_AUTH_SESSION_MAX_PER_USER),
+        server.getServerName());
+    this.clusterAuthSessionResolver = new ClusterAuthSessionResolver(server, authSessionManager);
     this.webSocketEventBus = new WebSocketEventBus(this.server);
     final long ttlMs = server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_IDEMPOTENCY_CACHE_TTL_MS);
     final int maxEntries = server.getConfiguration().getValueAsInteger(GlobalConfiguration.HA_IDEMPOTENCY_CACHE_MAX_ENTRIES);
@@ -233,6 +237,7 @@ public class HttpServer implements ServerPlugin {
         .get("/progress/{database}", new GetProgressHandler(this))
         .post("/login", new PostLoginHandler(this))
         .post("/logout", new PostLogoutHandler(this))
+        .post("/cluster/auth-session", new PostClusterAuthSessionHandler(this))
         .get("/query/{database}/{language}/{command}", new GetQueryHandler(this))
         .get("/sessions", new GetSessionsHandler(this))
         .post("/query/{database}", new PostQueryHandler(this))
@@ -430,6 +435,10 @@ public class HttpServer implements ServerPlugin {
 
   public HttpAuthSessionManager getAuthSessionManager() {
     return authSessionManager;
+  }
+
+  public ClusterAuthSessionResolver getClusterAuthSessionResolver() {
+    return clusterAuthSessionResolver;
   }
 
   public ArcadeDBServer getServer() {

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -32,6 +32,7 @@ import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.HAReplicatedDatabase;
 import com.arcadedb.server.LeaderForwardContext;
+import com.arcadedb.server.http.ClusterAuthSessionResolver;
 import com.arcadedb.server.http.HttpAuthSession;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.http.HttpSessionException;
@@ -400,9 +401,14 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
                   return;
                 }
               } else {
-                // Session token authentication (AU- prefix)
-                final HttpAuthSession authSession = httpServer.getAuthSessionManager().getSessionByToken(token);
-                if (authSession == null) {
+                // Session token authentication (AU- prefix). A token this node has never seen may have been
+                // issued by another node of the cluster - the token names it - and a copy this node holds is
+                // a lease the issuer renews (issue #7424).
+                final ClusterAuthSessionResolver clusterResolver = httpServer.getClusterAuthSessionResolver();
+                HttpAuthSession authSession = httpServer.getAuthSessionManager().getSessionByToken(token);
+                if (authSession == null)
+                  authSession = clusterResolver.resolve(token);
+                if (authSession == null || !clusterResolver.renew(authSession)) {
                   exchange.setStatusCode(401);
                   sendErrorResponse(exchange, 401, "Invalid or expired authentication token", null, null);
                   return;

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetSessionsHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetSessionsHandler.java
@@ -70,6 +70,9 @@ public class GetSessionsHandler extends AbstractServerHttpHandler {
       sessionJson.put("userAgent", session.getUserAgent());
       sessionJson.put("country", session.getCountry());
       sessionJson.put("city", session.getCity());
+      // Which node issued the session, for a copy resolved from a peer (issue #7424); absent for a local session.
+      if (session.isRemote())
+        sessionJson.put("issuer", session.getIssuer());
       sessionsArray.put(sessionJson);
     }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostClusterAuthSessionHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostClusterAuthSessionHandler.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.http.HttpAuthSession;
+import com.arcadedb.server.http.HttpServer;
+import com.arcadedb.server.security.ServerSecurityUser;
+import io.undertow.server.HttpServerExchange;
+
+/**
+ * Cluster-internal {@code POST /api/v1/cluster/auth-session}: the node that issued an authentication token answers
+ * a peer that received it (issue #7424). {@code validate} confirms the session and counts as activity on it;
+ * {@code revoke} drops it, which is how a logout served by one node reaches every other.
+ * <p>
+ * Only a peer may ask: the request must have come in through the cluster-token channel. A caller presenting user
+ * credentials, root included, is refused with 403, because the answer discloses which principal a token belongs
+ * to and the route exists for nodes, not for users. A copy held here on behalf of another issuer never vouches:
+ * {@code validate} answers 404 for it, so a stale copy cannot keep a revoked session alive through a third node.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class PostClusterAuthSessionHandler extends AbstractServerHttpHandler {
+  static final String CLUSTER_TOKEN_HEADER = "X-ArcadeDB-Cluster-Token";
+
+  public PostClusterAuthSessionHandler(final HttpServer httpServer) {
+    super(httpServer);
+  }
+
+  /**
+   * The body is parsed only for handlers that run on a worker thread; this one reads a JSON body.
+   */
+  @Override
+  protected boolean mustExecuteOnWorkerThread() {
+    return true;
+  }
+
+  @Override
+  protected ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user,
+      final JSONObject payload) {
+    if (!exchange.getRequestHeaders().contains(CLUSTER_TOKEN_HEADER))
+      return new ExecutionResponse(403,
+          new JSONObject().put("error", "This route answers cluster peers only").toString());
+    checkRootUser(user);
+
+    final String token = payload != null ? payload.getString("token", null) : null;
+    if (token == null || token.isBlank())
+      return new ExecutionResponse(400, new JSONObject().put("error", "Missing token").toString());
+
+    final String action = payload.getString("action", "validate");
+    switch (action) {
+    case "validate" -> {
+      final HttpAuthSession session = httpServer.getAuthSessionManager().getSessionByToken(token);
+      if (session == null || session.isRemote())
+        return new ExecutionResponse(404,
+            new JSONObject().put("error", "Invalid or expired authentication token").toString());
+      return new ExecutionResponse(200, new JSONObject()
+          .put("user", session.getUser().getName())
+          .put("createdAt", session.getCreatedAt())
+          .toString());
+    }
+    case "revoke" -> {
+      httpServer.getAuthSessionManager().removeSession(token);
+      return new ExecutionResponse(204, "");
+    }
+    default -> {
+      return new ExecutionResponse(400, new JSONObject().put("error", "Unknown action '" + action + "'").toString());
+    }
+    }
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostLogoutHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostLogoutHandler.java
@@ -51,6 +51,9 @@ public class PostLogoutHandler extends AbstractServerHttpHandler {
       if (auth.startsWith(AUTHORIZATION_BEARER)) {
         final String token = auth.substring(AUTHORIZATION_BEARER.length()).trim();
         httpServer.getAuthSessionManager().removeSession(token);
+        // The other nodes of a cluster may hold a copy of this session (issue #7424): drop those too, so a
+        // logout is a logout wherever the load balancer sends the next request.
+        httpServer.getClusterAuthSessionResolver().revoke(token);
       }
     }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/AuthApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/AuthApiSpec.java
@@ -24,6 +24,8 @@ import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 
+import java.util.List;
+
 /**
  * Documents the session endpoints. Login mints a bearer session token from credentials already
  * validated by the handler chain, so it declares no request body of its own.
@@ -35,9 +37,12 @@ public class AuthApiSpec implements OpenApiContributor {
     openAPI.getPaths().addPathItem("/api/v1/login", createLoginPath());
     openAPI.getPaths().addPathItem("/api/v1/logout", createLogoutPath());
     openAPI.getPaths().addPathItem("/api/v1/sessions", createSessionsPath());
+    openAPI.getPaths().addPathItem("/api/v1/cluster/auth-session", createClusterAuthSessionPath());
 
     openAPI.getComponents().addSchemas("LoginResponse", createLoginResponseSchema());
     openAPI.getComponents().addSchemas("SessionList", createSessionListSchema());
+    openAPI.getComponents().addSchemas("ClusterAuthSessionRequest", createClusterAuthSessionRequestSchema());
+    openAPI.getComponents().addSchemas("ClusterAuthSessionResponse", createClusterAuthSessionResponseSchema());
   }
 
   private PathItem createLoginPath() {
@@ -69,6 +74,32 @@ public class AuthApiSpec implements OpenApiContributor {
     final ApiResponses responses = new ApiResponses();
     responses.addApiResponse("204", SpecBuilders.emptyResponse("Session invalidated"));
     responses.addApiResponse("401", SpecBuilders.errorResponse("Unauthorized"));
+    responses.addApiResponse("500", SpecBuilders.errorResponse("Internal server error"));
+    post.setResponses(responses);
+
+    final PathItem pathItem = new PathItem();
+    pathItem.setPost(post);
+    return pathItem;
+  }
+
+  private PathItem createClusterAuthSessionPath() {
+    final Operation post = SpecBuilders.operation("resolveClusterAuthSession", "Auth",
+        "Confirm or revoke an authentication session on the node that issued it",
+        """
+            Cluster-internal. A session token is held by the node that answered /api/v1/login and names that \
+            node ('AU-<server name>-<uuid>'). A peer that receives the token asks the issuer through this route \
+            whether the session is still valid ('validate', which also counts as activity on the issuer), and a \
+            logout tells every peer to drop its copy ('revoke'). Peers authenticate with the cluster token; a \
+            request that carries user credentials instead is refused with 403 (issue #7424).""");
+    post.setRequestBody(SpecBuilders.jsonBody("The token and what to do with it", "ClusterAuthSessionRequest", true));
+    final ApiResponses responses = new ApiResponses();
+    responses.addApiResponse("200", SpecBuilders.jsonResponse("The session, as the issuer holds it",
+        "ClusterAuthSessionResponse"));
+    responses.addApiResponse("204", SpecBuilders.emptyResponse("Copy dropped"));
+    responses.addApiResponse("400", SpecBuilders.errorResponse("Missing token or unknown action"));
+    responses.addApiResponse("401", SpecBuilders.errorResponse("Unauthorized"));
+    responses.addApiResponse("403", SpecBuilders.errorResponse("Not a cluster peer"));
+    responses.addApiResponse("404", SpecBuilders.errorResponse("The issuer does not hold this session"));
     responses.addApiResponse("500", SpecBuilders.errorResponse("Internal server error"));
     post.setResponses(responses);
 
@@ -109,10 +140,27 @@ public class AuthApiSpec implements OpenApiContributor {
     session.addProperty("userAgent", SpecBuilders.string("Client user agent"));
     session.addProperty("country", SpecBuilders.string("Country reported by the proxy, when available"));
     session.addProperty("city", SpecBuilders.string("City reported by the proxy, when available"));
+    session.addProperty("issuer", SpecBuilders.string(
+        "Name of the cluster node that issued the session, when this node holds a copy of it; absent for a session this node issued"));
 
     final Schema<Object> schema = SpecBuilders.object("Active authentication sessions");
     schema.addProperty("result", SpecBuilders.arrayOf(session, "Active sessions"));
     schema.addProperty("count", SpecBuilders.integer("Number of active sessions"));
+    return schema;
+  }
+
+  private Schema<?> createClusterAuthSessionRequestSchema() {
+    final Schema<Object> schema = SpecBuilders.object("A session token and the action to apply to it");
+    schema.addProperty("token", SpecBuilders.string("The session token, 'AU-<server name>-<uuid>'"));
+    schema.addProperty("action", SpecBuilders.string("'validate' (default) or 'revoke'"));
+    schema.setRequired(List.of("token"));
+    return schema;
+  }
+
+  private Schema<?> createClusterAuthSessionResponseSchema() {
+    final Schema<Object> schema = SpecBuilders.object("The session as held by the node that issued it");
+    schema.addProperty("user", SpecBuilders.string("The principal the session belongs to"));
+    schema.addProperty("createdAt", SpecBuilders.integer("Creation time, epoch milliseconds"));
     return schema;
   }
 }

--- a/server/src/test/java/com/arcadedb/server/http/ClusterAuthSessionResolverTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/ClusterAuthSessionResolverTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http;
+
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.HAServerPlugin;
+import com.arcadedb.server.security.ServerSecurity;
+import com.arcadedb.server.security.ServerSecurityUser;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ClusterAuthSessionResolver}: what a node does with a token it does not hold, how a
+ * copy's lease is renewed, and how a logout reaches the other nodes (issue #7424). The peer is a scripted
+ * {@link HAServerPlugin}; the HTTP leg is covered by {@code PostClusterAuthSessionHandlerTest} and the
+ * three-node run by {@code ClusterAuthSessionTokenIT} in ha-raft.
+ */
+class ClusterAuthSessionResolverTest {
+  private static final String TOKEN_FROM_A = "AU-node-a-2af64e60-8455-423a-bc64-ed0e19729f04";
+
+  private volatile long          fakeNow;
+  private HttpAuthSessionManager sessions;
+  private ScriptedPeer           peer;
+  private ArcadeDBServer         server;
+  private ServerSecurityUser     alice;
+
+  /** A peer whose answers the test scripts: a session, "unknown" (null), or "unreachable" (throws). */
+  private static final class ScriptedPeer {
+    final AtomicReference<Object> answer  = new AtomicReference<>();
+    final List<String>            lookups = new ArrayList<>();
+    final List<String>            revoked = new ArrayList<>();
+
+    HAServerPlugin asPlugin() throws IOException {
+      final HAServerPlugin plugin = mock(HAServerPlugin.class);
+      // doAnswer, not when(): when() would run the interface's default method for real while stubbing.
+      doAnswer(invocation -> {
+        lookups.add(invocation.getArgument(0) + ":" + invocation.getArgument(1));
+        final Object a = answer.get();
+        if (a instanceof IOException e)
+          throw e;
+        return a;
+      }).when(plugin).lookupAuthSession(anyString(), anyString());
+      doAnswer(invocation -> {
+        revoked.add(invocation.getArgument(0));
+        return null;
+      }).when(plugin).revokeAuthSession(anyString());
+      return plugin;
+    }
+  }
+
+  @BeforeEach
+  void setUp() throws IOException {
+    fakeNow = 1_000_000L;
+    sessions = new HttpAuthSessionManager(30_000L, 0L, 0, 0, "node-b", () -> fakeNow);
+    peer = new ScriptedPeer();
+    alice = mock(ServerSecurityUser.class);
+    when(alice.getName()).thenReturn("alice");
+    when(alice.getAuthorizedDatabases()).thenReturn(Set.of());
+    final ServerSecurity security = mock(ServerSecurity.class);
+    when(security.getUser(anyString())).thenReturn(null);
+    when(security.getUser("alice")).thenReturn(alice);
+    // Built before the stubbing below opens: a mock created inside thenReturn(...) is a nested stubbing.
+    final HAServerPlugin plugin = peer.asPlugin();
+    server = mock(ArcadeDBServer.class);
+    when(server.getHA()).thenReturn(plugin);
+    when(server.getSecurity()).thenReturn(security);
+  }
+
+  @AfterEach
+  void tearDown() {
+    sessions.close();
+  }
+
+  private ClusterAuthSessionResolver resolver() {
+    return new ClusterAuthSessionResolver(server, sessions);
+  }
+
+  @Test
+  void tokenVouchedForByItsIssuerBecomesALocalCopy() {
+    peer.answer.set(new HAServerPlugin.PeerAuthSession("alice", 900_000L));
+
+    final HttpAuthSession copy = resolver().resolve(TOKEN_FROM_A);
+
+    assertThat(copy).isNotNull();
+    assertThat(copy.isRemote()).isTrue();
+    assertThat(copy.getIssuer()).isEqualTo("node-a");
+    assertThat(copy.getUser()).isSameAs(alice);
+    assertThat(copy.getCreatedAt()).isEqualTo(900_000L);
+    assertThat(peer.lookups).containsExactly("node-a:" + TOKEN_FROM_A);
+    assertThat(sessions.getSessionByToken(TOKEN_FROM_A)).as("the next request hits locally").isSameAs(copy);
+  }
+
+  @Test
+  void tokenNamingNoIssuerOrThisNodeOrNoClusterIsRefusedWithoutAsking() {
+    peer.answer.set(new HAServerPlugin.PeerAuthSession("alice", 0L));
+    final ClusterAuthSessionResolver resolver = resolver();
+
+    assertThat(resolver.resolve("AU-2af64e60-8455-423a-bc64-ed0e19729f04")).as("legacy token").isNull();
+    assertThat(resolver.resolve("AU-node-b-2af64e60-8455-423a-bc64-ed0e19729f04")).as("own token, so expired").isNull();
+    assertThat(peer.lookups).isEmpty();
+
+    when(server.getHA()).thenReturn(null);
+    assertThat(resolver.resolve(TOKEN_FROM_A)).as("not clustered").isNull();
+    assertThat(peer.lookups).isEmpty();
+  }
+
+  @Test
+  void issuerThatDoesNotKnowTheTokenIsRememberedSoARepeatCostsNoCall() {
+    peer.answer.set(null);
+    final ClusterAuthSessionResolver resolver = resolver();
+
+    assertThat(resolver.resolve(TOKEN_FROM_A)).isNull();
+    assertThat(resolver.resolve(TOKEN_FROM_A)).isNull();
+    assertThat(peer.lookups).as("second miss served from the refusal cache").hasSize(1);
+  }
+
+  @Test
+  void unreachableIssuerRefusesTheTokenForNow() {
+    peer.answer.set(new IOException("connection refused"));
+
+    assertThat(resolver().resolve(TOKEN_FROM_A)).isNull();
+    assertThat(sessions.getSessionByToken(TOKEN_FROM_A)).isNull();
+  }
+
+  @Test
+  void principalTheIssuerNamesMustStillExistHere() {
+    peer.answer.set(new HAServerPlugin.PeerAuthSession("dropped-user", 0L));
+
+    assertThat(resolver().resolve(TOKEN_FROM_A)).isNull();
+  }
+
+  @Test
+  void copyIsServedWithoutAskingUntilTheRenewalIntervalPasses() {
+    peer.answer.set(new HAServerPlugin.PeerAuthSession("alice", 0L));
+    final ClusterAuthSessionResolver resolver = resolver();
+    final HttpAuthSession copy = resolver.resolve(TOKEN_FROM_A);
+    peer.lookups.clear();
+
+    fakeNow += sessions.getRemoteRenewalIntervalMs() - 1;
+    assertThat(resolver.renew(copy)).isTrue();
+    assertThat(peer.lookups).isEmpty();
+
+    fakeNow += 1;
+    assertThat(resolver.renew(copy)).isTrue();
+    assertThat(peer.lookups).as("lease renewed with the issuer").hasSize(1);
+    assertThat(copy.elapsedFromConfirmation()).isZero();
+  }
+
+  @Test
+  void localSessionNeverAsksAnyone() {
+    final HttpAuthSession local = sessions.createSession(alice);
+    fakeNow += 10 * sessions.getRemoteRenewalIntervalMs();
+
+    assertThat(resolver().renew(local)).isTrue();
+    assertThat(peer.lookups).isEmpty();
+  }
+
+  @Test
+  void copyIsDroppedWhenTheIssuerNoLongerHoldsTheSession() {
+    peer.answer.set(new HAServerPlugin.PeerAuthSession("alice", 0L));
+    final ClusterAuthSessionResolver resolver = resolver();
+    final HttpAuthSession copy = resolver.resolve(TOKEN_FROM_A);
+
+    peer.answer.set(null);
+    fakeNow += sessions.getRemoteRenewalIntervalMs();
+    assertThat(resolver.renew(copy)).isFalse();
+    assertThat(sessions.getSessionByToken(TOKEN_FROM_A)).isNull();
+  }
+
+  @Test
+  void copyOutlivesAnUnreachableIssuerForOneIdleTimeoutOnly() {
+    peer.answer.set(new HAServerPlugin.PeerAuthSession("alice", 0L));
+    final ClusterAuthSessionResolver resolver = resolver();
+    final HttpAuthSession copy = resolver.resolve(TOKEN_FROM_A);
+
+    peer.answer.set(new IOException("connection refused"));
+    fakeNow += sessions.getRemoteRenewalIntervalMs();
+    assertThat(resolver.renew(copy)).as("a blip does not log the user out").isTrue();
+    assertThat(sessions.getSessionByToken(TOKEN_FROM_A)).isSameAs(copy);
+
+    fakeNow += sessions.getSessionTimeoutInMs();
+    assertThat(resolver.renew(copy)).as("unconfirmed for a whole idle timeout").isFalse();
+    assertThat(sessions.getSessionByToken(TOKEN_FROM_A)).isNull();
+  }
+
+  @Test
+  void logoutFansOutOnlyForClusterAwareTokens() {
+    final ClusterAuthSessionResolver resolver = resolver();
+
+    resolver.revoke(TOKEN_FROM_A);
+    resolver.revoke("AU-2af64e60-8455-423a-bc64-ed0e19729f04");
+
+    assertThat(peer.revoked).containsExactly(TOKEN_FROM_A);
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/HttpAuthSessionManagerTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/HttpAuthSessionManagerTest.java
@@ -435,4 +435,117 @@ class HttpAuthSessionManagerTest {
     assertThat(manager.checkSessionsValidity()).isEqualTo(2);
     assertThat(manager.getActiveSessionCount("testuser")).isZero();
   }
+
+  // --- Cluster-aware tokens (issue #7424) ---------------------------------------------------------------------
+
+  @Test
+  void tokenNamesTheIssuingNode() {
+    manager = new HttpAuthSessionManager(30_000L, 0L, 0, 0, "arcadedb-0");
+    final HttpAuthSession session = manager.createSession(createMockUser("alice"));
+
+    assertThat(session.getToken()).startsWith("AU-arcadedb-0-");
+    assertThat(HttpAuthSessionManager.issuerOf(session.getToken())).isEqualTo("arcadedb-0");
+    assertThat(session.isRemote()).isFalse();
+    assertThat(session.getIssuer()).isNull();
+    assertThat(manager.getSessionByToken(session.getToken())).isSameAs(session);
+  }
+
+  @Test
+  void tokenWithoutIssuerKeepsTheLegacyForm() {
+    manager = new HttpAuthSessionManager(30_000L);
+    final HttpAuthSession session = manager.createSession(createMockUser("alice"));
+
+    assertThat(session.getToken()).matches("AU-[0-9a-f-]{36}");
+    assertThat(HttpAuthSessionManager.issuerOf(session.getToken())).isNull();
+  }
+
+  @Test
+  void issuerIsParsedFromTheEndSoNamesMayCarryDashes() {
+    final String uuid = "2af64e60-8455-423a-bc64-ed0e19729f04";
+    assertThat(HttpAuthSessionManager.issuerOf("AU-arcadedb-0-" + uuid)).isEqualTo("arcadedb-0");
+    assertThat(HttpAuthSessionManager.issuerOf("AU-ArcadeDB_1-" + uuid)).isEqualTo("ArcadeDB_1");
+    assertThat(HttpAuthSessionManager.issuerOf("AU-my-db-node-12-" + uuid)).isEqualTo("my-db-node-12");
+    assertThat(HttpAuthSessionManager.issuerOf("AU-" + uuid)).as("legacy form").isNull();
+    assertThat(HttpAuthSessionManager.issuerOf("AU--" + uuid)).as("empty issuer").isNull();
+    assertThat(HttpAuthSessionManager.issuerOf("AU-node" + uuid)).as("no separator").isNull();
+    assertThat(HttpAuthSessionManager.issuerOf("AU-bad name-" + uuid)).as("unsanitized issuer").isNull();
+    assertThat(HttpAuthSessionManager.issuerOf("at-node-" + uuid)).as("API token").isNull();
+    assertThat(HttpAuthSessionManager.issuerOf("AU-")).isNull();
+    assertThat(HttpAuthSessionManager.issuerOf(null)).isNull();
+  }
+
+  @Test
+  void issuerNameIsSanitizedOnBothSides() {
+    assertThat(HttpAuthSessionManager.sanitizeIssuerName("node one/2")).isEqualTo("node_one_2");
+    assertThat(HttpAuthSessionManager.sanitizeIssuerName("arcadedb-0.ns")).isEqualTo("arcadedb-0.ns");
+    assertThat(HttpAuthSessionManager.sanitizeIssuerName("x".repeat(100))).hasSize(HttpAuthSessionManager.MAX_ISSUER_NAME_LENGTH);
+    assertThat(HttpAuthSessionManager.sanitizeIssuerName("  ")).isNull();
+    assertThat(HttpAuthSessionManager.sanitizeIssuerName(null)).isNull();
+
+    manager = new HttpAuthSessionManager(30_000L, 0L, 0, 0, "node one/2");
+    final HttpAuthSession session = manager.createSession(createMockUser("alice"));
+    assertThat(HttpAuthSessionManager.issuerOf(session.getToken())).isEqualTo("node_one_2");
+    assertThat(manager.getIssuerName()).isEqualTo("node_one_2");
+  }
+
+  @Test
+  void remoteCopyKeepsTheIssuersCreationTimeAndIsIndexedLikeALocalSession() {
+    fakeNow = 100_000L;
+    manager = new HttpAuthSessionManager(30_000L, 60_000L, 0, 0, "node-b", () -> fakeNow);
+    final ServerSecurityUser alice = createMockUser("alice");
+    final String token = "AU-node-a-2af64e60-8455-423a-bc64-ed0e19729f04";
+
+    final HttpAuthSession copy = manager.addRemoteSession(token, alice, 50_000L, "node-a");
+
+    assertThat(copy).isNotNull();
+    assertThat(copy.isRemote()).isTrue();
+    assertThat(copy.getIssuer()).isEqualTo("node-a");
+    assertThat(copy.getCreatedAt()).as("absolute timeout counts from the original login").isEqualTo(50_000L);
+    assertThat(copy.getLastUpdate()).as("idle timeout counts from the copy's own use").isEqualTo(100_000L);
+    assertThat(copy.elapsedFromConfirmation()).isZero();
+    assertThat(manager.getSessionByToken(token)).isSameAs(copy);
+    assertThat(manager.getActiveSessionCount("alice")).isEqualTo(1);
+
+    fakeNow = 110_001L;
+    assertThat(manager.getSessionByToken(token)).as("absolute timeout, 60s after the issuer's login").isNull();
+  }
+
+  @Test
+  void remoteCopyConfirmationIsTrackedSeparatelyFromUse() {
+    fakeNow = 0L;
+    manager = new HttpAuthSessionManager(30_000L, 0L, 0, 0, "node-b", () -> fakeNow);
+    final HttpAuthSession copy = manager.addRemoteSession("AU-node-a-2af64e60-8455-423a-bc64-ed0e19729f04",
+        createMockUser("alice"), 0L, "node-a");
+
+    fakeNow = 5_000L;
+    copy.touch();
+    assertThat(copy.elapsedFromConfirmation()).isEqualTo(5_000L);
+    copy.confirm();
+    assertThat(copy.elapsedFromConfirmation()).isZero();
+
+    final HttpAuthSession local = manager.createSession(createMockUser("bob"));
+    fakeNow = 20_000L;
+    assertThat(local.elapsedFromConfirmation()).as("a local session needs no confirmation").isZero();
+  }
+
+  @Test
+  void remoteCopyIsRefusedByTheGlobalCapLikeALogin() {
+    manager = new HttpAuthSessionManager(30_000L, 0L, 1, 0, "node-b");
+    assertThat(manager.createSession(createMockUser("alice"))).isNotNull();
+
+    assertThat(manager.addRemoteSession("AU-node-a-2af64e60-8455-423a-bc64-ed0e19729f04", createMockUser("bob"), 0L,
+        "node-a")).isNull();
+  }
+
+  @Test
+  void renewalIntervalIsAThirdOfTheIdleTimeoutCapped() {
+    manager = new HttpAuthSessionManager(30_000L, 0L, 0, 0, "n");
+    assertThat(manager.getRemoteRenewalIntervalMs()).isEqualTo(10_000L);
+    manager.close();
+    manager = new HttpAuthSessionManager(30 * 60_000L, 0L, 0, 0, "n");
+    assertThat(manager.getRemoteRenewalIntervalMs()).isEqualTo(HttpAuthSessionManager.MAX_RENEWAL_INTERVAL_MS);
+    manager.close();
+    manager = new HttpAuthSessionManager(2L, 0L, 0, 0, "n");
+    assertThat(manager.getRemoteRenewalIntervalMs()).isEqualTo(1L);
+  }
 }

--- a/server/src/test/java/com/arcadedb/server/http/OpenApiSpecGenerationIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/OpenApiSpecGenerationIT.java
@@ -436,6 +436,7 @@ class OpenApiSpecGenerationIT extends BaseGraphServerTest {
       "POST /api/v1/vector/{database}/fulltext",
       // Auth
       "POST /api/v1/login", "POST /api/v1/logout", "GET /api/v1/sessions",
+      "POST /api/v1/cluster/auth-session",
       // Security admin
       "GET /api/v1/server/users", "POST /api/v1/server/users",
       "PUT /api/v1/server/users", "DELETE /api/v1/server/users",
@@ -506,14 +507,14 @@ class OpenApiSpecGenerationIT extends BaseGraphServerTest {
   }
 
   @Test
-  void specDocumentsExactlyTheExpectedSixtyEightOperations() throws Exception {
+  void specDocumentsExactlyTheExpectedSixtyNineOperations() throws Exception {
     final OpenAPI openAPI = new OpenAPIV3Parser().readContents(getOpenApiSpec()).getOpenAPI();
     final List<String> declared = declaredOperations(openAPI);
 
     assertThat(EXPECTED_OPERATIONS)
         .as("the inventory itself must hold no duplicate")
         .doesNotHaveDuplicates()
-        .hasSize(68);
+        .hasSize(69);
 
     assertThat(declared)
         .as("operations missing from the specification")
@@ -580,7 +581,7 @@ class OpenApiSpecGenerationIT extends BaseGraphServerTest {
         .as("client generators derive a method name per operationId, so a collision breaks codegen")
         .doesNotHaveDuplicates()
         .doesNotContainNull()
-        .hasSize(68);
+        .hasSize(69);
   }
 
   @Test

--- a/server/src/test/java/com/arcadedb/server/http/handler/PostClusterAuthSessionHandlerTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/PostClusterAuthSessionHandlerTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.http.HttpAuthSession;
+import com.arcadedb.server.security.ServerSecurityUser;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The issuer's side of a cross-node token lookup (issue #7424): what {@code POST /api/v1/cluster/auth-session}
+ * answers a peer, and that it answers nobody else.
+ */
+class PostClusterAuthSessionHandlerTest extends BaseGraphServerTest {
+  private static final String     CLUSTER_TOKEN = "test-cluster-secret-token";
+  private static final HttpClient HTTP          = HttpClient.newHttpClient();
+
+  @BeforeEach
+  void setClusterToken() {
+    getServer(0).getConfiguration().setValue(GlobalConfiguration.HA_CLUSTER_TOKEN, CLUSTER_TOKEN);
+  }
+
+  @AfterEach
+  void clearClusterToken() {
+    getServer(0).getConfiguration().setValue(GlobalConfiguration.HA_CLUSTER_TOKEN, "");
+  }
+
+  @Test
+  void tokenIsNamedAfterTheServer() throws Exception {
+    final String token = login();
+    assertThat(token).startsWith("AU-" + getServer(0).getServerName() + "-");
+  }
+
+  @Test
+  void peerCanValidateASessionThisNodeIssued() throws Exception {
+    final String token = login();
+    final HttpAuthSession before = getServer(0).getHttpServer().getAuthSessionManager().getSessionByToken(token);
+
+    final HttpResponse<String> response = asPeer(new JSONObject().put("action", "validate").put("token", token));
+
+    assertThat(response.statusCode()).isEqualTo(200);
+    final JSONObject body = new JSONObject(response.body());
+    assertThat(body.getString("user")).isEqualTo("root");
+    assertThat(body.getLong("createdAt")).isEqualTo(before.getCreatedAt());
+  }
+
+  @Test
+  void validateIsTheDefaultAction() throws Exception {
+    final HttpResponse<String> response = asPeer(new JSONObject().put("token", login()));
+    assertThat(response.statusCode()).isEqualTo(200);
+  }
+
+  @Test
+  void unknownTokenAnswers404() throws Exception {
+    final HttpResponse<String> response = asPeer(new JSONObject().put("action", "validate")
+        .put("token", "AU-" + getServer(0).getServerName() + "-2af64e60-8455-423a-bc64-ed0e19729f04"));
+    assertThat(response.statusCode()).isEqualTo(404);
+  }
+
+  @Test
+  void aCopyHeldForAnotherIssuerNeverVouches() throws Exception {
+    final ServerSecurityUser root = getServer(0).getSecurity().getUser("root");
+    final String token = "AU-other-node-2af64e60-8455-423a-bc64-ed0e19729f04";
+    getServer(0).getHttpServer().getAuthSessionManager().addRemoteSession(token, root, 0L, "other-node");
+    try {
+      final HttpResponse<String> response = asPeer(new JSONObject().put("action", "validate").put("token", token));
+      assertThat(response.statusCode()).isEqualTo(404);
+    } finally {
+      getServer(0).getHttpServer().getAuthSessionManager().removeSession(token);
+    }
+  }
+
+  @Test
+  void peerCanRevokeASession() throws Exception {
+    final String token = login();
+
+    final HttpResponse<String> response = asPeer(new JSONObject().put("action", "revoke").put("token", token));
+
+    assertThat(response.statusCode()).isEqualTo(204);
+    assertThat(getServer(0).getHttpServer().getAuthSessionManager().getSessionByToken(token)).isNull();
+    assertThat(asPeer(new JSONObject().put("action", "validate").put("token", token)).statusCode()).isEqualTo(404);
+  }
+
+  @Test
+  void missingTokenAndUnknownActionAnswer400() throws Exception {
+    assertThat(asPeer(new JSONObject().put("action", "validate")).statusCode()).isEqualTo(400);
+    assertThat(asPeer(new JSONObject().put("action", "wipe").put("token", login())).statusCode()).isEqualTo(400);
+  }
+
+  @Test
+  void rootWithCredentialsIsRefused() throws Exception {
+    final String token = login();
+    final HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create("http://localhost:2480/api/v1/cluster/auth-session"))
+        .header("Content-Type", "application/json")
+        .header("Authorization", basicRoot())
+        .POST(HttpRequest.BodyPublishers.ofString(new JSONObject().put("token", token).toString()))
+        .build();
+
+    final HttpResponse<String> response = HTTP.send(request, HttpResponse.BodyHandlers.ofString());
+
+    assertThat(response.statusCode()).as("the answer names a principal; only nodes may ask").isEqualTo(403);
+  }
+
+  @Test
+  void wrongClusterTokenIsRefused() throws Exception {
+    final HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create("http://localhost:2480/api/v1/cluster/auth-session"))
+        .header("Content-Type", "application/json")
+        .header("X-ArcadeDB-Cluster-Token", "not-the-token")
+        .header("X-ArcadeDB-Forwarded-User", "root")
+        .POST(HttpRequest.BodyPublishers.ofString(new JSONObject().put("token", login()).toString()))
+        .build();
+    assertThat(HTTP.send(request, HttpResponse.BodyHandlers.ofString()).statusCode()).isEqualTo(401);
+  }
+
+  private HttpResponse<String> asPeer(final JSONObject payload) throws Exception {
+    final HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create("http://localhost:2480/api/v1/cluster/auth-session"))
+        .header("Content-Type", "application/json")
+        .header("X-ArcadeDB-Cluster-Token", CLUSTER_TOKEN)
+        .header("X-ArcadeDB-Forwarded-User", "root")
+        .POST(HttpRequest.BodyPublishers.ofString(payload.toString()))
+        .build();
+    return HTTP.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  private String login() throws Exception {
+    final HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create("http://localhost:2480/api/v1/login"))
+        .header("Authorization", basicRoot())
+        .POST(HttpRequest.BodyPublishers.noBody())
+        .build();
+    final HttpResponse<String> response = HTTP.send(request, HttpResponse.BodyHandlers.ofString());
+    assertThat(response.statusCode()).isEqualTo(200);
+    return new JSONObject(response.body()).getString("token");
+  }
+
+  private static String basicRoot() {
+    return "Basic " + Base64.getEncoder()
+        .encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/AuthApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/AuthApiSpecTest.java
@@ -73,7 +73,7 @@ class AuthApiSpecTest {
     assertThat(schema.getProperties().keySet()).containsExactlyInAnyOrder("result", "count");
     assertThat(schema.getProperties().get("result").getItems().getProperties().keySet())
         .containsExactlyInAnyOrder("token", "user", "createdAt", "lastUpdate", "elapsedMs",
-            "sourceIp", "userAgent", "country", "city");
+            "sourceIp", "userAgent", "country", "city", "issuer");
   }
 
   @Test


### PR DESCRIPTION
Fixes #7424.

## Problem

A login token (`AU-…`) lived only in the in-memory session map of the node that answered `POST /api/v1/login`. Behind the Helm chart's `ClusterIP` service the next request lands on another node, which has never seen the token and answers 401. Studio treats the first 401 as an expired session and sends the user back to the login screen, which is exactly the symptom reported.

## Fix

- **The token names its issuer**: `AU-<server name>-<uuid>`, where the name is `arcadedb.server.name` sanitized to `[A-Za-z0-9._-]` and capped at 64 chars. Parsed from the end, so names with dashes (`arcadedb-0`) are fine. Legacy `AU-<uuid>` tokens keep working, but only on their issuer.
- **A node that does not hold the token asks the issuer once** (`ClusterAuthSessionResolver`, via `HAServerPlugin.lookupAuthSession`) over the existing cluster-token channel and installs a local copy. The copy is a lease: re-confirmed with the issuer every third of the idle timeout (at most every 60 s), and the confirmation counts as activity on the issuer so a session in use anywhere never idles out at its source. An issuer that answers 404 drops the copy at once; an unreachable issuer keeps it alive for one idle timeout only.
- **Logout anywhere revokes everywhere**: `POST /api/v1/logout` fans out a `revoke` to every peer, asynchronously and bounded by `arcadedb.ha.proxyConnectTimeout`.
- **New cluster-internal route** `POST /api/v1/cluster/auth-session` `{token, action: validate|revoke}`. Cluster-token only: a caller presenting user credentials, root included, gets 403. A copy held for another issuer never vouches (404), so a stale copy cannot keep a revoked session alive through a third node.
- **Bounded abuse surface**: at most 16 lookups in flight (a miss past that is refused without dialling), a 5 s refusal cache per token, and no network call for a token naming this node, a non-member, or no issuer at all.
- **ha-raft**: `RaftHAServer.resolvePeerIdByServerName` applies the same rules a node uses to find itself in `arcadedb.ha.serverList` (`name@host`, host match, `-N`/`_N` suffix), so the Helm chart works unchanged. `PeerAuthSessionQuery` mirrors `PeerCapabilityQuery`, including the `PeerDialAddress` guard and the HTTPS preference.
- `GET /api/v1/sessions` reports `issuer` for copies; OpenAPI spec updated.

Not covered: API tokens (`at-` prefix) stay per node in `server-api-tokens.json`.

## Tests

- New `ClusterAuthSessionTokenIT` (3 nodes): token honoured on every node, logout on any node revokes it everywhere, a copy dies when the issuer forgets the session, a copy in use keeps the session alive on the issuer, unknown issuer / legacy token refused without asking anyone.
- New `ClusterAuthSessionResolverTest` (10), `PostClusterAuthSessionHandlerTest` (9), and 8 cases added to `HttpAuthSessionManagerTest` for the token format and parsing.
- Existing `HTTPAuthSessionIT`, `Issue6808LoginTokenRevocationIT`, `ClusterInternalAuthTest`, `OpenApiSpecGenerationIT`, `FollowerSessionTokenQueryIT` green.

Docs: `http.adoc` gets a "Tokens in a cluster" section (arcadedb-docs, separate commit).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for authentication sessions shared across HA cluster nodes.
  * Tokens issued by one node can be validated and renewed on another node.
  * Logging out now revokes sessions across the cluster.
  * Session listings identify the issuing node for remote sessions.
  * Added a cluster authentication-session endpoint for validation and revocation.

* **Documentation**
  * Updated the API specification with the new endpoint and related schemas.

* **Tests**
  * Added coverage for cross-node authentication, renewal, revocation, expiration, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->