### PR TITLE
fix(#7423,#7416,#7413,#7407,#7404): five follow-ups from the gRPC and /ws insert reviews

### DIFF
--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
@@ -154,8 +154,12 @@ import java.util.stream.Collectors;
  */
 public class RemoteGrpcDatabase extends RemoteDatabase {
 
-  private final    ArcadeDbServiceGrpc.ArcadeDbServiceBlockingV2Stub blockingStub;
-  private final    ArcadeDbServiceGrpc.ArcadeDbServiceStub           asyncStub;
+  // Not final: a stub binds the channel it was built on, and RemoteGrpcServer.start() after close() builds a
+  // new one. Read through blockingStub() / asyncStub(), which rebuild both when the channel has moved (#7416).
+  private          ArcadeDbServiceGrpc.ArcadeDbServiceBlockingV2Stub blockingStub;
+  private          ArcadeDbServiceGrpc.ArcadeDbServiceStub           asyncStub;
+  /** The {@link RemoteGrpcServer#channelGeneration()} the two stubs above were built under. */
+  private          long                                              stubChannelGeneration;
   private final    RemoteSchema                                      schema;
   private final    String                                            userName;
   private final    String                                            userPassword;
@@ -182,9 +186,43 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     this.userName = userName;
     this.userPassword = userPassword;
     this.databaseName = databaseName;
-    this.blockingStub = createBlockingStub();
-    this.asyncStub = createAsyncStub();
+    rebuildStubs();
     this.schema = new RemoteSchema(this);
+  }
+
+  /**
+   * The data-plane stub every unary call goes through, on the server's CURRENT channel.
+   * <p>
+   * The admin stub was already built per call for this reason - "a server restarted through start() is
+   * honoured" - while these two were built once in the constructor, so after a {@code close()} / {@code start()}
+   * cycle {@code getProgress()} kept working and every query, command, lookup and insert on the same object
+   * failed with {@code UNAVAILABLE: Channel shutdown invoked} (issue #7416). Rebuilding on a generation change
+   * keeps the per-call cost at one volatile read and one compare, and keeps {@link #createBlockingStub()} the
+   * single place a subclass customises stub construction.
+   */
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingV2Stub blockingStub() {
+    if (stubChannelGeneration != remoteGrpcServer.channelGeneration())
+      rebuildStubs();
+    return blockingStub;
+  }
+
+  /** @see #blockingStub() */
+  private ArcadeDbServiceGrpc.ArcadeDbServiceStub asyncStub() {
+    if (stubChannelGeneration != remoteGrpcServer.channelGeneration())
+      rebuildStubs();
+    return asyncStub;
+  }
+
+  /**
+   * The generation is read BEFORE the stubs are built: a restart landing between the read and the build leaves
+   * the stubs on the new channel under the old generation, which only costs one more rebuild on the next call.
+   * Reading it after would let that same restart pin stale stubs under the new generation for good.
+   */
+  private void rebuildStubs() {
+    final long generation = remoteGrpcServer.channelGeneration();
+    blockingStub = createBlockingStub();
+    asyncStub = createAsyncStub();
+    stubChannelGeneration = generation;
   }
 
   /**
@@ -299,7 +337,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     callUnaryVoid("BeginTransaction", () -> {
 
       try {
-        BeginTransactionResponse response = blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
+        BeginTransactionResponse response = blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
             .beginTransaction(request);
         transactionId = response.getTransactionId();
         // Store transaction ID in parent class session management
@@ -350,7 +388,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
         try {
 
-          CommitTransactionResponse response = blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
+          CommitTransactionResponse response = blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
               .commitTransaction(request);
 
           LogManager.instance()
@@ -431,7 +469,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
         try {
 
-          RollbackTransactionResponse response = blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
+          RollbackTransactionResponse response = blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
               .rollbackTransaction(request);
 
           LogManager.instance()
@@ -521,7 +559,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       }
 
       final DeleteRecordResponse resp = callUnary("DeleteRecord",
-          () -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).deleteRecord(req));
+          () -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).deleteRecord(req));
 
       // Prefer the proto's 'deleted' flag (your other overload uses it)
       if (!resp.getDeleted()) {
@@ -556,7 +594,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       }
 
       final DeleteRecordResponse res = callUnary("DeleteRecord",
-          () -> blockingStub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).deleteRecord(req));
+          () -> blockingStub().withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).deleteRecord(req));
 
       return res.getDeleted();
 
@@ -631,7 +669,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
                 requestBuilder.getCommand().length(), requestBuilder.getParametersCount());
 
       final ExecuteCommandResponse response = callUnary("ExecuteCommand",
-          () -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).executeCommand(requestBuilder.build()));
+          () -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).executeCommand(requestBuilder.build()));
 
       if (LogManager.instance().isDebugEnabled())
         LogManager.instance().log(this, Level.FINE, "CLIENT executeCommand: success = %s", response.getSuccess());
@@ -726,7 +764,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       final ExecuteQueryRequest req = requestBuilder.build();
 
       final ExecuteQueryResponse response = callUnary("ExecuteQuery",
-          () -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS) // or getTimeout(MODE_QUERY)
+          () -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS) // or getTimeout(MODE_QUERY)
               .executeQuery(req));
 
       if (LogManager.instance().isDebugEnabled()) {
@@ -766,7 +804,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
     try {
       return callUnary("ExecuteCommand",
-          () -> blockingStub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).executeCommand(reqB.build()));
+          () -> blockingStub().withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).executeCommand(reqB.build()));
     } catch (StatusException | StatusRuntimeException e) {
       // handleGrpcException already called in callUnary, this is unreachable
       throw new IllegalStateException("unreachable");
@@ -787,7 +825,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
     try {
       return callUnary("ExecuteCommand",
-          () -> blockingStub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).executeCommand(reqB.build()));
+          () -> blockingStub().withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).executeCommand(reqB.build()));
     } catch (StatusException | StatusRuntimeException e) {
       // handleGrpcException already called in callUnary, this is unreachable
       throw new IllegalStateException("unreachable");
@@ -819,7 +857,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
         @SuppressWarnings("unused")
         UpdateRecordResponse response =
-            blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).updateRecord(updateBuilder.build());
+            blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).updateRecord(updateBuilder.build());
 
         // If your proto has flags, you can check response.getSuccess()/getUpdated()
         // Otherwise, treat non-exception as success.
@@ -847,7 +885,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
       try {
         CreateRecordResponse response =
-            blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).createRecord(request);
+            blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).createRecord(request);
 
         // Proto returns the newly created RID as a string
         final String ridStr = response.getRid();
@@ -941,7 +979,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     bindActiveTransaction(b);
 
     final BlockingClientCall<?, QueryResult> responseIterator = callServerStreaming("StreamQuery",
-        () -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).streamQuery(b.build()));
+        () -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).streamQuery(b.build()));
 
     // Return a streaming ResultSet implementation
     return new StreamingResultSet(responseIterator, this);
@@ -984,7 +1022,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     bindActiveTransaction(b);
 
     final BlockingClientCall<?, QueryResult> responseIterator = callServerStreaming("StreamQuery",
-        () -> blockingStub.withWaitForReady().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).streamQuery(b.build()));
+        () -> blockingStub().withWaitForReady().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).streamQuery(b.build()));
 
     return new BatchedStreamingResultSet(responseIterator, this);
   }
@@ -1008,7 +1046,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     bindActiveTransaction(b);
 
     final BlockingClientCall<?, QueryResult> responseIterator = callServerStreaming("StreamQuery",
-        () -> blockingStub.withWaitForReady().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).streamQuery(b.build()));
+        () -> blockingStub().withWaitForReady().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).streamQuery(b.build()));
 
     return new Iterator<QueryBatch>() {
       private QueryBatch nextBatch = null;
@@ -1094,7 +1132,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       reqB.setTransaction(tx);
 
     final BlockingClientCall<?, QueryResult> it = callServerStreaming("StreamQuery",
-        () -> blockingStub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).streamQuery(reqB.build()));
+        () -> blockingStub().withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).streamQuery(reqB.build()));
 
     return new Iterator<GrpcRecord>() {
       private Iterator<GrpcRecord> curr = Collections.emptyIterator();
@@ -1208,7 +1246,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       }
 
       final CreateRecordResponse res = callUnary("CreateRecord",
-          () -> blockingStub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).createRecord(req));
+          () -> blockingStub().withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).createRecord(req));
 
       return res.getRid(); // e.g. "#12:0"
 
@@ -1229,7 +1267,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
     try {
       final CreateRecordResponse res = callUnary("CreateRecord",
-          () -> blockingStub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).createRecord(req));
+          () -> blockingStub().withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).createRecord(req));
       return res.getRid();
 
     } catch (StatusRuntimeException | StatusException e) {
@@ -1272,7 +1310,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       }
 
       final UpdateRecordResponse res = callUnary("UpdateRecord",
-          () -> blockingStub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).updateRecord(req));
+          () -> blockingStub().withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).updateRecord(req));
 
       // Most builds expose getSuccess(); if your proto has getUpdated(), swap here.
       return res.getSuccess();
@@ -1306,7 +1344,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       }
 
       final UpdateRecordResponse res = callUnary("UpdateRecord",
-          () -> blockingStub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).updateRecord(req));
+          () -> blockingStub().withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).updateRecord(req));
 
       return res.getSuccess();
 
@@ -1382,7 +1420,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       }
 
       final LookupByRidResponse resp = callUnary("LookupByRid",
-          () -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).lookupByRid(req));
+          () -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).lookupByRid(req));
 
       if (!resp.getFound())
         throw new RecordNotFoundException("Record " + rid + " not found", rid);
@@ -1452,7 +1490,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
       // use callUnary so tx cross-thread checks + rpcSeq happen in one place
       return callUnary("BulkInsert",
-          () -> blockingStub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).bulkInsert(req));
+          () -> blockingStub().withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).bulkInsert(req));
 
     } catch (StatusRuntimeException | StatusException e) {
       handleGrpcException(e); // maps to your domain exceptions and rethrows
@@ -1963,7 +2001,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
         .setBatchSize(100).build();
 
     final BlockingClientCall<?, QueryResult> responseIterator = callServerStreaming("StreamQuery",
-        () -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).streamQuery(request));
+        () -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).streamQuery(request));
 
     return new Iterator<Record>() {
       private Iterator<GrpcRecord> currentBatch = Collections.emptyIterator();
@@ -2254,7 +2292,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       builder.setTransaction(openTransaction());
 
     return searchCall("VectorSearch", builder.build(),
-        req -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).vectorSearch(req));
+        req -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).vectorSearch(req));
   }
 
   /**
@@ -2268,7 +2306,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       builder.setTransaction(openTransaction());
 
     return searchCall("HybridSearch", builder.build(),
-        req -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).hybridSearch(req));
+        req -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).hybridSearch(req));
   }
 
   /**
@@ -2282,7 +2320,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       builder.setTransaction(openTransaction());
 
     return searchCall("FullTextSearch", builder.build(),
-        req -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).fullTextSearch(req));
+        req -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).fullTextSearch(req));
   }
 
   /**
@@ -2348,7 +2386,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
     try {
       final com.arcadedb.server.grpc.TimeSeriesWriteSummary response = callUnary("TimeSeriesWrite",
-          () -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
+          () -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
               .timeSeriesWrite(request.build()));
       return toWriteSummary(response);
     } catch (final StatusRuntimeException | StatusException e) {
@@ -2485,7 +2523,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
     final BlockingClientCall<?, com.arcadedb.server.grpc.TimeSeriesQueryResult> stream =
         callServerStreaming("TimeSeriesQuery",
-            () -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
+            () -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
                 .timeSeriesQuery(request.build()));
 
     final List<String> columns = new ArrayList<>();
@@ -2541,7 +2579,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
     try {
       final TimeSeriesLatestResponse response = callUnary("TimeSeriesLatest",
-          () -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
+          () -> blockingStub().withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
               .timeSeriesLatest(request.build()));
 
       return new TimeSeriesLatestResult(response.getType(), response.getColumnsList(),
@@ -2668,7 +2706,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       checkCrossThreadUse("STREAM " + opName);
       logTx("STREAM(local)", opName);
     }
-    final var stub = asyncStub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS);
+    final var stub = asyncStub().withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS);
     // Don't double-wrap if the observer is already a ClientResponseObserver (e.g. from wrapClientResponseObserver)
     // because wrapping it again with wrapObserver would hide the ClientResponseObserver interface
     // and prevent beforeStart() from being called.
@@ -2692,7 +2730,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       checkCrossThreadUse("STREAM " + opName);
       logTx("STREAM(local)", opName);
     }
-    final var stub = asyncStub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS);
+    final var stub = asyncStub().withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS);
     invoker.accept(stub, wrapObserver(opName, responseObserver));
     if (debugTx != null) {
       debugTx.rpcSeq.incrementAndGet();

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
@@ -160,6 +160,13 @@ public class RemoteGrpcServer implements AutoCloseable {
   // read it WITHOUT the monitor, so without volatile a reader racing the first start() or a close() has no
   // happens-before edge and may observe a stale (or half-published) value (issue #6762).
   private volatile ManagedChannel channel;
+  /**
+   * Bumped every time {@link #start()} builds a channel and every time {@link #close()} shuts one down. A gRPC
+   * stub binds the channel it was built on, so a
+   * {@link RemoteGrpcDatabase} that cached its stubs compares this against the generation it built them under
+   * and rebuilds them when a {@link #close()} / {@link #start()} cycle has replaced the channel (issue #7416).
+   */
+  private volatile long           channelGeneration;
   private volatile EventLoopGroup eventLoopGroup;
   /**
    * Set the moment {@link #close()} begins and cleared by the next explicit {@link #start()}. Without it,
@@ -235,6 +242,16 @@ public class RemoteGrpcServer implements AutoCloseable {
       chBuilder.usePlaintext();
 
     channel = chBuilder.build();
+    channelGeneration++;
+  }
+
+  /**
+   * Identifies the channel {@link #channel()} currently hands out: the value changes whenever {@link #start()}
+   * builds a new one and whenever {@link #close()} shuts one down. Cheaper than comparing channels, which
+   * {@link #channel()} may wrap in interceptors on every call.
+   */
+  public long channelGeneration() {
+    return channelGeneration;
   }
 
   /**
@@ -348,6 +365,10 @@ public class RemoteGrpcServer implements AutoCloseable {
       channel.shutdownNow();
     } finally {
       channel = null;
+      // Bumped on close as well as on start, so a stub cached against the channel just shut down is rebuilt on
+      // its next use - and, while the server stays closed, that rebuild is refused by channel() with the reason
+      // instead of the dead channel's "Channel shutdown invoked" (issue #7416).
+      channelGeneration++;
       adminServiceBlockingV2Stub = null;
       if (eventLoopGroup != null) {
         eventLoopGroup.shutdownGracefully(0, 2, TimeUnit.SECONDS);
@@ -392,35 +413,60 @@ public class RemoteGrpcServer implements AutoCloseable {
   }
 
   /**
-   * Creates a database with type "graph" or "document".
+   * Creates a database. A name already taken is refused with {@code ALREADY_EXISTS}, the same answer the HTTP
+   * {@code create database} command gives (issue #7413); use {@link #createDatabaseIfMissing(String)} for the
+   * idempotent form.
    */
   public void createDatabase(final String database) {
+    createDatabase(database, false);
+  }
 
+  /**
+   * Creates the database unless one of that name is already there, and says which happened. The decision is
+   * the server's, in one call: the previous exists-then-create pair left a window in which another client's
+   * create made the second half fail.
+   *
+   * @return {@code true} when this call created it, {@code false} when it already existed
+   */
+  public boolean createDatabaseIfMissing(final String database) {
+    return createDatabase(database, true);
+  }
+
+  private boolean createDatabase(final String database, final boolean ifNotExists) {
     try {
-      withDeadline(adminServiceBlockingV2Stub(), defaultTimeoutMs)
-          .createDatabase(CreateDatabaseRequest.newBuilder().setName(database).setCredentials(buildCredentials()).build());
+      return withDeadline(adminServiceBlockingV2Stub(), defaultTimeoutMs)
+          .createDatabase(CreateDatabaseRequest.newBuilder().setName(database).setCredentials(buildCredentials())
+              .setIfNotExists(ifNotExists).build())
+          .getCreated();
     } catch (StatusException e) {
       throw new RuntimeException("Failed to create database: " + e.getMessage(), e);
     }
   }
 
   /**
-   * No-op if already present; creates otherwise.
+   * Drops a database. A name that does not exist is refused with {@code NOT_FOUND}, the same answer the HTTP
+   * {@code drop database} command gives (issue #7413); use {@link #dropDatabaseIfExists(String)} for the
+   * idempotent form.
    */
-  public void createDatabaseIfMissing(final String database) {
-    if (!existsDatabase(database)) {
-      createDatabase(database);
-    }
+  public void dropDatabase(final String database) {
+    dropDatabase(database, false);
   }
 
   /**
-   * Drops a database. If your proto supports 'force', add it here.
+   * Drops the database if there is one of that name, and says which happened.
+   *
+   * @return {@code true} when this call dropped it, {@code false} when there was nothing to drop
    */
-  public void dropDatabase(final String database) {
+  public boolean dropDatabaseIfExists(final String database) {
+    return dropDatabase(database, true);
+  }
 
+  private boolean dropDatabase(final String database, final boolean ifExists) {
     try {
-      withDeadline(adminServiceBlockingV2Stub(), defaultTimeoutMs)
-          .dropDatabase(DropDatabaseRequest.newBuilder().setName(database).setCredentials(buildCredentials()).build());
+      return withDeadline(adminServiceBlockingV2Stub(), defaultTimeoutMs)
+          .dropDatabase(DropDatabaseRequest.newBuilder().setName(database).setCredentials(buildCredentials())
+              .setIfExists(ifExists).build())
+          .getDropped();
     } catch (StatusException e) {
       throw new RuntimeException("Failed to drop database: " + e.getMessage(), e);
     }

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue7416RemoteGrpcDatabaseSurvivesServerRestartIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue7416RemoteGrpcDatabaseSurvivesServerRestartIT.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7416: a {@link RemoteGrpcDatabase} built its two data-plane stubs once, in the constructor, on the
+ * channel its {@link RemoteGrpcServer} had at the time. A {@code close()} / {@code start()} cycle on the server
+ * replaces that channel, and every query, command, lookup and insert on the same database object then failed
+ * with {@code UNAVAILABLE: Channel shutdown invoked} - while {@code getProgress()}, whose admin stub was built
+ * per call, kept working.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7416RemoteGrpcDatabaseSurvivesServerRestartIT extends BaseGraphServerTest {
+  private static final int GRPC_PORT = 50051;
+
+  private RemoteGrpcServer   grpcServer;
+  private RemoteGrpcDatabase database;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @AfterEach
+  void closeClient() {
+    if (database != null)
+      database.close();
+    if (grpcServer != null)
+      grpcServer.close();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+  }
+
+  @Test
+  void theSameDatabaseObjectKeepsWorkingAcrossACloseAndStartOfItsServer() {
+    grpcServer = new RemoteGrpcServer("localhost", GRPC_PORT, "root", DEFAULT_PASSWORD_FOR_TESTS, true, List.of());
+    database = new RemoteGrpcDatabase(grpcServer, "localhost", GRPC_PORT, getServer(0).getHttpServer().getPort(),
+        getDatabaseName(), "root", DEFAULT_PASSWORD_FOR_TESTS);
+
+    assertThat(countV1()).isGreaterThan(0);
+    final long generationBefore = grpcServer.channelGeneration();
+
+    grpcServer.close();
+    // While closed, the same object fails with the reason rather than with a dead channel's UNAVAILABLE.
+    assertThatThrownBy(this::countV1).hasMessageContaining("closed");
+
+    grpcServer.start();
+    assertThat(grpcServer.channelGeneration()).isNotEqualTo(generationBefore);
+
+    // The unary data plane, on the stub the constructor built.
+    assertThat(countV1()).isGreaterThan(0);
+    // A write and a read-back through the same object, so the command path is covered as well as the query one.
+    database.command("sql", "INSERT INTO " + VERTEX1_TYPE_NAME + " SET id = 7416, name = 'after-restart'");
+    try (final ResultSet rs = database.query("sql", "SELECT FROM " + VERTEX1_TYPE_NAME + " WHERE id = 7416")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<String>getProperty("name")).isEqualTo("after-restart");
+    }
+    // The admin stub the class already rebuilt per call, kept as the control.
+    assertThat(database.getProgress()).isNotNull();
+  }
+
+  /** A second restart is followed the same way: the check is per call, not once. */
+  @Test
+  void everyRestartIsFollowedNotJustTheFirst() {
+    grpcServer = new RemoteGrpcServer("localhost", GRPC_PORT, "root", DEFAULT_PASSWORD_FOR_TESTS, true, List.of());
+    database = new RemoteGrpcDatabase(grpcServer, "localhost", GRPC_PORT, getServer(0).getHttpServer().getPort(),
+        getDatabaseName(), "root", DEFAULT_PASSWORD_FOR_TESTS);
+
+    for (int cycle = 0; cycle < 3; cycle++) {
+      grpcServer.close();
+      grpcServer.start();
+      assertThat(countV1()).as("cycle " + cycle).isGreaterThan(0);
+    }
+  }
+
+  private long countV1() {
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS total FROM " + VERTEX1_TYPE_NAME)) {
+      return rs.next().<Long>getProperty("total");
+    }
+  }
+}

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/RemoteGrpcServerIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/RemoteGrpcServerIT.java
@@ -87,6 +87,22 @@ class RemoteGrpcServerIT extends BaseGraphServerTest {
     assertThat(server.existsDatabase("nonexistent_database")).isFalse();
   }
 
+  /** Issue #7413: the client's two create flavours map onto the server's strict and idempotent contracts. */
+  @Test
+  void createIfMissingSaysWhetherItCreatedAndStrictCreateRefusesATakenName() {
+    server = new RemoteGrpcServer("localhost", 50051, "root", DEFAULT_PASSWORD_FOR_TESTS, true, List.of());
+    final String testDb = "test_grpc_if_missing_db";
+    try {
+      assertThat(server.createDatabaseIfMissing(testDb)).isTrue();
+      assertThat(server.createDatabaseIfMissing(testDb)).isFalse();
+      assertThatThrownBy(() -> server.createDatabase(testDb)).hasMessageContaining("ALREADY_EXISTS");
+    } finally {
+      assertThat(server.dropDatabaseIfExists(testDb)).isTrue();
+    }
+    assertThat(server.dropDatabaseIfExists(testDb)).isFalse();
+    assertThatThrownBy(() -> server.dropDatabase(testDb)).hasMessageContaining("NOT_FOUND");
+  }
+
   @Test
   void shouldCreateAndDropDatabase() {
     server = new RemoteGrpcServer("localhost", 50051, "root", DEFAULT_PASSWORD_FOR_TESTS, true, List.of());
@@ -147,13 +163,8 @@ class RemoteGrpcServerIT extends BaseGraphServerTest {
   void shouldHandleDropNonExistentDatabase() {
     server = new RemoteGrpcServer("localhost", 50051, "root", DEFAULT_PASSWORD_FOR_TESTS, true, List.of());
 
-    // Dropping a non-existent database may or may not throw an exception depending on implementation
-    try {
-      server.dropDatabase("nonexistent_database_12345");
-    } catch (final Exception e) {
-      // Expected - database doesn't exist
-      assertThat(e.getMessage()).containsIgnoringCase("not found");
-    }
+    // Strict by contract since issue #7413: the same answer the HTTP `drop database` command gives.
+    assertThatThrownBy(() -> server.dropDatabase("nonexistent_database_12345")).hasMessageContaining("NOT_FOUND");
   }
 
   @Test

--- a/grpc/src/main/proto/arcadedb-server.proto
+++ b/grpc/src/main/proto/arcadedb-server.proto
@@ -1083,14 +1083,25 @@ message CreateDatabaseRequest {
   DatabaseCredentials credentials = 1;
   string name = 2; // database name
   string type = 3; // "graph" or "document" (logical)
+  // When false (the default) a name already taken is answered ALREADY_EXISTS, as the HTTP `create database`
+  // command answers it. When true the call is idempotent: an existing database of that name is left as it
+  // is and the response says so with created = false. Names are exact, never case-folded.
+  bool if_not_exists = 4;
 }
-message CreateDatabaseResponse {}
+message CreateDatabaseResponse {
+  bool created = 1; // true when this call created the database, false when if_not_exists found it already there
+}
 
 message DropDatabaseRequest {
   DatabaseCredentials credentials = 1;
   string name = 2; // database name
+  // When false (the default) a name that does not exist is answered NOT_FOUND, as the HTTP `drop database`
+  // command answers it. When true the call is idempotent and the response says which with dropped = false.
+  bool if_exists = 3;
 }
-message DropDatabaseResponse {}
+message DropDatabaseResponse {
+  bool dropped = 1; // true when this call dropped the database, false when if_exists found nothing to drop
+}
 
 message GetDatabaseInfoRequest {
   DatabaseCredentials credentials = 1;

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
@@ -144,7 +144,9 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
       final ServerSecurityUser user = authenticate(req.getCredentials());
 
       final String name = req.getName(); // proto should define 'name' for the DB
-      final boolean exists = containsDatabaseIgnoreCase(name) && (user == null || user.canAccessToDatabase(name));
+      // Exact name, like createDatabase / dropDatabase (issue #7413): what this reports as existing is what a
+      // create of the same name would refuse.
+      final boolean exists = server.existsDatabase(name) && (user == null || user.canAccessToDatabase(name));
 
       return ExistsDatabaseResponse.newBuilder().setExists(exists).build();
     });
@@ -159,8 +161,15 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
       final String name = req.getName(); // DB name in proto
       final String type = req.getType(); // "graph" or "document" (logical)
 
-      if (containsDatabaseIgnoreCase(name))
-        return CreateDatabaseResponse.newBuilder().build();
+      // Exact name, the registry's and the HTTP command's notion of "the same database": the case-folded guard
+      // this used to be let CreateDatabase("MyDb") answer OK for an existing "mydb" and then DropDatabase("MyDb")
+      // fail inside the drop (issue #7413). An empty OK told a provisioning tool nothing either way; now the
+      // strict default refuses a taken name as HTTP does, and the idempotent form says which happened.
+      if (server.existsDatabase(name)) {
+        if (req.getIfNotExists())
+          return CreateDatabaseResponse.newBuilder().setCreated(false).build();
+        throw new ServerControlPlane.AlreadyExistsException("Database '" + name + "' already exists");
+      }
 
       // Physical creation (READ_WRITE is the common default)
       createDatabasePhysical(name);
@@ -177,7 +186,7 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
             s.createEdgeType("E");
         });
       }
