### PR TITLE
fix(#7432): GraphImporter holds the vector rebuild off for the whole run and builds the graph before returning

### DIFF
--- a/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
@@ -36,6 +36,7 @@ import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.IndexMaintenanceSuspension;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.EdgeType;
@@ -373,15 +374,10 @@ public class GraphBatch implements AutoCloseable {
   private int[] flushDurableOutRanges;
 
   /**
-   * The indexes whose speculative background maintenance this batch suspended for the duration of the load
-   * (issue #7357), and the guard that makes resuming them happen exactly once.
-   * <p>
-   * Captured at construction rather than looked up again on the way out: an index dropped mid-load must still have
-   * its suspension lifted, and looking the list up again would silently leak the count of one that is no longer in
-   * the schema.
+   * This batch's hold on the speculative background maintenance of the database's indexes for the duration of the
+   * load (issue #7357). Lifted exactly once, on every way out of the batch.
    */
-  private final IndexInternal[] maintenanceSuspendedIndexes;
-  private final AtomicBoolean   maintenanceResumed = new AtomicBoolean();
+  private final IndexMaintenanceSuspension maintenanceSuspension;
 
   // --- Saved state for restore after close ---
   private final boolean savedReadYourWrites;
@@ -527,78 +523,10 @@ public class GraphBatch implements AutoCloseable {
     // what has been loaded so far and is superseded by the rest of the load. A 4.2M-record load paid four full
     // graph rebuilds that way and had not finished after six and a half hours; the same load with no vector index
     // took twenty-six minutes. Suspending is a pure deferral - the writes stay searchable through the index's own
-    // delta path meanwhile - and close()/abandon() resume it, which is when the one rebuild the load is actually
-    // worth gets scheduled.
-    maintenanceSuspendedIndexes = suspendIndexBackgroundMaintenance();
-  }
-
-  /**
-   * Suspends the speculative background maintenance of every index of this database, returning the ones that were
-   * actually asked so {@link #resumeIndexBackgroundMaintenance()} can lift exactly those.
-   * <p>
-   * A failure to suspend one index must not leave the batch half-suspended and must not fail the load either - the
-   * suspension is an optimization, not a correctness requirement - so an index that cannot be asked is skipped and
-   * the rest are still suspended. Caught per index rather than around the loop for exactly that reason (PR #7360
-   * review): the cast is the failure this is most likely to see, and one {@code Index} that does not implement
-   * {@link IndexInternal} must not cost every OTHER index of the database its suspension.
-   * <p>
-   * The list is a snapshot. An index created while this batch is open runs its background maintenance as usual -
-   * an acceptable gap, since creating an index in the middle of a bulk load is not a shape worth complicating the
-   * lifetime of these suspensions for, and the maintenance it would do is over a corpus it has just been built on.
-   *
-   * @return the indexes actually suspended, empty when none was
-   */
-  private IndexInternal[] suspendIndexBackgroundMaintenance() {
-    final Index[] all = database.getSchema().getIndexes();
-    final IndexInternal[] suspended = new IndexInternal[all.length];
-    int count = 0;
-    for (final Index idx : all) {
-      try {
-        // Every index type in the tree implements IndexInternal, so this cast does not fail today: the catch is
-        // future-proofing for an implementation that does not, not cover for one that exists (PR #7360 review).
-        final IndexInternal index = (IndexInternal) idx;
-        index.suspendBackgroundMaintenance();
-        suspended[count++] = index;
-      } catch (final Exception e) {
-        LogManager.instance().log(this, Level.WARNING,
-            "GraphBatch: could not suspend the background maintenance of index %s for the bulk load: %s", e,
-            idx.getName(), e.getMessage());
-      }
-    }
-    return count == suspended.length ? suspended : Arrays.copyOf(suspended, count);
-  }
-
-  /**
-   * Lifts the suspensions {@link #suspendIndexBackgroundMaintenance()} took, once. Idempotent because
-   * {@link #abandon()} and {@link #close()} can both reach it, and a second lift would decrement a count this
-   * batch no longer holds - handing another batch's suspension away with it.
-   */
-  private void resumeIndexBackgroundMaintenance() {
-    if (!maintenanceResumed.compareAndSet(false, true))
-      return;
-    for (final IndexInternal index : maintenanceSuspendedIndexes)
-      resumeQuietly(index);
-  }
-
-  /**
-   * One index's resume, never allowed to throw: a batch on its way out must lift every OTHER suspension it holds
-   * whatever one index does, and an index dropped mid-load is the ordinary way this fails.
-   * <p>
-   * Logged at WARNING, the same level a failed suspension gets, and deliberately not lower (PR #7360 review): the
-   * two failures are not equally harmless. A suspension that could not be taken costs an optimization; one that
-   * could not be LIFTED strands that index's background maintenance off until the process reopens the database,
-   * and does it silently. That is worth seeing even when the cause turns out to be an index dropped mid-load.
-   *
-   * @param index the index to resume
-   */
-  private void resumeQuietly(final IndexInternal index) {
-    try {
-      index.resumeBackgroundMaintenance();
-    } catch (final Exception e) {
-      LogManager.instance().log(this, Level.WARNING,
-          "GraphBatch: could not resume the background maintenance of index %s, it stays suspended until this "
-              + "database is reopened: %s", e, index.getName(), e.getMessage());
-    }
+    // delta path meanwhile - and close()/abandon() lift it, which is when the one rebuild the load is actually
+    // worth gets scheduled. A loader that runs several batches in a row holds its own suspension around all of
+    // them (issue #7432); the counts compose, so this one nests inside it.
+    maintenanceSuspension = IndexMaintenanceSuspension.suspend(database, "GraphBatch");
   }
 
   /**
@@ -1508,7 +1436,7 @@ public class GraphBatch implements AutoCloseable {
   public void abandon() {
     database.setReadYourWrites(savedReadYourWrites);
     restoreAsyncSettings();
-    resumeIndexBackgroundMaintenance();
+    maintenanceSuspension.close();
     releaseBatchGuard();
   }
 
@@ -1529,7 +1457,7 @@ public class GraphBatch implements AutoCloseable {
   private void restoreDatabaseSettings() {
     database.setReadYourWrites(savedReadYourWrites);
     restoreAsyncSettings();
-    resumeIndexBackgroundMaintenance();
+    maintenanceSuspension.close();
 
     // If the thread still has no TransactionContext (the batch never began a transaction), nothing leaked.
     final TransactionContext tx = database.getTransactionIfExists();

--- a/engine/src/main/java/com/arcadedb/index/IndexMaintenanceSuspension.java
+++ b/engine/src/main/java/com/arcadedb/index/IndexMaintenanceSuspension.java
@@ -102,13 +102,6 @@ public final class IndexMaintenanceSuspension implements AutoCloseable {
   }
 
   /**
-   * @return how many indexes this suspension holds
-   */
-  public int size() {
-    return suspended.length;
-  }
-
-  /**
    * Lifts the suspensions {@link #suspend(Database, String)} took, once. Idempotent because a loader's abandon and
    * close paths can both reach it, and a second lift would decrement a count this suspension no longer holds -
    * handing another loader's suspension away with it.

--- a/engine/src/main/java/com/arcadedb/index/IndexMaintenanceSuspension.java
+++ b/engine/src/main/java/com/arcadedb/index/IndexMaintenanceSuspension.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.log.LogManager;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+
+/**
+ * One bulk load's hold on the speculative background maintenance of every index of a database, taken with
+ * {@link #suspend(Database, String)} and lifted exactly once by {@link #close()}.
+ * <p>
+ * The maintenance that matters today is the LSM vector index's inactivity graph rebuild: it reads the index going
+ * quiet as "the writer is done", which during a bulk load is produced by the load stalling on a compaction or a
+ * flush burst, and the rebuild it starts then covers only what has been loaded so far and is superseded by the
+ * rest of the load (issue #7357). Suspending is a pure deferral - the writes stay searchable through the index's
+ * own delta path meanwhile - and lifting the last suspension is when the one rebuild the load is actually worth
+ * gets scheduled.
+ * <p>
+ * Suspensions compose: {@link IndexInternal#suspendBackgroundMaintenance()} is reference-counted, so a loader
+ * that opens several batches in a row holds one of these around the whole load and each batch nests its own
+ * inside it, and the index stays quiet across the gaps between the batches as well as during them. That is the
+ * shape {@code GraphImporter} has - a vertex batch, a topology pass with no batch open at all, then one edge
+ * batch per edge type - and the gap between its two batches is exactly where a 4.2M-vector load saw the rebuild
+ * fire and then run alongside the whole edge pass (issue #7432).
+ * <p>
+ * The list is a snapshot taken at {@link #suspend(Database, String)}, and {@link #close()} lifts exactly those:
+ * an index dropped mid-load must still have its suspension lifted, and looking the list up again would silently
+ * leak the count of one that is no longer in the schema. An index created while the suspension is held runs its
+ * background maintenance as usual - an acceptable gap, since creating an index in the middle of a bulk load is
+ * not a shape worth complicating the lifetime of these suspensions for, and the maintenance it would do is over
+ * a corpus it has just been built on.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class IndexMaintenanceSuspension implements AutoCloseable {
+  private static final IndexInternal[] NONE = new IndexInternal[0];
+
+  private final String          owner;
+  private final IndexInternal[] suspended;
+  private final AtomicBoolean   lifted = new AtomicBoolean();
+
+  private IndexMaintenanceSuspension(final String owner, final IndexInternal[] suspended) {
+    this.owner = owner;
+    this.suspended = suspended;
+  }
+
+  /**
+   * Suspends the speculative background maintenance of every index of {@code database}.
+   * <p>
+   * A failure to suspend one index must not leave the load half-suspended and must not fail the load either - the
+   * suspension is an optimization, not a correctness requirement - so an index that cannot be asked is skipped and
+   * the rest are still suspended. Caught per index rather than around the loop for exactly that reason (PR #7360
+   * review): the cast is the failure this is most likely to see, and one {@link Index} that does not implement
+   * {@link IndexInternal} must not cost every OTHER index of the database its suspension.
+   *
+   * @param database the database whose indexes are to be held quiet
+   * @param owner    who is asking, for the log line a failure produces (e.g. {@code "GraphBatch"})
+   *
+   * @return the suspension to {@link #close()} when the load is over; never null
+   */
+  public static IndexMaintenanceSuspension suspend(final Database database, final String owner) {
+    final Index[] all = database.getSchema().getIndexes();
+    if (all.length == 0)
+      return new IndexMaintenanceSuspension(owner, NONE);
+
+    final IndexInternal[] suspended = new IndexInternal[all.length];
+    int count = 0;
+    for (final Index idx : all) {
+      try {
+        // Every index type in the tree implements IndexInternal, so this cast does not fail today: the catch is
+        // future-proofing for an implementation that does not, not cover for one that exists (PR #7360 review).
+        final IndexInternal index = (IndexInternal) idx;
+        index.suspendBackgroundMaintenance();
+        suspended[count++] = index;
+      } catch (final Exception e) {
+        LogManager.instance().log(IndexMaintenanceSuspension.class, Level.WARNING,
+            "%s: could not suspend the background maintenance of index %s for the bulk load: %s", e, owner,
+            idx.getName(), e.getMessage());
+      }
+    }
+    return new IndexMaintenanceSuspension(owner, count == suspended.length ? suspended : Arrays.copyOf(suspended, count));
+  }
+
+  /**
+   * @return how many indexes this suspension holds
+   */
+  public int size() {
+    return suspended.length;
+  }
+
+  /**
+   * Lifts the suspensions {@link #suspend(Database, String)} took, once. Idempotent because a loader's abandon and
+   * close paths can both reach it, and a second lift would decrement a count this suspension no longer holds -
+   * handing another loader's suspension away with it.
+   * <p>
+   * Never throws: a load on its way out must lift every OTHER suspension it holds whatever one index does, and an
+   * index dropped mid-load is the ordinary way one fails. Logged at WARNING, the same level a failed suspension
+   * gets, and deliberately not lower (PR #7360 review): the two failures are not equally harmless. A suspension
+   * that could not be taken costs an optimization; one that could not be LIFTED strands that index's background
+   * maintenance off until the process reopens the database, and does it silently. That is worth seeing even when
+   * the cause turns out to be an index dropped mid-load.
+   */
+  @Override
+  public void close() {
+    if (!lifted.compareAndSet(false, true))
+      return;
+    for (final IndexInternal index : suspended) {
+      try {
+        index.resumeBackgroundMaintenance();
+      } catch (final Exception e) {
+        LogManager.instance().log(IndexMaintenanceSuspension.class, Level.WARNING,
+            "%s: could not resume the background maintenance of index %s, it stays suspended until this database "
+                + "is reopened: %s", e, owner, index.getName(), e.getMessage());
+      }
+    }
+  }
+}

--- a/engine/src/main/java/com/arcadedb/index/vector/ArcadePageVectorValues.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/ArcadePageVectorValues.java
@@ -350,6 +350,7 @@ public class ArcadePageVectorValues implements RandomAccessVectorValues {
    * Both signals are checked because neither alone is reliable: the flag is what {@code PageManager} leaves behind,
    * but a layer in between may have cleared it while wrapping the exception; the cause chain carries the
    * {@link InterruptedIOException} in that case, but not when the read was refused by a check of the flag alone.
+   * Either way the flag is set when this throws, so the cancellation is observable both ways.
    *
    * @param failure the exception the read failed with
    * @param ordinal the ordinal being read, for the message; -1 when the caller reads by offset rather than ordinal
@@ -357,8 +358,13 @@ public class ArcadePageVectorValues implements RandomAccessVectorValues {
    * @throws CancellationException when the failure is an interruption
    */
   static void abortIfInterrupted(final Exception failure, final int ordinal) {
-    if (!Thread.currentThread().isInterrupted() && !causedByInterrupt(failure))
-      return;
+    if (!Thread.currentThread().isInterrupted()) {
+      if (!causedByInterrupt(failure))
+        return;
+      // A caught InterruptedException has cleared the flag as part of being thrown; put it back so a caller that
+      // keys off the flag rather than off this exception's type still sees the cancellation (PR #7433 review).
+      Thread.currentThread().interrupt();
+    }
     final CancellationException cancelled = new CancellationException(
         "Vector read interrupted" + (ordinal >= 0 ? " (ordinal=" + ordinal + ")" : "") + ": " + failure.getMessage());
     cancelled.initCause(failure);

--- a/engine/src/main/java/com/arcadedb/index/vector/ArcadePageVectorValues.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/ArcadePageVectorValues.java
@@ -350,7 +350,11 @@ public class ArcadePageVectorValues implements RandomAccessVectorValues {
    * Both signals are checked because neither alone is reliable: the flag is what {@code PageManager} leaves behind,
    * but a layer in between may have cleared it while wrapping the exception; the cause chain carries the
    * {@link InterruptedIOException} in that case, but not when the read was refused by a check of the flag alone.
-   * Either way the flag is set when this throws, so the cancellation is observable both ways.
+   * Either way the flag is set when this throws, so the cancellation is observable both ways. The flag also makes
+   * the trigger deliberately broad: on an interrupted thread ANY read failure is reported as the cancellation,
+   * including one that would have been a bad page on an uninterrupted thread. That is the right reading for the
+   * only thread that is interrupted today (a build worker being shut down), and it stays right for a query thread
+   * cancelled mid-search: whatever else went wrong, the caller asked for the work to stop.
    *
    * @param failure the exception the read failed with
    * @param ordinal the ordinal being read, for the message; -1 when the caller reads by offset rather than ordinal

--- a/engine/src/main/java/com/arcadedb/index/vector/ArcadePageVectorValues.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/ArcadePageVectorValues.java
@@ -31,7 +31,10 @@ import io.github.jbellis.jvector.vector.VectorizationProvider;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 
+import java.io.InterruptedIOException;
+import java.nio.channels.ClosedByInterruptException;
 import java.util.Arrays;
+import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 
 /**
@@ -222,6 +225,7 @@ public class ArcadePageVectorValues implements RandomAccessVectorValues {
           }
         }
       } catch (final Exception e) {
+        abortIfInterrupted(e, ordinal);
         LogManager.instance().log(this, Level.WARNING,
             "Error reading vector from graph file (ordinal=%d), falling back: %s",
             ordinal, e.getMessage());
@@ -249,6 +253,7 @@ public class ArcadePageVectorValues implements RandomAccessVectorValues {
           return result;
         }
       } catch (final Exception e) {
+        abortIfInterrupted(e, ordinal);
         // Fall through to document-based retrieval
         LogManager.instance().log(this, Level.WARNING,
             "Error reading quantized vector from index pages (ordinal=%d), falling back to document: %s",
@@ -321,10 +326,50 @@ public class ArcadePageVectorValues implements RandomAccessVectorValues {
       // DELETED RECORD — return sentinel to avoid NPE in JVector (issue #3715)
       return deletedSentinelVector;
     } catch (final Exception e) {
+      abortIfInterrupted(e, ordinal);
       LogManager.instance().log(this, Level.WARNING,
           "Error reading vector from document (ordinal=%d, RID=%s): %s", ordinal, rid, e.getMessage());
       return deletedSentinelVector;
     }
+  }
+
+  /**
+   * Turns a read that failed because the calling thread was interrupted into a {@link CancellationException},
+   * instead of letting it be logged and papered over like a bad vector.
+   * <p>
+   * Every read in {@link #getVector(int)} swallows its failure and falls through to the next source, ending on the
+   * deleted sentinel: the right answer for a vector that is genuinely unreadable, and the wrong one for a thread
+   * that has been told to stop. A graph build is cancelled by interrupting its pool workers
+   * ({@code LSMVectorIndex.releaseBackgroundResources()}), and {@code PageManager} refuses I/O on an interrupted
+   * thread and leaves the flag set - so before this, every read after the interrupt failed, was logged at WARNING,
+   * fed the builder a sentinel, and the worker went on to the next node. A 4.2M-vector build cancelled by a database
+   * close logged 42,700 such lines in five seconds and kept its pool alive past the close's 5s grace (issue #7432).
+   * Throwing here ends the parallel insertion at the first interrupted read, which {@code buildGraphFromScratch}
+   * already reports as a cancellation rather than a build failure.
+   * <p>
+   * Both signals are checked because neither alone is reliable: the flag is what {@code PageManager} leaves behind,
+   * but a layer in between may have cleared it while wrapping the exception; the cause chain carries the
+   * {@link InterruptedIOException} in that case, but not when the read was refused by a check of the flag alone.
+   *
+   * @param failure the exception the read failed with
+   * @param ordinal the ordinal being read, for the message; -1 when the caller reads by offset rather than ordinal
+   *
+   * @throws CancellationException when the failure is an interruption
+   */
+  static void abortIfInterrupted(final Exception failure, final int ordinal) {
+    if (!Thread.currentThread().isInterrupted() && !causedByInterrupt(failure))
+      return;
+    final CancellationException cancelled = new CancellationException(
+        "Vector read interrupted" + (ordinal >= 0 ? " (ordinal=" + ordinal + ")" : "") + ": " + failure.getMessage());
+    cancelled.initCause(failure);
+    throw cancelled;
+  }
+
+  private static boolean causedByInterrupt(final Throwable failure) {
+    for (Throwable t = failure; t != null; t = t.getCause())
+      if (t instanceof InterruptedException || t instanceof InterruptedIOException || t instanceof ClosedByInterruptException)
+        return true;
+    return false;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -2300,6 +2300,34 @@ public class LSMVectorIndex implements Index, IndexInternal {
   }
 
   /**
+   * Builds the vector graph now if, and only if, the index has vectors the graph does not cover yet.
+   * <p>
+   * The end of a bulk load, done synchronously. {@link #buildVectorGraphNow(GraphBuildCallback)} always rebuilds;
+   * a loader that touched a type carrying several vector indexes, or one whose index was already current, would
+   * pay a full O(N) build for nothing. The other trigger a load has is the inactivity timer, and that one is
+   * asynchronous: it fires a window after the load, on a background thread, and a caller that closes the database
+   * once the load returns - which is what every loader does - cancels it and loses the build (issue #7432, where a
+   * 20-minute build over 4.2M vectors was cancelled five seconds after "Import complete"). A load is not complete
+   * until the index it wrote to is queryable at index speed, so {@code GraphImporter} calls this before returning.
+   * <p>
+   * Pending work is what {@link #put} and the reopen gap detection count in {@code mutationsSinceSerialize}: the
+   * vectors the delta scan is serving in place of the graph. A count of zero means the graph already covers every
+   * vector this index holds, and nothing is built.
+   *
+   * @param graphCallback optional progress callback invoked during graph construction/persistence; null logs the
+   *                      build's progress the way an automatic rebuild does
+   *
+   * @return true when a build ran, false when the graph was already current
+   */
+  public boolean buildVectorGraphIfPending(final GraphBuildCallback graphCallback) {
+    checkIsValid();
+    if (mutationsSinceSerialize.get() == 0)
+      return false;
+    buildVectorGraphNow(graphCallback);
+    return true;
+  }
+
+  /**
    * Build (or rebuild) the vector graph immediately with an optional progress callback.
    * This forces a full rebuild even if the mutation threshold has not been reached yet.
    *
@@ -3642,9 +3670,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
       LogManager.instance().log(this, Level.INFO, "Built graph for index: " + indexName);
 
     } catch (final CancellationException e) {
-      // releaseBackgroundResources() is this exception's only source (issue #5872): it sets valid = false
-      // before ever cancelling the insertion task, so isValid() is always false by the time this runs. Expected
-      // shutdown, not a build failure: no SEVERE log, and IndexException would misreport it as one.
+      // releaseBackgroundResources() is this exception's only source, by two routes: it cancels the insertion task
+      // directly (issue #5872), and its pool shutdownNow() interrupts the workers, whose next vector read then
+      // throws this rather than feeding the builder a sentinel (issue #7432). Either way it sets valid = false
+      // first, so isValid() is always false by the time this runs. Expected shutdown, not a build failure: no
+      // SEVERE log, and IndexException would misreport it as one.
       LogManager.instance().log(this, Level.INFO, "Graph build for index %s cancelled: index is closing", indexName);
       throw e;
     } catch (final Exception e) {
@@ -5328,6 +5358,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
       }
 
     } catch (final Exception e) {
+      // An interrupted thread has been told to stop, not handed a bad vector (issue #7432): see
+      // ArcadePageVectorValues.abortIfInterrupted() for why this must not be logged and swallowed like one.
+      ArcadePageVectorValues.abortIfInterrupted(e, -1);
       LogManager.instance().log(this, Level.WARNING, "Error reading vector from offset %d: %s", fileOffset,
           e.getMessage());
       return null;

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue7432InterruptedVectorReadAbortsTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue7432InterruptedVectorReadAbortsTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.PageManager;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.util.Random;
+import java.util.concurrent.CancellationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #7432, third defect: a vector read on an interrupted thread was logged and swallowed
+ * like a bad vector.
+ * <p>
+ * A graph build is cancelled by interrupting the workers of its pool, and {@code PageManager} refuses I/O on an
+ * interrupted thread and leaves the flag set. Every read in {@link ArcadePageVectorValues#getVector(int)} caught
+ * its failure, logged it at WARNING, and fell through to the deleted sentinel - so after the interrupt each
+ * worker went on reading, failing and logging, one line per node, until the executor's cancellation surfaced. A
+ * 4.2M-vector build cancelled by a database close logged 42,700 such lines in five seconds and kept its pool alive
+ * past the close's 5s grace. An interrupted read is a cancellation and must end the build at the first one.
+ * <p>
+ * Pinned at the read, where it is deterministic, rather than by racing a close against a build: the read only
+ * reaches the interrupt check when the page is not cached, so each test reopens the database (which drops its
+ * pages from the cache) and evicts again after the location index has been materialised.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7432InterruptedVectorReadAbortsTest {
+  private static final String DB_ROOT    = "target/test-databases/Issue7432InterruptedVectorReadAbortsTest";
+  private static final int    DIMENSIONS = 16;
+  private static final int    RECORDS    = 20;
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+    // The flag must not leak between tests whatever an assertion below does.
+    Thread.interrupted();
+  }
+
+  @AfterEach
+  void tearDown() {
+    Thread.interrupted();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  /**
+   * The document path: an index without quantization reads the vector back from the record.
+   */
+  @Test
+  void anInterruptedDocumentReadIsACancellationNotASentinel() {
+    assertInterruptedReadAborts("{ \"dimensions\": " + DIMENSIONS + ", \"similarity\": \"EUCLIDEAN\" }");
+  }
+
+  /**
+   * The page path: a quantized index reads the vector back from its own pages
+   * ({@code LSMVectorIndex.readVectorFromOffset}), which has a swallowing catch of its own.
+   */
+  @Test
+  void anInterruptedQuantizedPageReadIsACancellationNotASentinel() {
+    assertInterruptedReadAborts("{ \"dimensions\": " + DIMENSIONS
+        + ", \"similarity\": \"EUCLIDEAN\", \"quantization\": \"INT8\" }");
+  }
+
+  private void assertInterruptedReadAborts(final String indexMetadata) {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database created = factory.create();
+      try {
+        created.transaction(() -> {
+          final var type = created.getSchema().createVertexType("Doc");
+          type.createProperty("id", Type.INTEGER);
+          type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+          created.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA " + indexMetadata);
+        });
+        created.begin();
+        for (int i = 0; i < RECORDS; i++)
+          created.newVertex("Doc").set("id", i).set("vector", embedding(i)).save();
+        created.commit();
+      } finally {
+        // Closing drops this database's pages from the cache; the reads below start cold.
+        created.close();
+      }
+
+      final Database db = factory.open();
+      try {
+        final LSMVectorIndex index = (LSMVectorIndex) db.getSchema().getType("Doc")
+            .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+
+        // Materialising the location index scans the index pages, so evict again after it.
+        final VectorLocationIndex locations = index.getVectorIndex();
+        final int vectorId = locations.getActiveVectorIds().findFirst().orElseThrow();
+        PageManager.INSTANCE.removeAllReadPagesOfDatabase(db);
+
+        final ArcadePageVectorValues values = ArcadePageVectorValues.forSearch((DatabaseInternal) db, DIMENSIONS,
+            "vector", locations, new int[] { vectorId }, index);
+
+        Thread.currentThread().interrupt();
+        try {
+          assertThatThrownBy(() -> values.getVector(0))
+              .as("a read refused because the thread was interrupted is a cancellation, not a vector that "
+                  + "could not be read: swallowing it fed the graph builder a sentinel per node and logged a "
+                  + "line per node for the rest of the build (issue #7432)")
+              .isInstanceOf(CancellationException.class);
+        } finally {
+          assertThat(Thread.interrupted()).as("the read leaves the interrupt flag for the caller to observe").isTrue();
+        }
+
+        // The control: the same read with the flag clear returns the vector, so the throw above was the
+        // interruption and not a fixture that cannot read vectors at all.
+        final VectorFloat<?> vector = values.getVector(0);
+        assertThat(values.isDeletedSentinel(vector)).as("a real vector, not the sentinel").isFalse();
+        assertThat(vector.length()).isEqualTo(DIMENSIONS);
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  /** Deterministic per-id embedding, so a fixture is reproducible run to run. */
+  private static float[] embedding(final int id) {
+    final Random random = new Random(0x7432L * 17 + id);
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = random.nextFloat();
+    return vector;
+  }
+}

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -25,6 +25,9 @@ import com.arcadedb.graph.GraphBatch;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.olap.GraphAnalyticalView;
 import com.arcadedb.graph.olap.GraphAnalyticalViewRegistry;
+import com.arcadedb.index.Index;
+import com.arcadedb.index.IndexMaintenanceSuspension;
+import com.arcadedb.index.vector.LSMVectorIndex;
 import com.arcadedb.index.vector.VectorUtils;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONArray;
@@ -60,7 +63,14 @@ import java.util.logging.Level;
  *       collect graph topology as compressed int arrays (~300 MB for 8M vertices / 15M edges).</li>
  *   <li><b>Pass 2</b> — Create all edges from the in-memory topology, one batch per edge type
  *       with bidirectional=true for full IN+OUT traversal.</li>
+ *   <li><b>Vector graphs</b> — Build the graph of every LSM vector index on a type the import wrote to,
+ *       synchronously, so the index is queryable at index speed when {@link #run()} returns. Opt out with
+ *       {@link Builder#withVectorGraphBuild(boolean)} to leave it to the index's own background rebuild.</li>
  * </ol>
+ * <p>
+ * The speculative background maintenance of the database's indexes (the vector index's inactivity rebuild) is
+ * suspended for the whole of {@link #run()}, not only while one of its batches is open: the gap between the two
+ * passes is where it used to fire and then run alongside the whole edge pass (issue #7432).
  * <p>
  * Usage:
  * <pre>
@@ -107,6 +117,7 @@ public class GraphImporter implements AutoCloseable {
   private final List<VertexSourceDef>               vertexSources;
   private final List<EdgeSourceDef>                 edgeSources;
   private final long                                limit;
+  private final boolean                             vectorGraphBuild;
   private final Map<String, TypeState>              typeStates     = new LinkedHashMap<>();
   private final Map<String, EdgeCollector>          edgeCollectors = new LinkedHashMap<>();
 
@@ -115,11 +126,12 @@ public class GraphImporter implements AutoCloseable {
   private long unresolvedEdges;
 
   private GraphImporter(final Database database, final List<VertexSourceDef> vertexSources,
-                        final List<EdgeSourceDef> edgeSources, final long limit) {
+                        final List<EdgeSourceDef> edgeSources, final long limit, final boolean vectorGraphBuild) {
     this.database = database;
     this.vertexSources = vertexSources;
     this.edgeSources = edgeSources;
     this.limit = limit;
+    this.vectorGraphBuild = vectorGraphBuild;
   }
 
   // ═══════════════════════════════════════════════════════════════════
@@ -293,6 +305,8 @@ public class GraphImporter implements AutoCloseable {
 
     if (config.has("limit"))
       b.limit(config.getLong("limit"));
+    if (config.has("vectorGraphBuild"))
+      b.withVectorGraphBuild(config.getBoolean("vectorGraphBuild"));
 
     // Vertex sources
     if (config.has("vertices")) {
@@ -563,6 +577,7 @@ public class GraphImporter implements AutoCloseable {
     private final List<VertexSourceDef> vertexSources = new ArrayList<>();
     private final List<EdgeSourceDef>   edgeSources   = new ArrayList<>();
     private       long                  limit;
+    private       boolean               vectorGraphBuild = true;
 
     Builder(final Database database) {
       this.database = database;
@@ -598,8 +613,21 @@ public class GraphImporter implements AutoCloseable {
       return this;
     }
 
+    /**
+     * Whether {@link #run()} ends by building the graph of every LSM vector index on a type the import wrote to
+     * (the default), so the index answers at graph speed the moment the import returns and a database close that
+     * follows finds nothing left to do. {@code false} leaves the build to the index's own background rebuild, which
+     * starts once the index has been quiet for its inactivity window - only useful when the database stays open
+     * long enough for that build to complete, since a close cancels it (issue #7432). JSON key:
+     * {@code "vectorGraphBuild"}.
+     */
+    public Builder withVectorGraphBuild(final boolean enabled) {
+      this.vectorGraphBuild = enabled;
+      return this;
+    }
+
     public GraphImporter build() {
-      return new GraphImporter(database, vertexSources, edgeSources, limit);
+      return new GraphImporter(database, vertexSources, edgeSources, limit, vectorGraphBuild);
     }
   }
 
@@ -953,38 +981,52 @@ public class GraphImporter implements AutoCloseable {
 
     validateEdgeTargets();
 
-    // ── Pass 1: Create vertices + collect topology ──
-    LogManager.instance().log(this, Level.INFO, "Pass 1: Vertices + Topology");
+    // Held around the WHOLE import, not only while one of the batches below is open. Each GraphBatch suspends the
+    // indexes' speculative maintenance for its own lifetime (issue #7357), but this importer is not one batch: the
+    // vertex batch closes, the edge sources are read for their topology with no batch open at all, then one edge
+    // batch per edge type opens. The first close used to lift the only suspension and arm the vector index's
+    // inactivity timer, which fired in that gap and started a full graph build that then ran alongside the whole
+    // edge pass (issue #7432). The counts compose, so the batches' own suspensions nest inside this one.
+    try (final IndexMaintenanceSuspension maintenance = IndexMaintenanceSuspension.suspend(database, "GraphImporter")) {
+      // ── Pass 1: Create vertices + collect topology ──
+      LogManager.instance().log(this, Level.INFO, "Pass 1: Vertices + Topology");
 
-    try (final GraphBatch batch = database.batch()
-        .withBidirectional(false)
-        .withWAL(false)
-        .withPreAllocateEdgeChunks(true)
-        .withCommitEvery(0)
-        .build()) {
+      try (final GraphBatch batch = database.batch()
+          .withBidirectional(false)
+          .withWAL(false)
+          .withPreAllocateEdgeChunks(true)
+          .withCommitEvery(0)
+          .build()) {
 
-      for (final VertexSourceDef vsd : vertexSources)
-        processVertexSource(batch, vsd);
+        for (final VertexSourceDef vsd : vertexSources)
+          processVertexSource(batch, vsd);
+      }
+
+      // Process edge-only sources
+      for (int i = 0; i < edgeSources.size(); i++)
+        processEdgeSource(edgeSources.get(i), i);
+
+      // Free ID maps (edges now use internal indices)
+      for (final TypeState ts : typeStates.values()) {
+        ts.idToIdx = null;
+        ts.nameToIdx = null;
+      }
+
+      LogManager.instance().log(this, Level.INFO, "  Topology: %,d vertices, %,d edge refs", totalVertices,
+          countEdgeRefs());
+
+      // ── Pass 2: Create edges from topology ──
+      LogManager.instance().log(this, Level.INFO, "Pass 2: Edges (bidirectional)");
+
+      for (final EdgeCollector ec : edgeCollectors.values())
+        flushEdgeType(ec);
+
+      // ── Vector graphs: the part of the index state the load leaves deferred, built before this returns ──
+      // Still under the suspension: a build that ran here with the timer live could race an inactivity rebuild
+      // for the same corpus. Once this has drained the pending count, lifting the suspension arms nothing.
+      if (vectorGraphBuild)
+        buildVectorGraphs();
     }
-
-    // Process edge-only sources
-    for (int i = 0; i < edgeSources.size(); i++)
-      processEdgeSource(edgeSources.get(i), i);
-
-    // Free ID maps (edges now use internal indices)
-    for (final TypeState ts : typeStates.values()) {
-      ts.idToIdx = null;
-      ts.nameToIdx = null;
-    }
-
-    LogManager.instance().log(this, Level.INFO, "  Topology: %,d vertices, %,d edge refs", totalVertices,
-        countEdgeRefs());
-
-    // ── Pass 2: Create edges from topology ──
-    LogManager.instance().log(this, Level.INFO, "Pass 2: Edges (bidirectional)");
-
-    for (final EdgeCollector ec : edgeCollectors.values())
-      flushEdgeType(ec);
 
     final long elapsed = System.currentTimeMillis() - start;
     LogManager.instance().log(this, Level.INFO, "Import complete: %,d vertices, %,d edges in %d.%ds",
@@ -993,6 +1035,40 @@ public class GraphImporter implements AutoCloseable {
       LogManager.instance().log(this, Level.WARNING,
           "%,d edges named an identity no vertex carries and were skipped: check that the referenced rows "
               + "are not filtered out and that both files spell the identity the same way", unresolvedEdges);
+  }
+
+  /**
+   * Builds, synchronously, the graph of every LSM vector index on a type this import wrote to that has vectors its
+   * graph does not cover yet. Indexes on other types are not this import's business, and one whose graph is
+   * already current is skipped by the index itself.
+   * <p>
+   * Synchronous by design: the alternative is the index's own inactivity rebuild, which starts a window after the
+   * load on a background thread, and the database close that follows every completed load cancels it - the
+   * reporter of issue #7432 lost a 20-minute build over 4.2M vectors five seconds after "Import complete". A load
+   * whose index would need another half hour of background work the caller cannot see is not complete.
+   * <p>
+   * A build that fails propagates: the data is on disk, but "Import complete" must not be logged over an index
+   * that is not.
+   */
+  private void buildVectorGraphs() {
+    final Set<String> touchedTypes = new HashSet<>(typeStates.keySet());
+    for (final EdgeCollector ec : edgeCollectors.values())
+      touchedTypes.add(ec.edgeTypeName);
+
+    for (final Index index : database.getSchema().getIndexes()) {
+      if (!(index instanceof LSMVectorIndex vectorIndex) || !touchedTypes.contains(vectorIndex.getTypeName()))
+        continue;
+
+      final long t = System.currentTimeMillis();
+      LogManager.instance().log(this, Level.INFO, "Building vector graph for index '%s' on type '%s'...",
+          vectorIndex.getName(), vectorIndex.getTypeName());
+      if (vectorIndex.buildVectorGraphIfPending(null))
+        LogManager.instance().log(this, Level.INFO, "  Vector graph for index '%s' built in %,d ms",
+            vectorIndex.getName(), System.currentTimeMillis() - t);
+      else
+        LogManager.instance().log(this, Level.INFO, "  Vector graph for index '%s' already current, nothing to build",
+            vectorIndex.getName());
+    }
   }
 
   /**

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -70,7 +70,11 @@ import java.util.logging.Level;
  * <p>
  * The speculative background maintenance of the database's indexes (the vector index's inactivity rebuild) is
  * suspended for the whole of {@link #run()}, not only while one of its batches is open: the gap between the two
- * passes is where it used to fire and then run alongside the whole edge pass (issue #7432).
+ * passes is where it used to fire and then run alongside the whole edge pass (issue #7432). The suspension covers
+ * EVERY index of the database, as a {@link GraphBatch}'s does, and lasts for the load plus the graph build at the
+ * end of it - half an hour at a few million vectors. An unrelated writer sharing the same open database has that
+ * index's automatic rebuild deferred for that long; its writes stay searchable through the delta scan meanwhile.
+ * The importer is meant for a database being loaded, not one serving other writers at the same time.
  * <p>
  * Usage:
  * <pre>
@@ -1051,6 +1055,10 @@ public class GraphImporter implements AutoCloseable {
    * that is not.
    */
   private void buildVectorGraphs() {
+    // Matched on the type each bucket index names. A vector index declared on a parent type covers the buckets
+    // of every subtype through one bucket index per bucket, and each of those names the SUBTYPE that owns the
+    // bucket, so an import that writes only to a subtype matches its bucket index here without walking the
+    // hierarchy (PR #7433 review; pinned by Issue7432GraphImporterVectorGraphTest).
     final Set<String> touchedTypes = new HashSet<>(typeStates.keySet());
     for (final EdgeCollector ec : edgeCollectors.values())
       touchedTypes.add(ec.edgeTypeName);
@@ -1060,13 +1068,11 @@ public class GraphImporter implements AutoCloseable {
         continue;
 
       final long t = System.currentTimeMillis();
-      LogManager.instance().log(this, Level.INFO, "Building vector graph for index '%s' on type '%s'...",
-          vectorIndex.getName(), vectorIndex.getTypeName());
       if (vectorIndex.buildVectorGraphIfPending(null))
-        LogManager.instance().log(this, Level.INFO, "  Vector graph for index '%s' built in %,d ms",
-            vectorIndex.getName(), System.currentTimeMillis() - t);
+        LogManager.instance().log(this, Level.INFO, "  Vector graph for index '%s' on type '%s' built in %,d ms",
+            vectorIndex.getName(), vectorIndex.getTypeName(), System.currentTimeMillis() - t);
       else
-        LogManager.instance().log(this, Level.INFO, "  Vector graph for index '%s' already current, nothing to build",
+        LogManager.instance().log(this, Level.FINE, "  Vector graph for index '%s' already current, nothing to build",
             vectorIndex.getName());
     }
   }

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.logging.Level;
@@ -1062,9 +1063,18 @@ public class GraphImporter implements AutoCloseable {
     // of every subtype through one bucket index per bucket, and each of those names the SUBTYPE that owns the
     // bucket, so an import that writes only to a subtype matches its bucket index here without walking the
     // hierarchy (PR #7433 review; pinned by Issue7432GraphImporterVectorGraphTest).
-    final Set<String> touchedTypes = new HashSet<>(typeStates.keySet());
+    //
+    // "Wrote to" is counted, not configured (PR #7433 review): a type is in typeStates as soon as a source names
+    // it, or as soon as an edge points at it, and an edge collector exists for every edge mapping - a source that
+    // was filtered down to nothing, or one that turned out empty, must not have this import rebuild an index it
+    // never touched, over pending work that is somebody else's.
+    final Set<String> touchedTypes = new HashSet<>();
+    for (final Map.Entry<String, TypeState> entry : typeStates.entrySet())
+      if (entry.getValue().count > 0)
+        touchedTypes.add(entry.getKey());
     for (final EdgeCollector ec : edgeCollectors.values())
-      touchedTypes.add(ec.edgeTypeName);
+      if (ec.srcIdx.size > 0)
+        touchedTypes.add(ec.edgeTypeName);
 
     for (final Index index : database.getSchema().getIndexes()) {
       if (!(index instanceof LSMVectorIndex vectorIndex) || !touchedTypes.contains(vectorIndex.getTypeName()))
@@ -1078,6 +1088,10 @@ public class GraphImporter implements AutoCloseable {
         else
           LogManager.instance().log(this, Level.FINE, "  Vector graph for index '%s' already current, nothing to build",
               vectorIndex.getName());
+      } catch (final CancellationException e) {
+        // The importer's own thread was interrupted: every later build would see the flag too and fail the same
+        // way, so this is the caller's cancellation to receive now, not a failure to log and carry on from.
+        throw e;
       } catch (final RuntimeException e) {
         if (firstFailure == null)
           firstFailure = e;

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -1052,9 +1052,12 @@ public class GraphImporter implements AutoCloseable {
    * whose index would need another half hour of background work the caller cannot see is not complete.
    * <p>
    * A build that fails propagates: the data is on disk, but "Import complete" must not be logged over an index
-   * that is not.
+   * that is not. It propagates AFTER the other indexes have had their builds (PR #7433 review): one index whose
+   * build fails must not leave the graphs of the others unbuilt as well, or the caller would have to rerun the
+   * whole import to get them. The first failure is what is thrown; the later ones are logged against it.
    */
   private void buildVectorGraphs() {
+    RuntimeException firstFailure = null;
     // Matched on the type each bucket index names. A vector index declared on a parent type covers the buckets
     // of every subtype through one bucket index per bucket, and each of those names the SUBTYPE that owns the
     // bucket, so an import that writes only to a subtype matches its bucket index here without walking the
@@ -1068,13 +1071,25 @@ public class GraphImporter implements AutoCloseable {
         continue;
 
       final long t = System.currentTimeMillis();
-      if (vectorIndex.buildVectorGraphIfPending(null))
-        LogManager.instance().log(this, Level.INFO, "  Vector graph for index '%s' on type '%s' built in %,d ms",
-            vectorIndex.getName(), vectorIndex.getTypeName(), System.currentTimeMillis() - t);
-      else
-        LogManager.instance().log(this, Level.FINE, "  Vector graph for index '%s' already current, nothing to build",
-            vectorIndex.getName());
+      try {
+        if (vectorIndex.buildVectorGraphIfPending(null))
+          LogManager.instance().log(this, Level.INFO, "  Vector graph for index '%s' on type '%s' built in %,d ms",
+              vectorIndex.getName(), vectorIndex.getTypeName(), System.currentTimeMillis() - t);
+        else
+          LogManager.instance().log(this, Level.FINE, "  Vector graph for index '%s' already current, nothing to build",
+              vectorIndex.getName());
+      } catch (final RuntimeException e) {
+        if (firstFailure == null)
+          firstFailure = e;
+        else
+          firstFailure.addSuppressed(e);
+        LogManager.instance().log(this, Level.SEVERE, "  Vector graph for index '%s' on type '%s' could not be built: %s",
+            e, vectorIndex.getName(), vectorIndex.getTypeName(), e.getMessage());
+      }
     }
+
+    if (firstFailure != null)
+      throw firstFailure;
   }
 
   /**

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue7432GraphImporterVectorGraphTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue7432GraphImporterVectorGraphTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.index.vector.LSMVectorIndex;
+import com.arcadedb.integration.importer.graph.CsvRowSource;
+import com.arcadedb.integration.importer.graph.GraphImporter;
+import com.arcadedb.integration.importer.graph.JsonlRowSource;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.StallAwareStopwatch;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7432: a {@link GraphImporter} load into a type carrying an {@code LSM_VECTOR} index
+ * ended with no graph, twice over.
+ * <p>
+ * {@code GraphBatch} suspends the index's inactivity rebuild while it is open (issue #7357), but the importer is
+ * not one batch: the vertex batch closes, the edge sources are read for their topology with no batch open, then
+ * one edge batch per edge type opens. The first close lifted the only suspension and armed the timer, which fired
+ * in that gap and started a full build that then ran alongside the whole edge pass. And the one build the load is
+ * worth was scheduled by the timer, asynchronously, a window after the load - so the {@code database.close()} that
+ * follows every completed import cancelled it. The reporter lost a 20-minute build over 4.2M vectors five seconds
+ * after "Import complete".
+ * <p>
+ * The fixture is the reporter's shape at toy scale: a JSONL vertex file with an embedding per row, a tab-separated
+ * edge file, a unique index on the id and an INT8 vector index storing its vectors in the graph.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7432GraphImporterVectorGraphTest {
+  private static final String DB_PATH    = "target/databases/issue-7432-graph-importer-vector-graph";
+  private static final String DATA_DIR   = "target/test-data/issue-7432";
+  private static final int    DIMENSIONS = 16;
+  private static final int    VERTICES   = 300;
+  private static final int    TIMEOUT_MS = 300;
+
+  private DatabaseFactory factory;
+  private Database        database;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    writeFixture();
+    factory = new DatabaseFactory(DB_PATH);
+    database = factory.create();
+    createSchema(database);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null && database.isOpen())
+      database.drop();
+    else
+      FileUtils.deleteRecursively(new File(DB_PATH));
+    if (factory != null)
+      factory.close();
+    FileUtils.deleteRecursively(new File(DATA_DIR));
+  }
+
+  /**
+   * The edge source stalls for several inactivity windows before yielding its first row. In the importer that
+   * stall lands exactly between the vertex batch's close and the edge batch's open, which is the gap the rebuild
+   * used to fire in. One build for the whole load, run by the importer itself before {@code run()} returns, and
+   * a database closed the moment the import returns reopens with that graph on disk.
+   */
+  @Test
+  void theRebuildWaitsForTheWholeImportAndTheGraphIsBuiltBeforeRunReturns() throws Exception {
+    final LSMVectorIndex index = vectorIndex(database);
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("WORK", new JsonlRowSource(DATA_DIR + "/vertices.jsonl"), v -> {
+          v.id("id");
+          v.longProperty("id", "id");
+          v.floatArrayProperty("embedding", "embedding");
+        })
+        .edgeSource("CITE", new StallingSource(new CsvRowSource(DATA_DIR + "/edges.tsv", '\t', 0), TIMEOUT_MS * 6L, () -> {
+          // Observed from inside the gap, where the vertex batch is closed and no edge batch is open yet. Without
+          // the importer's own suspension the timer has fired by now and, on a graph this small, built
+          // synchronously on its own thread - which the count after run() cannot tell apart from the importer's
+          // build, because that one finds nothing pending and skips.
+          final Map<String, Long> midGap = index.getStats();
+          assertThat(midGap.get("graphRebuildCount"))
+              .as("no rebuild fires in the gap between the vertex pass and the edge pass (issue #7432)").isZero();
+          assertThat(midGap.get("asyncRebuildInProgress")).as("nor is one running").isZero();
+          assertThat(midGap.get("backgroundMaintenanceSuspensions"))
+              .as("the importer's suspension is what holds the timer off while no batch is open").isEqualTo(1L);
+        }), e -> {
+          e.from("from_id", "WORK");
+          e.to("to_id", "WORK");
+        })
+        .build()) {
+
+      importer.run();
+      assertThat(importer.getVertexCount()).isEqualTo(VERTICES);
+      assertThat(importer.getEdgeCount()).isEqualTo(VERTICES * 2L);
+    }
+
+    final Map<String, Long> stats = index.getStats();
+    assertThat(stats.get("graphRebuildCount"))
+        .as("exactly one build for the whole load: the importer's own, and none from the inactivity timer in the "
+            + "gap between the vertex pass and the edge pass (issue #7432)")
+        .isEqualTo(1L);
+    assertThat(stats.get("graphNodeCount"))
+        .as("and it covers every vector the load wrote")
+        .isEqualTo((long) VERTICES);
+    assertThat(stats.get("mutationsSinceRebuild"))
+        .as("nothing is left for a background rebuild the caller cannot see")
+        .isZero();
+    assertThat(stats.get("asyncRebuildInProgress"))
+        .as("the build ran on the importer's thread, so run() returned with it complete")
+        .isZero();
+    assertThat(stats.get("backgroundMaintenanceSuspensions"))
+        .as("the importer lifted its own suspension on the way out")
+        .isZero();
+
+    // The reporter's next line: close the database as soon as the import returns. The graph must be on disk.
+    database.close();
+    database = factory.open();
+    final LSMVectorIndex reopened = vectorIndex(database);
+    assertThat(reopened.getStats().get("persistedGraphNodeCount"))
+        .as("the graph built before run() returned survived the close that followed it")
+        .isEqualTo((long) VERTICES);
+    assertThat(reopened.getStats().get("mutationsSinceRebuild"))
+        .as("no vector is outside the persisted graph on reopen")
+        .isZero();
+
+    assertThat(nearestId(database, 42)).as("and the reopened index answers from that graph").isEqualTo(1_000_042L);
+  }
+
+  /**
+   * The JSON form of the opt-out, for a loader that keeps the database open and prefers the index's background
+   * rebuild. The load leaves its vectors pending and the index unsuspended, and nothing has been built on the
+   * importer's thread.
+   */
+  @Test
+  void optingOutLeavesTheBuildToTheIndex() throws Exception {
+    // Well beyond the test: a background rebuild must not start before the assertions below read the counters.
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS, 600_000);
+    final LSMVectorIndex index = vectorIndex(database);
+
+    final JSONObject config = new JSONObject()
+        .put("vectorGraphBuild", false)
+        .put("vertices", new JSONArray().put(new JSONObject()
+            .put("type", "WORK").put("file", "vertices.jsonl").put("id", "id")
+            .put("properties", new JSONObject().put("id", "long:id").put("embedding", "vector:embedding"))))
+        .put("edgeSources", new JSONArray().put(new JSONObject()
+            .put("edge", "CITE").put("file", "edges.tsv").put("format", "csv").put("delimiter", "\t")
+            .put("from", "from_id:WORK").put("to", "to_id:WORK")));
+
+    try (final GraphImporter importer = GraphImporter.fromJSON(database, config, DATA_DIR)) {
+      importer.run();
+      assertThat(importer.getVertexCount()).isEqualTo(VERTICES);
+      assertThat(importer.getEdgeCount()).isEqualTo(VERTICES * 2L);
+    }
+
+    final Map<String, Long> stats = index.getStats();
+    assertThat(stats.get("graphRebuildCount")).as("opted out: the importer built nothing").isZero();
+    assertThat(stats.get("mutationsSinceRebuild"))
+        .as("every vector is still pending, served by the delta scan until the index rebuilds on its own")
+        .isEqualTo((long) VERTICES);
+    assertThat(stats.get("backgroundMaintenanceSuspensions"))
+        .as("and the index is free to do so: the importer lifted its suspension")
+        .isZero();
+  }
+
+  /**
+   * Wraps a source so that its first row comes only after {@code stallMs} of running time: what an LSM compaction
+   * or a GC pause looks like from inside the vector index, placed where the importer has no batch open. Runs
+   * {@code afterStall} before the first row, which is where the test looks at what the stall did.
+   */
+  private static final class StallingSource implements GraphImporter.RecordSource {
+    private final GraphImporter.RecordSource delegate;
+    private final long                       stallMs;
+    private final Runnable                   afterStall;
+
+    private StallingSource(final GraphImporter.RecordSource delegate, final long stallMs, final Runnable afterStall) {
+      this.delegate = delegate;
+      this.stallMs = stallMs;
+      this.afterStall = afterStall;
+    }
+
+    @Override
+    public void forEach(final GraphImporter.RecordVisitor visitor) throws Exception {
+      // Running time, not wall clock: a stop-the-world pause covering the stall would leave the timer no CPU to
+      // fire on, and "nothing rebuilt" would then hold because nothing ran rather than because the suspension held.
+      final StallAwareStopwatch stall = StallAwareStopwatch.start();
+      while (stall.effectiveMs() < stallMs)
+        Thread.sleep(25);
+      afterStall.run();
+      delegate.forEach(visitor);
+    }
+
+    @Override
+    public Character fieldSeparator() {
+      return delegate.fieldSeparator();
+    }
+  }
+
+  private static void createSchema(final Database db) {
+    db.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS, TIMEOUT_MS);
+    db.command("sqlscript", """
+        CREATE VERTEX TYPE WORK;
+        CREATE PROPERTY WORK.id LONG;
+        CREATE PROPERTY WORK.embedding ARRAY_OF_FLOATS;
+        CREATE INDEX ON WORK (id) UNIQUE;
+        CREATE INDEX ON WORK (embedding) LSM_VECTOR METADATA {
+          "dimensions": %d, "similarity": "COSINE", "quantization": "INT8", "storeVectorsInGraph": true
+        };
+        CREATE EDGE TYPE CITE;
+        """.formatted(DIMENSIONS));
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("WORK")
+        .getPolymorphicIndexByProperties("embedding").getIndexesOnBuckets()[0];
+  }
+
+  private static long nearestId(final Database db, final int id) {
+    try (final ResultSet rs = db.query("sql",
+        "SELECT id FROM (SELECT expand(vectorNeighbors('WORK[embedding]', ?, 1)))", (Object) embedding(id))) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next().getProperty("id");
+    }
+  }
+
+  private static void writeFixture() throws IOException {
+    final File dir = new File(DATA_DIR);
+    FileUtils.deleteRecursively(dir);
+    assertThat(dir.mkdirs()).isTrue();
+
+    final StringBuilder vertices = new StringBuilder();
+    for (int i = 0; i < VERTICES; i++)
+      // Arrays.toString() spells a float[] as a JSON array.
+      vertices.append("{\"id\":").append(1_000_000L + i).append(",\"embedding\":").append(Arrays.toString(embedding(i)))
+          .append("}\n");
+    Files.writeString(new File(dir, "vertices.jsonl").toPath(), vertices.toString(), StandardCharsets.UTF_8);
+
+    final StringBuilder edges = new StringBuilder("from_id\tto_id\n");
+    for (int i = 0; i < VERTICES; i++) {
+      edges.append(1_000_000L + i).append('\t').append(1_000_000L + (i + 1) % VERTICES).append('\n');
+      edges.append(1_000_000L + i).append('\t').append(1_000_000L + (i * 7) % VERTICES).append('\n');
+    }
+    Files.writeString(new File(dir, "edges.tsv").toPath(), edges.toString(), StandardCharsets.UTF_8);
+  }
+
+  /** Deterministic per-id embedding, so a fixture is reproducible run to run. */
+  private static float[] embedding(final int id) {
+    final Random random = new Random(0x7432L * 17 + id);
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = random.nextFloat();
+    return vector;
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue7432GraphImporterVectorGraphTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue7432GraphImporterVectorGraphTest.java
@@ -163,6 +163,58 @@ class Issue7432GraphImporterVectorGraphTest {
   }
 
   /**
+   * The per-index loop: a second vector index on a type the import never touched keeps its own pending vectors
+   * and is not built (it is not this import's business), and an index declared on a PARENT type is built when the
+   * import writes only to a subtype. The importer matches on the type each bucket index names, and the subtype's
+   * bucket index names the subtype - pinned here because it is what makes the match correct without a walk of the
+   * hierarchy (PR #7433 review).
+   */
+  @Test
+  void aParentTypeIndexIsBuiltAndAnUntouchedTypeIndexIsLeftAlone() throws Exception {
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS, 600_000);
+    database.command("sqlscript", """
+        CREATE VERTEX TYPE PAPER EXTENDS WORK;
+        CREATE VERTEX TYPE NOTE;
+        CREATE PROPERTY NOTE.embedding ARRAY_OF_FLOATS;
+        CREATE INDEX ON NOTE (embedding) LSM_VECTOR METADATA { "dimensions": %d, "similarity": "COSINE" };
+        """.formatted(DIMENSIONS));
+    database.transaction(() -> {
+      for (int i = 0; i < 5; i++)
+        database.newVertex("NOTE").set("embedding", embedding(i)).save();
+    });
+    final LSMVectorIndex noteIndex = (LSMVectorIndex) database.getSchema().getType("NOTE")
+        .getPolymorphicIndexByProperties("embedding").getIndexesOnBuckets()[0];
+    assertThat(noteIndex.getStats().get("mutationsSinceRebuild")).as("precondition: NOTE has work pending").isEqualTo(5L);
+
+    try (final GraphImporter importer = GraphImporter.builder(database)
+        .vertex("PAPER", new JsonlRowSource(DATA_DIR + "/vertices.jsonl"), v -> {
+          v.id("id");
+          v.longProperty("id", "id");
+          v.floatArrayProperty("embedding", "embedding");
+        })
+        .build()) {
+      importer.run();
+      assertThat(importer.getVertexCount()).isEqualTo(VERTICES);
+    }
+
+    // The index on WORK covers PAPER's bucket through its own bucket index, which names PAPER as its type.
+    final int paperBucket = database.getSchema().getType("PAPER").getBuckets(false).get(0).getFileId();
+    final LSMVectorIndex paperIndex = (LSMVectorIndex) Arrays.stream(database.getSchema().getType("PAPER")
+            .getPolymorphicIndexByProperties("embedding").getIndexesOnBuckets())
+        .filter(i -> i.getAssociatedBucketId() == paperBucket).findFirst().orElseThrow();
+    assertThat(paperIndex.getTypeName()).as("the shape the type match relies on: the subtype's bucket index names the subtype")
+        .isEqualTo("PAPER");
+    assertThat(paperIndex.getStats().get("graphRebuildCount"))
+        .as("the parent-type index the import wrote into through the subtype is built").isEqualTo(1L);
+    assertThat(paperIndex.getStats().get("graphNodeCount")).isEqualTo((long) VERTICES);
+    assertThat(paperIndex.getStats().get("mutationsSinceRebuild")).isZero();
+
+    assertThat(noteIndex.getStats().get("graphRebuildCount"))
+        .as("an index on a type the import never touched is left to its own rebuild").isZero();
+    assertThat(noteIndex.getStats().get("mutationsSinceRebuild")).isEqualTo(5L);
+  }
+
+  /**
    * The JSON form of the opt-out, for a loader that keeps the database open and prefers the index's background
    * rebuild. The load leaves its vectors pending and the index unsuspended, and nothing has been built on the
    * importer's thread.

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue7432GraphImporterVectorGraphTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue7432GraphImporterVectorGraphTest.java
@@ -163,14 +163,15 @@ class Issue7432GraphImporterVectorGraphTest {
   }
 
   /**
-   * The per-index loop: a second vector index on a type the import never touched keeps its own pending vectors
-   * and is not built (it is not this import's business), and an index declared on a PARENT type is built when the
+   * The per-index loop: a second vector index on a type the import CONFIGURED a source for but wrote nothing to
+   * (the source is filtered down to no rows) keeps its own pending vectors and is not built - the import never
+   * touched it, and the pending work is somebody else's - and an index declared on a PARENT type is built when the
    * import writes only to a subtype. The importer matches on the type each bucket index names, and the subtype's
    * bucket index names the subtype - pinned here because it is what makes the match correct without a walk of the
    * hierarchy (PR #7433 review).
    */
   @Test
-  void aParentTypeIndexIsBuiltAndAnUntouchedTypeIndexIsLeftAlone() throws Exception {
+  void aParentTypeIndexIsBuiltAndAnIndexNothingWasWrittenToIsLeftAlone() throws Exception {
     database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS, 600_000);
     database.command("sqlscript", """
         CREATE VERTEX TYPE PAPER EXTENDS WORK;
@@ -192,9 +193,15 @@ class Issue7432GraphImporterVectorGraphTest {
           v.longProperty("id", "id");
           v.floatArrayProperty("embedding", "embedding");
         })
+        // Configured, so NOTE is a type this import knows about, but the filter admits no row: nothing is written.
+        .vertex("NOTE", new JsonlRowSource(DATA_DIR + "/vertices.jsonl"), v -> {
+          v.id("id");
+          v.filter("id", "no such id");
+          v.floatArrayProperty("embedding", "embedding");
+        })
         .build()) {
       importer.run();
-      assertThat(importer.getVertexCount()).isEqualTo(VERTICES);
+      assertThat(importer.getVertexCount()).as("PAPER's rows only; NOTE's source admitted none").isEqualTo(VERTICES);
     }
 
     // The index on WORK covers PAPER's bucket through its own bucket index, which names PAPER as its type.
@@ -210,7 +217,8 @@ class Issue7432GraphImporterVectorGraphTest {
     assertThat(paperIndex.getStats().get("mutationsSinceRebuild")).isZero();
 
     assertThat(noteIndex.getStats().get("graphRebuildCount"))
-        .as("an index on a type the import never touched is left to its own rebuild").isZero();
+        .as("an index on a type the import wrote nothing to is left to its own rebuild, configured source or not")
+        .isZero();
     assertThat(noteIndex.getStats().get("mutationsSinceRebuild")).isEqualTo(5L);
   }
 


### PR DESCRIPTION
Fixes #7432 (follow-up to #7357, discussion #7333).

The reporter re-ran the 4.2M-vertex / 75M-edge `GraphImporter` load with the vector index against a snapshot carrying #7360 and #7364. Ingest now finishes in 39 minutes, matching the no-index run, but the index still ends the run with no graph. Three defects in the log, three fixes.

## 1. The suspension now spans the whole import, not each batch

`GraphBatch` suspends the vector index's inactivity rebuild while it is open (#7357), but `GraphImporter` is not one batch: the vertex batch closes, the edge sources are read for their topology with no batch open (36 seconds in the reporter's run), then one edge batch per edge type opens. The first close lifted the only suspension and armed the 15s timer, which fired in that gap and started a full build that then ran alongside the whole edge pass:

```
12:27:13.525 GraphBatch closed: vertices=4243018 edges=0
12:27:28.526 Inactivity timeout expired (15000 ms), triggering graph rebuild for 4243018 pending mutations
12:27:49.777 Pass 2: Edges (bidirectional)
```

The suspend/resume-all logic moves out of `GraphBatch` into a reusable `IndexMaintenanceSuspension` (`AutoCloseable`, lifts exactly once, never throws on the way out). `GraphBatch` uses it unchanged in behaviour, and `GraphImporter.run()` now holds one around the whole run. The counts compose, so the batches' own suspensions nest inside the importer's.

## 2. The importer builds the vector graph before `run()` returns

The one build the load is worth was scheduled by the timer, asynchronously, 15 seconds after the load. The `database.close()` that follows every completed import cancelled it:

```
12:47:47.089 Import complete: 4,243,018 vertices, 75,539,070 edges in 2316.9s
12:47:52.120 Graph build for index WORK_0_53421708781870 cancelled: index is closing
```

A load is not complete while its index needs another half hour of background work the caller cannot see. `run()` now ends by building, synchronously, the graph of every `LSM_VECTOR` index on a type the import wrote to, through a new `LSMVectorIndex.buildVectorGraphIfPending()` that skips an index whose graph is already current (the existing `buildVectorGraphNow()` always rebuilds). Done while the suspension is still held, so the timer cannot race it; once the pending count is drained, lifting the suspension arms nothing. Opt out with `.withVectorGraphBuild(false)` or `"vectorGraphBuild": false` in the JSON configuration, for a loader that keeps the database open and prefers the background rebuild.

## 3. A cancelled build stops at the first interrupted read

Cancelling a build interrupts its pool workers, and `PageManager` refuses I/O on an interrupted thread. Every read in `ArcadePageVectorValues.getVector()` and `LSMVectorIndex.readVectorFromOffset()` caught that, logged it at WARNING, and fell through to the deleted sentinel, so each worker kept reading, failing and logging one line per node. The reporter's log carries 42,700 such lines in five seconds, and the pool outlived the close's 5s grace. An interrupted read is now rethrown as `CancellationException`, which the build already reports as a cancellation rather than a failure, so the parallel insertion ends at the first one.

## Tests

- `Issue7432GraphImporterVectorGraphTest` (integration): the reporter's shape at toy scale. The edge source stalls for six inactivity windows exactly in the gap between the two passes; after `run()` there is exactly one build, it covers every vector, nothing is pending, and a database closed immediately and reopened has the graph on disk and answers a nearest-neighbour query from it. Plus the JSON opt-out.
- `Issue7432InterruptedVectorReadAbortsTest` (engine): a vector read on an interrupted thread is a `CancellationException`, on both the document path and the quantized page path. Fails on `main` (both reads returned normally).
- Docs: `graph-importer.adoc` gains the third step, the `vectorGraphBuild` option and a section on loading into a type with a vector index (arcadedb-docs, local commit).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Graph imports now build vector search graphs automatically by default after loading data.
  - Added an option to disable automatic vector graph building during imports.
  - Vector graph updates can now be built synchronously when pending changes are detected.
  - Imports now rebuild vector graphs only for types that received data.

- **Bug Fixes**
  - Interrupted vector reads now stop promptly with a cancellation error instead of being treated as invalid data.
  - Bulk imports now suspend background index maintenance and reliably resume it afterward.
  - Vector graph rebuilds no longer run unnecessarily for empty or untouched sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->