### PR TITLE
fix(#7368,#7393,#7392,#7391): schema gate only on mutation, full-text parse errors are client errors, one backup directory, Studio flame graph reads totalCost

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -24,7 +24,6 @@ import com.arcadedb.function.text.TextLevenshteinDistance;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexCursor;
 import com.arcadedb.index.IndexCursorEntry;
-import com.arcadedb.index.IndexException;
 import com.arcadedb.index.TempIndexCursor;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.FullTextIndexMetadata;
@@ -239,7 +238,7 @@ public class FullTextQueryExecutor {
       // QueryParser is not thread-safe, so create one per invocation.
       return createQueryParser().parse(queryString);
     } catch (final ParseException e) {
-      throw new IndexException("Invalid search query: " + queryString, e);
+      throw new FullTextQueryParseException("Invalid search query: " + queryString, e);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryParseException.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryParseException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.fulltext;
+
+import com.arcadedb.index.IndexException;
+
+/**
+ * Raised when the text of a full-text query does not parse: an unbalanced quote, a dangling operator, a stray
+ * {@code ~} or {@code ^}. It is the caller's mistake, and the search surfaces answer it as one (HTTP 400, gRPC
+ * INVALID_ARGUMENT), which is why it has a type of its own: the plain {@link IndexException} it extends is also what
+ * the index raises for an execution-time fault - a tokenizer or analyzer failure, a missing search engine - and
+ * those must keep surfacing as internal errors with their stack trace rather than be misfiled as a bad request
+ * (issue #7393). Extending {@link IndexException} keeps every caller that already catches the parent working.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class FullTextQueryParseException extends IndexException {
+  public FullTextQueryParseException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/search/FullTextQuery.java
+++ b/engine/src/main/java/com/arcadedb/query/search/FullTextQuery.java
@@ -108,7 +108,9 @@ public final class FullTextQuery {
     } catch (final IndexException e) {
       // Lucene syntax the parser rejects is the caller's mistake and must be answered as one - HTTP 400, gRPC
       // INVALID_ARGUMENT - rather than as an internal error with a stack trace in the server log (issue #7393).
-      // Only the parser's IndexException is re-typed: any other failure on this path is a server fault.
+      // Only the parser's IndexException is re-typed: any other failure on this path is a server fault. The same type
+      // is raised for an analyzer failure while tokenizing; no path under this call tokenizes today, so a future one
+      // has to be told apart here before it is filed as a client error.
       final String detail = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
       throw new IllegalArgumentException("Invalid full-text query: " + detail, e);
     }

--- a/engine/src/main/java/com/arcadedb/query/search/FullTextQuery.java
+++ b/engine/src/main/java/com/arcadedb/query/search/FullTextQuery.java
@@ -101,7 +101,17 @@ public final class FullTextQuery {
     // The limit is pushed down per bucket: each bucket keeps only its own top-'limit' matches by score (a bounded
     // min-heap on the BM25 path, a sort-and-truncate on CLASSIC), so this merges at most (bucket count * limit)
     // entries instead of every match in the index.
-    final Map<RID, Float> hits = FullTextSearch.search(typeIndex, queryText, limit);
+    final Map<RID, Float> hits;
+    try {
+      hits = FullTextSearch.search(typeIndex, queryText, limit);
+    } catch (final SecurityException e) {
+      throw e;
+    } catch (final RuntimeException e) {
+      // Lucene syntax the parser rejects is the caller's mistake and must be answered as one - HTTP 400, gRPC
+      // INVALID_ARGUMENT - rather than as an internal error with a stack trace in the server log (issue #7393).
+      final String detail = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+      throw new IllegalArgumentException("Invalid full-text query: " + detail, e);
+    }
 
     final List<Map.Entry<RID, Float>> ranked = new ArrayList<>(hits.entrySet());
     // Score descending, tie-broken by RID so tied hits have a stable, deterministic order instead of depending on

--- a/engine/src/main/java/com/arcadedb/query/search/FullTextQuery.java
+++ b/engine/src/main/java/com/arcadedb/query/search/FullTextQuery.java
@@ -25,8 +25,8 @@ import com.arcadedb.database.Record;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.SchemaException;
-import com.arcadedb.index.IndexException;
 import com.arcadedb.index.TypeIndex;
+import com.arcadedb.index.fulltext.FullTextQueryParseException;
 import com.arcadedb.index.fulltext.FullTextSearch;
 import com.arcadedb.serializer.JsonSerializer;
 import com.arcadedb.serializer.json.JSONArray;
@@ -105,12 +105,10 @@ public final class FullTextQuery {
     final Map<RID, Float> hits;
     try {
       hits = FullTextSearch.search(typeIndex, queryText, limit);
-    } catch (final IndexException e) {
+    } catch (final FullTextQueryParseException e) {
       // Lucene syntax the parser rejects is the caller's mistake and must be answered as one - HTTP 400, gRPC
       // INVALID_ARGUMENT - rather than as an internal error with a stack trace in the server log (issue #7393).
-      // Only the parser's IndexException is re-typed: any other failure on this path is a server fault. The same type
-      // is raised for an analyzer failure while tokenizing; no path under this call tokenizes today, so a future one
-      // has to be told apart here before it is filed as a client error.
+      // Only the parser's own exception is re-typed: an execution-time IndexException is a server fault.
       final String detail = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
       throw new IllegalArgumentException("Invalid full-text query: " + detail, e);
     }

--- a/engine/src/main/java/com/arcadedb/query/search/FullTextQuery.java
+++ b/engine/src/main/java/com/arcadedb/query/search/FullTextQuery.java
@@ -25,6 +25,7 @@ import com.arcadedb.database.Record;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.SchemaException;
+import com.arcadedb.index.IndexException;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.index.fulltext.FullTextSearch;
 import com.arcadedb.serializer.JsonSerializer;
@@ -104,11 +105,10 @@ public final class FullTextQuery {
     final Map<RID, Float> hits;
     try {
       hits = FullTextSearch.search(typeIndex, queryText, limit);
-    } catch (final SecurityException e) {
-      throw e;
-    } catch (final RuntimeException e) {
+    } catch (final IndexException e) {
       // Lucene syntax the parser rejects is the caller's mistake and must be answered as one - HTTP 400, gRPC
       // INVALID_ARGUMENT - rather than as an internal error with a stack trace in the server log (issue #7393).
+      // Only the parser's IndexException is re-typed: any other failure on this path is a server fault.
       final String detail = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
       throw new IllegalArgumentException("Invalid full-text query: " + detail, e);
     }

--- a/engine/src/main/java/com/arcadedb/query/search/HybridSearch.java
+++ b/engine/src/main/java/com/arcadedb/query/search/HybridSearch.java
@@ -541,7 +541,17 @@ public final class HybridSearch {
           + "indexes in '" + database.getName() + "': " + FullTextSearch.listFullTextIndexes(database), e);
     }
 
-    final Map<RID, Float> hits = FullTextSearch.search(typeIndex, queryText, limit);
+    // The parser's complaint about the caller's own query text is a client error, like every other stage's bad
+    // input; left unwrapped it reached the protocol surfaces as an internal error with a logged stack trace
+    // (issue #7393). A SecurityException stays what it is: the request was well-formed and refused.
+    final Map<RID, Float> hits;
+    try {
+      hits = FullTextSearch.search(typeIndex, queryText, limit);
+    } catch (final SecurityException e) {
+      throw e;
+    } catch (final RuntimeException e) {
+      throw invalidExpression("full-text leg", e);
+    }
     final List<Map.Entry<RID, Float>> ranked = new ArrayList<>(hits.entrySet());
     // Score descending, tie-broken by RID so tied hits rank deterministically rather than by hash order.
     ranked.sort(Map.Entry.<RID, Float>comparingByValue().reversed().thenComparing(Map.Entry::getKey));

--- a/engine/src/main/java/com/arcadedb/query/search/HybridSearch.java
+++ b/engine/src/main/java/com/arcadedb/query/search/HybridSearch.java
@@ -24,8 +24,8 @@ import com.arcadedb.database.RID;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.SchemaException;
-import com.arcadedb.index.IndexException;
 import com.arcadedb.index.TypeIndex;
+import com.arcadedb.index.fulltext.FullTextQueryParseException;
 import com.arcadedb.index.fulltext.FullTextSearch;
 import com.arcadedb.query.QueryEngine;
 import com.arcadedb.query.sql.executor.Result;
@@ -544,14 +544,12 @@ public final class HybridSearch {
 
     // The parser's complaint about the caller's own query text is a client error, like every other stage's bad
     // input; left unwrapped it reached the protocol surfaces as an internal error with a logged stack trace
-    // (issue #7393). Only IndexException is the parser's: this call runs no generated SQL, so anything else thrown
-    // here is a server fault and must stay a 500 with its stack trace rather than be misfiled as a bad request.
-    // The type is also what the index raises for an analyzer failure while tokenizing; no path under this call
-    // tokenizes today, so if one is added the catch has to tell the two apart before it files the failure as a 400.
+    // (issue #7393). Only the parser's own exception is re-typed: an execution-time IndexException - a tokenizer,
+    // analyzer or search-engine fault - is a server fault and stays a 500 with its stack trace.
     final Map<RID, Float> hits;
     try {
       hits = FullTextSearch.search(typeIndex, queryText, limit);
-    } catch (final IndexException e) {
+    } catch (final FullTextQueryParseException e) {
       throw invalidExpression("full-text leg", e);
     }
     final List<Map.Entry<RID, Float>> ranked = new ArrayList<>(hits.entrySet());

--- a/engine/src/main/java/com/arcadedb/query/search/HybridSearch.java
+++ b/engine/src/main/java/com/arcadedb/query/search/HybridSearch.java
@@ -24,6 +24,7 @@ import com.arcadedb.database.RID;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.SchemaException;
+import com.arcadedb.index.IndexException;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.index.fulltext.FullTextSearch;
 import com.arcadedb.query.QueryEngine;
@@ -543,13 +544,12 @@ public final class HybridSearch {
 
     // The parser's complaint about the caller's own query text is a client error, like every other stage's bad
     // input; left unwrapped it reached the protocol surfaces as an internal error with a logged stack trace
-    // (issue #7393). A SecurityException stays what it is: the request was well-formed and refused.
+    // (issue #7393). Only IndexException is the parser's: this call runs no generated SQL, so anything else thrown
+    // here is a server fault and must stay a 500 with its stack trace rather than be misfiled as a bad request.
     final Map<RID, Float> hits;
     try {
       hits = FullTextSearch.search(typeIndex, queryText, limit);
-    } catch (final SecurityException e) {
-      throw e;
-    } catch (final RuntimeException e) {
+    } catch (final IndexException e) {
       throw invalidExpression("full-text leg", e);
     }
     final List<Map.Entry<RID, Float>> ranked = new ArrayList<>(hits.entrySet());

--- a/engine/src/main/java/com/arcadedb/query/search/HybridSearch.java
+++ b/engine/src/main/java/com/arcadedb/query/search/HybridSearch.java
@@ -546,6 +546,8 @@ public final class HybridSearch {
     // input; left unwrapped it reached the protocol surfaces as an internal error with a logged stack trace
     // (issue #7393). Only IndexException is the parser's: this call runs no generated SQL, so anything else thrown
     // here is a server fault and must stay a 500 with its stack trace rather than be misfiled as a bad request.
+    // The type is also what the index raises for an analyzer failure while tokenizing; no path under this call
+    // tokenizes today, so if one is added the catch has to tell the two apart before it files the failure as a 400.
     final Map<RID, Float> hits;
     try {
       hits = FullTextSearch.search(typeIndex, queryText, limit);

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FilterNotMatchPatternStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FilterNotMatchPatternStep.java
@@ -65,6 +65,10 @@ public class FilterNotMatchPatternStep extends AbstractExecutionStep {
             }
           }
           nextItem = prevResult.next();
+          // This region runs a plan built from the very sub-steps published by getSubSteps(), so its time is the
+          // subtree's time. That is only correct while none of those sub-steps keeps a timer of its own: today the one
+          // child is a MatchStep, which reports -1 and is dropped from every roll-up. Give a sub-step a timer and this
+          // measurement has to become a self cost (subtract the children) or the tree double counts (issue #7329).
           final long begin = context.isProfiling() ? System.nanoTime() : 0;
           try {
             if (!matchesPattern(nextItem, context)) {

--- a/engine/src/main/java/com/arcadedb/schema/TypeBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeBuilder.java
@@ -57,8 +57,6 @@ public class TypeBuilder<T> {
   }
 
   public T create() {
-    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
-
     if (typeName == null || typeName.isEmpty())
       throw new IllegalArgumentException("Missing type");
 
@@ -71,6 +69,11 @@ public class TypeBuilder<T> {
     // thread - which publishes itself into schema.types BEFORE its buckets are added - is never observed
     // half-populated; anything that mutates re-checks under the exclusive lock. The fast path can also throw,
     // for the type-already-exists and wrong-type cases, exactly as the locked path does.
+    //
+    // UPDATE_SCHEMA is demanded by createInternal(), at the point the builder is about to change the schema, and
+    // not here: a getOrCreate on a type that already exists as requested changes nothing, so a user holding only
+    // record grants can run a Cypher CREATE (whose label resolution is a getOrCreateVertexType) on a declared type
+    // exactly as they can run the equivalent SQL INSERT (issue #7368).
     final T alreadyComplete = database.executeInReadLock(() -> {
       final LocalDocumentType existing = schema.types.get(typeName);
       return existing != null && isComplete(existing) ? (T) checkExistingIsCompatible(existing) : null;
@@ -121,6 +124,13 @@ public class TypeBuilder<T> {
     if (t != null) {
       checkExistingIsCompatible(t);
 
+      // Re-checked under the exclusive lock: another thread may have completed the type since the shared-lock
+      // fast path looked, and a type that needs nothing added is not a schema change.
+      if (isComplete(t))
+        return (T) t;
+
+      database.checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
+
       if (t.buckets.size() < buckets) {
         // CREATE MISSING BUCKETS
         for (int i = t.buckets.size(); i < buckets; ++i) {
@@ -150,6 +160,8 @@ public class TypeBuilder<T> {
 
       return (T) t;
     }
+
+    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
 
     if (buckets > 32)
       throw new IllegalArgumentException("Cannot create " + buckets + " buckets: maximum is 32");

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue7368CreateOnExistingTypeWithoutSchemaPermissionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue7368CreateOnExistingTypeWithoutSchemaPermissionTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseContext;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.security.SecurityDatabaseUser;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A user granted only record access (create/read/update/delete on every type) could not run a Cypher
+ * {@code CREATE (:ExistingType {...})}: the label resolution goes through {@code getOrCreateVertexType}, whose
+ * builder demanded {@code UPDATE_SCHEMA} before even looking at whether the type already existed, so a statement
+ * that changed nothing in the schema was refused with "not allowed to update schema" while the equivalent SQL
+ * {@code INSERT INTO} worked (issue #7368).
+ * <p>
+ * The permission must be demanded exactly when the builder is about to mutate the schema: a missing type, a type
+ * missing a requested bucket, or a type missing a requested super type.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7368CreateOnExistingTypeWithoutSchemaPermissionTest {
+  private static final String PATH = "target/databases/issue7368";
+
+  private DatabaseFactory factory;
+  private Database        database;
+
+  @BeforeEach
+  void setUp() {
+    factory = new DatabaseFactory(PATH).setSecurity(db -> {
+    });
+    if (factory.exists())
+      factory.open().drop();
+
+    database = factory.create();
+    database.getSchema().createVertexType("project_metadata");
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createVertexType("Employee");
+    database.getSchema().createEdgeType("KNOWS");
+  }
+
+  @AfterEach
+  void tearDown() {
+    unbindUser();
+    database.drop();
+    factory.close();
+  }
+
+  @Test
+  void cypherCreateOnAnExistingVertexTypeNeedsNoSchemaPermission() {
+    bindRecordOnlyUser();
+
+    database.transaction(() -> {
+      try (final ResultSet rs = database.command("opencypher",
+          "CREATE (p:project_metadata {projectId: 'test123', accountId: 1, name: 'test'}) RETURN p.projectId AS id")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<String>getProperty("id")).isEqualTo("test123");
+      }
+    });
+
+    assertThat(database.countType("project_metadata", false)).isEqualTo(1);
+  }
+
+  @Test
+  void cypherCreateOfAnEdgeBetweenExistingTypesNeedsNoSchemaPermission() {
+    bindRecordOnlyUser();
+
+    database.transaction(() -> database.command("opencypher",
+        "CREATE (a:Person {name: 'a'})-[:KNOWS]->(b:Person {name: 'b'})").close());
+
+    assertThat(database.countType("KNOWS", false)).isEqualTo(1);
+  }
+
+  @Test
+  void cypherCreateOnAMissingLabelIsStillRefused() {
+    bindRecordOnlyUser();
+
+    assertThatThrownBy(() -> database.transaction(() ->
+        database.command("opencypher", "CREATE (p:NotDeclaredYet {name: 'x'})").close()))
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("not allowed to update schema");
+
+    assertThat(database.getSchema().existsType("NotDeclaredYet")).isFalse();
+  }
+
+  @Test
+  void cypherCreateWithAMissingCompositeLabelTypeIsStillRefused() {
+    // Both labels exist, but the composite type Person~Employee that a multi-label vertex is stored in does not,
+    // so this CREATE would have to add a type and inherits the schema gate.
+    bindRecordOnlyUser();
+
+    assertThatThrownBy(() -> database.transaction(() ->
+        database.command("opencypher", "CREATE (p:Person:Employee {name: 'x'})").close()))
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("not allowed to update schema");
+  }
+
+  @Test
+  void getOrCreateOnAnExistingTypeNeedsNoSchemaPermission() {
+    bindRecordOnlyUser();
+
+    final DocumentType existing = database.getSchema().getOrCreateVertexType("Person");
+    assertThat(existing.getName()).isEqualTo("Person");
+    assertThat(database.getSchema().getOrCreateEdgeType("KNOWS").getName()).isEqualTo("KNOWS");
+    assertThat(database.getSchema().getOrCreateDocumentType("Person").getName()).isEqualTo("Person");
+  }
+
+  @Test
+  void getOrCreateThatWouldAddBucketsOrSuperTypesIsStillRefused() {
+    bindRecordOnlyUser();
+
+    final int declared = database.getSchema().getType("Person").getBuckets(false).size();
+    assertThatThrownBy(() -> database.getSchema().getOrCreateVertexType("Person", declared + 1))
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("not allowed to update schema");
+    assertThat(database.getSchema().getType("Person").getBuckets(false)).hasSize(declared);
+
+    assertThatThrownBy(() -> database.getSchema().buildVertexType().withName("Employee").withSuperType("Person")
+        .withIgnoreIfExists(true).create())
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("not allowed to update schema");
+    assertThat(database.getSchema().getType("Employee").getSuperTypes()).isEmpty();
+
+    assertThatThrownBy(() -> database.getSchema().getOrCreateVertexType("Brand_New"))
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("not allowed to update schema");
+    assertThat(database.getSchema().existsType("Brand_New")).isFalse();
+  }
+
+  @Test
+  void getOrCreateOnAnExistingTypeOfAnotherKindStillFailsAsBefore() {
+    // The "already exists" fast path must keep refusing a kind mismatch even when the caller holds no schema grant:
+    // the check answers "is this the type you asked for", not "may you change it".
+    bindRecordOnlyUser();
+
+    assertThatThrownBy(() -> database.getSchema().getOrCreateEdgeType("Person"))
+        .hasMessageContaining("is not a edge type");
+  }
+
+  private void bindRecordOnlyUser() {
+    DatabaseContext.INSTANCE.getContext(database.getDatabasePath()).setCurrentUser(new SecurityDatabaseUser() {
+      @Override
+      public String getName() {
+        return "crud";
+      }
+
+      @Override
+      public boolean requestAccessOnDatabase(final DATABASE_ACCESS access) {
+        return false;
+      }
+
+      @Override
+      public boolean requestAccessOnFile(final int fileId, final ACCESS access) {
+        return true;
+      }
+
+      @Override
+      public boolean requestAccessOnType(final String typeName, final ACCESS access) {
+        return true;
+      }
+
+      @Override
+      public long getResultSetLimit() {
+        return -1L;
+      }
+
+      @Override
+      public long getReadTimeout() {
+        return -1L;
+      }
+    });
+  }
+
+  private void unbindUser() {
+    if (database != null && database.isOpen())
+      DatabaseContext.INSTANCE.getContext(database.getDatabasePath()).setCurrentUser(null);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/search/Issue7393MalformedFullTextQueryIsAClientErrorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/search/Issue7393MalformedFullTextQueryIsAClientErrorTest.java
@@ -20,6 +20,8 @@ package com.arcadedb.query.search;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.MutableDocument;
+import com.arcadedb.index.IndexException;
+import com.arcadedb.index.fulltext.FullTextQueryParseException;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.json.JSONArray;
@@ -74,6 +76,14 @@ class Issue7393MalformedFullTextQueryIsAClientErrorTest extends TestHelper {
           .hasMessageContaining("full-text leg")
           .hasMessageContaining(malformed);
     }
+  }
+
+  @Test
+  void anExecutionTimeIndexFaultIsNotFiledAsAClientError() {
+    // The parser's exception is the only one re-typed: a plain IndexException from the same call is a server fault.
+    assertThat(new FullTextQueryParseException("x", null)).isInstanceOf(IndexException.class);
+    assertThat(IndexException.class.isAssignableFrom(FullTextQueryParseException.class)).isTrue();
+    assertThat(new IndexException("Error on tokenizer")).isNotInstanceOf(FullTextQueryParseException.class);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/search/Issue7393MalformedFullTextQueryIsAClientErrorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/search/Issue7393MalformedFullTextQueryIsAClientErrorTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.search;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Type;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A full-text query the Lucene parser rejects is the caller's mistake, and every protocol surface maps an
+ * {@link IllegalArgumentException} raised by the search services to a client error (HTTP 400, gRPC
+ * INVALID_ARGUMENT). The full-text leg of {@link HybridSearch} was the one stage that let the parser's
+ * {@code IndexException} through untouched, so an unbalanced quote or a dangling operator surfaced as an
+ * "Internal error" with a stack trace in the server log; the standalone {@link FullTextQuery} surface had the
+ * same gap (issue #7393).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7393MalformedFullTextQueryIsAClientErrorTest extends TestHelper {
+  private static final String TYPE       = "Doc";
+  private static final String VECTOR_IDX = "Doc[embedding]";
+  private static final String TEXT_IDX   = "Doc[title]";
+  private static final int    DIM        = 4;
+
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType(TYPE);
+      type.createProperty("title", Type.STRING);
+      type.createProperty("embedding", Type.ARRAY_OF_FLOATS);
+
+      database.getSchema().buildTypeIndex(TYPE, new String[] { "embedding" })
+          .withLSMVectorType().withDimensions(DIM).withSimilarity("COSINE").create();
+      database.command("sql", "CREATE INDEX ON " + TYPE + " (title) FULL_TEXT");
+
+      for (int i = 0; i < 5; i++) {
+        final MutableDocument doc = database.newDocument(TYPE);
+        doc.set("title", "gearbox manual " + i);
+        doc.set("embedding", new float[] { 1f, i * 0.1f, 0f, 0f });
+        doc.save();
+      }
+    });
+  }
+
+  @Test
+  void aMalformedFullTextQueryInAHybridSearchIsReportedAsAnInvalidArgument() {
+    for (final String malformed : new String[] { "title:(foo AND", "\"unbalanced", "gearbox AND", "~", "^2" }) {
+      assertThatThrownBy(() -> HybridSearch.search(database, hybridArgs(malformed)))
+          .as("fulltextQuery <%s>", malformed)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("full-text leg")
+          .hasMessageContaining(malformed);
+    }
+  }
+
+  @Test
+  void aWellFormedFullTextQueryStillRunsTheLeg() {
+    final JSONObject result = HybridSearch.search(database, hybridArgs("gearbox"));
+    assertThat(result.getJSONObject("legs").getJSONObject("fulltext").getInt("count")).isGreaterThan(0);
+  }
+
+  @Test
+  void aMalformedQueryOnTheStandaloneFullTextSurfaceIsReportedAsAnInvalidArgument() {
+    assertThatThrownBy(() -> FullTextQuery.search(database,
+        new JSONObject().put("indexName", TEXT_IDX).put("queryText", "title:(foo AND")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("title:(foo AND");
+  }
+
+  private static JSONObject hybridArgs(final String fulltextQuery) {
+    final JSONArray vector = new JSONArray();
+    for (int i = 0; i < DIM; i++)
+      vector.put(i == 0 ? 1f : 0f);
+    return new JSONObject()
+        .put("vectorIndexName", VECTOR_IDX)
+        .put("queryVector", vector)
+        .put("k", 3)
+        .put("fulltextIndexName", TEXT_IDX)
+        .put("fulltextQuery", fulltextQuery);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ContainerStepSelfCostIssue7329Test.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ContainerStepSelfCostIssue7329Test.java
@@ -53,7 +53,8 @@ class ContainerStepSelfCostIssue7329Test {
   @BeforeEach
   void setup() {
     database = new DatabaseFactory(DATABASE_DIR).create();
-    database.getSchema().createDocumentType("Item");
+    // Two buckets, so a bucket-list target plans the multi-bucket container and not the single-bucket step.
+    database.getSchema().createDocumentType("Item", 2);
     database.transaction(() -> {
       for (int i = 0; i < 200; i++)
         database.newDocument("Item").set("idx", i).save();
@@ -82,6 +83,39 @@ class ContainerStepSelfCostIssue7329Test {
     assertThat(buckets).as("the container must carry the bucket steps that do the timing").isNotEmpty();
     assertThat(buckets.stream().anyMatch(s -> s.getLong("cost", -1) >= 0))
         .as("at least one bucket step must have been timed").isTrue();
+  }
+
+  /**
+   * The other two containers the fix changed, planned by a filtered type scan and by a bucket-list target: each must
+   * report the same shape as the plain type scan - no self cost, timed children, the roll-up under
+   * {@code totalCost} - or a regression in one of them would go unnoticed by a test that only scans a type (#7391).
+   */
+  @Test
+  void theFilteredTypeScanAndTheBucketListContainersReportTheSameShape() {
+    assertContainerShape(profiledPlanOf("select from Item where idx > 100"), "FetchFromTypeWithFilterStep");
+    assertContainerShape(profiledPlanOf("select from bucket:[Item_0, Item_1]"), "FetchFromClustersExecutionStep");
+  }
+
+  private void assertContainerShape(final JSONObject plan, final String containerName) {
+    final JSONObject container = findStep(plan, containerName);
+    assertThat(container).as("%s must be in the plan: %s", containerName, plan).isNotNull();
+    assertThat(container.getLong("cost", 0)).as("%s times nothing itself", containerName).isEqualTo(-1L);
+
+    final List<JSONObject> children = collectSteps(container.getJSONArray("subSteps"));
+    assertThat(children).as("%s must carry the bucket steps that do the timing", containerName).isNotEmpty();
+    assertThat(children.stream().anyMatch(s -> s.getLong("cost", -1) >= 0))
+        .as("at least one child of %s must have been timed", containerName).isTrue();
+
+    // The roll-up is the sum of the direct children's totals: the container adds nothing of its own.
+    long childrenTotal = 0;
+    final JSONArray direct = container.getJSONArray("subSteps");
+    for (int i = 0; i < direct.length(); i++) {
+      final long cost = direct.getJSONObject(i).getLong("totalCost", -1);
+      if (cost >= 0)
+        childrenTotal += cost;
+    }
+    assertThat(childrenTotal).as("the children of %s must have been timed", containerName).isGreaterThan(0L);
+    assertThat(container.getLong("totalCost", -1)).isEqualTo(childrenTotal);
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -28,6 +28,7 @@ import com.arcadedb.engine.OperationProgressRegistry;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.backup.AutoBackupConfig;
 import com.arcadedb.server.backup.AutoBackupSchedulerPlugin;
@@ -772,7 +773,7 @@ public class ServerControlPlane {
    * scheduler was running (issue #7392).
    */
   public JSONObject listBackups(final String databaseName) {
-    requireDatabaseName(databaseName);
+    requireBackupDatabaseName(databaseName);
 
     final JSONArray backups = new JSONArray();
     long totalSize = 0;
@@ -812,6 +813,16 @@ public class ServerControlPlane {
     return response;
   }
 
+  /**
+   * The database name is a path segment under the backup directory for every backup command, and {@code trigger}
+   * creates that directory, so a name with a separator or a {@code ..} must be refused before any path is built
+   * rather than caught by the file-level {@code startsWith} check that only guards the archive name.
+   */
+  private void requireBackupDatabaseName(final String databaseName) {
+    requireDatabaseName(databaseName);
+    server.checkDatabaseNameIsValid(databaseName);
+  }
+
   private static boolean isBackupArchive(final Path p) {
     final String name = p.getFileName().toString();
     return name.endsWith(".zip") && name.contains("-backup-");
@@ -830,7 +841,7 @@ public class ServerControlPlane {
    *                                   handed the other run's archive (issue #6753).
    */
   public JSONObject triggerBackup(final String databaseName) {
-    requireDatabaseName(databaseName);
+    requireBackupDatabaseName(databaseName);
 
 
     final BackupCoordinator coordinator = server.getBackupCoordinator();
@@ -873,7 +884,7 @@ public class ServerControlPlane {
    * wrote (issue #7392).
    */
   public Path resolveBackupFile(final String databaseName, final String fileName) {
-    requireDatabaseName(databaseName);
+    requireBackupDatabaseName(databaseName);
 
     // Reject anything that is not a plain backup file name.
     if (fileName.contains("/") || fileName.contains("\\") || fileName.contains("..") || fileName.isBlank()
@@ -967,7 +978,9 @@ public class ServerControlPlane {
         final String configured = new JSONObject(Files.readString(configPath)).getString("backupDirectory", null);
         if (configured != null && !configured.isBlank())
           return AutoBackupSchedulerPlugin.validateAndResolveBackupPath(configured, serverRoot);
-      } catch (final IOException e) {
+      } catch (final IOException | JSONException e) {
+        // Unreadable or malformed: the scheduler ignores such a file at start-up too, so fall through to the server
+        // setting with a warning rather than answer every backup command with an internal error.
         LogManager.instance().log(this, Level.WARNING, "Cannot read '%s', falling back to the server backup directory: %s",
             configPath, e.getMessage());
       }

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -732,9 +732,12 @@ public class ServerControlPlane {
           response.put("enabled", false); // Plugin not running, but config exists
           response.put("config", configJson);
           response.put("message", "Configuration saved but requires server restart to take effect");
-        } catch (final IOException e) {
+        } catch (final IOException | JSONException e) {
+          // Unreadable or malformed: this is the command the operator uses to find out, so answer with the reason
+          // rather than an internal error.
           response.put("enabled", false);
           response.put("config", JSONObject.NULL);
+          response.put("message", "Cannot read " + configPath + ": " + e.getMessage());
         }
       } else {
         response.put("enabled", false);

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -943,6 +943,10 @@ public class ServerControlPlane {
    * The first two are caller-supplied through {@code set backup config} and are re-validated here as relative
    * paths inside the server root, exactly as the scheduler validates them at start-up. The third is a server
    * setting, not client input, and is taken as configured. Every archive lives under {@code <directory>/<database>}.
+   * A configured directory that fails validation is an {@link IllegalArgumentException} out of every command that
+   * needs it, deliberately: listing nothing for a directory the server refuses to use is what hid the archives in
+   * the first place, and {@link #getBackupConfig()} reports the same failure as {@code backupDirectoryError} so the
+   * operator can see it without triggering anything.
    * <p>
    * Retention pruning is the scheduler's job and runs only while it is enabled; with the scheduler off an
    * on-demand archive stays until {@code delete backup} removes it, which is now possible.

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -32,7 +32,6 @@ import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.backup.AutoBackupConfig;
 import com.arcadedb.server.backup.AutoBackupSchedulerPlugin;
 import com.arcadedb.server.backup.BackupCoordinator;
-import com.arcadedb.server.backup.BackupRetentionManager;
 import com.arcadedb.server.http.HttpAuthSession;
 import com.arcadedb.server.http.HttpAuthSessionManager;
 import com.arcadedb.server.http.HttpServer;
@@ -709,6 +708,14 @@ public class ServerControlPlane {
     final AutoBackupSchedulerPlugin plugin = getBackupPlugin();
 
     final JSONObject response = new JSONObject();
+    // The directory every backup command reads and writes, whichever source it came from (issue #7392). A directory
+    // that fails validation is reported rather than thrown: this is the command an operator uses to see what is
+    // wrong before fixing it with 'set backup config'.
+    try {
+      response.put("backupDirectory", resolveBackupDirectory().toString());
+    } catch (final IllegalArgumentException e) {
+      response.put("backupDirectoryError", e.getMessage());
+    }
 
     if (plugin != null && plugin.isEnabled()) {
       response.put("enabled", true);
@@ -758,64 +765,56 @@ public class ServerControlPlane {
     return new JSONObject().put("result", "ok");
   }
 
+  /**
+   * The archives of {@code databaseName} under {@link #resolveBackupDirectory() the backup directory}, newest
+   * first, with the count and the total size of the same files. Both were previously read off the scheduler's
+   * retention manager and left out when the plugin was off, so the listing carried a count only when the
+   * scheduler was running (issue #7392).
+   */
   public JSONObject listBackups(final String databaseName) {
     requireDatabaseName(databaseName);
 
-
-    final AutoBackupSchedulerPlugin plugin = getBackupPlugin();
-
     final JSONArray backups = new JSONArray();
+    long totalSize = 0;
 
-    if (plugin != null && plugin.isEnabled()) {
-      final AutoBackupConfig config = plugin.getBackupConfig();
-      if (config != null) {
-        // Resolve backup directory
-        String backupDirectory = config.getBackupDirectory();
-        final Path backupPath = Paths.get(backupDirectory);
-        if (!backupPath.isAbsolute())
-          backupDirectory = Paths.get(server.getRootPath(), backupDirectory).toString();
-
-        final Path dbBackupDir = Paths.get(backupDirectory, databaseName);
-        if (Files.exists(dbBackupDir) && Files.isDirectory(dbBackupDir)) {
-          try (var stream = Files.list(dbBackupDir)) {
-            stream.filter(p -> p.toString().endsWith(".zip") && p.getFileName().toString().contains("-backup-"))
-                .sorted(Comparator.reverseOrder())
-                .forEach(p -> {
-                  final JSONObject backup = new JSONObject();
-                  backup.put("fileName", p.getFileName().toString());
-                  try {
-                    backup.put("size", Files.size(p));
-                    backup.put("lastModified", Files.getLastModifiedTime(p).toMillis());
-                  } catch (final IOException e) {
-                    backup.put("size", 0);
-                    backup.put("lastModified", 0);
-                  }
-
-                  // Parse timestamp from filename, through the same convention that wrote it (issue #6753)
-                  final LocalDateTime timestamp = BackupCoordinator.parseArchiveTimestamp(p.getFileName().toString());
-                  backup.put("timestamp", timestamp != null ? timestamp.toString() : JSONObject.NULL);
-
-                  backups.put(backup);
-                });
+    final Path dbBackupDir = resolveBackupDirectory().resolve(databaseName);
+    if (Files.isDirectory(dbBackupDir)) {
+      try (final var stream = Files.list(dbBackupDir)) {
+        for (final Path p : stream.filter(ServerControlPlane::isBackupArchive).sorted(Comparator.reverseOrder()).toList()) {
+          final JSONObject backup = new JSONObject();
+          backup.put("fileName", p.getFileName().toString());
+          try {
+            final long size = Files.size(p);
+            totalSize += size;
+            backup.put("size", size);
+            backup.put("lastModified", Files.getLastModifiedTime(p).toMillis());
           } catch (final IOException e) {
-            throw new RuntimeException("Error listing backups for database '" + databaseName + "'", e);
+            backup.put("size", 0);
+            backup.put("lastModified", 0);
           }
+
+          // Parse timestamp from filename, through the same convention that wrote it (issue #6753)
+          final LocalDateTime timestamp = BackupCoordinator.parseArchiveTimestamp(p.getFileName().toString());
+          backup.put("timestamp", timestamp != null ? timestamp.toString() : JSONObject.NULL);
+
+          backups.put(backup);
         }
+      } catch (final IOException e) {
+        throw new RuntimeException("Error listing backups for database '" + databaseName + "'", e);
       }
     }
 
     final JSONObject response = new JSONObject();
     response.put("database", databaseName);
     response.put("backups", backups);
-
-    // Get retention manager stats if available
-    if (plugin != null && plugin.getRetentionManager() != null) {
-      final BackupRetentionManager retentionManager = plugin.getRetentionManager();
-      response.put("totalSize", retentionManager.getBackupSizeBytes(databaseName));
-      response.put("totalCount", retentionManager.getBackupCount(databaseName));
-    }
-
+    response.put("totalSize", totalSize);
+    response.put("totalCount", backups.length());
     return response;
+  }
+
+  private static boolean isBackupArchive(final Path p) {
+    final String name = p.getFileName().toString();
+    return name.endsWith(".zip") && name.contains("-backup-");
   }
 
   /**
@@ -868,8 +867,10 @@ public class ServerControlPlane {
   }
 
   /**
-   * Resolves a backup file name to an absolute path inside the configured auto-backup directory for
-   * the given database, rejecting any name that contains path separators or traversal sequences.
+   * Resolves a backup file name to an absolute path inside {@link #resolveBackupDirectory() the backup directory}
+   * for the given database, rejecting any name that contains path separators or traversal sequences. Used by
+   * {@code delete backup} and {@code restore backup}, so both can address exactly what {@code trigger backup}
+   * wrote (issue #7392).
    */
   public Path resolveBackupFile(final String databaseName, final String fileName) {
     requireDatabaseName(databaseName);
@@ -879,16 +880,7 @@ public class ServerControlPlane {
         || !fileName.endsWith(".zip") || !fileName.contains("-backup-"))
       throw new IllegalArgumentException("Invalid backup file name: " + fileName);
 
-    final AutoBackupSchedulerPlugin plugin = getBackupPlugin();
-    if (plugin == null || !plugin.isEnabled() || plugin.getBackupConfig() == null)
-      throw new IllegalArgumentException("Auto-backup is not configured");
-
-    String backupDirectory = plugin.getBackupConfig().getBackupDirectory();
-    final Path backupPath = Paths.get(backupDirectory);
-    if (!backupPath.isAbsolute())
-      backupDirectory = Paths.get(server.getRootPath(), backupDirectory).toString();
-
-    final Path dbBackupDir = Paths.get(backupDirectory, databaseName).normalize();
+    final Path dbBackupDir = resolveBackupDirectory().resolve(databaseName).normalize();
     final Path resolved = dbBackupDir.resolve(fileName).normalize();
 
     // Defence in depth: the resolved file must still live inside the database backup directory.
@@ -902,98 +894,83 @@ public class ServerControlPlane {
   }
 
   private JSONObject executeImmediateBackup(final String databaseName) {
-    final AutoBackupSchedulerPlugin plugin = getBackupPlugin();
-
-    // Try to get backup directory from config (plugin or file)
-    String backupDirectory = null;
-
-    if (plugin != null && plugin.isEnabled()) {
-      final AutoBackupConfig config = plugin.getBackupConfig();
-      backupDirectory = config != null ? config.getBackupDirectory() : null;
-    }
-
-    // If plugin not enabled, try to read from config file directly
-    if (backupDirectory == null) {
-      final Path configPath = Paths.get(server.getRootPath(), "config", AutoBackupConfig.CONFIG_FILE_NAME);
-      if (Files.exists(configPath)) {
-        try {
-          final String content = Files.readString(configPath);
-          final JSONObject configJson = new JSONObject(content);
-          if (configJson.has("backupDirectory"))
-            backupDirectory = configJson.getString("backupDirectory");
-        } catch (final IOException ignored) {
-        }
-      }
-    }
-
-    // Use config directory if available
-    if (backupDirectory != null) {
-      try {
-        // Validate the directory
-        validateBackupDirectory(backupDirectory);
-
-        // Resolve relative path
-        final Path backupPath = Paths.get(backupDirectory);
-        if (!backupPath.isAbsolute())
-          backupDirectory = Paths.get(server.getRootPath(), backupDirectory).toString();
-
-        // Perform backup using reflection (same as BackupTask)
-        final Database database = server.getDatabase(databaseName);
-        final Class<?> clazz = Class.forName("com.arcadedb.integration.backup.Backup");
-
-        final String backupFileName = server.getBackupCoordinator().newArchiveName(databaseName);
-
-        final Path dbBackupPath = Paths.get(backupDirectory, databaseName);
-        // Use Files.createDirectories to avoid TOCTOU race condition
-        Files.createDirectories(dbBackupPath);
-        final String dbBackupDir = dbBackupPath.toString();
-
-        final Object backup = clazz.getConstructor(Database.class, String.class)
-            .newInstance(database, backupFileName);
-        clazz.getMethod("setDirectory", String.class).invoke(backup, dbBackupDir);
-        clazz.getMethod("setVerboseLevel", Integer.TYPE).invoke(backup, 1);
-
-        final String backupFile = (String) clazz.getMethod("backupDatabase").invoke(backup);
-
-        final JSONObject response = new JSONObject();
-        response.put("result", "ok");
-        response.put("backupFile", backupFile);
-        return response;
-
-      } catch (final ClassNotFoundException e) {
-        throw new RuntimeException("Backup libs not found in classpath. Make sure arcadedb-integration module is included.", e);
-      } catch (final Exception e) {
-        final Throwable cause = e.getCause() != null ? e.getCause() : e;
-        throw new RuntimeException("Error triggering backup for database '" + databaseName + "': " + cause.getMessage(), cause);
-      }
-    }
-
-    // Fallback: use SQL command (uses GlobalConfiguration.SERVER_BACKUP_DIRECTORY). This one does not name the
-    // archive through the coordinator: with no target the SQL statement lets BackupSettings apply its own default,
-    // which is the same convention down to the milliseconds - the coordinator is where that convention was copied
-    // from in the first place.
+    final Path dbBackupPath = resolveBackupDirectory().resolve(databaseName);
     try {
+      // Perform backup using reflection (same as BackupTask)
       final Database database = server.getDatabase(databaseName);
-      try (final var result = database.command("sql", "backup database")) {
+      final Class<?> clazz = Class.forName("com.arcadedb.integration.backup.Backup");
 
-        final JSONObject response = new JSONObject();
-        response.put("result", "ok");
-        // The SQL "backup database" command sets backupFile as a property on a Result row
-        // (see BackupDatabaseStatement). Read it via Result.getProperty rather than the
-        // pre-existing dead instanceof Map check, which never matched.
-        while (result.hasNext()) {
-          final var row = result.next();
-          final Object backupFile = row.getProperty("backupFile");
-          if (backupFile != null) {
-            response.put("backupFile", backupFile.toString());
-            break;
-          }
-        }
-        return response;
-      }
+      final String backupFileName = server.getBackupCoordinator().newArchiveName(databaseName);
+
+      // Use Files.createDirectories to avoid TOCTOU race condition
+      Files.createDirectories(dbBackupPath);
+
+      final Object backup = clazz.getConstructor(Database.class, String.class)
+          .newInstance(database, backupFileName);
+      clazz.getMethod("setDirectory", String.class).invoke(backup, dbBackupPath.toString());
+      clazz.getMethod("setVerboseLevel", Integer.TYPE).invoke(backup, 1);
+
+      final String backupFile = (String) clazz.getMethod("backupDatabase").invoke(backup);
+
+      final JSONObject response = new JSONObject();
+      response.put("result", "ok");
+      response.put("backupFile", backupFile);
+      return response;
+
+    } catch (final ClassNotFoundException e) {
+      throw new RuntimeException("Backup libs not found in classpath. Make sure arcadedb-integration module is included.", e);
     } catch (final Exception e) {
-      throw new RuntimeException("Error triggering backup for database '" + databaseName + "': " + e.getMessage(), e);
+      final Throwable cause = e.getCause() != null ? e.getCause() : e;
+      throw new RuntimeException("Error triggering backup for database '" + databaseName + "': " + cause.getMessage(), cause);
     }
+  }
+
+  /**
+   * Where this server keeps its backups: the one definition every backup command - {@code trigger}, {@code list},
+   * {@code delete}, {@code restore} and {@code get backup config} - resolves through, so an archive one of them
+   * writes the others can see. Before this, only {@code trigger backup} fell back past the live scheduler, so an
+   * on-demand archive taken with auto-backup off was invisible to {@code list}, refused by {@code delete} and
+   * {@code restore}, and left on disk for good (issue #7392).
+   * <p>
+   * The chain, first hit wins:
+   * <ol>
+   *   <li>the running auto-backup plugin's configuration;</li>
+   *   <li>{@code config/backup.json} on disk, whether or not it enables the scheduler - an operator who set a
+   *       directory there and turned the schedule off still means that directory;</li>
+   *   <li>{@link GlobalConfiguration#SERVER_BACKUP_DIRECTORY}, the server-wide setting the SQL
+   *       {@code BACKUP DATABASE} statement writes to.</li>
+   * </ol>
+   * The first two are caller-supplied through {@code set backup config} and are re-validated here as relative
+   * paths inside the server root, exactly as the scheduler validates them at start-up. The third is a server
+   * setting, not client input, and is taken as configured. Every archive lives under {@code <directory>/<database>}.
+   * <p>
+   * Retention pruning is the scheduler's job and runs only while it is enabled; with the scheduler off an
+   * on-demand archive stays until {@code delete backup} removes it, which is now possible.
+   */
+  public Path resolveBackupDirectory() {
+    final Path serverRoot = Paths.get(server.getRootPath()).toAbsolutePath().normalize();
+
+    final AutoBackupSchedulerPlugin plugin = getBackupPlugin();
+    if (plugin != null && plugin.isEnabled() && plugin.getBackupConfig() != null) {
+      final String configured = plugin.getBackupConfig().getBackupDirectory();
+      if (configured != null && !configured.isBlank())
+        return AutoBackupSchedulerPlugin.validateAndResolveBackupPath(configured, serverRoot);
+    }
+
+    final Path configPath = Paths.get(server.getRootPath(), "config", AutoBackupConfig.CONFIG_FILE_NAME);
+    if (Files.exists(configPath)) {
+      try {
+        final String configured = new JSONObject(Files.readString(configPath)).getString("backupDirectory", null);
+        if (configured != null && !configured.isBlank())
+          return AutoBackupSchedulerPlugin.validateAndResolveBackupPath(configured, serverRoot);
+      } catch (final IOException e) {
+        LogManager.instance().log(this, Level.WARNING, "Cannot read '%s', falling back to the server backup directory: %s",
+            configPath, e.getMessage());
+      }
+    }
+
+    return Paths.get(server.getConfiguration().getValueAsString(GlobalConfiguration.SERVER_BACKUP_DIRECTORY))
+        .toAbsolutePath().normalize();
   }
 
   private AutoBackupSchedulerPlugin getBackupPlugin() {

--- a/server/src/test/java/com/arcadedb/server/backup/BackupApiCommandsIT.java
+++ b/server/src/test/java/com/arcadedb/server/backup/BackupApiCommandsIT.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.backup;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.BaseGraphServerTest;
 import org.junit.jupiter.api.AfterEach;
@@ -99,6 +100,13 @@ class BackupApiCommandsIT extends BaseGraphServerTest {
 
   @Test
   void listBackupsEmptyDatabase() throws Exception {
+    // With no backup.json the listing reads the server-wide backup directory, the same place 'trigger backup' and
+    // the SQL BACKUP DATABASE write to (issue #7392), so clear what other tests left there for this database.
+    final File serverBackups = new File(
+        getServer(0).getConfiguration().getValueAsString(GlobalConfiguration.SERVER_BACKUP_DIRECTORY), getDatabaseName());
+    if (serverBackups.exists())
+      deleteDirectory(serverBackups);
+
     final HttpClient client = HttpClient.newHttpClient();
 
     final JSONObject payload = new JSONObject();
@@ -119,8 +127,9 @@ class BackupApiCommandsIT extends BaseGraphServerTest {
     assertThat(result.has("database")).isTrue();
     assertThat(result.getString("database")).isEqualTo(getDatabaseName());
     assertThat(result.has("backups")).isTrue();
-    // No backups should exist (backup not configured)
     assertThat(result.getJSONArray("backups").length()).isZero();
+    assertThat(result.getInt("totalCount")).isZero();
+    assertThat(result.getLong("totalSize")).isZero();
   }
 
   @Test

--- a/server/src/test/java/com/arcadedb/server/backup/Issue7392OnDemandBackupWithoutAutoBackupIT.java
+++ b/server/src/test/java/com/arcadedb/server/backup/Issue7392OnDemandBackupWithoutAutoBackupIT.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.backup;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * With the auto-backup scheduler disabled, {@code trigger backup} wrote an archive that {@code list backups} did
+ * not show, {@code delete backup} refused to remove and {@code restore backup} refused to read: the writer fell
+ * back from the plugin to the config file and then to the server's backup directory, while the readers required
+ * the live plugin (issue #7392). Every backup command now resolves the directory through the same chain, so
+ * what one of them writes the others can see.
+ * <p>
+ * One server boot covers both fallbacks: the config file is present but says {@code "enabled": false}, so the
+ * plugin is registered and disabled and the file's {@code backupDirectory} is the first fallback; deleting the
+ * file half way through the test leaves only the server-wide {@code arcadedb.server.backupDirectory}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7392OnDemandBackupWithoutAutoBackupIT extends BaseGraphServerTest {
+  private static final String CONFIG_BACKUP_DIR_NAME = "test-backups-7392-config";
+  private static final String SERVER_BACKUP_DIR_NAME = "test-backups-7392-server";
+  private static final String BACKUP_CONFIG          = """
+      {
+        "version": 1,
+        "enabled": false,
+        "backupDirectory": "%s",
+        "defaults": {
+          "enabled": true,
+          "runOnServer": "*",
+          "schedule": {
+            "type": "frequency",
+            "frequencyMinutes": 9999
+          },
+          "retention": {
+            "maxFiles": 50
+          }
+        }
+      }
+      """.formatted(CONFIG_BACKUP_DIR_NAME);
+
+  private File   backupConfigFile;
+  private File   configBackupDir;
+  private File   serverBackupDir;
+  private String restoredDatabaseName;
+
+  @Override
+  protected boolean isCreateDatabases() {
+    return true;
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+
+    try {
+      final File configDir = new File("./target/config");
+      configDir.mkdirs();
+
+      backupConfigFile = new File(configDir, "backup.json");
+      try (final FileWriter writer = new FileWriter(backupConfigFile)) {
+        writer.write(BACKUP_CONFIG);
+      }
+
+      configBackupDir = freshDirectory("./target/" + CONFIG_BACKUP_DIR_NAME);
+      serverBackupDir = freshDirectory("./target/" + SERVER_BACKUP_DIR_NAME);
+    } catch (final IOException e) {
+      throw new RuntimeException("Failed to set up backup config", e);
+    }
+
+    config.setValue(GlobalConfiguration.SERVER_ROOT_PATH, "./target");
+    config.setValue(GlobalConfiguration.SERVER_BACKUP_DIRECTORY, serverBackupDir.getPath());
+    config.setValue(GlobalConfiguration.SERVER_PLUGINS, "auto-backup:" + AutoBackupSchedulerPlugin.class.getName());
+  }
+
+  @AfterEach
+  void cleanUp() {
+    if (restoredDatabaseName != null) {
+      try {
+        final ArcadeDBServer server = getServer(0);
+        if (server.existsDatabase(restoredDatabaseName))
+          server.getDatabase(restoredDatabaseName).getEmbedded().drop();
+      } catch (final Exception ignore) {
+        // best-effort
+      }
+    }
+
+    if (backupConfigFile != null && backupConfigFile.exists())
+      backupConfigFile.delete();
+    if (configBackupDir != null && configBackupDir.exists())
+      FileUtils.deleteRecursively(configBackupDir);
+    if (serverBackupDir != null && serverBackupDir.exists())
+      FileUtils.deleteRecursively(serverBackupDir);
+  }
+
+  @Test
+  void everyBackupCommandAgreesOnWhereBackupsLiveWhenAutoBackupIsOff() throws Exception {
+    final String databaseName = getDatabaseName();
+    restoredDatabaseName = databaseName + "_restored_7392";
+
+    // The plugin is registered but disabled by its own file, which is the configuration the issue describes.
+    assertThat(getServer(0).getPlugins()).anyMatch(p -> p instanceof AutoBackupSchedulerPlugin plugin && !plugin.isEnabled());
+
+    // --- Fallback 1: config/backup.json names the directory even though the scheduler is off ---
+    final String fileFromConfig = triggerAndExpectVisible(databaseName, new File(configBackupDir, databaseName));
+
+    final HttpResponse<String> restoreResponse = postCommand(
+        "restore backup " + databaseName + " " + fileFromConfig + " as " + restoredDatabaseName);
+    assertThat(restoreResponse.statusCode()).as(restoreResponse.body()).isEqualTo(200);
+    assertThat(getServer(0).existsDatabase(restoredDatabaseName)).isTrue();
+
+    deleteAndExpectGone(databaseName, fileFromConfig, new File(configBackupDir, databaseName));
+
+    // --- Fallback 2: no config file at all, only the server-wide backup directory ---
+    assertThat(backupConfigFile.delete()).isTrue();
+
+    final String fileFromServerSetting = triggerAndExpectVisible(databaseName, new File(serverBackupDir, databaseName));
+    deleteAndExpectGone(databaseName, fileFromServerSetting, new File(serverBackupDir, databaseName));
+
+    // A file name that was never written is still refused, through the same resolution.
+    final HttpResponse<String> missing = postCommand("delete backup " + databaseName + " " + databaseName + "-backup-19700101-000000000.zip");
+    assertThat(missing.statusCode()).isEqualTo(400);
+    assertThat(missing.body()).contains("not found");
+  }
+
+  private String triggerAndExpectVisible(final String databaseName, final File expectedDirectory) throws Exception {
+    final HttpResponse<String> triggerResponse = postCommand("trigger backup " + databaseName);
+    assertThat(triggerResponse.statusCode()).as(triggerResponse.body()).isEqualTo(200);
+    final String writtenFile = new File(new JSONObject(triggerResponse.body()).getString("backupFile")).getName();
+
+    final File[] onDisk = expectedDirectory.listFiles((dir, name) -> name.endsWith(".zip"));
+    assertThat(onDisk).as("the archive must land in the directory the resolution chain names").hasSize(1);
+    assertThat(onDisk[0].getName()).isEqualTo(writtenFile);
+
+    final HttpResponse<String> listResponse = postCommand("list backups " + databaseName);
+    assertThat(listResponse.statusCode()).isEqualTo(200);
+    final JSONObject listing = new JSONObject(listResponse.body());
+    final JSONArray backups = listing.getJSONArray("backups");
+    assertThat(backups.length()).as("the archive trigger just wrote must be listed: " + listing).isEqualTo(1);
+    assertThat(backups.getJSONObject(0).getString("fileName")).isEqualTo(writtenFile);
+    assertThat(listing.getInt("totalCount")).isEqualTo(1);
+    assertThat(listing.getLong("totalSize")).isEqualTo(onDisk[0].length());
+
+    return writtenFile;
+  }
+
+  private void deleteAndExpectGone(final String databaseName, final String fileName, final File directory) throws Exception {
+    final HttpResponse<String> deleteResponse = postCommand("delete backup " + databaseName + " " + fileName);
+    assertThat(deleteResponse.statusCode()).as(deleteResponse.body()).isEqualTo(200);
+    assertThat(new File(directory, fileName)).doesNotExist();
+
+    final HttpResponse<String> listAfterDelete = postCommand("list backups " + databaseName);
+    assertThat(new JSONObject(listAfterDelete.body()).getJSONArray("backups").length()).isZero();
+  }
+
+  private static File freshDirectory(final String path) {
+    final File dir = new File(path);
+    if (dir.exists())
+      FileUtils.deleteRecursively(dir);
+    dir.mkdirs();
+    return dir;
+  }
+
+  private HttpResponse<String> postCommand(final String command) throws Exception {
+    final HttpClient client = HttpClient.newHttpClient();
+    final HttpRequest request = HttpRequest.newBuilder()
+        .uri(new URI("http://localhost:2480/api/v1/server"))
+        .header("Authorization",
+            "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()))
+        .header("Content-Type", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString(new JSONObject().put("command", command).toString()))
+        .build();
+    return client.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/backup/Issue7392OnDemandBackupWithoutAutoBackupIT.java
+++ b/server/src/test/java/com/arcadedb/server/backup/Issue7392OnDemandBackupWithoutAutoBackupIT.java
@@ -165,6 +165,13 @@ class Issue7392OnDemandBackupWithoutAutoBackupIT extends BaseGraphServerTest {
     try (final FileWriter writer = new FileWriter(backupConfigFile)) {
       writer.write("{ not json");
     }
+    final HttpResponse<String> configWithBrokenFile = postCommand("get backup config");
+    assertThat(configWithBrokenFile.statusCode()).as(configWithBrokenFile.body()).isEqualTo(200);
+    final JSONObject brokenConfig = new JSONObject(configWithBrokenFile.body());
+    assertThat(brokenConfig.getBoolean("enabled")).isFalse();
+    assertThat(brokenConfig.getString("message", "")).contains("Cannot read");
+    assertThat(brokenConfig.getString("backupDirectory", "")).isEqualTo(serverBackupDir.getAbsoluteFile().toPath().normalize().toString());
+
     final String fileWithBrokenConfig = triggerAndExpectVisible(databaseName, new File(serverBackupDir, databaseName));
     deleteAndExpectGone(databaseName, fileWithBrokenConfig, new File(serverBackupDir, databaseName));
     assertThat(backupConfigFile.delete()).isTrue();

--- a/server/src/test/java/com/arcadedb/server/backup/Issue7392OnDemandBackupWithoutAutoBackupIT.java
+++ b/server/src/test/java/com/arcadedb/server/backup/Issue7392OnDemandBackupWithoutAutoBackupIT.java
@@ -152,6 +152,23 @@ class Issue7392OnDemandBackupWithoutAutoBackupIT extends BaseGraphServerTest {
     final String fileFromServerSetting = triggerAndExpectVisible(databaseName, new File(serverBackupDir, databaseName));
     deleteAndExpectGone(databaseName, fileFromServerSetting, new File(serverBackupDir, databaseName));
 
+    // A database name is a path segment under the backup directory: a traversal in it is refused by every command
+    // before any path is built, and trigger in particular must not create a directory outside the tree.
+    for (final String command : new String[] { "trigger backup ../escaped", "list backups ../escaped",
+        "delete backup ../escaped " + databaseName + "-backup-19700101-000000000.zip" }) {
+      final HttpResponse<String> traversal = postCommand(command);
+      assertThat(traversal.statusCode()).as(command + " -> " + traversal.body()).isEqualTo(400);
+    }
+    assertThat(new File(serverBackupDir.getParentFile(), "escaped")).doesNotExist();
+
+    // A malformed config file is not the caller's fault: the chain falls through to the server setting.
+    try (final FileWriter writer = new FileWriter(backupConfigFile)) {
+      writer.write("{ not json");
+    }
+    final String fileWithBrokenConfig = triggerAndExpectVisible(databaseName, new File(serverBackupDir, databaseName));
+    deleteAndExpectGone(databaseName, fileWithBrokenConfig, new File(serverBackupDir, databaseName));
+    assertThat(backupConfigFile.delete()).isTrue();
+
     // A file name that was never written is still refused, through the same resolution.
     final HttpResponse<String> missing = postCommand("delete backup " + databaseName + " " + databaseName + "-backup-19700101-000000000.zip");
     assertThat(missing.statusCode()).isEqualTo(400);

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -5700,9 +5700,13 @@ function stepsHaveCost(steps) {
  */
 function stepTotalCost(step) {
   if (step.totalCost != null && step.totalCost >= 0) return step.totalCost;
+  // The fallback walks the subtree, and renderFlameRow asks for every node on its way down; remember the answer on
+  // the node so a deep plan is summed once rather than once per ancestor.
+  if (step._subtreeCost != null) return step._subtreeCost;
   var total = step.cost != null && step.cost > 0 ? step.cost : 0;
   if (step.subSteps)
     for (var i = 0; i < step.subSteps.length; i++) total += stepTotalCost(step.subSteps[i]);
+  step._subtreeCost = total;
   return total;
 }
 

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -5634,7 +5634,11 @@ function renderFlameRow(steps, rootCost, depth) {
   var html = "<div class='flame-row'>";
   for (var i = 0; i < steps.length; i++) {
     var step = steps[i];
-    var cost = step.cost != null ? step.cost : -1;
+    // A bar spans its whole subtree: "cost" is the step's SELF time since #7329 (-1 for a container that only
+    // dispatches to its children), "totalCost" the roll-up. Sizing by self time drew a container at the minimum
+    // width with its timed children squeezed inside it (issue #7391).
+    var selfCost = step.cost != null ? step.cost : -1;
+    var cost = stepTotalCost(step);
     var pctOfRoot = rootCost > 0 && cost > 0 ? (cost / rootCost * 100) : 0;
     var widthPct = Math.max(pctOfRoot, 1.5); // minimum 1.5% for visibility
     var depthClass = "flame-depth-" + (depth % 5);
@@ -5645,6 +5649,8 @@ function renderFlameRow(steps, rootCost, depth) {
     // Wrapper holds the bar + its children (so children sit below, constrained to parent width)
     html += "<div class='flame-cell' style='width:" + widthPct + "%'>";
     var tipHtml = escapeHtml(name) + " &mdash; " + escapeHtml(costLabel) + " (" + pctOfRoot.toFixed(1) + "% of total)";
+    if (step.subSteps && step.subSteps.length > 0)
+      tipHtml += "<br>self: " + escapeHtml(formatCostNanos(selfCost));
     if (desc) tipHtml += "<br>" + escapeHtml(desc);
     html += "<div class='flame-bar " + depthClass + "'";
     html += flameTipAttr(tipHtml) + ">";
@@ -5687,13 +5693,28 @@ function stepsHaveCost(steps) {
   return false;
 }
 
+/**
+ * The subtree total of one step: the server's "totalCost" roll-up when present, otherwise the sum of the
+ * self costs of the step and everything under it (an older server, or a step serialized without the roll-up).
+ * Both give the same number, and a container's self cost of -1 contributes nothing either way.
+ */
+function stepTotalCost(step) {
+  if (step.totalCost != null && step.totalCost >= 0) return step.totalCost;
+  var total = step.cost != null && step.cost > 0 ? step.cost : 0;
+  if (step.subSteps)
+    for (var i = 0; i < step.subSteps.length; i++) total += stepTotalCost(step.subSteps[i]);
+  return total;
+}
+
+/**
+ * The plan's total: the roll-up of each top-level step. Summing "cost" here read the self time of a container
+ * as the total, so a plain type scan - one container over timed bucket steps - came out as zero and the graph
+ * reported no measurable cost on a plan that had it (issue #7391).
+ */
 function computeTotalCost(steps) {
   var total = 0;
   if (!steps) return 0;
-  for (var i = 0; i < steps.length; i++) {
-    var cost = steps[i].cost;
-    if (cost != null && cost > 0) total += cost;
-  }
+  for (var i = 0; i < steps.length; i++) total += stepTotalCost(steps[i]);
   return total;
 }
 

--- a/studio/test/flame-graph-total-cost.test.js
+++ b/studio/test/flame-graph-total-cost.test.js
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+
+// Regression test for issue #7391. Since #7329 a step's "cost" is its SELF time and the subtree roll-up travels
+// as "totalCost"; a container step such as FetchFromTypeExecutionStep times nothing itself and reports cost -1.
+// The flame graph kept reading "cost" as the roll-up, so a plain type scan - whose only top-level step is the
+// container - summed to zero and rendered "No measurable cost recorded." on a plan full of cost data, and a
+// container's bar was drawn at the 1.5% minimum with its timed children squeezed inside it. Run with:
+//
+//     node --test studio/test/flame-graph-total-cost.test.js
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const SRC_PATH = path.join(__dirname, "..", "src", "main", "resources", "static", "js", "studio-database.js");
+const src = fs.readFileSync(SRC_PATH, "utf8");
+
+function extractFn(name) {
+  const start = src.indexOf("function " + name + "(");
+  if (start < 0) throw new Error("function not found in studio-database.js: " + name);
+  let i = src.indexOf("{", start);
+  let depth = 1;
+  i++;
+  while (i < src.length && depth > 0) {
+    const c = src[i];
+    if (c === "{") depth++;
+    else if (c === "}") depth--;
+    i++;
+  }
+  if (depth !== 0) throw new Error("unbalanced braces while extracting " + name + ": reached end of file");
+  const source = src.substring(start, i);
+  try {
+    new Function("return (" + source + ")");
+  } catch (e) {
+    throw new Error("the extracted source of " + name + " does not parse: " + e.message);
+  }
+  return source;
+}
+
+// Stubs for the globals the flame graph reaches for.
+var flameTips = [];
+function escapeHtml(s) {
+  return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+function formatCostNanos(n) {
+  return n < 0 ? "n/a" : n + "ns";
+}
+function simplifyStepName(name) {
+  return name;
+}
+
+eval(extractFn("flameTipAttr"));
+eval(extractFn("stepsHaveCost"));
+eval(extractFn("stepTotalCost"));
+eval(extractFn("computeTotalCost"));
+eval(extractFn("renderFlameRow"));
+
+// The plan the server emits for `SELECT FROM Item` once profiled: one container with self cost -1 whose bucket
+// children carry the time, and totalCost the roll-up on every node.
+function typeScanPlan() {
+  return [
+    {
+      name: "FetchFromTypeExecutionStep",
+      cost: -1,
+      totalCost: 3000,
+      subSteps: [
+        { name: "FetchFromBucketExecutionStep", cost: 1000, totalCost: 1000 },
+        { name: "FetchFromBucketExecutionStep", cost: 2000, totalCost: 2000 },
+      ],
+    },
+  ];
+}
+
+// Widths of the bars rendered at a given depth, in document order.
+function widthsAtDepth(html, depth) {
+  const re = new RegExp("<div class='flame-cell' style='width:([0-9.]+)%'><div class='flame-bar flame-depth-" + depth + "'", "g");
+  const widths = [];
+  let m;
+  while ((m = re.exec(html)) !== null) widths.push(parseFloat(m[1]));
+  return widths;
+}
+
+test("a plain type scan has cost data and a non-zero total", () => {
+  const steps = typeScanPlan();
+  assert.equal(stepsHaveCost(steps), true);
+  assert.equal(computeTotalCost(steps), 3000);
+});
+
+test("the total is the roll-up of the top-level steps, never a double count of nested ones", () => {
+  const steps = typeScanPlan();
+  steps.push({ name: "ProjectionCalculationStep", cost: 500, totalCost: 500 });
+  assert.equal(computeTotalCost(steps), 3500);
+});
+
+test("a plan without totalCost still sums the self costs of the whole tree", () => {
+  // An older server, or a step serialized before the roll-up was added: fall back to walking the tree.
+  const steps = [
+    { name: "Container", cost: -1, subSteps: [{ name: "Leaf", cost: 700 }, { name: "Leaf", cost: 300 }] },
+    { name: "Projection", cost: 200 },
+  ];
+  assert.equal(computeTotalCost(steps), 1200);
+});
+
+test("a container bar spans its children instead of collapsing to the minimum width", () => {
+  const steps = typeScanPlan();
+  const html = renderFlameRow(steps, computeTotalCost(steps), 1);
+
+  assert.deepEqual(widthsAtDepth(html, 1), [100], "the container is the whole subtree");
+  assert.deepEqual(widthsAtDepth(html, 2).map((w) => w.toFixed(3)), ["33.333", "66.667"], "each child is its share of the root");
+});
+
+test("the tooltip of a container names both its self cost and its subtree total", () => {
+  const html = renderFlameRow(typeScanPlan(), 3000, 1);
+  const containerTip = flameTips.find((tip) => tip.indexOf("FetchFromTypeExecutionStep") >= 0);
+  assert.ok(containerTip, "the container must have a tooltip");
+  assert.ok(containerTip.indexOf("3000ns") >= 0, "the subtree total must be shown: " + containerTip);
+  assert.ok(containerTip.indexOf("self") >= 0, "the self cost must be labelled as such: " + containerTip);
+});


### PR DESCRIPTION
Fixes #7368, #7393, #7392 and #7391 - four small, independent defects that surfaced from other analyses.

## #7368 Cypher CREATE required the schema permission on an existing type

`TypeBuilder.create()` demanded `UPDATE_SCHEMA` before looking at whether the type already existed, so a Cypher `CREATE (:ExistingType {...})` - whose label resolution is a `getOrCreateVertexType` - was refused for a user holding only record grants, while the equivalent SQL `INSERT INTO` worked.

The issue proposed moving the check after the fast path. The fix goes one step further and demands the permission exactly where the builder mutates the schema, inside `createInternal()` under the write lock: a type that exists and already carries every requested bucket and super type returns without any grant, whichever lock path found it; a missing type, a missing bucket or a missing super type still needs `UPDATE_SCHEMA`. This covers every `getOrCreate*` caller (Cypher, Gremlin, MongoDB, `CREATE ... IF NOT EXISTS`) with one change and keeps the kind-mismatch check ("is not a edge type") on the fast path.

## #7393 A malformed `fulltextQuery` in a hybrid search answered HTTP 500

The full-text leg was the one stage of `HybridSearch` not funnelled through `invalidExpression`, so a Lucene parse error surfaced as an internal error with a logged stack trace. The parser now raises a dedicated `FullTextQueryParseException` (extends `IndexException`, so existing callers keep working), and that is the only type the hybrid leg and the standalone `FullTextQuery` surface re-type as `IllegalArgumentException`: an execution-time `IndexException` (tokenizer, analyzer, search engine) stays a 500 with its stack trace. HTTP, MCP and gRPC all answer a bad query text as a client error; the message carries the parser's complaint about the caller's own query text, and in production mode the detail is concealed by the existing handler policy.

## #7392 `trigger backup` worked with auto-backup off, `list`/`delete`/`restore` did not

Four commands had three definitions of "where backups live". They now share one: `ServerControlPlane.resolveBackupDirectory()` resolves, first hit wins, the running plugin's directory, then `config/backup.json` (even with `"enabled": false`), then `arcadedb.server.backupDirectory`. `trigger`, `list`, `delete`, `restore` and `get backup config` all use it, so an on-demand archive is listed, deletable and restorable regardless of the scheduler. The SQL fallback in `trigger backup` is gone: the third step of the chain is the very directory it wrote to, so one path with the coordinator's archive name replaces two.

`list backups` also reports `totalSize`/`totalCount` from the listing itself rather than from the scheduler's retention manager, so the numbers are present whenever the list is. `get backup config` gains `backupDirectory` (the resolved path) so an operator can see where on-demand backups go. Retention pruning stays the scheduler's job: with auto-backup off nothing prunes, but `delete backup` can now reach the archive, which is documented.

## #7391 Studio flame graph said "No measurable cost recorded" on a plain type scan

Since #7329 a step's `cost` is its self time (-1 for a container) and the roll-up travels as `totalCost`. Studio's `computeTotalCost` still summed top-level `cost`, so a type scan's root total was zero. It now sums each top-level step's `totalCost`, falling back to a recursive self-cost sum when the roll-up is absent. `renderFlameRow` is fixed the same way: a container's bar spans its subtree instead of collapsing to the 1.5% minimum with its timed children squeezed inside, and its tooltip shows both the subtree total and the self cost.

The two minor points from the issue are covered too: `ContainerStepSelfCostIssue7329Test` now exercises `FetchFromTypeWithFilterStep` and `FetchFromClustersExecutionStep`, and `FilterNotMatchPatternStep` carries the comment about why its timing is not a double count today.

## Tests

- `Issue7368CreateOnExistingTypeWithoutSchemaPermissionTest` (engine): Cypher CREATE on existing vertex and edge types with a record-only user; missing label, missing composite type, extra bucket and extra super type still refused; kind mismatch unchanged.
- `Issue7393MalformedFullTextQueryIsAClientErrorTest` (engine): five malformed Lucene inputs on the hybrid and standalone surfaces answer `IllegalArgumentException`; a well-formed one still runs the leg.
- `Issue7392OnDemandBackupWithoutAutoBackupIT` (server): plugin registered but disabled by its file; trigger/list/restore/delete through the config-file directory, then through the server setting after the file is removed.
- `studio/test/flame-graph-total-cost.test.js`: total from `totalCost`, fallback sum, container width, tooltip.

Each test was run against the unfixed sources first and failed there. Docs: `how-to/operations/auto-backup.adoc` gains a section on where an on-demand backup goes (local commit in arcadedb-docs, not pushed).