-      return CreateDatabaseResponse.newBuilder().build();
+      return CreateDatabaseResponse.newBuilder().setCreated(true).build();
     });
   }
 
@@ -189,10 +198,16 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
 
       final String name = req.getName();
 
-      if (containsDatabaseIgnoreCase(name))
-        dropDatabasePhysical(name);
+      // See createDatabase: exact name, strict by default, explicit outcome either way (issue #7413).
+      if (!server.existsDatabase(name)) {
+        if (req.getIfExists())
+          return DropDatabaseResponse.newBuilder().setDropped(false).build();
+        throw new ServerControlPlane.NotFoundException("Database '" + name + "' does not exist");
+      }
 
-      return DropDatabaseResponse.newBuilder().build();
+      dropDatabasePhysical(name);
+
+      return DropDatabaseResponse.newBuilder().setDropped(true).build();
     });
   }
 
@@ -210,7 +225,7 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
       if (user != null && !user.canAccessToDatabase(name))
         throw Status.NOT_FOUND.withDescription("Database not found: " + name).asException();
 
-      if (!containsDatabaseIgnoreCase(name))
+      if (!server.existsDatabase(name))
         throw Status.NOT_FOUND.withDescription("Database not found: " + name).asException();
 
       // Use getDatabase which returns a shared ServerDatabase - don't close it
@@ -1154,14 +1169,6 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
    */
   private Collection<String> getDatabaseNames() {
     return server.getDatabaseNames();
-  }
-
-  private boolean containsDatabaseIgnoreCase(String name) {
-    for (String n : getDatabaseNames()) {
-      if (n.equalsIgnoreCase(name))
-        return true;
-    }
-    return false;
   }
 
   /**

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -139,6 +139,9 @@ import java.util.logging.Level;
  * gRPC Service implementation for ArcadeDB
  */
 public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImplBase {
+  /** The {@code protocol} tag every query this service runs is metered under. */
+  private static final String GRPC_PROTOCOL = "grpc";
+
 
   // Pick serializer once
   private static final JsonSerializer FAST = JsonSerializer.createJsonSerializer().setIncludeVertexEdges(false)
@@ -4214,7 +4217,28 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     }
   }
 
+  /**
+   * Runs on whichever thread the caller hands it: {@code bulkInsert}'s own, a transaction's dedicated executor,
+   * or the {@code insertStream} / {@code insertBidirectional} stream executors. The upsert and ignore lookups
+   * inside are real SQL, so the protocol tag is set HERE, around the work, rather than on the RPC's entry thread:
+   * the streaming RPCs do their work from observer callbacks that hop threads, and a tag set in {@code onNext}
+   * never reached the thread the lookup ran on, which metered every conflict probe as {@code internal}
+   * (issue #7407). Left alone when the caller already tagged the thread, so {@code bulkInsert}'s outer
+   * set/clear pair still owns it.
+   */
   private Counts insertRows(InsertContext ctx, Iterator<GrpcRecord> it) {
+    final boolean tagHere = !GRPC_PROTOCOL.equals(ProtocolContext.get());
+    if (tagHere)
+      ProtocolContext.set(GRPC_PROTOCOL);
+    try {
+      return insertRowsTagged(ctx, it);
+    } finally {
+      if (tagHere)
+        ProtocolContext.clear();
+    }
+  }
+
+  private Counts insertRowsTagged(InsertContext ctx, Iterator<GrpcRecord> it) {
 
     Counts c = new Counts();
 

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcAdminServiceIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcAdminServiceIT.java
@@ -22,6 +22,7 @@ import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.server.BaseGraphServerTest;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -186,37 +187,79 @@ public class GrpcAdminServiceIT extends BaseGraphServerTest {
     assertThat(adminStub.existsDatabase(existsRequest).getExists()).isFalse();
   }
 
+  /**
+   * Issue #7413: a name already taken is refused as the HTTP command refuses it, and the idempotent form says
+   * whether it created anything, so a client can tell "created for me" from "already there".
+   */
   @Test
-  void createDatabaseIsIdempotent() {
-    String testDbName = "grpc_idempotent_db_" + System.currentTimeMillis();
-
-    CreateDatabaseRequest request = CreateDatabaseRequest.newBuilder()
+  void createDatabaseRefusesATakenNameUnlessAskedToTolerateIt() {
+    final String testDbName = "grpc_exists_db_" + System.currentTimeMillis();
+    final CreateDatabaseRequest strict = CreateDatabaseRequest.newBuilder()
         .setCredentials(credentials())
         .setName(testDbName)
         .setType("document")
         .build();
+    try {
+      assertThat(adminStub.createDatabase(strict).getCreated()).isTrue();
 
-    // Create twice - should not throw
-    adminStub.createDatabase(request);
-    adminStub.createDatabase(request);
+      assertThatThrownBy(() -> adminStub.createDatabase(strict))
+          .isInstanceOf(StatusRuntimeException.class)
+          .satisfies(e -> assertThat(((StatusRuntimeException) e).getStatus().getCode()).isEqualTo(Status.Code.ALREADY_EXISTS))
+          .hasMessageContaining(testDbName);
 
-    // Cleanup
-    DropDatabaseRequest dropRequest = DropDatabaseRequest.newBuilder()
-        .setCredentials(credentials())
-        .setName(testDbName)
-        .build();
-    adminStub.dropDatabase(dropRequest);
+      final CreateDatabaseResponse tolerated = adminStub.createDatabase(strict.toBuilder().setIfNotExists(true).build());
+      assertThat(tolerated.getCreated()).isFalse();
+    } finally {
+      adminStub.dropDatabase(DropDatabaseRequest.newBuilder().setCredentials(credentials()).setName(testDbName)
+          .setIfExists(true).build());
+    }
   }
 
   @Test
-  void dropNonExistentDatabaseIsIdempotent() {
-    DropDatabaseRequest request = DropDatabaseRequest.newBuilder()
+  void dropDatabaseRefusesAMissingNameUnlessAskedToTolerateIt() {
+    final DropDatabaseRequest strict = DropDatabaseRequest.newBuilder()
         .setCredentials(credentials())
         .setName("nonexistent_db_for_drop_test")
         .build();
 
-    // Should not throw
-    adminStub.dropDatabase(request);
+    assertThatThrownBy(() -> adminStub.dropDatabase(strict))
+        .isInstanceOf(StatusRuntimeException.class)
+        .satisfies(e -> assertThat(((StatusRuntimeException) e).getStatus().getCode()).isEqualTo(Status.Code.NOT_FOUND))
+        .hasMessageContaining("nonexistent_db_for_drop_test");
+
+    assertThat(adminStub.dropDatabase(strict.toBuilder().setIfExists(true).build()).getDropped()).isFalse();
+  }
+
+  /** A database that IS there is dropped and the answer says so, in both forms. */
+  @Test
+  void dropDatabaseReportsWhatItDropped() {
+    final String testDbName = "grpc_dropped_db_" + System.currentTimeMillis();
+    adminStub.createDatabase(CreateDatabaseRequest.newBuilder().setCredentials(credentials()).setName(testDbName).build());
+    assertThat(adminStub.dropDatabase(DropDatabaseRequest.newBuilder().setCredentials(credentials()).setName(testDbName)
+        .setIfExists(true).build()).getDropped()).isTrue();
+    assertThat(adminStub.existsDatabase(ExistsDatabaseRequest.newBuilder().setCredentials(credentials())
+        .setName(testDbName).build()).getExists()).isFalse();
+  }
+
+  /**
+   * Names are exact. The guard used to be case-folded while the registry and the operation were not, so a
+   * differently-cased name was reported as existing by one and unknown by the other.
+   */
+  @Test
+  void databaseNamesAreExactNotCaseFolded() {
+    final String testDbName = "grpc_Cased_db_" + System.currentTimeMillis();
+    adminStub.createDatabase(CreateDatabaseRequest.newBuilder().setCredentials(credentials()).setName(testDbName).build());
+    try {
+      final String otherCase = testDbName.toLowerCase();
+      assertThat(adminStub.existsDatabase(ExistsDatabaseRequest.newBuilder().setCredentials(credentials())
+          .setName(otherCase).build()).getExists()).isFalse();
+      assertThatThrownBy(() -> adminStub.dropDatabase(DropDatabaseRequest.newBuilder().setCredentials(credentials())
+          .setName(otherCase).build()))
+          .isInstanceOf(StatusRuntimeException.class)
+          .satisfies(e -> assertThat(((StatusRuntimeException) e).getStatus().getCode()).isEqualTo(Status.Code.NOT_FOUND));
+    } finally {
+      adminStub.dropDatabase(DropDatabaseRequest.newBuilder().setCredentials(credentials()).setName(testDbName).build());
+    }
   }
 
   @Test

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7407InsertStreamUpsertMetricsIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7407InsertStreamUpsertMetricsIT.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.stub.ServerCallStreamObserver;
+import io.grpc.stub.StreamObserver;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7407: the upsert and ignore lookups of {@code insertStream} and {@code insertBidirectional} are real
+ * SQL, run from observer callbacks on a thread that is not the one the RPC arrived on. They were metered and
+ * traced as {@code protocol="internal"}; they belong to {@code grpc}, as {@code bulkInsert}'s already were.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue7407InsertStreamUpsertMetricsIT extends BaseGraphServerTest {
+  private static final int ROWS = 20;
+
+  private String              typeName;
+  private ArcadeDbGrpcService service;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void createKeyedType() {
+    typeName = "Issue7407Keyed_" + System.currentTimeMillis();
+    final Database database = getServer(0).getDatabase(getDatabaseName());
+    database.command("sql", "CREATE DOCUMENT TYPE " + typeName);
+    database.command("sql", "CREATE PROPERTY " + typeName + ".name STRING");
+    database.command("sql", "CREATE INDEX ON " + typeName + " (name) UNIQUE");
+    database.transaction(() -> {
+      for (int i = 0; i < ROWS; i++)
+        database.newDocument(typeName).set("name", "k" + i).set("v", 0).save();
+    });
+    service = new ArcadeDbGrpcService(getDatabaseName(), getServer(0));
+  }
+
+  @AfterEach
+  void dropKeyedType() {
+    service.close();
+    getServer(0).getDatabase(getDatabaseName()).command("sql", "DROP TYPE " + typeName + " IF EXISTS UNSAFE");
+  }
+
+  @Test
+  void insertStreamUpsertLookupsAreMeteredAsGrpc() throws Exception {
+    final long grpcBefore = timerCount("grpc");
+    final long internalBefore = timerCount("internal");
+
+    final AtomicReference<InsertSummary> summaryRef = new AtomicReference<>();
+    final CountDownLatch done = new CountDownLatch(1);
+    final StreamObserver<InsertChunk> req = service.insertStream(new RecordingSummaryObserver(summaryRef, done));
+
+    final InsertChunk.Builder chunk = InsertChunk.newBuilder().setSessionId("issue-7407-stream").setChunkSeq(0)
+        .setLast(true).setOptions(upsertOptions());
+    for (int i = 0; i < ROWS; i++)
+      chunk.addRows(row(i));
+    req.onNext(chunk.build());
+    req.onCompleted();
+
+    assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+    assertThat(summaryRef.get().getUpdated()).isEqualTo(ROWS);
+    assertThat(summaryRef.get().getFailed()).isZero();
+
+    assertThat(timerCount("grpc") - grpcBefore).as("one metered lookup per upserted row").isGreaterThanOrEqualTo(ROWS);
+    assertThat(timerCount("internal") - internalBefore).as("none of them attributed to internal").isZero();
+  }
+
+  @Test
+  void insertBidirectionalUpsertLookupsAreMeteredAsGrpc() throws Exception {
+    final long grpcBefore = timerCount("grpc");
+    final long internalBefore = timerCount("internal");
+
+    final RecordingInsertResponseObserver resp = new RecordingInsertResponseObserver();
+    final StreamObserver<InsertRequest> req = service.insertBidirectional(resp);
+
+    req.onNext(InsertRequest.newBuilder().setStart(Start.newBuilder().setDatabase(getDatabaseName())
+        .setCredentials(credentials()).setOptions(upsertOptions()).build()).build());
+    final Started started = resp.await(resp.started);
+
+    final InsertChunk.Builder chunk = InsertChunk.newBuilder().setSessionId(started.getSessionId()).setChunkSeq(1);
+    for (int i = 0; i < ROWS; i++)
+      chunk.addRows(row(i));
+    req.onNext(InsertRequest.newBuilder().setChunk(chunk.build()).build());
+    final BatchAck ack = resp.await(resp.batchAck);
+    assertThat(ack.getUpdated()).isEqualTo(ROWS);
+    assertThat(ack.getFailed()).isZero();
+
+    req.onNext(InsertRequest.newBuilder().setCommit(Commit.newBuilder().setSessionId(started.getSessionId())
+        .setCommit(true).build()).build());
+    resp.await(resp.committed);
+    req.onCompleted();
+
+    assertThat(timerCount("grpc") - grpcBefore).as("one metered lookup per upserted row").isGreaterThanOrEqualTo(ROWS);
+    assertThat(timerCount("internal") - internalBefore).as("none of them attributed to internal").isZero();
+  }
+
+  private InsertOptions upsertOptions() {
+    return InsertOptions.newBuilder().setDatabase(getDatabaseName()).setCredentials(credentials())
+        .setTargetClass(typeName).setConflictMode(InsertOptions.ConflictMode.CONFLICT_UPDATE).addKeyColumns("name")
+        .setTransactionMode(InsertOptions.TransactionMode.PER_STREAM).build();
+  }
+
+  private GrpcRecord row(final int i) {
+    return GrpcRecord.newBuilder().setType(typeName)
+        .putProperties("name", GrpcValue.newBuilder().setStringValue("k" + i).build())
+        .putProperties("v", GrpcValue.newBuilder().setInt32Value(1).build()).build();
+  }
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  /** Total count of the {@code arcadedb.query.duration} timers carrying this {@code protocol} tag. */
+  private static long timerCount(final String protocol) {
+    return Metrics.globalRegistry.find("arcadedb.query.duration").tag("protocol", protocol).timers().stream()
+        .mapToLong(Timer::count).sum();
+  }
+
+  private static final class RecordingSummaryObserver extends ServerCallStreamObserver<InsertSummary> {
+    private final AtomicReference<InsertSummary> summaryRef;
+    private final CountDownLatch                 done;
+
+    private RecordingSummaryObserver(final AtomicReference<InsertSummary> summaryRef, final CountDownLatch done) {
+      this.summaryRef = summaryRef;
+      this.done = done;
+    }
+
+    @Override public void onNext(final InsertSummary value) { summaryRef.set(value); }
+    @Override public void onError(final Throwable t) { done.countDown(); }
+    @Override public void onCompleted() { done.countDown(); }
+    @Override public boolean isCancelled() { return false; }
+    @Override public void setOnCancelHandler(final Runnable onCancelHandler) { }
+    @Override public void setCompression(final String compression) { }
+    @Override public boolean isReady() { return true; }
+    @Override public void setOnReadyHandler(final Runnable onReadyHandler) { }
+    @Override public void request(final int count) { }
+    @Override public void setMessageCompression(final boolean enable) { }
+    @Override public void disableAutoInboundFlowControl() { }
+  }
+
+  private static final class RecordingInsertResponseObserver extends ServerCallStreamObserver<InsertResponse> {
+    private final Slot<Started>   started   = new Slot<>();
+    private final Slot<BatchAck>  batchAck  = new Slot<>();
+    private final Slot<Committed> committed = new Slot<>();
+    private final AtomicReference<Throwable> error = new AtomicReference<>();
+
+    private static final class Slot<T> {
+      private final AtomicReference<T> value = new AtomicReference<>();
+      private final CountDownLatch     latch = new CountDownLatch(1);
+    }
+
+    private <T> T await(final Slot<T> slot) throws InterruptedException {
+      assertThat(slot.latch.await(30, TimeUnit.SECONDS)).as("timed out waiting for the frame").isTrue();
+      if (error.get() != null)
+        throw new AssertionError("insertBidirectional errored", error.get());
+      return slot.value.get();
+    }
+
+    @Override
+    public void onNext(final InsertResponse value) {
+      switch (value.getMsgCase()) {
+      case STARTED -> { started.value.set(value.getStarted()); started.latch.countDown(); }
+      case BATCH_ACK -> { batchAck.value.set(value.getBatchAck()); batchAck.latch.countDown(); }
+      case COMMITTED -> { committed.value.set(value.getCommitted()); committed.latch.countDown(); }
+      default -> { }
+      }
+    }
+
+    @Override
+    public void onError(final Throwable t) {
+      error.set(t);
+      started.latch.countDown();
+      batchAck.latch.countDown();
+      committed.latch.countDown();
+    }
+
+    @Override public void onCompleted() { }
+    @Override public boolean isCancelled() { return false; }
+    @Override public void setOnCancelHandler(final Runnable onCancelHandler) { }
+    @Override public void setCompression(final String compression) { }
+    @Override public boolean isReady() { return true; }
+    @Override public void setOnReadyHandler(final Runnable onReadyHandler) { }
+    @Override public void request(final int count) { }
+    @Override public void setMessageCompression(final boolean enable) { }
+    @Override public void disableAutoInboundFlowControl() { }
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/ws/WebSocketEventBus.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/WebSocketEventBus.java
@@ -25,7 +25,6 @@ import com.arcadedb.server.security.ServerSecurity;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.websockets.core.WebSocketCallback;
 import io.undertow.websockets.core.WebSocketChannel;
-import io.undertow.websockets.core.WebSockets;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -178,7 +177,7 @@ public class WebSocketEventBus {
         }
 
         try {
-          WebSockets.sendText(json, subscription.getChannel(), callback);
+          WebSocketFrameSender.send(subscription.getChannel(), json, callback);
         } catch (final Exception e) {
           // The frame never reached Undertow, so nothing is outstanding: give the reservation back rather than let
           // a channel that fails synchronously look like a slow consumer.

--- a/server/src/main/java/com/arcadedb/server/http/ws/WebSocketFrameSender.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/WebSocketFrameSender.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.ws;
+
+import io.undertow.websockets.core.WebSocketCallback;
+import io.undertow.websockets.core.WebSocketChannel;
+import io.undertow.websockets.core.WebSockets;
+
+/**
+ * The one place a {@code /ws} text frame is written from, so what the connection's several senders rely on is
+ * written down once (issue #7423).
+ * <p>
+ * A {@code /ws} connection has more than one writer and nothing of ours serializing them: the change-stream
+ * fan-out of {@link WebSocketEventBus} runs on the per-database watcher thread, the subscription acknowledgements
+ * of {@code WebSocketReceiveListener} on the I/O thread that read the frame, the insert-session answers of
+ * {@code WebSocketInsertProtocol} on an Undertow worker thread, and the idle sweep's unsolicited {@code error}
+ * on whichever thread expired the session. That is safe because of how Undertow 2.4.3.Final builds a frame,
+ * established from its source rather than assumed:
+ * <ul>
+ * <li>{@link WebSockets#sendText(String, WebSocketChannel, WebSocketCallback)} calls {@code WebSocketChannel.send(TEXT)},
+ *     which creates a NEW {@code StreamSinkFrameChannel} per call and appends it to the channel's
+ *     {@code WebSocketFramePriority.strictOrderQueue}, a {@code ConcurrentLinkedDeque}. The whole payload is
+ *     then attached to that sink as its single body and {@code AbstractFramedChannel.queueFrame} adds the sink
+ *     to {@code newFrames}, a {@code LinkedBlockingDeque}. Both queues take concurrent adds.</li>
+ * <li>Bytes reach the socket only from {@code AbstractFramedChannel.flushSenders()}, which is
+ *     {@code synchronized} and runs on the channel's I/O thread ({@code runNowOrInIoThread}). It drains
+ *     {@code newFrames} in order and the frame priority releases the next sink only when the one ahead of it in
+ *     {@code strictOrderQueue} has been written to the end, so one frame's bytes are never split around
+ *     another's.</li>
+ * </ul>
+ * So concurrent callers each get a complete frame on the wire, in the order their {@code send(TEXT)} calls
+ * happened. What they do NOT get is an ordering between senders - a change event and a {@code batchAck} may
+ * arrive in either order - which the protocols on {@code /ws} already tolerate: every frame carries its own
+ * {@code action}. The one plain read in the path is the {@code closeFrameSent} / {@code closeFrameReceived} pair
+ * in {@code WebSocketChannel.send()}: a sender racing a close can be refused with an {@code IOException} from
+ * {@code queueFrame} instead of the "channel closed" message, and that is handed to the callback, or closes the
+ * channel when there is none, exactly as any other send failure is.
+ * <p>
+ * Every sender goes through here so the next one added inherits the note above instead of re-deriving it, and
+ * so that if a future Undertow changes the guarantee there is one method to put a lock in.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class WebSocketFrameSender {
+  private WebSocketFrameSender() {
+  }
+
+  /**
+   * Queues one complete text frame on the channel. Returns as soon as the frame is queued: the write itself
+   * happens on the channel's I/O thread.
+   *
+   * @param callback notified when the frame has been written or has failed, or {@code null} to let Undertow close
+   *                 the channel on a failed write
+   */
+  public static void send(final WebSocketChannel channel, final String text, final WebSocketCallback<Void> callback) {
+    WebSockets.sendText(text, channel, callback);
+  }
+
+  /** {@link #send(WebSocketChannel, String, WebSocketCallback)} with no callback, skipped when the channel is gone. */
+  public static void sendIfOpen(final WebSocketChannel channel, final String text) {
+    if (channel.isOpen())
+      WebSockets.sendText(text, channel, null);
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/ws/WebSocketReceiveListener.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/WebSocketReceiveListener.java
@@ -30,7 +30,6 @@ import io.undertow.websockets.core.AbstractReceiveListener;
 import io.undertow.websockets.core.BufferedTextMessage;
 import io.undertow.websockets.core.StreamSourceFrameChannel;
 import io.undertow.websockets.core.WebSocketChannel;
-import io.undertow.websockets.core.WebSockets;
 
 import java.io.IOException;
 import java.util.Locale;
@@ -120,7 +119,7 @@ public class WebSocketReceiveListener extends AbstractReceiveListener {
   private void sendAck(final WebSocketChannel channel, final ACTION action) {
     final var json = new JSONObject("{\"result\": \"ok\"}");
     json.put("action", action.toString().toLowerCase(Locale.ENGLISH));
-    WebSockets.sendText(json.toString(), channel, null);
+    WebSocketFrameSender.send(channel, json.toString(), null);
   }
 
   private void sendError(final WebSocketChannel channel, final String error, final String detail, final Throwable exception) {
@@ -130,7 +129,7 @@ public class WebSocketReceiveListener extends AbstractReceiveListener {
       json.put("detail", encodeError(detail));
     if (exception != null)
       json.put("exception", exception.getClass().getName());
-    WebSockets.sendText(json.toString(), channel, null);
+    WebSocketFrameSender.send(channel, json.toString(), null);
   }
 
   private String encodeError(final String message) {

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/InsertSessionOptions.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/InsertSessionOptions.java
@@ -18,18 +18,23 @@
  */
 package com.arcadedb.server.http.ws.insert;
 
+import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 
+import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 /**
- * The subset of the gRPC {@code InsertOptions} message a {@code /ws} insert session understands, parsed from the
+ * The gRPC {@code InsertOptions} message as a {@code /ws} insert session understands it, parsed from the
  * {@code options} object of a {@code start} frame (issue #7382).
  * <p>
- * Only the fields whose behaviour the control frames change are here. {@code conflictMode}, {@code keyColumns},
- * {@code updateColumnsOnConflict} and {@code validateOnly} are gRPC-only for now and are rejected rather than
- * ignored, so a client porting a working {@code InsertBidirectional} loader is told what is missing instead of
- * silently getting plain inserts where it asked for upserts - see issue #7404.
+ * The control frames decide WHEN a transaction commits ({@code transactionMode}); the conflict options decide
+ * WHAT HAPPENS TO A ROW THAT ALREADY EXISTS ({@code conflictMode}, {@code keyColumns},
+ * {@code updateColumnsOnConflict}) and {@code validateOnly} whether anything is written at all. All of them are
+ * honoured with the semantics gRPC gives them (issue #7404), so a loader ported from {@code InsertBidirectional}
+ * keeps its behaviour. The gRPC spellings of the enum values ({@code CONFLICT_UPDATE}, {@code PER_BATCH}) are
+ * accepted next to the short ones.
  *
  * @author Arcade Data Ltd
  */
@@ -58,13 +63,52 @@ public class InsertSessionOptions {
     NONE
   }
 
+  /**
+   * What to do with a row whose key is already taken. Mirrors {@code InsertOptions.ConflictMode}, and like it a
+   * "key" is either the {@link #keyColumns} the session names or, when it names none, whatever unique index the
+   * insert trips over.
+   */
+  public enum ConflictMode {
+    /** The row is counted in {@code failed} and described in {@code errors} with the code {@code CONFLICT}. */
+    ERROR,
+    /**
+     * The matching record is updated in place with the incoming values - {@link #updateColumnsOnConflict} when
+     * given, every non-key property of the record otherwise - and the row is counted in {@code updated}. Needs
+     * {@link #keyColumns}: with nothing to look the existing record up by, there is nothing to update.
+     */
+    UPDATE,
+    /** The row is dropped and counted in {@code ignored}. */
+    IGNORE,
+    /**
+     * Accepted for parity with gRPC, where it is answered exactly as {@link #ERROR} is: the row is reported as a
+     * {@code CONFLICT} and the rest of the chunk still goes in.
+     */
+    ABORT
+  }
+
   /** Default type of the records of every chunk, overridable per record with {@code @class}. */
   public final String          targetType;
   public final TransactionMode transactionMode;
+  public final ConflictMode    conflictMode;
+  /** The properties a row is matched on for {@link ConflictMode#UPDATE} and {@link ConflictMode#IGNORE}. */
+  public final List<String>    keyColumns;
+  /** {@link #keyColumns} as a set, for the per-property "is this a key" check of a merge. */
+  public final Set<String>     keyColumnSet;
+  /** The properties an {@link ConflictMode#UPDATE} overwrites; empty means every non-key property sent. */
+  public final List<String>    updateColumnsOnConflict;
+  /** Rows are received, parsed and counted but nothing is written. */
+  public final boolean         validateOnly;
 
-  private InsertSessionOptions(final String targetType, final TransactionMode transactionMode) {
+  private InsertSessionOptions(final String targetType, final TransactionMode transactionMode,
+      final ConflictMode conflictMode, final List<String> keyColumns, final List<String> updateColumnsOnConflict,
+      final boolean validateOnly) {
     this.targetType = targetType;
     this.transactionMode = transactionMode;
+    this.conflictMode = conflictMode;
+    this.keyColumns = keyColumns;
+    this.keyColumnSet = Set.copyOf(keyColumns);
+    this.updateColumnsOnConflict = updateColumnsOnConflict;
+    this.validateOnly = validateOnly;
   }
 
   /**
@@ -76,42 +120,91 @@ public class InsertSessionOptions {
    */
   public static InsertSessionOptions parse(final JSONObject options) {
     if (options == null)
-      return new InsertSessionOptions(null, TransactionMode.PER_STREAM);
-
-    for (final String unsupported : new String[] { "conflictMode", "keyColumns", "updateColumnsOnConflict",
-        "validateOnly" })
-      if (options.has(unsupported) && !options.isNull(unsupported))
-        throw new IllegalArgumentException(
-            "Option '" + unsupported + "' is not supported by a /ws insert session yet (issue #7404)");
+      return new InsertSessionOptions(null, TransactionMode.PER_STREAM, ConflictMode.ERROR, List.of(), List.of(), false);
 
     final String targetType = options.getString("targetType", null);
+    final TransactionMode mode = parseTransactionMode(options.getString("transactionMode", null));
+    final ConflictMode conflictMode = parseConflictMode(options.getString("conflictMode", null));
+    final List<String> keyColumns = parseColumns(options, "keyColumns");
+    final List<String> updateColumns = parseColumns(options, "updateColumnsOnConflict");
+    final boolean validateOnly = options.getBoolean("validateOnly", false);
 
-    final String rawMode = options.getString("transactionMode", null);
-    final TransactionMode mode;
+    // gRPC accepts this combination and then reports every conflicting row as a CONFLICT, because with no key
+    // to look the existing record up by tryUpsertByRecord never matches. A session that asked for updates and
+    // can never perform one is better refused at start than discovered chunk by chunk.
+    if (conflictMode == ConflictMode.UPDATE && keyColumns.isEmpty())
+      throw new IllegalArgumentException(
+          "conflictMode 'update' needs 'keyColumns': the properties an existing record is matched on before it is updated");
+
+    return new InsertSessionOptions(targetType, mode, conflictMode, keyColumns, updateColumns, validateOnly);
+  }
+
+  private static TransactionMode parseTransactionMode(final String rawMode) {
     if (rawMode == null || rawMode.isBlank())
-      mode = TransactionMode.PER_STREAM;
-    else {
-      final String normalized = rawMode.trim().toUpperCase(Locale.ENGLISH);
-      if ("PER_REQUEST".equals(normalized))
-        mode = TransactionMode.PER_STREAM;
-      else
-        try {
-          mode = TransactionMode.valueOf(normalized);
-        } catch (final IllegalArgumentException e) {
-          throw new IllegalArgumentException("Unknown transactionMode '" + rawMode
-              + "'. Expected one of: per_stream, per_request, per_batch, per_row, none");
-        }
+      return TransactionMode.PER_STREAM;
+
+    final String normalized = rawMode.trim().toUpperCase(Locale.ENGLISH);
+    if ("PER_REQUEST".equals(normalized))
+      return TransactionMode.PER_STREAM;
+
+    final TransactionMode mode;
+    try {
+      mode = TransactionMode.valueOf(normalized);
+    } catch (final IllegalArgumentException e) {
+      throw new IllegalArgumentException("Unknown transactionMode '" + rawMode
+          + "'. Expected one of: per_stream, per_request, per_batch, per_row, none");
     }
 
     if (mode == TransactionMode.NONE)
       throw new IllegalArgumentException(
           "transactionMode 'none' needs an externally-managed transaction, which a /ws insert session cannot name yet (issue #7403)");
 
-    return new InsertSessionOptions(targetType, mode);
+    return mode;
+  }
+
+  private static ConflictMode parseConflictMode(final String rawMode) {
+    if (rawMode == null || rawMode.isBlank())
+      return ConflictMode.ERROR;
+
+    // "CONFLICT_UPDATE" is how the gRPC enum spells it; a ported loader may well send that.
+    String normalized = rawMode.trim().toUpperCase(Locale.ENGLISH);
+    if (normalized.startsWith("CONFLICT_"))
+      normalized = normalized.substring("CONFLICT_".length());
+
+    try {
+      return ConflictMode.valueOf(normalized);
+    } catch (final IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Unknown conflictMode '" + rawMode + "'. Expected one of: error, update, ignore, abort");
+    }
+  }
+
+  /**
+   * A list of property names. Refuses a blank name up front, the way gRPC's {@code INVALID_KEY_COLUMN} does,
+   * rather than letting every row fail on the quoting of an empty identifier.
+   */
+  private static List<String> parseColumns(final JSONObject options, final String key) {
+    if (!options.has(key) || options.isNull(key))
+      return List.of();
+
+    final JSONArray array = options.getJSONArray(key);
+    final String[] columns = new String[array.length()];
+    for (int i = 0; i < columns.length; i++) {
+      final Object column = array.isNull(i) ? null : array.get(i);
+      if (!(column instanceof String name) || name.isBlank())
+        throw new IllegalArgumentException("Option '" + key + "' must not contain empty names");
+      columns[i] = name;
+    }
+    return List.of(columns);
   }
 
   /** The name this mode is spelled with on the wire, i.e. what a {@code started} frame echoes back. */
   public String transactionModeName() {
     return transactionMode.name().toLowerCase(Locale.ENGLISH);
+  }
+
+  /** The name this mode is spelled with on the wire, i.e. what a {@code started} frame echoes back. */
+  public String conflictModeName() {
+    return conflictMode.name().toLowerCase(Locale.ENGLISH);
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertProtocol.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertProtocol.java
@@ -18,14 +18,15 @@
  */
 package com.arcadedb.server.http.ws.insert;
 
+import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.ws.WebSocketEventBus;
+import com.arcadedb.server.http.ws.WebSocketFrameSender;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.websockets.core.WebSocketChannel;
-import io.undertow.websockets.core.WebSockets;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -47,8 +48,9 @@ import java.util.logging.Level;
  * Client to server, on the existing {@code /ws} connection, as the {@code action} of a JSON text frame:
  * <ul>
  * <li>{@code start} - {@code database} (required), {@code sessionId} (optional; the server generates one when it
- *     is absent) and {@code options} ({@code targetType}, {@code transactionMode}). Answered with
- *     {@code started}. A client-chosen id lives in ONE server-wide namespace, not one per user or per database -
+ *     is absent) and {@code options} ({@code targetType}, {@code transactionMode}, and the conflict options of
+ *     issue #7404: {@code conflictMode}, {@code keyColumns}, {@code updateColumnsOnConflict},
+ *     {@code validateOnly}). Answered with {@code started}, which echoes the modes the session runs under. A client-chosen id lives in ONE server-wide namespace, not one per user or per database -
  *     that is what makes "the same session id is refused to a second concurrent {@code start}" true whichever
  *     connection the second one arrives on. Two unrelated clients that both pick a house convention like
  *     {@code batch-1} will therefore collide; a client that does not need to name its own session should leave
@@ -159,6 +161,8 @@ public class WebSocketInsertProtocol {
         started.put("sessionId", session.id);
         started.put("database", session.databaseName);
         started.put("transactionMode", session.options.transactionModeName());
+        started.put("conflictMode", session.options.conflictModeName());
+        started.put("validateOnly", session.options.validateOnly);
         send(channel, started);
       }
       case "chunk" -> {
@@ -189,11 +193,12 @@ public class WebSocketInsertProtocol {
       }
     } catch (final SecurityException e) {
       send(channel, error("Security error", e.getMessage(), message.getString("sessionId", null), e));
-    } catch (final JSONException | IllegalArgumentException | IllegalStateException e) {
+    } catch (final JSONException | IllegalArgumentException | IllegalStateException | DuplicatedKeyException e) {
       // JSONException joins them because a frame whose 'options' carries a value of the wrong JSON TYPE is the
       // same class of mistake as one carrying a value of the wrong content, and answering the first with
       // "Internal error" and the second with "Insert session error" told a client the server had broken when it
-      // had not.
+      // had not. DuplicatedKeyException is the per_stream commit refusing a key the client sent twice (issue
+      // #7404): the client's data, not the server's fault.
       send(channel, error("Insert session error", e.getMessage(), message.getString("sessionId", null), e));
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.FINE, "Error on /ws insert session action '%s'", e, action);
@@ -218,9 +223,12 @@ public class WebSocketInsertProtocol {
     return json;
   }
 
+  /**
+   * One of several independent senders on a {@code /ws} channel; see {@link WebSocketFrameSender} for why they
+   * need no lock between them (issue #7423).
+   */
   private static void send(final WebSocketChannel channel, final JSONObject message) {
-    if (channel.isOpen())
-      WebSockets.sendText(message.toString(), channel, null);
+    WebSocketFrameSender.sendIfOpen(channel, message.toString());
   }
 
   private void registerCloseHook(final WebSocketChannel channel, final UUID channelId) {

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSession.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSession.java
@@ -501,9 +501,10 @@ public class WebSocketInsertSession {
       case ERROR, ABORT -> {
         // With key columns the conflict is found on the row that caused it rather than left to the engine,
         // which reports it only where the transaction commits.
+        // The "index" the exception names is the session's key, which reads as such: "Keyed on [name]".
         final RID taken = findByKey(typeName, properties);
         if (taken != null)
-          throw new DuplicatedKeyException(typeName + options.keyColumns, keyValues(properties), taken);
+          throw new DuplicatedKeyException(typeName + " on " + options.keyColumns, keyValues(properties), taken);
       }
       }
 

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSession.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSession.java
@@ -21,10 +21,17 @@ package com.arcadedb.server.http.ws.insert;
 import com.arcadedb.database.DatabaseContext;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.ProtocolContext;
+import com.arcadedb.database.RID;
 import com.arcadedb.database.TransactionContext;
+import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.graph.MutableEdge;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.query.sql.parser.Identifier;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.EdgeType;
 import com.arcadedb.schema.VertexType;
@@ -33,15 +40,29 @@ import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.websockets.core.WebSocketChannel;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
+import java.util.logging.Level;
 
 /**
  * One duplex insert session opened on {@code /ws} by a {@code start} frame (issue #7382). Mirrors the state the
  * gRPC {@code InsertBidirectional} RPC keeps for the lifetime of its stream: the transaction, the running totals,
  * and the chunk watermark that makes a replayed chunk idempotent.
+ * <p>
+ * <b>Conflicts.</b> The {@code conflictMode} / {@code keyColumns} / {@code updateColumnsOnConflict} /
+ * {@code validateOnly} options are honoured the way {@code ArcadeDbGrpcService.insertRows} honours them (issue
+ * #7404): a row is first matched on its {@code keyColumns} with a {@code SELECT} against its type, and the mode
+ * decides whether a match is updated in place, dropped, or reported as a {@code CONFLICT}. A duplicate the engine
+ * itself detects - a unique index the session named no key columns for - is answered by the same mode, wherever
+ * it surfaces: at the row's own {@code save()} when the twin was written by this same transaction, at the chunk's
+ * commit under {@code per_batch}, at the row's commit under {@code per_row}, and at the session's {@code commit}
+ * frame under {@code per_stream}. That last case is the engine's contract, not this session's: a unique index is
+ * checked against durable state when the transaction commits, so a session that wants a conflict reported on
+ * the row that caused it names its {@code keyColumns}.
  * <p>
  * <b>Threading.</b> The session's {@link TransactionContext} is bound to whichever thread is currently running one
  * of its frames and detached again when that frame finishes - the same borrow-per-request lifecycle
@@ -79,6 +100,8 @@ public class WebSocketInsertSession {
   /** Highest chunk sequence already applied. A chunk at or below it is acknowledged without being applied again. */
   private       long                          watermark;
   private volatile boolean                    closed;
+  /** Set once the "out/in in updateColumnsOnConflict are ignored" warning has been logged for this session. */
+  private          boolean                    warnedEdgeEndpointUpdateColumns;
   private volatile long                       lastUsed   = System.currentTimeMillis();
   /** The connection this session was opened on, so the idle sweep can tell its client it gave up on it. */
   private volatile WebSocketChannel            channel;
@@ -175,6 +198,9 @@ public class WebSocketInsertSession {
       final int rows = records == null ? 0 : records.length();
 
       DatabaseContext.INSTANCE.init(database, transaction);
+      // The key lookups below are real SQL: tagged with the transport they serve so they are metered as such,
+      // which is the misattribution issue #7407 found on the gRPC streaming inserts.
+      ProtocolContext.set("ws");
       try {
         DatabaseContext.INSTANCE.getContext(database.getDatabasePath()).setCurrentUser(user.getDatabaseUser(database));
 
@@ -193,8 +219,17 @@ public class WebSocketInsertSession {
           for (int i = 0; i < rows; i++) {
             final int row = i;
             try {
-              counts.absorb(inOwnTransaction(attempt -> applyRow(records.getJSONObject(row), row, attempt)));
+              counts.absorb(inOwnTransaction(attempt -> applyRowCounting(records, row, attempt)));
+            } catch (final DuplicatedKeyException e) {
+              // The row's own commit hit a unique index the session named no key columns for. The row IS the
+              // transaction here, so the mode can still answer per row: dropped under ignore, a CONFLICT
+              // otherwise.
+              if (options.conflictMode == InsertSessionOptions.ConflictMode.IGNORE)
+                counts.ignored++;
+              else
+                counts.conflict(row, e);
             } catch (final Exception e) {
+              // Anything else that stops the row's commit is reported on the row, since the row is the transaction.
               counts.fail(row, e);
             }
           }
@@ -202,6 +237,7 @@ public class WebSocketInsertSession {
         default -> throw new IllegalStateException("Unsupported transaction mode " + options.transactionMode);
         }
       } finally {
+        ProtocolContext.clear();
         DatabaseContext.INSTANCE.removeContext(database.getDatabasePath());
       }
 
@@ -241,6 +277,11 @@ public class WebSocketInsertSession {
     try {
       requireOpen();
 
+      // Closed BEFORE the commit is attempted: a commit the engine refuses - a unique index it checks only now,
+      // see the class comment - rolls the transaction back, and a session whose transaction is gone must not
+      // stay open to take more chunks.
+      closed = true;
+
       if (transaction != null) {
         DatabaseContext.INSTANCE.init(database, transaction);
         try {
@@ -253,8 +294,6 @@ public class WebSocketInsertSession {
           transaction = null;
         }
       }
-
-      closed = true;
 
       final JSONObject summary = new JSONObject();
       summary.put("received", received);
@@ -374,13 +413,26 @@ public class WebSocketInsertSession {
 
   private void applyRows(final JSONArray records, final int rows, final ChunkCounts counts) {
     for (int i = 0; i < rows; i++)
-      try {
-        applyRow(records.getJSONObject(i), i, counts);
-      } catch (final Exception e) {
-        counts.fail(i, e);
-      }
+      applyRowCounting(records, i, counts);
   }
 
+  /** {@link #applyRow} with its outcome tallied: a row that cannot be applied is counted, never thrown. */
+  private void applyRowCounting(final JSONArray records, final int rowIndex, final ChunkCounts counts) {
+    try {
+      applyRow(records.getJSONObject(rowIndex), rowIndex, counts);
+    } catch (final DuplicatedKeyException e) {
+      // Reaches here only from the modes that report a duplicate rather than absorb it.
+      counts.conflict(rowIndex, e);
+    } catch (final Exception e) {
+      counts.fail(rowIndex, e);
+    }
+  }
+
+  /**
+   * Applies one record under the session's conflict mode. Throws for a row that could not be applied; the
+   * caller decides how that is tallied. A {@link DuplicatedKeyException} that escapes is one the mode wants
+   * reported as a {@code CONFLICT}.
+   */
   private void applyRow(final JSONObject record, final int rowIndex, final ChunkCounts counts) {
     final String typeName = record.getString(CLASS_KEY, options.targetType);
     if (typeName == null || typeName.isBlank())
@@ -388,12 +440,15 @@ public class WebSocketInsertSession {
           "Record " + rowIndex + " has no type: set '@class' on it or 'targetType' in the start frame options");
 
     final DocumentType type = database.getSchema().getType(typeName);
+    final boolean isEdge = type instanceof EdgeType;
     final Map<String, Object> properties = record.toMap();
     properties.remove(CLASS_KEY);
 
-    if (type instanceof EdgeType) {
-      final String from = firstNonBlank(record.getString(FROM_KEY, null), record.getString(OUT_KEY, null));
-      final String to = firstNonBlank(record.getString(TO_KEY, null), record.getString(IN_KEY, null));
+    String from = null;
+    String to = null;
+    if (isEdge) {
+      from = firstNonBlank(record.getString(FROM_KEY, null), record.getString(OUT_KEY, null));
+      to = firstNonBlank(record.getString(TO_KEY, null), record.getString(IN_KEY, null));
       if (from == null || to == null)
         throw new IllegalArgumentException(
             "Edge record " + rowIndex + " of type '" + typeName + "' needs both '@from' and '@to' (or 'out' and 'in')");
@@ -403,6 +458,59 @@ public class WebSocketInsertSession {
       properties.remove(OUT_KEY);
       properties.remove(IN_KEY);
 
+      warnAboutEdgeEndpointUpdateColumns(typeName);
+    }
+
+    // A dry run parses and validates the row - the type, the endpoints - and stops here, so `received` counts it
+    // and nothing else does. Same as gRPC's validate_only.
+    if (options.validateOnly)
+      return;
+
+    try {
+      switch (options.conflictMode) {
+      case UPDATE -> {
+        if (updateExisting(typeName, properties, isEdge)) {
+          counts.updated++;
+          return;
+        }
+      }
+      case IGNORE -> {
+        if (findByKey(typeName, properties) != null) {
+          counts.ignored++;
+          return;
+        }
+      }
+      case ERROR, ABORT -> {
+        // With key columns the conflict is found on the row that caused it rather than left to the engine,
+        // which reports it only where the transaction commits.
+        final RID taken = findByKey(typeName, properties);
+        if (taken != null)
+          throw new DuplicatedKeyException(typeName + options.keyColumns, keyValues(properties), taken);
+      }
+      }
+
+      insert(type, typeName, properties, from, to);
+      counts.inserted++;
+    } catch (final DuplicatedKeyException dup) {
+      switch (options.conflictMode) {
+      case IGNORE -> counts.ignored++;
+      // A concurrent writer landed this key after the lookup above; the index proves it exists now, so update
+      // it rather than lose the row. If the match is gone again (a transient window), or a third writer races
+      // the retry too, it is a retriable CONFLICT. Anything else is a real failure, not a conflict.
+      case UPDATE -> {
+        if (updateExisting(typeName, properties, isEdge))
+          counts.updated++;
+        else
+          throw dup;
+      }
+      case ERROR, ABORT -> throw dup;
+      }
+    }
+  }
+
+  private void insert(final DocumentType type, final String typeName, final Map<String, Object> properties,
+      final String from, final String to) {
+    if (type instanceof EdgeType) {
       final Vertex fromVertex = database.lookupByRID(database.newRID(from), false).asVertex(false);
       final MutableEdge edge = fromVertex.newEdge(typeName, database.newRID(to));
       edge.set(properties);
@@ -416,7 +524,94 @@ public class WebSocketInsertSession {
       document.set(properties);
       document.save();
     }
-    counts.inserted++;
+  }
+
+  /**
+   * Matches an existing record of {@code typeName} on the session's key columns and merges the incoming values
+   * onto it: the {@code updateColumnsOnConflict} when the session names some, every non-key property sent
+   * otherwise. A property whose incoming value is absent or null is left as it is, so nothing can be nulled
+   * through this path; an edge's endpoints are never rewritten, because {@code set()} would bypass the graph
+   * engine's edge-list bookkeeping. The same rules as gRPC's {@code applyConflictUpdates}.
+   *
+   * @return {@code false} when no record matched, in which case the caller inserts
+   */
+  private boolean updateExisting(final String typeName, final Map<String, Object> properties, final boolean isEdge) {
+    try (final ResultSet rs = lookupByKey(typeName, properties)) {
+      if (!rs.hasNext())
+        return false;
+
+      final Result match = rs.next();
+      if (!match.isElement())
+        return false;
+
+      final MutableDocument existing = match.getElement().get().asDocument().modify();
+
+      final boolean mergeAll = options.updateColumnsOnConflict.isEmpty();
+      final Iterable<String> columns = mergeAll ? properties.keySet() : options.updateColumnsOnConflict;
+      for (final String column : columns) {
+        if (column.startsWith("@"))
+          continue;
+        if (mergeAll && options.keyColumnSet.contains(column))
+          continue;
+        if (isEdge && (OUT_KEY.equals(column) || IN_KEY.equals(column)))
+          continue;
+        final Object value = properties.get(column);
+        if (value == null)
+          continue;
+        existing.set(column, value);
+      }
+      existing.save();
+      return true;
+    }
+  }
+
+  /** @return the record of {@code typeName} carrying this row's key values, or {@code null} when there is none */
+  private RID findByKey(final String typeName, final Map<String, Object> properties) {
+    if (options.keyColumns.isEmpty())
+      return null;
+    try (final ResultSet rs = lookupByKey(typeName, properties)) {
+      return rs.hasNext() ? rs.next().getIdentity().orElse(null) : null;
+    }
+  }
+
+  /**
+   * {@code SELECT FROM type WHERE k1 = ? AND k2 = ?} on the session's key columns. Identifiers are
+   * backtick-quoted so a client-supplied name cannot inject SQL; the values stay parameters.
+   */
+  private ResultSet lookupByKey(final String typeName, final Map<String, Object> properties) {
+    final List<String> keys = options.keyColumns;
+    final StringBuilder sql = new StringBuilder("SELECT FROM ").append(Identifier.quote(typeName)).append(" WHERE ");
+    final Object[] params = new Object[keys.size()];
+    for (int i = 0; i < params.length; i++) {
+      if (i > 0)
+        sql.append(" AND ");
+      sql.append(Identifier.quote(keys.get(i))).append(" = ?");
+      params[i] = properties.get(keys.get(i));
+    }
+    return database.query("sql", sql.toString(), params);
+  }
+
+  private String keyValues(final Map<String, Object> properties) {
+    final List<String> keys = options.keyColumns;
+    final Object[] values = new Object[keys.size()];
+    for (int i = 0; i < values.length; i++)
+      values[i] = properties.get(keys.get(i));
+    return Arrays.toString(values);
+  }
+
+  /**
+   * Tells the operator, once per session, that the endpoints named in {@code updateColumnsOnConflict} are not
+   * going to be rewritten, rather than dropping them silently. Same warning gRPC logs for an edge target.
+   */
+  private void warnAboutEdgeEndpointUpdateColumns(final String typeName) {
+    if (warnedEdgeEndpointUpdateColumns || options.conflictMode != InsertSessionOptions.ConflictMode.UPDATE)
+      return;
+    if (!options.updateColumnsOnConflict.contains(OUT_KEY) && !options.updateColumnsOnConflict.contains(IN_KEY))
+      return;
+    warnedEdgeEndpointUpdateColumns = true;
+    LogManager.instance().log(this, Level.WARNING,
+        "/ws insert session %s: upsert on edge type '%s' ignores 'out'/'in' in updateColumnsOnConflict (edge endpoints cannot be re-pointed by an upsert)",
+        id, typeName);
   }
 
   private static String firstNonBlank(final String first, final String second) {
@@ -446,7 +641,18 @@ public class WebSocketInsertSession {
 
     private void fail(final int rowIndex, final Exception e) {
       failed++;
-      errors.put(error(rowIndex, "DB_ERROR", e));
+      errors.put(error(rowIndex, codeOf(e), e));
+    }
+
+    /** A row refused because its key is already taken: the {@code CONFLICT} code of the gRPC {@code InsertError}. */
+    private void conflict(final int rowIndex, final DuplicatedKeyException e) {
+      failed++;
+      errors.put(error(rowIndex, "CONFLICT", e));
+    }
+
+    /** A duplicate the engine reported on a commit rather than on a row is still a conflict, not a server fault. */
+    private static String codeOf(final Exception e) {
+      return e instanceof DuplicatedKeyException ? "CONFLICT" : "DB_ERROR";
     }
 
     /**
@@ -461,7 +667,7 @@ public class WebSocketInsertSession {
       failed = rows;
       wholeChunkFailed = true;
       errors = new JSONArray();
-      errors.put(error(-1, "DB_ERROR", e));
+      errors.put(error(-1, codeOf(e), e));
     }
 
     private static JSONObject error(final int rowIndex, final String code, final Exception e) {

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSession.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSession.java
@@ -469,7 +469,7 @@ public class WebSocketInsertSession {
     try {
       switch (options.conflictMode) {
       case UPDATE -> {
-        if (updateExisting(typeName, properties, isEdge)) {
+        if (updateExisting(typeName, properties)) {
           counts.updated++;
           return;
         }
@@ -498,7 +498,7 @@ public class WebSocketInsertSession {
       // it rather than lose the row. If the match is gone again (a transient window), or a third writer races
       // the retry too, it is a retriable CONFLICT. Anything else is a real failure, not a conflict.
       case UPDATE -> {
-        if (updateExisting(typeName, properties, isEdge))
+        if (updateExisting(typeName, properties))
           counts.updated++;
         else
           throw dup;
@@ -530,12 +530,15 @@ public class WebSocketInsertSession {
    * Matches an existing record of {@code typeName} on the session's key columns and merges the incoming values
    * onto it: the {@code updateColumnsOnConflict} when the session names some, every non-key property sent
    * otherwise. A property whose incoming value is absent or null is left as it is, so nothing can be nulled
-   * through this path; an edge's endpoints are never rewritten, because {@code set()} would bypass the graph
-   * engine's edge-list bookkeeping. The same rules as gRPC's {@code applyConflictUpdates}.
+   * through this path. An edge's endpoints are never rewritten - {@code set()} would bypass the graph engine's
+   * edge-list bookkeeping - which needs no check here: {@link #applyRow} strips {@code @from}/{@code @to} and
+   * {@code out}/{@code in} out of {@code properties} before this runs, so naming them in
+   * {@code updateColumnsOnConflict} finds no value and is skipped like any absent column. The same rules as
+   * gRPC's {@code applyConflictUpdates}.
    *
    * @return {@code false} when no record matched, in which case the caller inserts
    */
-  private boolean updateExisting(final String typeName, final Map<String, Object> properties, final boolean isEdge) {
+  private boolean updateExisting(final String typeName, final Map<String, Object> properties) {
     try (final ResultSet rs = lookupByKey(typeName, properties)) {
       if (!rs.hasNext())
         return false;
@@ -552,8 +555,6 @@ public class WebSocketInsertSession {
         if (column.startsWith("@"))
           continue;
         if (mergeAll && options.keyColumnSet.contains(column))
-          continue;
-        if (isEdge && (OUT_KEY.equals(column) || IN_KEY.equals(column)))
           continue;
         final Object value = properties.get(column);
         if (value == null)

--- a/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSessionManager.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/insert/WebSocketInsertSessionManager.java
@@ -60,7 +60,8 @@ public class WebSocketInsertSessionManager {
   private volatile boolean                              closed;
   /**
    * Notified when a session is rolled back by something other than its own client, so the client can be told.
-   * Its write is one of several independent senders on a {@code /ws} channel, which is issue #7423.
+   * Its write is one of several independent senders on a {@code /ws} channel; {@code WebSocketFrameSender}
+   * records why they need no lock between them (issue #7423).
    */
   private volatile ExpiryListener                       expiryListener = (session, reason) -> {
   };

--- a/server/src/test/java/com/arcadedb/server/http/ws/insert/InsertSessionOptionsTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/ws/insert/InsertSessionOptionsTest.java
@@ -101,23 +101,82 @@ class InsertSessionOptionsTest {
    * asked for upserts must not silently get plain inserts (#7404).
    */
   @Test
-  void everyOptionThisServerDoesNotImplementIsRefusedByName() {
-    assertThatThrownBy(() -> InsertSessionOptions.parse(new JSONObject().put("conflictMode", "update")))
-        .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("conflictMode").hasMessageContaining("#7404");
-    assertThatThrownBy(() -> InsertSessionOptions.parse(new JSONObject().put("keyColumns", new JSONArray().put("id"))))
-        .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("keyColumns");
-    assertThatThrownBy(
-        () -> InsertSessionOptions.parse(new JSONObject().put("updateColumnsOnConflict", new JSONArray().put("name"))))
-        .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("updateColumnsOnConflict");
-    assertThatThrownBy(() -> InsertSessionOptions.parse(new JSONObject().put("validateOnly", true)))
-        .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("validateOnly");
+  void noConflictOptionsMeansErrorOnADuplicateWithNoKeyColumnsAndNoDryRun() {
+    final InsertSessionOptions options = InsertSessionOptions.parse(new JSONObject().put("targetType", "Person"));
+    assertThat(options.conflictMode).isEqualTo(InsertSessionOptions.ConflictMode.ERROR);
+    assertThat(options.conflictModeName()).isEqualTo("error");
+    assertThat(options.keyColumns).isEmpty();
+    assertThat(options.updateColumnsOnConflict).isEmpty();
+    assertThat(options.validateOnly).isFalse();
   }
 
-  /** An explicit JSON null is "not set", not "set to something unsupported". */
+  /** Issue #7404: the four gRPC conflict options are honoured, in either the short or the gRPC spelling. */
   @Test
-  void anExplicitNullForAnUnsupportedOptionIsNotTreatedAsAskingForIt() {
+  void everyConflictModeIsAcceptedInEitherSpelling() {
+    final JSONArray key = new JSONArray().put("id");
+    assertThat(InsertSessionOptions.parse(new JSONObject().put("conflictMode", "update").put("keyColumns", key)).conflictMode)
+        .isEqualTo(InsertSessionOptions.ConflictMode.UPDATE);
+    assertThat(InsertSessionOptions.parse(new JSONObject().put("conflictMode", "CONFLICT_UPDATE").put("keyColumns", key)).conflictMode)
+        .isEqualTo(InsertSessionOptions.ConflictMode.UPDATE);
+    assertThat(InsertSessionOptions.parse(new JSONObject().put("conflictMode", " Ignore ")).conflictMode)
+        .isEqualTo(InsertSessionOptions.ConflictMode.IGNORE);
+    assertThat(InsertSessionOptions.parse(new JSONObject().put("conflictMode", "conflict_abort")).conflictMode)
+        .isEqualTo(InsertSessionOptions.ConflictMode.ABORT);
+    assertThat(InsertSessionOptions.parse(new JSONObject().put("conflictMode", "error")).conflictMode)
+        .isEqualTo(InsertSessionOptions.ConflictMode.ERROR);
+  }
+
+  @Test
+  void keyColumnsUpdateColumnsAndValidateOnlyAreCarried() {
+    final InsertSessionOptions options = InsertSessionOptions.parse(new JSONObject().put("conflictMode", "update")
+        .put("keyColumns", new JSONArray().put("id").put("tenant"))
+        .put("updateColumnsOnConflict", new JSONArray().put("name"))
+        .put("validateOnly", true));
+    assertThat(options.keyColumns).containsExactly("id", "tenant");
+    assertThat(options.keyColumnSet).containsExactlyInAnyOrder("id", "tenant");
+    assertThat(options.updateColumnsOnConflict).containsExactly("name");
+    assertThat(options.validateOnly).isTrue();
+  }
+
+  @Test
+  void anUnknownConflictModeIsRefusedAndTheMessageListsTheRealOnes() {
+    assertThatThrownBy(() -> InsertSessionOptions.parse(new JSONObject().put("conflictMode", "merge")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("merge")
+        .hasMessageContaining("update")
+        .hasMessageContaining("ignore");
+  }
+
+  /**
+   * gRPC accepts an update mode with no key columns and then reports every duplicate as a CONFLICT, because it
+   * has nothing to match the existing record on. A session that can never perform the update it asked for is
+   * refused up front instead.
+   */
+  @Test
+  void updateWithoutKeyColumnsIsRefusedAtStart() {
+    assertThatThrownBy(() -> InsertSessionOptions.parse(new JSONObject().put("conflictMode", "update")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("keyColumns");
+  }
+
+  @Test
+  void aBlankOrNonStringKeyColumnIsRefusedByName() {
+    assertThatThrownBy(() -> InsertSessionOptions.parse(new JSONObject().put("keyColumns", new JSONArray().put("id").put(" "))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("keyColumns");
+    assertThatThrownBy(() -> InsertSessionOptions.parse(new JSONObject().put("updateColumnsOnConflict", new JSONArray().put(42))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("updateColumnsOnConflict");
+  }
+
+  @Test
+  void anExplicitNullForAConflictOptionMeansItsDefault() {
     final JSONObject options = new JSONObject().put("targetType", "Person");
     options.put("conflictMode", (Object) null);
-    assertThat(InsertSessionOptions.parse(options).targetType).isEqualTo("Person");
+    options.put("keyColumns", (Object) null);
+    final InsertSessionOptions parsed = InsertSessionOptions.parse(options);
+    assertThat(parsed.targetType).isEqualTo("Person");
+    assertThat(parsed.conflictMode).isEqualTo(InsertSessionOptions.ConflictMode.ERROR);
+    assertThat(parsed.keyColumns).isEmpty();
   }
 }

--- a/server/src/test/java/com/arcadedb/server/ws/WebSocketClientHelper.java
+++ b/server/src/test/java/com/arcadedb/server/ws/WebSocketClientHelper.java
@@ -56,11 +56,22 @@ public class WebSocketClientHelper implements AutoCloseable {
   private final XnioWorker                 worker;
   private final ByteBufferPool             pool         = new DefaultByteBufferPool(true, BUFFER_SIZE, 1000, 10, 100);
   private final WebSocketChannel           channel;
-  private final ArrayBlockingQueue<String> messageQueue = new ArrayBlockingQueue<>(20);
+  private final ArrayBlockingQueue<String> messageQueue;
 
   private static final int DEFAULT_DELAY = 5_000;
 
   public WebSocketClientHelper(final String uri, final String user, final String pass) throws URISyntaxException, IOException {
+    this(uri, user, pass, 20);
+  }
+
+  /**
+   * @param queueCapacity how many frames the client keeps before dropping the next one on the floor. The default
+   *                      of 20 fits a request/answer exchange; a test that has the server push a change stream
+   *                      at the client while it drives its own frames needs room for all of them
+   */
+  public WebSocketClientHelper(final String uri, final String user, final String pass, final int queueCapacity)
+      throws URISyntaxException, IOException {
+    this.messageQueue = new ArrayBlockingQueue<>(queueCapacity);
     final Xnio xnio = Xnio.getInstance(BaseGraphServerTest.class.getClassLoader());
     worker = xnio.createWorker(OptionMap.builder()//
         .set(Options.WORKER_IO_THREADS, 4)//
@@ -115,9 +126,14 @@ public class WebSocketClientHelper implements AutoCloseable {
   }
 
   public String send(final String payload) throws URISyntaxException, IOException {
+    sendWithoutWaiting(payload);
+    return this.popMessage(DEFAULT_DELAY);
+  }
+
+  /** Queues a frame and returns at once, for a test that pipelines frames or reads the answers separately. */
+  public void sendWithoutWaiting(final String payload) throws IOException {
     final var sendChannel = this.channel.send(WebSocketFrameType.TEXT);
     new StringWriteChannelListener(payload).setup(sendChannel);
-    return this.popMessage(DEFAULT_DELAY);
   }
 
   public String popMessage() {

--- a/server/src/test/java/com/arcadedb/server/ws/WebSocketConcurrentSendersIT.java
+++ b/server/src/test/java/com/arcadedb/server/ws/WebSocketConcurrentSendersIT.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ws;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.http.ws.WebSocketFrameSender;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7423: one {@code /ws} connection with three independent senders - the change-stream fan-out on the
+ * database watcher thread, the insert session's answers on an Undertow worker thread, and the subscription
+ * acknowledgement on the I/O thread - and nothing of ours serializing them. Every frame the client receives
+ * must still be one complete JSON object; {@link WebSocketFrameSender} records why Undertow guarantees that.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class WebSocketConcurrentSendersIT extends BaseGraphServerTest {
+  private static final int CHUNKS          = 40;
+  private static final int ROWS_PER_CHUNK  = 5;
+  private static final int BACKGROUND_ROWS = 300;
+
+  @Test
+  void changeEventsAndBatchAcksInterleaveOnOneConnectionAsWholeFrames() throws Throwable {
+    final Database database = getServerDatabase(0, getDatabaseName());
+    final int expectedEvents = BACKGROUND_ROWS + CHUNKS * ROWS_PER_CHUNK;
+
+    final String url = "ws://localhost:" + getServer(0).getHttpServer().getPort() + "/ws";
+    try (final var client = new WebSocketClientHelper(url, "root", DEFAULT_PASSWORD_FOR_TESTS, expectedEvents + CHUNKS + 16)) {
+      final JSONObject subscribed = new JSONObject(client.send(new JSONObject().put("action", "subscribe")
+          .put("database", getDatabaseName()).put("type", "Person").toString()));
+      assertThat(subscribed.getString("result", "")).isEqualTo("ok");
+
+      final JSONObject started = new JSONObject(client.send(new JSONObject().put("action", "start")
+          .put("database", getDatabaseName())
+          .put("options", new JSONObject().put("targetType", "Person").put("transactionMode", "per_batch")).toString()));
+      assertThat(started.getString("action", "")).isEqualTo("started");
+      final String sessionId = started.getString("sessionId");
+
+      // A writer that is not this connection at all, so the watcher thread pushes events while the worker thread
+      // answers chunks. The session's own per_batch inserts feed the same watcher, so both senders are busy on
+      // this one channel for the whole run.
+      final CountDownLatch writerDone = new CountDownLatch(1);
+      final AtomicReference<Throwable> writerFailure = new AtomicReference<>();
+      final Thread writer = new Thread(() -> {
+        try {
+          for (int i = 0; i < BACKGROUND_ROWS; i++)
+            database.transaction(() -> database.newDocument("Person").set("name", "background").save());
+        } catch (final Throwable t) {
+          writerFailure.set(t);
+        } finally {
+          writerDone.countDown();
+        }
+      }, "issue-7423-writer");
+      writer.start();
+
+      // The chunks are pipelined without waiting for their acknowledgements: the point is to have as many frames
+      // in flight from as many senders as possible, not to drive the session politely.
+      for (int seq = 1; seq <= CHUNKS; seq++) {
+        final JSONArray records = new JSONArray();
+        for (int r = 0; r < ROWS_PER_CHUNK; r++)
+          records.put(new JSONObject().put("name", "chunk-" + seq + "-" + r));
+        client.sendWithoutWaiting(new JSONObject().put("action", "chunk").put("sessionId", sessionId)
+            .put("chunkSeq", seq).put("records", records).toString());
+      }
+
+      assertThat(writerDone.await(60, TimeUnit.SECONDS)).isTrue();
+      assertThat(writerFailure.get()).isNull();
+
+      // Every frame received, whatever thread sent it, parses as one complete JSON object with an action or a
+      // changeType of its own: a torn or interleaved frame would fail the parse or carry neither.
+      final List<JSONObject> acks = new ArrayList<>();
+      int events = 0;
+      String frame;
+      while ((frame = client.popMessage(5_000)) != null) {
+        final JSONObject json = new JSONObject(frame);
+        if (json.has("changeType")) {
+          assertThat(json.getString("changeType", "")).isEqualTo("create");
+          assertThat(json.getJSONObject("record").getString("@type", "")).isEqualTo("Person");
+          events++;
+        } else {
+          assertThat(json.getString("action", "")).as(frame).isEqualTo("batchAck");
+          assertThat(json.getLong("inserted", -1)).isEqualTo(ROWS_PER_CHUNK);
+          acks.add(json);
+        }
+        if (acks.size() == CHUNKS && events >= expectedEvents)
+          break;
+      }
+
+      assertThat(acks).hasSize(CHUNKS);
+      // At least: a per_batch chunk whose commit is retried on a page conflict with the background writer fires
+      // its create events again, so the stream may carry more than the rows that ended up durable.
+      assertThat(events).isGreaterThanOrEqualTo(expectedEvents);
+
+      final JSONObject committed = new JSONObject(client.send(new JSONObject().put("action", "commit")
+          .put("sessionId", sessionId).toString()));
+      assertThat(committed.getString("action", "")).isEqualTo("committed");
+      assertThat(committed.getJSONObject("summary").getLong("inserted", -1)).isEqualTo(CHUNKS * ROWS_PER_CHUNK);
+    }
+
+    assertThat(database.countType("Person", false)).isEqualTo(expectedEvents);
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/ws/WebSocketInsertSessionConflictIT.java
+++ b/server/src/test/java/com/arcadedb/server/ws/WebSocketInsertSessionConflictIT.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ws;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The conflict half of the gRPC {@code InsertOptions} on a {@code /ws} insert session (issue #7404):
+ * {@code conflictMode}, {@code keyColumns}, {@code updateColumnsOnConflict} and {@code validateOnly}, with the
+ * semantics {@code ArcadeDbGrpcService.insertRows} gives them.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class WebSocketInsertSessionConflictIT extends BaseGraphServerTest {
+  private static final String TYPE      = "Keyed7404";
+  private static final String EDGE_TYPE = "KeyedEdge7404";
+
+  private Database database;
+
+  @BeforeEach
+  void createKeyedType() {
+    database = getServerDatabase(0, getDatabaseName());
+    database.command("sql", "CREATE DOCUMENT TYPE " + TYPE);
+    database.command("sql", "CREATE PROPERTY " + TYPE + ".name STRING");
+    database.command("sql", "CREATE INDEX ON " + TYPE + " (name) UNIQUE");
+    database.command("sql", "CREATE EDGE TYPE " + EDGE_TYPE);
+    database.command("sql", "CREATE PROPERTY " + EDGE_TYPE + ".name STRING");
+    database.command("sql", "CREATE INDEX ON " + EDGE_TYPE + " (name) UNIQUE");
+    database.transaction(() -> {
+      database.newDocument(TYPE).set("name", "a").set("role", "old-a").save();
+      database.newDocument(TYPE).set("name", "b").set("role", "old-b").save();
+    });
+  }
+
+  @AfterEach
+  void dropKeyedType() {
+    database.command("sql", "DROP TYPE " + EDGE_TYPE + " IF EXISTS UNSAFE");
+    database.command("sql", "DROP TYPE " + TYPE + " IF EXISTS UNSAFE");
+  }
+
+  /** Verification 1: the duplicate chunk under {@code update} is acknowledged as updated, and nothing new is created. */
+  @Test
+  void updateMatchesOnTheKeyColumnsAndRewritesTheExistingRecords() throws Throwable {
+    try (final var client = newClient()) {
+      final JSONObject started = new JSONObject(client.send(start(options("update", "name"))));
+      assertThat(started.getString("action", "")).isEqualTo("started");
+      assertThat(started.getString("conflictMode", "")).isEqualTo("update");
+      final String sessionId = started.getString("sessionId");
+
+      final JSONObject ack = new JSONObject(client.send(chunk(sessionId, 1,
+          record("a", "new-a").put("extra", 1), record("b", "new-b"), record("c", "new-c"))));
+      assertThat(ack.getString("action", "")).isEqualTo("batchAck");
+      assertThat(ack.getLong("received", -1)).isEqualTo(3);
+      assertThat(ack.getLong("updated", -1)).isEqualTo(2);
+      assertThat(ack.getLong("inserted", -1)).isEqualTo(1);
+      assertThat(ack.getLong("failed", -1)).isZero();
+      assertThat(ack.has("errors")).isFalse();
+
+      final JSONObject committed = new JSONObject(client.send(control("commit", sessionId)));
+      assertThat(committed.getJSONObject("summary").getLong("updated", -1)).isEqualTo(2);
+    }
+
+    assertThat(database.countType(TYPE, false)).isEqualTo(3);
+    assertThat(roleOf("a")).isEqualTo("new-a");
+    assertThat(roleOf("b")).isEqualTo("new-b");
+    assertThat(propertyOf("a", "extra")).isEqualTo(1);
+  }
+
+  /** {@code updateColumnsOnConflict} narrows the merge to the columns it names; the others keep their values. */
+  @Test
+  void updateColumnsOnConflictLimitsWhatAnUpdateOverwrites() throws Throwable {
+    try (final var client = newClient()) {
+      final JSONObject options = options("update", "name").put("updateColumnsOnConflict", new JSONArray().put("extra"));
+      final String sessionId = new JSONObject(client.send(start(options))).getString("sessionId");
+
+      final JSONObject ack = new JSONObject(client.send(chunk(sessionId, 1, record("a", "should-not-land").put("extra", 7))));
+      assertThat(ack.getLong("updated", -1)).isEqualTo(1);
+      new JSONObject(client.send(control("commit", sessionId)));
+    }
+
+    assertThat(roleOf("a")).isEqualTo("old-a");
+    assertThat(propertyOf("a", "extra")).isEqualTo(7);
+  }
+
+  /** Verification 2: the same chunk under {@code ignore} is acknowledged as ignored. */
+  @Test
+  void ignoreDropsTheRowsWhoseKeyIsTaken() throws Throwable {
+    try (final var client = newClient()) {
+      final String sessionId = new JSONObject(client.send(start(options("ignore", "name")))).getString("sessionId");
+
+      final JSONObject ack = new JSONObject(client.send(chunk(sessionId, 1, record("a", "x"), record("b", "x"), record("c", "x"))));
+      assertThat(ack.getLong("ignored", -1)).isEqualTo(2);
+      assertThat(ack.getLong("inserted", -1)).isEqualTo(1);
+      assertThat(ack.getLong("failed", -1)).isZero();
+      new JSONObject(client.send(control("commit", sessionId)));
+    }
+
+    assertThat(database.countType(TYPE, false)).isEqualTo(3);
+    assertThat(roleOf("a")).isEqualTo("old-a");
+  }
+
+  /** Verification 3: under the default, each duplicate is a failed row with a {@code CONFLICT}-coded error. */
+  @Test
+  void theDefaultReportsEachDuplicateAsAConflictAndStillAppliesTheRest() throws Throwable {
+    try (final var client = newClient()) {
+      final String sessionId = new JSONObject(client.send(start(options(null, "name")))).getString("sessionId");
+
+      final JSONObject ack = new JSONObject(client.send(chunk(sessionId, 1, record("a", "x"), record("c", "x"), record("b", "x"))));
+      assertThat(ack.getLong("failed", -1)).isEqualTo(2);
+      assertThat(ack.getLong("inserted", -1)).isEqualTo(1);
+      final JSONArray errors = ack.getJSONArray("errors");
+      assertThat(errors.length()).isEqualTo(2);
+      assertThat(errors.getJSONObject(0).getInt("rowIndex", -1)).isZero();
+      assertThat(errors.getJSONObject(0).getString("code", "")).isEqualTo("CONFLICT");
+      assertThat(errors.getJSONObject(1).getInt("rowIndex", -1)).isEqualTo(2);
+      assertThat(errors.getJSONObject(1).getString("code", "")).isEqualTo("CONFLICT");
+      new JSONObject(client.send(control("commit", sessionId)));
+    }
+
+    assertThat(database.countType(TYPE, false)).isEqualTo(3);
+  }
+
+  /** {@code abort} is accepted for parity with gRPC and answered exactly as {@code error} is there. */
+  @Test
+  void abortIsAnsweredLikeError() throws Throwable {
+    try (final var client = newClient()) {
+      final String sessionId = new JSONObject(client.send(start(options("abort", "name")))).getString("sessionId");
+      final JSONObject ack = new JSONObject(client.send(chunk(sessionId, 1, record("a", "x"))));
+      assertThat(ack.getLong("failed", -1)).isEqualTo(1);
+      assertThat(ack.getJSONArray("errors").getJSONObject(0).getString("code", "")).isEqualTo("CONFLICT");
+      new JSONObject(client.send(control("rollback", sessionId)));
+    }
+  }
+
+  /** Verification 4: a dry run acknowledges every row as received while the database stays as it was. */
+  @Test
+  void validateOnlyReceivesEveryRowAndWritesNothing() throws Throwable {
+    try (final var client = newClient()) {
+      final JSONObject options = new JSONObject().put("targetType", TYPE).put("validateOnly", true);
+      final String sessionId = new JSONObject(client.send(start(options))).getString("sessionId");
+
+      final JSONObject ack = new JSONObject(client.send(chunk(sessionId, 1, record("a", "x"), record("z", "x"))));
+      assertThat(ack.getLong("received", -1)).isEqualTo(2);
+      assertThat(ack.getLong("inserted", -1)).isZero();
+      assertThat(ack.getLong("failed", -1)).isZero();
+
+      // Validation still validates: a row with no type is reported even though nothing would be written.
+      final JSONArray untyped = new JSONArray().put(new JSONObject().put("@class", "NoSuchType7404").put("name", "q"));
+      final JSONObject bad = new JSONObject(client.send(chunkOf(sessionId, 2, untyped)));
+      assertThat(bad.getLong("failed", -1)).isEqualTo(1);
+
+      final JSONObject committed = new JSONObject(client.send(control("commit", sessionId)));
+      assertThat(committed.getJSONObject("summary").getLong("received", -1)).isEqualTo(3);
+      assertThat(committed.getJSONObject("summary").getLong("inserted", -1)).isZero();
+    }
+
+    assertThat(database.countType(TYPE, false)).isEqualTo(2);
+  }
+
+  /** {@code update} with nothing to match on can never update anything, so it is refused at {@code start}. */
+  @Test
+  void updateWithoutKeyColumnsIsRefusedAtStart() throws Throwable {
+    try (final var client = newClient()) {
+      final JSONObject refused = new JSONObject(client.send(start(new JSONObject().put("conflictMode", "update"))));
+      assertThat(refused.getString("result", "")).isEqualTo("error");
+      assertThat(refused.getString("detail", "")).contains("keyColumns");
+    }
+    assertThat(getServer(0).getHttpServer().getInsertSessionManager().getOpenSessionCount()).isZero();
+  }
+
+  /**
+   * With no key columns the duplicate is the engine's to find, and it finds it where the transaction commits:
+   * under {@code per_row} that is the row itself, so the mode still gets to answer per row.
+   */
+  @Test
+  void withoutKeyColumnsPerRowStillAnswersPerRow() throws Throwable {
+    try (final var client = newClient()) {
+      final JSONObject ignoring = new JSONObject().put("targetType", TYPE).put("transactionMode", "per_row")
+          .put("conflictMode", "ignore");
+      final String ignoringSession = new JSONObject(client.send(start(ignoring))).getString("sessionId");
+      final JSONObject ignoredAck = new JSONObject(client.send(chunk(ignoringSession, 1, record("a", "x"), record("d", "x"))));
+      assertThat(ignoredAck.getLong("ignored", -1)).isEqualTo(1);
+      assertThat(ignoredAck.getLong("inserted", -1)).isEqualTo(1);
+      assertThat(ignoredAck.getLong("failed", -1)).isZero();
+      new JSONObject(client.send(control("commit", ignoringSession)));
+
+      final JSONObject erroring = new JSONObject().put("targetType", TYPE).put("transactionMode", "per_row");
+      final String erroringSession = new JSONObject(client.send(start(erroring))).getString("sessionId");
+      final JSONObject failedAck = new JSONObject(client.send(chunk(erroringSession, 1, record("b", "x"), record("e", "x"))));
+      assertThat(failedAck.getLong("failed", -1)).isEqualTo(1);
+      assertThat(failedAck.getLong("inserted", -1)).isEqualTo(1);
+      assertThat(failedAck.getJSONArray("errors").getJSONObject(0).getInt("rowIndex", -1)).isZero();
+      assertThat(failedAck.getJSONArray("errors").getJSONObject(0).getString("code", "")).isEqualTo("CONFLICT");
+      new JSONObject(client.send(control("commit", erroringSession)));
+    }
+
+    assertThat(database.countType(TYPE, false)).isEqualTo(4);
+    assertThat(roleOf("a")).isEqualTo("old-a");
+  }
+
+  /**
+   * And under {@code per_stream} the engine finds it at the session's commit: the {@code commit} frame is
+   * answered with a client error naming the duplicate, the session is closed, and nothing of it is durable.
+   */
+  @Test
+  void withoutKeyColumnsPerStreamRefusesTheCommit() throws Throwable {
+    try (final var client = newClient()) {
+      final String sessionId = new JSONObject(client.send(start(new JSONObject().put("targetType", TYPE)))).getString("sessionId");
+      final JSONObject ack = new JSONObject(client.send(chunk(sessionId, 1, record("a", "x"), record("f", "x"))));
+      assertThat(ack.getLong("inserted", -1)).isEqualTo(2);
+
+      final JSONObject refused = new JSONObject(client.send(control("commit", sessionId)));
+      assertThat(refused.getString("result", "")).isEqualTo("error");
+      assertThat(refused.getString("error", "")).isEqualTo("Insert session error");
+      assertThat(refused.getString("exception", "")).endsWith("DuplicatedKeyException");
+
+      final JSONObject gone = new JSONObject(client.send(chunk(sessionId, 2, record("g", "x"))));
+      assertThat(gone.getString("result", "")).isEqualTo("error");
+      assertThat(gone.getString("detail", "")).contains("not found or expired");
+    }
+
+    assertThat(database.countType(TYPE, false)).isEqualTo(2);
+    assertThat(getServer(0).getHttpServer().getInsertSessionManager().getOpenSessionCount()).isZero();
+  }
+
+  /** An edge upsert rewrites the edge's own properties and never its endpoints, even when asked to. */
+  @Test
+  void anEdgeUpsertKeepsItsEndpoints() throws Throwable {
+    final String fromRid = ridOfFirst("select from " + VERTEX1_TYPE_NAME + " limit 1");
+    final String toRid = ridOfFirst("select from " + VERTEX2_TYPE_NAME + " limit 1");
+    final String[] otherRid = new String[1];
+    database.transaction(() -> {
+      otherRid[0] = database.newVertex(VERTEX1_TYPE_NAME).set("id", 7404).set("name", "other").save().getIdentity().toString();
+      database.lookupByRID(database.newRID(fromRid), false).asVertex()
+          .newEdge(EDGE_TYPE, database.newRID(toRid)).set("name", "e1").set("weight", 1).save();
+    });
+
+    try (final var client = newClient()) {
+      final JSONObject options = new JSONObject().put("targetType", EDGE_TYPE).put("conflictMode", "update")
+          .put("keyColumns", new JSONArray().put("name"))
+          .put("updateColumnsOnConflict", new JSONArray().put("weight").put("out"));
+      final String sessionId = new JSONObject(client.send(start(options))).getString("sessionId");
+
+      final JSONArray records = new JSONArray().put(new JSONObject().put("name", "e1").put("weight", 2)
+          .put("@from", otherRid[0]).put("@to", toRid));
+      final JSONObject ack = new JSONObject(client.send(chunkOf(sessionId, 1, records)));
+      assertThat(ack.getLong("updated", -1)).isEqualTo(1);
+      assertThat(ack.getLong("inserted", -1)).isZero();
+      new JSONObject(client.send(control("commit", sessionId)));
+    }
+
+    try (final ResultSet rs = database.query("sql", "select from " + EDGE_TYPE + " where name = 'e1'")) {
+      final var edge = rs.next().getEdge().orElseThrow();
+      assertThat(edge.<Integer>get("weight")).isEqualTo(2);
+      assertThat(edge.getOut().toString()).isEqualTo(fromRid);
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  private WebSocketClientHelper newClient() throws Exception {
+    return new WebSocketClientHelper("ws://localhost:" + getServer(0).getHttpServer().getPort() + "/ws", "root",
+        BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
+  }
+
+  private static JSONObject options(final String conflictMode, final String... keyColumns) {
+    final JSONObject options = new JSONObject().put("targetType", TYPE);
+    if (conflictMode != null)
+      options.put("conflictMode", conflictMode);
+    options.put("keyColumns", new JSONArray(keyColumns));
+    return options;
+  }
+
+  private String start(final JSONObject options) {
+    final JSONObject message = new JSONObject();
+    message.put("action", "start");
+    message.put("database", getDatabaseName());
+    message.put("options", options);
+    return message.toString();
+  }
+
+  private static JSONObject record(final String name, final String role) {
+    return new JSONObject().put("name", name).put("role", role);
+  }
+
+  private static String chunk(final String sessionId, final long chunkSeq, final JSONObject... records) {
+    return chunkOf(sessionId, chunkSeq, new JSONArray(records));
+  }
+
+  private static String chunkOf(final String sessionId, final long chunkSeq, final JSONArray records) {
+    final JSONObject message = new JSONObject();
+    message.put("action", "chunk");
+    message.put("sessionId", sessionId);
+    message.put("chunkSeq", chunkSeq);
+    message.put("records", records);
+    return message.toString();
+  }
+
+  private static String control(final String action, final String sessionId) {
+    final JSONObject message = new JSONObject();
+    message.put("action", action);
+    message.put("sessionId", sessionId);
+    return message.toString();
+  }
+
+  private String roleOf(final String name) {
+    return (String) propertyOf(name, "role");
+  }
+
+  private Object propertyOf(final String name, final String property) {
+    try (final ResultSet rs = database.query("sql", "select from " + TYPE + " where name = ?", name)) {
+      return rs.next().getProperty(property);
+    }
+  }
+
+  private String ridOfFirst(final String query) {
+    try (final ResultSet rs = database.query("sql", query)) {
+      return rs.next().getIdentity().orElseThrow().toString();
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/ws/WebSocketInsertSessionIT.java
+++ b/server/src/test/java/com/arcadedb/server/ws/WebSocketInsertSessionIT.java
@@ -256,17 +256,13 @@ class WebSocketInsertSessionIT extends BaseGraphServerTest {
 
   /**
    * The options a {@code /ws} session does not implement are refused at {@code start}, not ignored: a loader
-   * ported from {@code InsertBidirectional} must not silently get plain inserts where it asked for upserts
-   * (issues #7403, #7404).
+   * ported from {@code InsertBidirectional} must not silently run under a different policy than the one it
+   * asked for (issue #7403). The conflict options are honoured since issue #7404; see
+   * {@link WebSocketInsertSessionConflictIT}.
    */
   @Test
   void optionsThisServerDoesNotImplementAreRefusedRatherThanIgnored() throws Throwable {
     try (final var client = newClient()) {
-      final JSONObject options = new JSONObject().put("targetType", "Person").put("conflictMode", "update");
-      final JSONObject refused = new JSONObject(client.send(startWithOptions(null, options)));
-      assertThat(refused.getString("result", "")).isEqualTo("error");
-      assertThat(refused.getString("detail", "")).contains("conflictMode").contains("#7404");
-
       final JSONObject noneMode = new JSONObject(
           client.send(startWithOptions(null, new JSONObject().put("targetType", "Person").put("transactionMode", "none"))));
       assertThat(noneMode.getString("result", "")).isEqualTo("error");


### PR DESCRIPTION
Closes #7423, closes #7416, closes #7413, closes #7407, closes #7404.

Stacked on #7422 (base branch `feat/7382-ws-bidirectional-insert-session`): #7423 and #7404 change the `/ws` insert session that only exists there. GitHub retargets this PR to `main` when #7422 merges. The other three items are independent of #7422 and touch files that #7414, #7417 and #7420 also touch; conflicts, if any, will be resolved here.

## #7423 - three senders, one `/ws` channel

Established from the Undertow 2.4.3.Final source (not inferred): `WebSockets.sendText` is safe for concurrent callers on one channel. Each call creates its own whole-frame `StreamSinkFrameChannel`, appends it to a `ConcurrentLinkedDeque` (frame priority order queue) and a `LinkedBlockingDeque` (`newFrames`), and the only writer to the socket is `AbstractFramedChannel.flushSenders()`, which is `synchronized` and runs on the I/O thread, releasing each frame only after the one ahead of it is fully written. So frames never interleave; only the order *between* senders is unspecified, which both `/ws` protocols tolerate since every frame carries its own `action`.

That is now written down once, in `WebSocketFrameSender`, and all senders go through it (event bus, receive listener, insert protocol and the expiry listener). `WebSocketConcurrentSendersIT` subscribes to a change stream and opens an insert session on the same connection, pipelines 40 chunks while a background thread writes 300 records, and parses every frame received as one complete JSON object.

## #7404 - `conflictMode` on a `/ws` insert session

`conflictMode` (`error` / `update` / `ignore` / `abort`, gRPC spellings such as `CONFLICT_UPDATE` accepted), `keyColumns`, `updateColumnsOnConflict` and `validateOnly` are honoured with the semantics `ArcadeDbGrpcService.insertRows` gives them: a row is matched on its key columns with a parameterised `SELECT` (identifiers backtick-quoted), then updated in place (explicit columns or all non-key ones, nulls skipped, edge endpoints never rewritten, with the once-per-session warning), dropped, or reported as a `CONFLICT`-coded error. The `batchAck` `updated` / `ignored` tallies are now real, and `started` echoes `conflictMode` and `validateOnly`.

Two deliberate departures from a literal port, both improvements:
- `update` with no `keyColumns` is refused at `start`. gRPC accepts it and then reports every conflicting row as a `CONFLICT`, because it has nothing to match on.
- Under `error` with `keyColumns`, the conflict is found on the row that caused it. Without key columns the duplicate is the engine's to find, and it finds it where the transaction commits; the session answers with the same mode wherever that is: per row under `per_row` (so `ignore` still ignores), whole-chunk `CONFLICT` under `per_batch`, and a client error on the `commit` frame under `per_stream`, which now also closes the session. The class comment documents this.

The key lookups are metered as `protocol="ws"`, so this transport does not reproduce #7407.

## #7407 - `insertStream` / `insertBidirectional` lookups metered as `internal`

The tag is set inside `insertRows`, around the work, on whichever thread runs it (a stream executor or a transaction's executor after the thread hop), and left alone when `bulkInsert`'s outer pair already set it. `Issue7407InsertStreamUpsertMetricsIT` drives both streaming RPCs under `CONFLICT_UPDATE` and asserts the `grpc` timer grows by at least one per row while `internal` does not move; it fails on the previous code.

## #7416 - stubs cached on a replaced channel

`RemoteGrpcServer` gains a `channelGeneration()` counter, bumped on `start()` and on `close()`. `RemoteGrpcDatabase` reads its two data-plane stubs through accessors that rebuild them when the generation moved: one volatile read and a compare per call, no per-call stub allocation, and `createBlockingStub()` stays the one override point. While the server is closed the same object now fails with the reason (`closed`) instead of `UNAVAILABLE: Channel shutdown invoked`. `Issue7416RemoteGrpcDatabaseSurvivesServerRestartIT` queries, writes and reads through one object across one and three close/start cycles.

## #7413 - `CreateDatabase` / `DropDatabase` silent no-op

Rather than choosing between the issue's two shapes, both contracts are offered and the answer is explicit either way:
- strict by default, matching HTTP and the gRPC API guidance: `ALREADY_EXISTS` / `NOT_FOUND`
- `if_not_exists` / `if_exists` request fields for the idempotent form
- `created` / `dropped` response fields, so OK never has to be read as "I own this fresh database"

Names are exact throughout the admin service now (`existsDatabase` and `getDatabaseInfo` too); the case-folded guard that let `CreateDatabase("MyDb")` answer OK for `mydb` and then `DropDatabase("MyDb")` fail inside the drop is gone. The Java client's `createDatabaseIfMissing` uses the flag (the old exists-then-create pair raced other clients) and returns the outcome; `dropDatabaseIfExists` is new. The proto change is additive. The default is a behaviour change for a client relying on the silent OK; `GrpcAdminServiceIT` and `RemoteGrpcServerIT` are updated to the new contract.

Docs: a companion commit on `arcadedb-docs` (`docs-7413-grpc-create-drop-contract`, not pushed) documents the create/drop contract in `grpc-api.adoc`.

## Verification

- `server`: `InsertSessionOptionsTest`, `WebSocketInsertSessionIT`, `WebSocketInsertSessionConflictIT` (new, 10 tests), `WebSocketConcurrentSendersIT` (new), `WebSocketEventBusIT`, `WebSocketInsertSessionExpiryIT`: green
- `grpcw`: `Issue7407InsertStreamUpsertMetricsIT` (new), `GrpcAdminServiceIT`, `GrpcQueryMetricsIT`, `Issue4214…`, `Issue4656…`, `Issue5039…`, `Issue7035…`, `Issue7304GrpcControlPlaneAuthorizationIT`, `Issue4644…`, `Issue6795…`: green
- `grpc-client`: `Issue7416…` (new), `RemoteGrpcServerIT`, `Issue6762ChannelLifecycleTest`, `Issue7320ScopedUserGrpcIT`, `BidiIngestionIT`, `RemoteGrpcDatabaseCoverageIT`: green
