### PR TITLE
fix(#7434, #7114, #7125): $matched.<alias>.<property> in MATCH, array receivers for five collection methods, vector filter from a subquery row

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorAbstract.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorAbstract.java
@@ -29,6 +29,7 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.utility.IntHashSet;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -288,6 +289,13 @@ public abstract class SQLFunctionVectorAbstract extends SQLFunctionAbstract {
     return Float.NaN;
   }
 
+  /**
+   * Reads the {@code filter} option into the set of RIDs the search is allowed to answer. Besides a bare {@link RID},
+   * an {@link Identifiable} or a RID string, an element may be the row a subquery produced (issue #7125): a
+   * {@link Result} that wraps a record, or that projects exactly one RID-valued column such as {@code SELECT @rid}. One
+   * level of nesting is flattened, so {@code (SELECT list(@rid) AS l ...).l} is accepted as well. Anything else keeps
+   * throwing, so a typo in the subquery projection stays loud rather than silently filtering nothing.
+   */
   protected static Set<RID> parseRidFilter(final List<?> items, final String functionName, final CommandContext context) {
     if (items == null || items.isEmpty())
       return null;
@@ -297,17 +305,46 @@ public abstract class SQLFunctionVectorAbstract extends SQLFunctionAbstract {
     for (final Object item : items) {
       if (item == null)
         continue;
-      if (item instanceof RID rid)
-        out.add(rid);
-      else if (item instanceof Identifiable id)
-        out.add(id.getIdentity());
-      else if (item instanceof String s)
-        out.add(db.newRID(s));
-      else
-        throw new CommandSQLParsingException(
-            "Option 'filter' for function '" + functionName + "' must contain RIDs, got: "
-                + item.getClass().getSimpleName());
+
+      if (item instanceof Collection<?> nested) {
+        // ONE LEVEL OF NESTING: A LIST OF LISTS OF RIDS. A DEEPER LEVEL IS REJECTED BY ridOf() BELOW
+        for (final Object inner : nested)
+          if (inner != null)
+            out.add(ridOf(inner, functionName, db));
+      } else
+        out.add(ridOf(item, functionName, db));
     }
     return out;
+  }
+
+  private static RID ridOf(final Object item, final String functionName, final BasicDatabase db) {
+    if (item instanceof RID rid)
+      return rid;
+    if (item instanceof Identifiable id)
+      return id.getIdentity();
+    if (item instanceof String s) {
+      try {
+        return db.newRID(s);
+      } catch (final IllegalArgumentException e) {
+        throw new CommandSQLParsingException(
+            "Option 'filter' for function '" + functionName + "' must contain RIDs, got: '" + s + "'", e);
+      }
+    }
+    if (item instanceof Result row) {
+      // THE ROW A SUBQUERY PRODUCED: EITHER A RECORD (SELECT FROM ...) OR A SINGLE RID-VALUED PROJECTION (SELECT @rid ...)
+      if (row.isElement())
+        return row.getElement().get().getIdentity();
+      final Set<String> columns = row.getPropertyNames();
+      if (columns.size() == 1) {
+        final Object value = row.getProperty(columns.iterator().next());
+        if (value instanceof RID || value instanceof Identifiable || value instanceof String)
+          return ridOf(value, functionName, db);
+      }
+      throw new CommandSQLParsingException(
+          "Option 'filter' for function '" + functionName + "' must contain RIDs, got a row with columns " + columns
+              + ": project the RID alone, e.g. (SELECT @rid FROM ...)");
+    }
+    throw new CommandSQLParsingException(
+        "Option 'filter' for function '" + functionName + "' must contain RIDs, got: " + item.getClass().getSimpleName());
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorAbstract.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorAbstract.java
@@ -323,12 +323,11 @@ public abstract class SQLFunctionVectorAbstract extends SQLFunctionAbstract {
     if (item instanceof Identifiable id)
       return id.getIdentity();
     if (item instanceof String s) {
-      try {
-        return db.newRID(s);
-      } catch (final IllegalArgumentException e) {
+      // VALIDATED UP FRONT: RID(String) THROWS A DIFFERENT EXCEPTION FOR EACH WAY A STRING CAN BE MALFORMED
+      if (!RID.is(s))
         throw new CommandSQLParsingException(
-            "Option 'filter' for function '" + functionName + "' must contain RIDs, got: '" + s + "'", e);
-      }
+            "Option 'filter' for function '" + functionName + "' must contain RIDs, got: '" + s + "'");
+      return db.newRID(s);
     }
     if (item instanceof Result row) {
       // THE ROW A SUBQUERY PRODUCED: EITHER A RECORD (SELECT FROM ...) OR A SINGLE RID-VALUED PROJECTION (SELECT @rid ...)

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CartesianProductStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CartesianProductStep.java
@@ -53,6 +53,8 @@ public class CartesianProductStep extends AbstractExecutionStep {
 
   private final List<ResultSet> resultSets   = new ArrayList<>();
   private       List<Result>    currentTuple = new ArrayList<>();
+  // THE OUTER TUPLE A CORRELATED LEVEL IS OPEN FOR, REBOUND TO $matched BEFORE EVERY PULL FROM IT
+  private final List<Result>    outerTuples  = new ArrayList<>();
 
   ResultInternal nextRecord;
 
@@ -100,6 +102,7 @@ public class CartesianProductStep extends AbstractExecutionStep {
     preFetches.clear();
     firstPass.clear();
     resultSets.clear();
+    outerTuples.clear();
     currentTuple = new ArrayList<>();
     nextRecord = null;
     // THE FIRST PASS OF AN INDEPENDENT LEVEL PULLS FROM THE SUB-PLAN ITSELF: ONE LEFT EXHAUSTED WOULD ANSWER NO ROW
@@ -121,6 +124,7 @@ public class CartesianProductStep extends AbstractExecutionStep {
       preFetches.add(new InternalResultSet());
       firstPass.add(true);
       currentTuple.add(null);
+      outerTuples.add(null);
     }
 
     for (int level = 0; level < subPlans.size(); level++) {
@@ -152,6 +156,11 @@ public class CartesianProductStep extends AbstractExecutionStep {
   private boolean advance(final int level) {
     while (true) {
       final ResultSet rs = resultSets.get(level);
+      // A CORRELATED LEG EVALUATES ITS FILTER LAZILY, ONE CANDIDATE PER PULL, AND THE PRODUCT PREPARES THE NEXT ROW BEFORE IT
+      // HANDS OUT THE CURRENT ONE: BY THEN MatchBindMatchedStep DOWNSTREAM HAS REBOUND $matched TO A ROW OF ANOTHER OUTER
+      // TUPLE, SO THE LEG'S OWN OUTER TUPLE IS BOUND AGAIN BEFORE EVERY PULL
+      if (factories.get(level) != null)
+        context.setVariable("matched", outerTuples.get(level));
       if (rs.hasNext()) {
         final Result item = rs.next();
         currentTuple.set(level, item);
@@ -174,10 +183,13 @@ public class CartesianProductStep extends AbstractExecutionStep {
   private void open(final int level) {
     final Supplier<InternalExecutionPlan> factory = factories.get(level);
     if (factory != null) {
-      // BOUND FOR AS LONG AS THE LEVEL IS PULLED, NOT JUST FOR THIS CALL: THE SUB-PLAN READS IT LAZILY, ROW BY ROW, SO THERE
-      // IS NOTHING TO RESTORE HERE. MatchBindMatchedStep REBINDS IT TO EVERY ROW THE PRODUCT EMITS BEFORE ANYTHING ELSE READS
-      // IT, AND A LEVEL IS ONE CONNECTED SUB-PATTERN, NEVER A PRODUCT OF ITS OWN, SO THE BINDINGS DO NOT NEST
-      context.setVariable("matched", partialTuple(level));
+      // THE ROOT OF THE LEG READS $matched AS ITS SEED WHEN IT IS FIRST PULLED, WHICH LocalResultSet DOES RIGHT HERE. THE
+      // BINDING IS NOT RESTORED: advance() BINDS IT AGAIN BEFORE EVERY LATER PULL, AND MatchBindMatchedStep BINDS EVERY ROW
+      // THE PRODUCT EMITS BEFORE THE RETURN CLAUSE READS IT. A LEVEL IS ONE CONNECTED SUB-PATTERN, NEVER A PRODUCT OF ITS
+      // OWN, SO THE BINDINGS DO NOT NEST
+      final ResultInternal outerTuple = partialTuple(level);
+      outerTuples.set(level, outerTuple);
+      context.setVariable("matched", outerTuple);
       final InternalExecutionPlan plan = factory.get();
       resultSets.set(level, new LocalResultSet(plan));
     } else if (firstPass.get(level))

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CartesianProductStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CartesianProductStep.java
@@ -24,22 +24,26 @@ import com.arcadedb.query.sql.parser.LocalResultSet;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.function.Supplier;
 
 /**
  * Combines the rows of the disjoint sub-patterns of a MATCH into their cartesian product, as a nested loop over the sub-plans.
  * <p>
  * The first pass of an independent sub-plan is buffered and replayed for every tuple of the levels before it. A
  * <b>correlated</b> sub-plan - one whose {@code where:} reads, through {@code $matched}, an alias bound by an earlier
- * sub-plan (issue #7434) - cannot be replayed: it is reset and executed again for every tuple of the outer levels, with the
- * {@code matched} context variable bound to that partial tuple so the predicate sees the aliases it reads. The planner
- * orders the sub-plans so that every alias a level reads is bound by a level before it.
+ * sub-plan (issue #7434) - cannot be replayed: it is planned and executed again for every tuple of the outer levels, with
+ * the {@code matched} context variable bound to that partial tuple so the predicate sees the aliases it reads. A fresh
+ * plan per tuple, rather than a reset of the same one, because the fetch and filter steps of a SELECT do not restart on
+ * reset (the same reason {@link LetQueryStep} plans a correlated subquery again per row). The planner orders the
+ * sub-plans so that every alias a level reads is bound by a level before it.
  * <p>
  * Created by luigidellaquila on 11/10/16.
  */
 public class CartesianProductStep extends AbstractExecutionStep {
 
-  private final List<InternalExecutionPlan> subPlans   = new ArrayList<>();
-  private final List<Boolean>               correlated = new ArrayList<>();
+  private final List<InternalExecutionPlan>           subPlans  = new ArrayList<>();
+  // NON-NULL FOR A CORRELATED LEVEL: PLANS THE SUB-PATTERN AGAIN FOR EVERY OUTER TUPLE
+  private final List<Supplier<InternalExecutionPlan>> factories = new ArrayList<>();
 
   private boolean inited = false;
   // THE ROWS OF AN INDEPENDENT LEVEL'S FIRST PASS, REPLAYED THROUGH reset() FOR EVERY LATER OUTER TUPLE
@@ -84,6 +88,11 @@ public class CartesianProductStep extends AbstractExecutionStep {
     };
   }
 
+  /**
+   * Best effort, like the reset of the other MATCH steps: the fetch and filter steps of a SELECT do not restart, so a
+   * sub-plan that was pulled to exhaustion answers nothing again. Nothing reaches it today, since a MATCH plan is never
+   * cached and a correlated subquery plans its statement again per row.
+   */
   @Override
   public void reset() {
     inited = false;
@@ -92,6 +101,10 @@ public class CartesianProductStep extends AbstractExecutionStep {
     resultSets.clear();
     currentTuple = new ArrayList<>();
     nextRecord = null;
+    // THE FIRST PASS OF AN INDEPENDENT LEVEL PULLS FROM THE SUB-PLAN ITSELF: ONE LEFT EXHAUSTED WOULD ANSWER NO ROW
+    for (int level = 0; level < subPlans.size(); level++)
+      if (factories.get(level) == null)
+        subPlans.get(level).reset(context);
   }
 
   private void init() {
@@ -141,7 +154,7 @@ public class CartesianProductStep extends AbstractExecutionStep {
       if (rs.hasNext()) {
         final Result item = rs.next();
         currentTuple.set(level, item);
-        if (firstPass.get(level) && !correlated.get(level))
+        if (firstPass.get(level) && factories.get(level) == null)
           preFetches.get(level).add(item);
         return true;
       }
@@ -158,10 +171,11 @@ public class CartesianProductStep extends AbstractExecutionStep {
    * the buffered first pass afterwards, or a fresh execution when the level is correlated with the outer tuple.
    */
   private void open(final int level) {
-    if (correlated.get(level)) {
+    final Supplier<InternalExecutionPlan> factory = factories.get(level);
+    if (factory != null) {
       context.setVariable("matched", partialTuple(level));
-      final InternalExecutionPlan plan = subPlans.get(level);
-      plan.reset(context);
+      final InternalExecutionPlan plan = factory.get();
+      subPlans.set(level, plan);
       resultSets.set(level, new LocalResultSet(plan));
     } else if (firstPass.get(level))
       resultSets.set(level, new LocalResultSet(subPlans.get(level)));
@@ -194,16 +208,17 @@ public class CartesianProductStep extends AbstractExecutionStep {
   }
 
   public void addSubPlan(final InternalExecutionPlan subPlan) {
-    addSubPlan(subPlan, false);
+    addSubPlan(subPlan, null);
   }
 
   /**
-   * @param correlated true when the sub-plan reads, through {@code $matched}, an alias bound by a sub-plan added before it,
-   *                   so it must be executed again for every tuple of those instead of being buffered and replayed
+   * @param factory non-null when the sub-plan reads, through {@code $matched}, an alias bound by a sub-plan added before
+   *                it: it is then planned again through the factory and executed for every tuple of those, instead of
+   *                being buffered and replayed. The sub-plan given is the one EXPLAIN prints
    */
-  public void addSubPlan(final InternalExecutionPlan subPlan, final boolean correlated) {
+  public void addSubPlan(final InternalExecutionPlan subPlan, final Supplier<InternalExecutionPlan> factory) {
     this.subPlans.add(subPlan);
-    this.correlated.add(correlated);
+    this.factories.add(factory);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CartesianProductStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CartesianProductStep.java
@@ -41,6 +41,7 @@ import java.util.function.Supplier;
  */
 public class CartesianProductStep extends AbstractExecutionStep {
 
+  // THE PLANS AS BUILT BY THE PLANNER, WHAT EXPLAIN PRINTS; A CORRELATED LEVEL RUNS A FRESH ONE PER OUTER TUPLE INSTEAD
   private final List<InternalExecutionPlan>           subPlans  = new ArrayList<>();
   // NON-NULL FOR A CORRELATED LEVEL: PLANS THE SUB-PATTERN AGAIN FOR EVERY OUTER TUPLE
   private final List<Supplier<InternalExecutionPlan>> factories = new ArrayList<>();
@@ -173,9 +174,11 @@ public class CartesianProductStep extends AbstractExecutionStep {
   private void open(final int level) {
     final Supplier<InternalExecutionPlan> factory = factories.get(level);
     if (factory != null) {
+      // BOUND FOR AS LONG AS THE LEVEL IS PULLED, NOT JUST FOR THIS CALL: THE SUB-PLAN READS IT LAZILY, ROW BY ROW, SO THERE
+      // IS NOTHING TO RESTORE HERE. MatchBindMatchedStep REBINDS IT TO EVERY ROW THE PRODUCT EMITS BEFORE ANYTHING ELSE READS
+      // IT, AND A LEVEL IS ONE CONNECTED SUB-PATTERN, NEVER A PRODUCT OF ITS OWN, SO THE BINDINGS DO NOT NEST
       context.setVariable("matched", partialTuple(level));
       final InternalExecutionPlan plan = factory.get();
-      subPlans.set(level, plan);
       resultSets.set(level, new LocalResultSet(plan));
     } else if (firstPass.get(level))
       resultSets.set(level, new LocalResultSet(subPlans.get(level)));

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CartesianProductStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CartesianProductStep.java
@@ -26,15 +26,25 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 /**
+ * Combines the rows of the disjoint sub-patterns of a MATCH into their cartesian product, as a nested loop over the sub-plans.
+ * <p>
+ * The first pass of an independent sub-plan is buffered and replayed for every tuple of the levels before it. A
+ * <b>correlated</b> sub-plan - one whose {@code where:} reads, through {@code $matched}, an alias bound by an earlier
+ * sub-plan (issue #7434) - cannot be replayed: it is reset and executed again for every tuple of the outer levels, with the
+ * {@code matched} context variable bound to that partial tuple so the predicate sees the aliases it reads. The planner
+ * orders the sub-plans so that every alias a level reads is bound by a level before it.
+ * <p>
  * Created by luigidellaquila on 11/10/16.
  */
 public class CartesianProductStep extends AbstractExecutionStep {
 
-  private final List<InternalExecutionPlan> subPlans = new ArrayList<>();
+  private final List<InternalExecutionPlan> subPlans   = new ArrayList<>();
+  private final List<Boolean>               correlated = new ArrayList<>();
 
-  private       boolean                 inited            = false;
-  private final List<Boolean>           completedPrefetch = new ArrayList<>();
-  private final List<InternalResultSet> preFetches        = new ArrayList<>();//consider using resultset.reset() instead of buffering
+  private boolean inited = false;
+  // THE ROWS OF AN INDEPENDENT LEVEL'S FIRST PASS, REPLAYED THROUGH reset() FOR EVERY LATER OUTER TUPLE
+  private final List<InternalResultSet> preFetches = new ArrayList<>();
+  private final List<Boolean>           firstPass  = new ArrayList<>();
 
   private final List<ResultSet> resultSets   = new ArrayList<>();
   private       List<Result>    currentTuple = new ArrayList<>();
@@ -50,7 +60,6 @@ public class CartesianProductStep extends AbstractExecutionStep {
     pullPrevious(context, nRecords);
 
     init();
-    //    return new OInternalResultSet();
     return new ResultSet() {
       int currentCount = 0;
 
@@ -73,8 +82,16 @@ public class CartesianProductStep extends AbstractExecutionStep {
         return result;
       }
     };
-    //    throw new UnsupportedOperationException("cartesian product is not yet implemented in MATCH statement");
-    //TODO
+  }
+
+  @Override
+  public void reset() {
+    inited = false;
+    preFetches.clear();
+    firstPass.clear();
+    resultSets.clear();
+    currentTuple = new ArrayList<>();
+    nextRecord = null;
   }
 
   private void init() {
@@ -83,93 +100,110 @@ public class CartesianProductStep extends AbstractExecutionStep {
 
     if (inited)
       return;
-
-    for (final InternalExecutionPlan plan : subPlans) {
-      resultSets.add(new LocalResultSet(plan));
-      this.preFetches.add(new InternalResultSet());
-    }
-    fetchFirstRecord();
     inited = true;
-  }
 
-  private void fetchFirstRecord() {
-    for (int i = 0; i < resultSets.size(); i++) {
-      final ResultSet rs = resultSets.get(i);
-      if (!rs.hasNext()) {
+    for (int level = 0; level < subPlans.size(); level++) {
+      resultSets.add(null);
+      preFetches.add(new InternalResultSet());
+      firstPass.add(true);
+      currentTuple.add(null);
+    }
+
+    for (int level = 0; level < subPlans.size(); level++) {
+      open(level);
+      if (!advance(level)) {
         nextRecord = null;
+        currentTuple = null;
         return;
       }
-      final Result item = rs.next();
-      currentTuple.add(item);
-      completedPrefetch.add(false);
-      bufferLiveValue(i, item);
     }
     buildNextRecord();
   }
 
   private void fetchNextRecord() {
-    fetchNextRecord(resultSets.size() - 1);
-  }
-
-  private void fetchNextRecord(final int level) {
-    ResultSet currentRs = resultSets.get(level);
-    if (!currentRs.hasNext()) {
-      if (level <= 0) {
-        nextRecord = null;
-        currentTuple = null;
-        return;
-      }
-      currentRs = preFetches.get(level);
-      currentRs.reset();
-      resultSets.set(level, currentRs);
-      currentTuple.set(level, currentRs.next());
-      fetchNextRecord(level - 1);
-    } else {
-      final Result item = currentRs.next();
-      currentTuple.set(level, item);
-      bufferLiveValue(level, item);
+    if (currentTuple != null && advance(resultSets.size() - 1))
+      buildNextRecord();
+    else {
+      nextRecord = null;
+      currentTuple = null;
     }
-    buildNextRecord();
   }
 
   /**
-   * Buffers a value read from the live result set of the given level so it can be replayed later via
-   * {@link InternalResultSet#reset()}. Only values seen during the first pass of a level are buffered, and each
-   * exactly once: while {@code completedPrefetch[level]} is false the level is still consuming its live source.
-   * This prevents the outer-level rows from being appended repeatedly while inner levels iterate (issue #4543).
+   * Moves the given level to its next row. When the level is exhausted, the level before it is advanced and this one is
+   * opened again for the new outer tuple; the loop covers a correlated level that answers no row for some outer tuples.
+   *
+   * @return false when the outermost level is exhausted, i.e. the product is complete
    */
-  private void bufferLiveValue(final int level, final Result value) {
-    if (completedPrefetch.get(level))
-      return;
-    preFetches.get(level).add(value);
-    if (!resultSets.get(level).hasNext())
-      completedPrefetch.set(level, true);
+  private boolean advance(final int level) {
+    while (true) {
+      final ResultSet rs = resultSets.get(level);
+      if (rs.hasNext()) {
+        final Result item = rs.next();
+        currentTuple.set(level, item);
+        if (firstPass.get(level) && !correlated.get(level))
+          preFetches.get(level).add(item);
+        return true;
+      }
+
+      firstPass.set(level, false);
+      if (level == 0 || !advance(level - 1))
+        return false;
+      open(level);
+    }
+  }
+
+  /**
+   * Opens the result set of a level for the current tuple of the levels before it: the live sub-plan on the first pass,
+   * the buffered first pass afterwards, or a fresh execution when the level is correlated with the outer tuple.
+   */
+  private void open(final int level) {
+    if (correlated.get(level)) {
+      context.setVariable("matched", partialTuple(level));
+      final InternalExecutionPlan plan = subPlans.get(level);
+      plan.reset(context);
+      resultSets.set(level, new LocalResultSet(plan));
+    } else if (firstPass.get(level))
+      resultSets.set(level, new LocalResultSet(subPlans.get(level)));
+    else {
+      final InternalResultSet buffered = preFetches.get(level);
+      buffered.reset();
+      resultSets.set(level, buffered);
+    }
+  }
+
+  private ResultInternal partialTuple(final int levels) {
+    final ResultInternal partial = new ResultInternal(context.getDatabase());
+    for (int i = 0; i < levels; i++) {
+      final Result res = currentTuple.get(i);
+      for (final String s : res.getPropertyNames())
+        partial.setProperty(s, res.getProperty(s));
+    }
+    return partial;
   }
 
   private void buildNextRecord() {
     final long begin = context.isProfiling() ? System.nanoTime() : 0;
     try {
-      if (currentTuple == null) {
-        nextRecord = null;
-        return;
-      }
-      nextRecord = new ResultInternal(context.getDatabase());
-
-      for (int i = 0; i < this.currentTuple.size(); i++) {
-        final Result res = this.currentTuple.get(i);
-        for (final String s : res.getPropertyNames()) {
-          nextRecord.setProperty(s, res.getProperty(s));
-        }
-      }
+      nextRecord = partialTuple(currentTuple.size());
     } finally {
-      if( context.isProfiling() ) {
+      if (context.isProfiling()) {
         cost += System.nanoTime() - begin;
       }
     }
   }
 
   public void addSubPlan(final InternalExecutionPlan subPlan) {
+    addSubPlan(subPlan, false);
+  }
+
+  /**
+   * @param correlated true when the sub-plan reads, through {@code $matched}, an alias bound by a sub-plan added before it,
+   *                   so it must be executed again for every tuple of those instead of being buffered and replayed
+   */
+  public void addSubPlan(final InternalExecutionPlan subPlan, final boolean correlated) {
     this.subPlans.add(subPlan);
+    this.correlated.add(correlated);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CartesianProductStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CartesianProductStep.java
@@ -160,7 +160,7 @@ public class CartesianProductStep extends AbstractExecutionStep {
       // HANDS OUT THE CURRENT ONE: BY THEN MatchBindMatchedStep DOWNSTREAM HAS REBOUND $matched TO A ROW OF ANOTHER OUTER
       // TUPLE, SO THE LEG'S OWN OUTER TUPLE IS BOUND AGAIN BEFORE EVERY PULL
       if (factories.get(level) != null)
-        context.setVariable("matched", outerTuples.get(level));
+        context.setVariable(MatchBindMatchedStep.MATCHED_VARIABLE, outerTuples.get(level));
       if (rs.hasNext()) {
         final Result item = rs.next();
         currentTuple.set(level, item);
@@ -168,6 +168,11 @@ public class CartesianProductStep extends AbstractExecutionStep {
           preFetches.get(level).add(item);
         return true;
       }
+
+      // AN INDEPENDENT LEVEL WITH NO ROW AT ALL EMPTIES THE WHOLE PRODUCT: ANSWER SO AT ONCE RATHER THAN WALKING EVERY ROW OF
+      // THE LEVELS BEFORE IT TO FIND OUT. A CORRELATED LEVEL ANSWERS PER OUTER TUPLE, SO IT GETS NO SUCH SHORTCUT
+      if (factories.get(level) == null && firstPass.get(level) && preFetches.get(level).countEntries() == 0)
+        return false;
 
       firstPass.set(level, false);
       if (level == 0 || !advance(level - 1))
@@ -189,7 +194,7 @@ public class CartesianProductStep extends AbstractExecutionStep {
       // OWN, SO THE BINDINGS DO NOT NEST
       final ResultInternal outerTuple = partialTuple(level);
       outerTuples.set(level, outerTuple);
-      context.setVariable("matched", outerTuple);
+      context.setVariable(MatchBindMatchedStep.MATCHED_VARIABLE, outerTuple);
       final InternalExecutionPlan plan = factory.get();
       resultSets.set(level, new LocalResultSet(plan));
     } else if (firstPass.get(level))

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CartesianProductStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CartesianProductStep.java
@@ -149,9 +149,16 @@ public class CartesianProductStep extends AbstractExecutionStep {
 
   /**
    * Moves the given level to its next row. When the level is exhausted, the level before it is advanced and this one is
-   * opened again for the new outer tuple; the loop covers a correlated level that answers no row for some outer tuples.
+   * opened again for the new outer tuple. The four cases, in the order the loop meets them:
+   * <ol>
+   *   <li>the level has a next row: bind it (and buffer it, when this is the first pass of an independent level)</li>
+   *   <li>an independent level answered no row at all on its first pass: the product is empty, answer so at once</li>
+   *   <li>the outermost level is exhausted: the product is complete</li>
+   *   <li>otherwise advance the level before, open this one again for the new outer tuple and loop: a correlated level
+   *       may answer no row for that tuple, in which case the loop backtracks once more</li>
+   * </ol>
    *
-   * @return false when the outermost level is exhausted, i.e. the product is complete
+   * @return false when the product is complete or empty
    */
   private boolean advance(final int level) {
     while (true) {
@@ -186,6 +193,11 @@ public class CartesianProductStep extends AbstractExecutionStep {
    * the buffered first pass afterwards, or a fresh execution when the level is correlated with the outer tuple.
    */
   private void open(final int level) {
+    // THE RESULT SET BEING REPLACED IS THE LIVE ONE OF A SUB-PLAN, EXHAUSTED OR SUPERSEDED: RELEASE WHAT ITS STEPS HOLD
+    final ResultSet previous = resultSets.get(level);
+    if (previous instanceof LocalResultSet)
+      previous.close();
+
     final Supplier<InternalExecutionPlan> factory = factories.get(level);
     if (factory != null) {
       // THE ROOT OF THE LEG READS $matched AS ITS SEED WHEN IT IS FIRST PULLED, WHICH LocalResultSet DOES RIGHT HERE. THE
@@ -204,6 +216,17 @@ public class CartesianProductStep extends AbstractExecutionStep {
       buffered.reset();
       resultSets.set(level, buffered);
     }
+  }
+
+  @Override
+  public void close() {
+    for (final ResultSet rs : resultSets)
+      if (rs != null)
+        rs.close();
+    for (int level = 0; level < subPlans.size(); level++)
+      if (factories.get(level) == null)
+        subPlans.get(level).close();
+    super.close();
   }
 
   private ResultInternal partialTuple(final int levels) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchBindMatchedStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchBindMatchedStep.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.exception.TimeoutException;
+
+/**
+ * Binds the {@code matched} context variable to every row leaving the pattern-matching part of a MATCH plan, so that
+ * {@code $matched.<alias>.<property>} in {@code RETURN} reads the row being projected.
+ * <p>
+ * The pattern-matching steps themselves bind the variable only while they evaluate a node's {@code where:} - to the partial
+ * match the hop starts from, or to the outer tuple a correlated sub-plan runs for - and restore it afterwards. Binding it
+ * on emit, as they used to, shadowed the partial match a correlated filter upstream was still reading, since the pipeline
+ * pulls rows lazily: the row emitted for one candidate was what the filter saw for the next (issue #7434).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class MatchBindMatchedStep extends AbstractExecutionStep {
+
+  public MatchBindMatchedStep(final CommandContext context) {
+    super(context);
+  }
+
+  @Override
+  public ResultSet syncPull(final CommandContext context, final int nRecords) throws TimeoutException {
+    checkForPrevious();
+
+    final ResultSet upstream = prev.syncPull(context, nRecords);
+    return new ResultSet() {
+      @Override
+      public boolean hasNext() {
+        return upstream.hasNext();
+      }
+
+      @Override
+      public Result next() {
+        final Result row = upstream.next();
+        context.setVariable("matched", row);
+        return row;
+      }
+
+      @Override
+      public void close() {
+        upstream.close();
+      }
+    };
+  }
+
+  @Override
+  public String prettyPrint(final int depth, final int indent) {
+    return ExecutionStepInternal.getIndent(depth, indent) + "+ BIND $matched";
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchBindMatchedStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchBindMatchedStep.java
@@ -32,6 +32,12 @@ import com.arcadedb.exception.TimeoutException;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class MatchBindMatchedStep extends AbstractExecutionStep {
+  /**
+   * Name of the context variable behind {@code $matched}. Every step that binds it does so only for the span in which it
+   * evaluates something, and restores it afterwards; this step is the one that binds it for the RETURN clause.
+   */
+  public static final String MATCHED_VARIABLE = "matched";
+
 
   public MatchBindMatchedStep(final CommandContext context) {
     super(context);
@@ -53,7 +59,7 @@ public class MatchBindMatchedStep extends AbstractExecutionStep {
         final Result row = upstream.next();
         final long begin = context.isProfiling() ? System.nanoTime() : 0;
         try {
-          context.setVariable("matched", row);
+          context.setVariable(MATCHED_VARIABLE, row);
           return row;
         } finally {
           if (context.isProfiling())

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchBindMatchedStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchBindMatchedStep.java
@@ -51,8 +51,14 @@ public class MatchBindMatchedStep extends AbstractExecutionStep {
       @Override
       public Result next() {
         final Result row = upstream.next();
-        context.setVariable("matched", row);
-        return row;
+        final long begin = context.isProfiling() ? System.nanoTime() : 0;
+        try {
+          context.setVariable("matched", row);
+          return row;
+        } finally {
+          if (context.isProfiling())
+            cost += System.nanoTime() - begin;
+        }
       }
 
       @Override
@@ -64,6 +70,9 @@ public class MatchBindMatchedStep extends AbstractExecutionStep {
 
   @Override
   public String prettyPrint(final int depth, final int indent) {
-    return ExecutionStepInternal.getIndent(depth, indent) + "+ BIND $matched";
+    String result = ExecutionStepInternal.getIndent(depth, indent) + "+ BIND $matched";
+    if (context.isProfiling())
+      result += " (" + getCostFormatted() + ")";
+    return result;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
@@ -253,10 +253,9 @@ public class MatchEdgeTraverser {
 
           public void fetchNext() {
             final Object previousMatch = iCommandContext.getVariable("currentMatch");
-//            final ResultInternal matched = (ResultInternal) iCommandContext.getVariable("matched");
-//            if (matched != null) {
-//              matched.setProperty(getStartingPointAlias(), sourceRecord.getProperty(getStartingPointAlias()));
-//            }
+            // $matched IS THE PARTIAL MATCH THIS HOP STARTS FROM, NOT THE ROW THE STEP LAST EMITTED (ISSUE #7434)
+            final Object previousMatched = iCommandContext.getVariable("matched");
+            iCommandContext.setVariable("matched", sourceRecord);
             while (iter.hasNext()) {
               final ResultInternal next = iter.next();
               final Document elem = next.toElement();
@@ -268,6 +267,7 @@ public class MatchEdgeTraverser {
               }
             }
             iCommandContext.setVariable("currentMatch", previousMatch);
+            iCommandContext.setVariable("matched", previousMatched);
           }
         };
       };
@@ -285,6 +285,8 @@ public class MatchEdgeTraverser {
       iCommandContext.setVariable("depth", depth);
       final Object previousMatch = iCommandContext.getVariable("currentMatch");
       iCommandContext.setVariable("currentMatch", startingPoint);
+      final Object previousMatched = iCommandContext.getVariable("matched");
+      iCommandContext.setVariable("matched", sourceRecord);
 
       if (matchesFilters(iCommandContext, filter, startingPoint) && matchesClass(className, startingPoint) && matchesCluster(
           clusterId, startingPoint) && matchesRid(iCommandContext, targetRid, startingPoint)) {
@@ -327,6 +329,7 @@ public class MatchEdgeTraverser {
         }
       }
       iCommandContext.setVariable("currentMatch", previousMatch);
+      iCommandContext.setVariable("matched", previousMatched);
     }
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
@@ -254,8 +254,8 @@ public class MatchEdgeTraverser {
           public void fetchNext() {
             final Object previousMatch = iCommandContext.getVariable("currentMatch");
             // $matched IS THE PARTIAL MATCH THIS HOP STARTS FROM, NOT THE ROW THE STEP LAST EMITTED (ISSUE #7434)
-            final Object previousMatched = iCommandContext.getVariable("matched");
-            iCommandContext.setVariable("matched", sourceRecord);
+            final Object previousMatched = iCommandContext.getVariable(MatchBindMatchedStep.MATCHED_VARIABLE);
+            iCommandContext.setVariable(MatchBindMatchedStep.MATCHED_VARIABLE, sourceRecord);
             try {
               while (iter.hasNext()) {
                 final ResultInternal next = iter.next();
@@ -270,7 +270,7 @@ public class MatchEdgeTraverser {
             } finally {
               // THE FILTER IS ARBITRARY SQL: RESTORE EVEN WHEN IT THROWS, OR THE CONTEXT KEEPS THIS HOP'S BINDINGS
               iCommandContext.setVariable("currentMatch", previousMatch);
-              iCommandContext.setVariable("matched", previousMatched);
+              iCommandContext.setVariable(MatchBindMatchedStep.MATCHED_VARIABLE, previousMatched);
             }
           }
         };
@@ -289,8 +289,8 @@ public class MatchEdgeTraverser {
       iCommandContext.setVariable("depth", depth);
       final Object previousMatch = iCommandContext.getVariable("currentMatch");
       iCommandContext.setVariable("currentMatch", startingPoint);
-      final Object previousMatched = iCommandContext.getVariable("matched");
-      iCommandContext.setVariable("matched", sourceRecord);
+      final Object previousMatched = iCommandContext.getVariable(MatchBindMatchedStep.MATCHED_VARIABLE);
+      iCommandContext.setVariable(MatchBindMatchedStep.MATCHED_VARIABLE, sourceRecord);
 
       try {
         if (matchesFilters(iCommandContext, filter, startingPoint) && matchesClass(className, startingPoint) && matchesCluster(
@@ -335,7 +335,7 @@ public class MatchEdgeTraverser {
         }
       } finally {
         iCommandContext.setVariable("currentMatch", previousMatch);
-        iCommandContext.setVariable("matched", previousMatched);
+        iCommandContext.setVariable(MatchBindMatchedStep.MATCHED_VARIABLE, previousMatched);
       }
     }
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
@@ -256,18 +256,22 @@ public class MatchEdgeTraverser {
             // $matched IS THE PARTIAL MATCH THIS HOP STARTS FROM, NOT THE ROW THE STEP LAST EMITTED (ISSUE #7434)
             final Object previousMatched = iCommandContext.getVariable("matched");
             iCommandContext.setVariable("matched", sourceRecord);
-            while (iter.hasNext()) {
-              final ResultInternal next = iter.next();
-              final Document elem = next.toElement();
-              iCommandContext.setVariable("currentMatch", elem);
-              if (matchesFilters(iCommandContext, theFilter, elem) && matchesClass(theClassName, elem) && matchesCluster(
-                  theClusterId, elem) && matchesRid(iCommandContext, theTargetRid, elem)) {
-                nextElement = next;
-                break;
+            try {
+              while (iter.hasNext()) {
+                final ResultInternal next = iter.next();
+                final Document elem = next.toElement();
+                iCommandContext.setVariable("currentMatch", elem);
+                if (matchesFilters(iCommandContext, theFilter, elem) && matchesClass(theClassName, elem) && matchesCluster(
+                    theClusterId, elem) && matchesRid(iCommandContext, theTargetRid, elem)) {
+                  nextElement = next;
+                  break;
+                }
               }
+            } finally {
+              // THE FILTER IS ARBITRARY SQL: RESTORE EVEN WHEN IT THROWS, OR THE CONTEXT KEEPS THIS HOP'S BINDINGS
+              iCommandContext.setVariable("currentMatch", previousMatch);
+              iCommandContext.setVariable("matched", previousMatched);
             }
-            iCommandContext.setVariable("currentMatch", previousMatch);
-            iCommandContext.setVariable("matched", previousMatched);
           }
         };
       };
@@ -288,48 +292,51 @@ public class MatchEdgeTraverser {
       final Object previousMatched = iCommandContext.getVariable("matched");
       iCommandContext.setVariable("matched", sourceRecord);
 
-      if (matchesFilters(iCommandContext, filter, startingPoint) && matchesClass(className, startingPoint) && matchesCluster(
-          clusterId, startingPoint) && matchesRid(iCommandContext, targetRid, startingPoint)) {
-        final ResultInternal rs = new ResultInternal(startingPoint.getRecord());
-        // set traversal depth in the metadata
-        rs.setMetadata("$depth", depth);
-        // set traversal path in the metadata
-        rs.setMetadata("$matchPath", pathToHere == null ? Collections.emptyList() : pathToHere);
-        // add the result to the list
-        ((List) result).add(rs);
-      }
+      try {
+        if (matchesFilters(iCommandContext, filter, startingPoint) && matchesClass(className, startingPoint) && matchesCluster(
+            clusterId, startingPoint) && matchesRid(iCommandContext, targetRid, startingPoint)) {
+          final ResultInternal rs = new ResultInternal(startingPoint.getRecord());
+          // set traversal depth in the metadata
+          rs.setMetadata("$depth", depth);
+          // set traversal path in the metadata
+          rs.setMetadata("$matchPath", pathToHere == null ? Collections.emptyList() : pathToHere);
+          // add the result to the list
+          ((List) result).add(rs);
+        }
 
-      if ((maxDepth == null || depth < maxDepth) && (whileCondition == null || whileCondition.matchesFilters(startingPoint,
-          iCommandContext))) {
+        if ((maxDepth == null || depth < maxDepth) && (whileCondition == null || whileCondition.matchesFilters(startingPoint,
+            iCommandContext))) {
 
-        final Iterable<ResultInternal> queryResult = traversePatternEdge(startingPoint, iCommandContext);
+          final Iterable<ResultInternal> queryResult = traversePatternEdge(startingPoint, iCommandContext);
 
-        for (final ResultInternal origin : queryResult) {
-          //          if(origin.equals(startingPoint)){
-          //            continue;
-          //          }
-          // TODO consider break strategies (eg. re-traverse nodes)
+          for (final ResultInternal origin : queryResult) {
+            //          if(origin.equals(startingPoint)){
+            //            continue;
+            //          }
+            // TODO consider break strategies (eg. re-traverse nodes)
 
-          final List<Identifiable> newPath = new ArrayList<>();
-          if (pathToHere != null) {
-            newPath.addAll(pathToHere);
-          }
+            final List<Identifiable> newPath = new ArrayList<>();
+            if (pathToHere != null) {
+              newPath.addAll(pathToHere);
+            }
 
-          final Document elem = origin.toElement();
-          newPath.add(elem.getIdentity());
+            final Document elem = origin.toElement();
+            newPath.add(elem.getIdentity());
 
-          final Iterable<ResultInternal> subResult = executeTraversal(iCommandContext, item, elem, depth + 1, newPath);
-          if (subResult instanceof Collection<? extends ResultInternal> collection) {
-            ((List) result).addAll(collection);
-          } else {
-            for (final ResultInternal i : subResult) {
-              ((List) result).add(i);
+            final Iterable<ResultInternal> subResult = executeTraversal(iCommandContext, item, elem, depth + 1, newPath);
+            if (subResult instanceof Collection<? extends ResultInternal> collection) {
+              ((List) result).addAll(collection);
+            } else {
+              for (final ResultInternal i : subResult) {
+                ((List) result).add(i);
+              }
             }
           }
         }
+      } finally {
+        iCommandContext.setVariable("currentMatch", previousMatch);
+        iCommandContext.setVariable("matched", previousMatched);
       }
-      iCommandContext.setVariable("currentMatch", previousMatch);
-      iCommandContext.setVariable("matched", previousMatched);
     }
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchExecutionPlanner.java
@@ -133,9 +133,13 @@ public class MatchExecutionPlanner {
       final CartesianProductStep step = new CartesianProductStep(context);
       final List<Set<Integer>> subPatternDependencies = orderSubPatternsByDependencies();
       for (int i = 0; i < subPatterns.size(); i++) {
+        final Pattern subPattern = subPatterns.get(i);
         final boolean correlated = !subPatternDependencies.get(i).isEmpty();
-        step.addSubPlan(createPlanForPattern(subPatterns.get(i), context, estimatedRootEntries, aliasesToPrefetch, correlated),
+        final InternalExecutionPlan subPlan = createPlanForPattern(subPattern, context, estimatedRootEntries, aliasesToPrefetch,
             correlated);
+        // A CORRELATED LEG IS PLANNED AGAIN FOR EVERY OUTER TUPLE: THE FETCH AND FILTER STEPS OF ITS ROOT SELECT DO NOT RESTART
+        step.addSubPlan(subPlan,
+            correlated ? () -> createPlanForPattern(subPattern, context, estimatedRootEntries, aliasesToPrefetch, true) : null);
       }
       result.chain(step);
     } else {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchExecutionPlanner.java
@@ -131,10 +131,10 @@ public class MatchExecutionPlanner {
 
     if (subPatterns.size() > 1) {
       final CartesianProductStep step = new CartesianProductStep(context);
-      final List<Set<Integer>> subPatternDependencies = orderSubPatternsByDependencies();
+      final List<Boolean> correlatedSubPatterns = orderSubPatternsByDependencies();
       for (int i = 0; i < subPatterns.size(); i++) {
         final Pattern subPattern = subPatterns.get(i);
-        final boolean correlated = !subPatternDependencies.get(i).isEmpty();
+        final boolean correlated = correlatedSubPatterns.get(i);
         final InternalExecutionPlan subPlan = createPlanForPattern(subPattern, context, estimatedRootEntries, aliasesToPrefetch,
             correlated);
         // A CORRELATED LEG IS PLANNED AGAIN FOR EVERY OUTER TUPLE: THE FETCH AND FILTER STEPS OF ITS ROOT SELECT DO NOT RESTART
@@ -369,6 +369,10 @@ public class MatchExecutionPlanner {
     for (int i = startIdx; i < edges.size(); i++) {
       final EdgeTraversal et = edges.get(i);
       if (!isFusibleEdge(et))
+        break;
+      // THE FUSED CSR WALK BINDS THE ALIASES IT REACHES WITHOUT EVALUATING THEIR where:, SO A FILTERED HOP STAYS ON THE
+      // REGULAR MatchStep, WHICH DOES (AND BINDS $matched FOR IT, ISSUE #7434)
+      if (aliasFilters.get(et.out ? et.edge.in.alias : et.edge.out.alias) != null)
         break;
 
       // Find provider for this edge's labels
@@ -668,9 +672,10 @@ public class MatchExecutionPlanner {
    * before it, with {@code $matched} bound to that tuple, which turns the comma-pattern into a correlated nested loop
    * (issue #7434). Sub-patterns without cross dependencies keep their original relative order.
    *
-   * @return for each sub-pattern, in the reordered position, the indexes of the sub-patterns it depends on
+   * @return for each sub-pattern, in its reordered position, whether it depends on another sub-pattern and so must run
+   * correlated
    */
-  private List<Set<Integer>> orderSubPatternsByDependencies() {
+  private List<Boolean> orderSubPatternsByDependencies() {
     final Map<String, Integer> owner = new HashMap<>();
     for (int i = 0; i < subPatterns.size(); i++)
       for (final String alias : subPatterns.get(i).aliasToNode.keySet())
@@ -690,7 +695,7 @@ public class MatchExecutionPlanner {
 
     // KAHN'S ALGORITHM, TAKING THE FIRST READY SUB-PATTERN IN ORIGINAL ORDER SO INDEPENDENT ONES KEEP THEIR PLACE
     final List<Pattern> ordered = new ArrayList<>(subPatterns.size());
-    final List<Set<Integer>> orderedDependencies = new ArrayList<>(subPatterns.size());
+    final List<Boolean> correlated = new ArrayList<>(subPatterns.size());
     final Set<Integer> scheduled = new HashSet<>();
     while (ordered.size() < subPatterns.size()) {
       int next = -1;
@@ -705,10 +710,10 @@ public class MatchExecutionPlanner {
 
       scheduled.add(next);
       ordered.add(subPatterns.get(next));
-      orderedDependencies.add(dependencies.get(next));
+      correlated.add(!dependencies.get(next).isEmpty());
     }
     subPatterns = ordered;
-    return orderedDependencies;
+    return correlated;
   }
 
   private void splitDisjointPatterns(final CommandContext context) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchExecutionPlanner.java
@@ -117,7 +117,10 @@ public class MatchExecutionPlanner {
 
     final SelectExecutionPlan result = new SelectExecutionPlan(context,  limit != null ? limit.getValue(context):0);
     final Map<String, Long> estimatedRootEntries = estimateRootEntries(aliasTypes, aliasBuckets, aliasRids, aliasFilters, context);
-    final Set<String> aliasesToPrefetch = estimatedRootEntries.entrySet().stream().filter(x -> x.getValue() < threshold)
+    // A NODE WHOSE where: READS ANOTHER ALIAS THROUGH $matched CANNOT BE PREFETCHED: THE PREFETCH RUNS BEFORE ANY ALIAS IS
+    // BOUND, SO THE PREDICATE WOULD BE FALSE FOR EVERY CANDIDATE AND THE STATEMENT WOULD SILENTLY ANSWER NOTHING (ISSUE #7434)
+    final Set<String> aliasesToPrefetch = estimatedRootEntries.entrySet().stream()
+        .filter(x -> x.getValue() < threshold && matchedDependencies(aliasFilters.get(x.getKey())).isEmpty())
         .map(x -> x.getKey()).collect(Collectors.toSet());
     if (estimatedRootEntries.containsValue(0L)) {
       result.chain(new EmptyStep(context));
@@ -128,12 +131,15 @@ public class MatchExecutionPlanner {
 
     if (subPatterns.size() > 1) {
       final CartesianProductStep step = new CartesianProductStep(context);
-      for (final Pattern subPattern : subPatterns) {
-        step.addSubPlan(createPlanForPattern(subPattern, context, estimatedRootEntries, aliasesToPrefetch));
+      final List<Set<Integer>> subPatternDependencies = orderSubPatternsByDependencies();
+      for (int i = 0; i < subPatterns.size(); i++) {
+        final boolean correlated = !subPatternDependencies.get(i).isEmpty();
+        step.addSubPlan(createPlanForPattern(subPatterns.get(i), context, estimatedRootEntries, aliasesToPrefetch, correlated),
+            correlated);
       }
       result.chain(step);
     } else {
-      final InternalExecutionPlan plan = createPlanForPattern(pattern, context, estimatedRootEntries, aliasesToPrefetch);
+      final InternalExecutionPlan plan = createPlanForPattern(pattern, context, estimatedRootEntries, aliasesToPrefetch, false);
       for (final ExecutionStep step : plan.getSteps()) {
         result.chain((ExecutionStepInternal) step);
       }
@@ -144,6 +150,8 @@ public class MatchExecutionPlanner {
     if (foundOptional) {
       result.chain(new RemoveEmptyOptionalsStep(context));
     }
+
+    result.chain(new MatchBindMatchedStep(context));
 
     if (returnElements || returnPaths || returnPatterns || returnPathElements) {
       addReturnStep(result, context);
@@ -277,8 +285,12 @@ public class MatchExecutionPlanner {
     }
   }
 
+  /**
+   * @param correlated true when the pattern is a disjoint sub-pattern that reads, through {@code $matched}, an alias bound
+   *                   by another sub-pattern, so its root must extend the outer tuple the cartesian product runs it for
+   */
   private InternalExecutionPlan createPlanForPattern(final Pattern pattern, final CommandContext context,
-      final Map<String, Long> estimatedRootEntries, final Set<String> prefetchedAliases) {
+      final Map<String, Long> estimatedRootEntries, final Set<String> prefetchedAliases, final boolean correlated) {
     final SelectExecutionPlan plan = new SelectExecutionPlan(context,  limit != null ? limit.getValue(context):0);
     final List<EdgeTraversal> sortedEdges = getTopologicalSortedSchedule(estimatedRootEntries, pattern);
 
@@ -301,7 +313,7 @@ public class MatchExecutionPlanner {
         final EdgeTraversal edge = sortedEdges.get(i);
 
         if (first) {
-          addStepsFor(plan, edge, context, true);
+          addStepsFor(plan, edge, context, true, correlated);
           first = false;
           i++;
           continue;
@@ -313,7 +325,7 @@ public class MatchExecutionPlanner {
           plan.chain(new MatchGAVFusedStep(context, chain, chain.get(0).gavProvider));
           i += chain.size();
         } else {
-          addStepsFor(plan, edge, context, false);
+          addStepsFor(plan, edge, context, false, correlated);
           i++;
         }
       }
@@ -321,7 +333,7 @@ public class MatchExecutionPlanner {
       final PatternNode node = pattern.getAliasToNode().values().iterator().next();
       if (prefetchedAliases.contains(node.alias)) {
         //from prefetch
-        plan.chain(new MatchFirstStep(context, node));
+        plan.chain(new MatchFirstStep(context, node, null, correlated));
       } else {
         //from actual execution plan
         final String typez = aliasTypes.get(node.alias);
@@ -329,7 +341,7 @@ public class MatchExecutionPlanner {
         final Rid rid = aliasRids.get(node.alias);
         final WhereClause filter = aliasFilters.get(node.alias);
         final SelectStatement select = createSelectStatement(typez, bucket, rid, filter);
-        plan.chain(new MatchFirstStep(context, node, select.createExecutionPlan(context)));
+        plan.chain(new MatchFirstStep(context, node, select.createExecutionPlan(context), correlated));
       }
     }
     return plan;
@@ -472,7 +484,10 @@ public class MatchExecutionPlanner {
       for (final String currentAlias : remainingStarts) {
         final PatternNode currentNode = pattern.aliasToNode.get(currentAlias);
 
-        if (visitedNodes.contains(currentNode)) {
+        if (currentNode == null) {
+          // THE ROOT ESTIMATES COVER EVERY ALIAS OF THE STATEMENT: ONE BOUND BY ANOTHER DISJOINT SUB-PATTERN IS NOT A START HERE
+          startsToRemove.add(currentAlias);
+        } else if (visitedNodes.contains(currentNode)) {
           // If a previous traversal already visited this alias, remove it from further consideration.
           startsToRemove.add(currentAlias);
         } else if (remainingDependencies.get(currentAlias) == null || remainingDependencies.get(currentAlias).isEmpty()) {
@@ -617,18 +632,77 @@ public class MatchExecutionPlanner {
     for (final PatternNode node : pattern.aliasToNode.values()) {
       final Set<String> currentDependencies = new HashSet<>();
 
-      final WhereClause filter = aliasFilters.get(node.alias);
-      if (filter != null && filter.getBaseExpression() != null) {
-        final List<String> involvedAliases = filter.getBaseExpression().getMatchPatternInvolvedAliases();
-        if (involvedAliases != null) {
-          currentDependencies.addAll(involvedAliases);
-        }
+      for (final String dependency : matchedDependencies(aliasFilters.get(node.alias))) {
+        // AN ALIAS BOUND BY ANOTHER DISJOINT SUB-PATTERN IS SATISFIED BY THE ORDER THE CARTESIAN PRODUCT RUNS THE SUB-PLANS IN
+        // (SEE orderSubPatternsByDependencies()), NOT BY THIS SCHEDULE. AN ALIAS NO PATTERN BINDS STAYS, SO THAT THE SCHEDULE
+        // STILL REPORTS IT AS UNDEFINED
+        if (pattern.aliasToNode.containsKey(dependency) || !this.pattern.aliasToNode.containsKey(dependency))
+          currentDependencies.add(dependency);
       }
 
       result.put(node.alias, currentDependencies);
     }
 
     return result;
+  }
+
+  /**
+   * The aliases a node's {@code where:} reads through {@code $matched}, or an empty list when it reads none.
+   */
+  private static List<String> matchedDependencies(final WhereClause filter) {
+    if (filter == null || filter.getBaseExpression() == null)
+      return Collections.emptyList();
+    final List<String> involvedAliases = filter.getBaseExpression().getMatchPatternInvolvedAliases();
+    return involvedAliases == null ? Collections.emptyList() : involvedAliases;
+  }
+
+  /**
+   * Orders the disjoint sub-patterns so that one whose {@code where:} reads, through {@code $matched}, an alias bound by
+   * another sub-pattern runs after it. The cartesian product then re-runs such a sub-plan for every tuple of the ones
+   * before it, with {@code $matched} bound to that tuple, which turns the comma-pattern into a correlated nested loop
+   * (issue #7434). Sub-patterns without cross dependencies keep their original relative order.
+   *
+   * @return for each sub-pattern, in the reordered position, the indexes of the sub-patterns it depends on
+   */
+  private List<Set<Integer>> orderSubPatternsByDependencies() {
+    final Map<String, Integer> owner = new HashMap<>();
+    for (int i = 0; i < subPatterns.size(); i++)
+      for (final String alias : subPatterns.get(i).aliasToNode.keySet())
+        owner.put(alias, i);
+
+    final List<Set<Integer>> dependencies = new ArrayList<>(subPatterns.size());
+    for (int i = 0; i < subPatterns.size(); i++) {
+      final Set<Integer> current = new HashSet<>();
+      for (final PatternNode node : subPatterns.get(i).aliasToNode.values())
+        for (final String dependency : matchedDependencies(aliasFilters.get(node.alias))) {
+          final Integer dependencyOwner = owner.get(dependency);
+          if (dependencyOwner != null && dependencyOwner != i)
+            current.add(dependencyOwner);
+        }
+      dependencies.add(current);
+    }
+
+    // KAHN'S ALGORITHM, TAKING THE FIRST READY SUB-PATTERN IN ORIGINAL ORDER SO INDEPENDENT ONES KEEP THEIR PLACE
+    final List<Pattern> ordered = new ArrayList<>(subPatterns.size());
+    final List<Set<Integer>> orderedDependencies = new ArrayList<>(subPatterns.size());
+    final Set<Integer> scheduled = new HashSet<>();
+    while (ordered.size() < subPatterns.size()) {
+      int next = -1;
+      for (int i = 0; i < subPatterns.size() && next < 0; i++)
+        if (!scheduled.contains(i) && scheduled.containsAll(dependencies.get(i)))
+          next = i;
+
+      if (next < 0)
+        throw new CommandExecutionException("""
+            This query contains MATCH conditions that cannot be evaluated, \
+            like an undefined alias or a circular dependency on a $matched condition.""");
+
+      scheduled.add(next);
+      ordered.add(subPatterns.get(next));
+      orderedDependencies.add(dependencies.get(next));
+    }
+    subPatterns = ordered;
+    return orderedDependencies;
   }
 
   private void splitDisjointPatterns(final CommandContext context) {
@@ -640,7 +714,7 @@ public class MatchExecutionPlanner {
   }
 
   private void addStepsFor(final SelectExecutionPlan plan, final EdgeTraversal edge, final CommandContext context,
-      final boolean first) {
+      final boolean first, final boolean correlated) {
     if (first) {
       final PatternNode patternNode = edge.out ? edge.edge.out : edge.edge.in;
       final String typez = this.aliasTypes.get(patternNode.alias);
@@ -660,8 +734,7 @@ public class MatchExecutionPlanner {
       select.setWhereClause(where == null ? null : where.copy());
       final BasicCommandContext subContxt = new BasicCommandContext();
       subContxt.setParentWithoutOverridingChild(context);
-      plan.chain(
-          new MatchFirstStep(context, patternNode, select.createExecutionPlan(subContxt)));
+      plan.chain(new MatchFirstStep(context, patternNode, select.createExecutionPlan(subContxt), correlated));
     }
     if (edge.edge.in.isOptionalNode()) {
       foundOptional = true;
@@ -870,7 +943,8 @@ public class MatchExecutionPlanner {
         final DocumentType oClass = schema.getType(typeName);
         final long upperBound;
         final WhereClause filter = aliasFilters.get(alias);
-        if (filter != null) {
+        // A FILTER THAT READS $matched CANNOT BE ESTIMATED BEFORE THE ALIASES IT READS ARE BOUND (ISSUE #7434)
+        if (filter != null && matchedDependencies(filter).isEmpty()) {
           upperBound = filter.estimate(oClass, threshold, context);
         } else {
           upperBound = context.getDatabase().countType(oClass.getName(), true);
@@ -890,7 +964,7 @@ public class MatchExecutionPlanner {
         if (oClass != null) {
           final long upperBound;
           final WhereClause filter = aliasFilters.get(alias);
-          if (filter != null) {
+          if (filter != null && matchedDependencies(filter).isEmpty()) {
             upperBound = Math.min(db.countBucket(bucketName), filter.estimate(oClass, threshold, context));
           } else {
             upperBound = db.countBucket(bucketName);

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchExecutionPlanner.java
@@ -640,7 +640,9 @@ public class MatchExecutionPlanner {
         // AN ALIAS BOUND BY ANOTHER DISJOINT SUB-PATTERN IS SATISFIED BY THE ORDER THE CARTESIAN PRODUCT RUNS THE SUB-PLANS IN
         // (SEE orderSubPatternsByDependencies()), NOT BY THIS SCHEDULE. AN ALIAS NO PATTERN BINDS STAYS, SO THAT THE SCHEDULE
         // STILL REPORTS IT AS UNDEFINED
-        if (pattern.aliasToNode.containsKey(dependency) || !this.pattern.aliasToNode.containsKey(dependency))
+        final boolean boundByAnotherSubPattern = !pattern.aliasToNode.containsKey(dependency)
+            && this.pattern.aliasToNode.containsKey(dependency);
+        if (!boundByAnotherSubPattern)
           currentDependencies.add(dependency);
       }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchFirstStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchFirstStep.java
@@ -71,6 +71,13 @@ public class MatchFirstStep extends AbstractExecutionStep {
   }
 
   @Override
+  public void close() {
+    if (subResultSet != null)
+      subResultSet.close();
+    super.close();
+  }
+
+  @Override
   public ResultSet syncPull(final CommandContext context, final int nRecords) throws TimeoutException {
     pullPrevious(context, nRecords);
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchFirstStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchFirstStep.java
@@ -31,24 +31,40 @@ import java.util.Set;
 public class MatchFirstStep extends AbstractExecutionStep {
   private final PatternNode           node;
   final         InternalExecutionPlan executionPlan;
+  private final boolean               correlated;
 
   Iterator<Result> iterator;
   ResultSet        subResultSet;
+  private Result   seed;
 
   public MatchFirstStep(final CommandContext context, final PatternNode node) {
     this(context, node, null);
   }
 
   public MatchFirstStep(final CommandContext context, final PatternNode node, final InternalExecutionPlan subPlan) {
+    this(context, node, subPlan, false);
+  }
+
+  /**
+   * @param correlated true when this is the root of a disjoint sub-pattern that reads, through {@code $matched}, an alias
+   *                   bound by another sub-pattern. {@link CartesianProductStep} then runs the sub-plan once per tuple of
+   *                   the sub-patterns before it, binding the {@code matched} context variable to that tuple: the step
+   *                   reads it as the seed every row it emits extends, so the hops after it see the outer aliases in the
+   *                   partial match exactly as they see the ones bound in their own sub-pattern (issue #7434)
+   */
+  public MatchFirstStep(final CommandContext context, final PatternNode node, final InternalExecutionPlan subPlan,
+      final boolean correlated) {
     super(context);
     this.node = node;
     this.executionPlan = subPlan;
+    this.correlated = correlated;
   }
 
   @Override
   public void reset() {
     this.iterator = null;
     this.subResultSet = null;
+    this.seed = null;
     if (executionPlan != null) {
       executionPlan.reset(this.getContext());
     }
@@ -81,12 +97,14 @@ public class MatchFirstStep extends AbstractExecutionStep {
           throw new NoSuchElementException();
 
         final ResultInternal result = new ResultInternal(context.getDatabase());
+        if (seed != null)
+          for (final String prop : seed.getPropertyNames())
+            result.setProperty(prop, seed.getProperty(prop));
         if (iterator != null)
           result.setProperty(getAlias(), iterator.next());
         else
           result.setProperty(getAlias(), subResultSet.next());
 
-        context.setVariable("matched", result);
         currentCount++;
         return result;
       }
@@ -102,6 +120,8 @@ public class MatchFirstStep extends AbstractExecutionStep {
 
   private void init(final CommandContext context) {
     if (iterator == null && subResultSet == null) {
+      if (correlated && context.getVariable("matched") instanceof Result outerTuple)
+        seed = outerTuple;
       final String alias = getAlias();
       final Object matchedNodes = context.getVariable(MatchPrefetchStep.PREFETCHED_MATCH_ALIAS_PREFIX + alias);
       if (matchedNodes != null) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchFirstStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchFirstStep.java
@@ -120,7 +120,7 @@ public class MatchFirstStep extends AbstractExecutionStep {
 
   private void init(final CommandContext context) {
     if (iterator == null && subResultSet == null) {
-      if (correlated && context.getVariable("matched") instanceof Result outerTuple)
+      if (correlated && context.getVariable(MatchBindMatchedStep.MATCHED_VARIABLE) instanceof Result outerTuple)
         seed = outerTuple;
       final String alias = getAlias();
       final Object matchedNodes = context.getVariable(MatchPrefetchStep.PREFETCHED_MATCH_ALIAS_PREFIX + alias);

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchStep.java
@@ -81,7 +81,6 @@ public class MatchStep extends AbstractExecutionStep {
         final Result result = nextResult;
         fetchNext(context, nRecords, guard);
         localCount++;
-        context.setVariable("matched", result);
         return result;
       }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodKeys.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodKeys.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.sql.method.collection;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.method.AbstractSQLMethod;
 
@@ -53,10 +54,12 @@ public class SQLMethodKeys extends AbstractSQLMethod {
       return result.getPropertyNames();
     }
 
-    if (value instanceof Collection<?> collection) {
+    // AN ARRAY-VALUED PARAMETER OR PROPERTY IS A COLLECTION RECEIVER TOO (ISSUE #7114)
+    final List<Object> list = listReceiverOrNull(value);
+    if (list != null) {
       final List<Object> result = new ArrayList<>();
-      for (final Object o : collection) {
-        if (o instanceof Map || o instanceof Document || o instanceof Result || o instanceof Collection) {
+      for (final Object o : list) {
+        if (o instanceof Map || o instanceof Document || o instanceof Result || MultiValue.isMultiValue(o)) {
           final Object keys = execute(o, currentRecord, context, params);
           if (keys instanceof Collection<?> keysCollection)
             result.addAll(keysCollection);

--- a/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodRemove.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodRemove.java
@@ -23,6 +23,10 @@ import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.method.AbstractSQLMethod;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 /**
  * Remove the first occurrence of elements from a collection.
  *
@@ -48,8 +52,11 @@ public class SQLMethodRemove extends AbstractSQLMethod {
       });
       // Work on a copy so the source value (e.g. a record property) is not mutated in place. Without it,
       // `UPDATE ... SET x = x.remove(...)` would return the same already-mutated instance as the current value,
-      // making UPDATE skip the write and leave the change unpersisted (issue #4730).
-      value = MultiValue.copy(value);
+      // making UPDATE skip the write and leave the change unpersisted (issue #4730). A Collection or a Map keeps its own
+      // kind (a Set stays a Set); any other collection receiver - an array-valued parameter or property, an iterable - is
+      // materialised through the shared helper, which MultiValue.remove() could not take as an array (issue #7114).
+      final List<Object> list = value instanceof Collection ? null : listReceiverOrNull(value);
+      value = list != null ? new ArrayList<>(list) : MultiValue.copy(value);
       for (final Object o : arguments) {
         value = MultiValue.remove(value, o, false);
       }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodRemoveAll.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodRemoveAll.java
@@ -23,6 +23,10 @@ import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.method.AbstractSQLMethod;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 /**
  * Remove all the occurrences of elements from a collection.
  *
@@ -46,8 +50,13 @@ public class SQLMethodRemoveAll extends AbstractSQLMethod {
         }
         return iArgument;
       });
-      // Work on a copy so the source value (e.g. a record property) is not mutated in place (issue #4730).
-      value = MultiValue.copy(value);
+      // Work on a copy so the source value (e.g. a record property) is not mutated in place. Without it,
+      // `UPDATE ... SET x = x.remove(...)` would return the same already-mutated instance as the current value,
+      // making UPDATE skip the write and leave the change unpersisted (issue #4730). A Collection or a Map keeps its own
+      // kind (a Set stays a Set); any other collection receiver - an array-valued parameter or property, an iterable - is
+      // materialised through the shared helper, which MultiValue.remove() could not take as an array (issue #7114).
+      final List<Object> list = value instanceof Collection ? null : listReceiverOrNull(value);
+      value = list != null ? new ArrayList<>(list) : MultiValue.copy(value);
       for (final Object o : arguments)
         value = MultiValue.remove(value, o, true);
     }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodRemoveAll.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodRemoveAll.java
@@ -51,7 +51,7 @@ public class SQLMethodRemoveAll extends AbstractSQLMethod {
         return iArgument;
       });
       // Work on a copy so the source value (e.g. a record property) is not mutated in place. Without it,
-      // `UPDATE ... SET x = x.remove(...)` would return the same already-mutated instance as the current value,
+      // `UPDATE ... SET x = x.removeAll(...)` would return the same already-mutated instance as the current value,
       // making UPDATE skip the write and leave the change unpersisted (issue #4730). A Collection or a Map keeps its own
       // kind (a Set stays a Set); any other collection receiver - an array-valued parameter or property, an iterable - is
       // materialised through the shared helper, which MultiValue.remove() could not take as an array (issue #7114).

--- a/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodValues.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodValues.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.sql.method.collection;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.method.AbstractSQLMethod;
 
@@ -54,10 +55,13 @@ public class SQLMethodValues extends AbstractSQLMethod {
       return new ArrayList<>(document.toMap(false).values());
     else if (value instanceof Result result)
       return result.toMap().values();
-    else if (value instanceof Collection<?> collection) {
+
+    // AN ARRAY-VALUED PARAMETER OR PROPERTY IS A COLLECTION RECEIVER TOO (ISSUE #7114)
+    final List<Object> list = listReceiverOrNull(value);
+    if (list != null) {
       final List<Object> result = new ArrayList<>();
-      for (final Object o : collection) {
-        if (o instanceof Map || o instanceof Document || o instanceof Result || o instanceof Collection) {
+      for (final Object o : list) {
+        if (o instanceof Map || o instanceof Document || o instanceof Result || MultiValue.isMultiValue(o)) {
           final Object values = execute(o, currentRecord, context, params);
           if (values instanceof Collection<?> valuesCollection)
             result.addAll(valuesCollection);

--- a/engine/src/main/java/com/arcadedb/query/sql/method/misc/SQLMethodIfEmpty.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/misc/SQLMethodIfEmpty.java
@@ -20,10 +20,9 @@ package com.arcadedb.query.sql.method.misc;
 
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.query.sql.executor.CommandContext;
-import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.method.AbstractSQLMethod;
 
-import java.util.Collection;
+import java.util.List;
 
 /**
  * Returns argument if result is empty else return result.
@@ -46,10 +45,11 @@ public class SQLMethodIfEmpty extends AbstractSQLMethod {
   @Override
   public Object execute(final Object value, final Identifiable currentRecord, final CommandContext context, final Object[] params) {
 
-    if ( (value instanceof String && value.toString().length() == 0)
-         || (value instanceof Collection<?> && MultiValue.getSize(value) == 0) )
-      return params[0];
-    else
-      return value;
+    if (value instanceof String string)
+      return string.isEmpty() ? params[0] : value;
+
+    // AN ARRAY-VALUED PARAMETER OR PROPERTY IS A COLLECTION RECEIVER TOO (ISSUE #7114)
+    final List<Object> list = listReceiverOrNull(value);
+    return list != null && list.isEmpty() ? params[0] : value;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/misc/SQLMethodIfEmpty.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/misc/SQLMethodIfEmpty.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.Identifiable;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.method.AbstractSQLMethod;
 
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -50,6 +51,11 @@ public class SQLMethodIfEmpty extends AbstractSQLMethod {
 
     // AN ARRAY-VALUED PARAMETER OR PROPERTY IS A COLLECTION RECEIVER TOO (ISSUE #7114)
     final List<Object> list = listReceiverOrNull(value);
-    return list != null && list.isEmpty() ? params[0] : value;
+    if (list == null)
+      return value;
+    if (list.isEmpty())
+      return params[0];
+    // A BARE Iterator (A RESULT SET INCLUDED) WAS CONSUMED TO ANSWER THE QUESTION: HAND BACK WHAT IT HELD, NOT ITS HUSK
+    return value instanceof Iterator<?> ? list : value;
   }
 }

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighborsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighborsTest.java
@@ -430,6 +430,93 @@ class SQLFunctionVectorNeighborsTest extends TestHelper {
     assertThat((RID) neighbors.getFirst().get("@rid")).isEqualTo(allowed.getFirst());
   }
 
+  // ISSUE #7125: THE filter OPTION MUST ACCEPT THE COLLECTION A SUBQUERY PRODUCES DIRECTLY, WITHOUT THE `.@rid` TRICK
+
+  @Test
+  void sqlVectorNeighborsFilterAcceptsARidProjectingSubquery() {
+    assertFilteredTo(neighbors("""
+        SELECT `vector.neighbors`('Doc[embedding]', [1.0, 0.0, 0.0], 5, {
+          filter: (SELECT @rid FROM Doc WHERE name IN ['docA', 'docB'])
+        }) AS neighbors"""), collectRIDs("docA", "docB"));
+  }
+
+  @Test
+  void sqlVectorNeighborsFilterAcceptsARecordProjectingSubquery() {
+    assertFilteredTo(neighbors("""
+        SELECT `vector.neighbors`('Doc[embedding]', [1.0, 0.0, 0.0], 5, {
+          filter: (SELECT FROM Doc WHERE name IN ['docA', 'docB'])
+        }) AS neighbors"""), collectRIDs("docA", "docB"));
+  }
+
+  @Test
+  void sqlVectorNeighborsFilterAcceptsALetBoundSubquery() {
+    assertFilteredTo(neighbors("""
+        SELECT `vector.neighbors`('Doc[embedding]', [1.0, 0.0, 0.0], 5, { filter: $ids }) AS neighbors
+        LET $ids = (SELECT @rid FROM Doc WHERE name IN ['docA', 'docB'])"""), collectRIDs("docA", "docB"));
+  }
+
+  @Test
+  void sqlVectorNeighborsFilterFlattensOneLevelOfNesting() {
+    assertFilteredTo(neighbors("""
+        SELECT `vector.neighbors`('Doc[embedding]', [1.0, 0.0, 0.0], 5, {
+          filter: (SELECT list(@rid) AS l FROM Doc WHERE name IN ['docA', 'docB']).l
+        }) AS neighbors"""), collectRIDs("docA", "docB"));
+  }
+
+  @Test
+  void sqlVectorNeighborsFilterStillAcceptsTheRidProjectionWorkaround() {
+    assertFilteredTo(neighbors("""
+        SELECT `vector.neighbors`('Doc[embedding]', [1.0, 0.0, 0.0], 5, {
+          filter: (SELECT @rid FROM Doc WHERE name IN ['docA', 'docB']).@rid
+        }) AS neighbors"""), collectRIDs("docA", "docB"));
+  }
+
+  @Test
+  void sqlVectorNeighborsFilterRejectsASubqueryThatDoesNotProjectARid() {
+    // A TYPO IN THE PROJECTION STAYS LOUD RATHER THAN SILENTLY FILTERING NOTHING
+    assertThatThrownBy(() -> database.query("sql", """
+        SELECT `vector.neighbors`('Doc[embedding]', [1.0, 0.0, 0.0], 5, {
+          filter: (SELECT name FROM Doc WHERE name IN ['docA', 'docB'])
+        }) AS neighbors""").next())
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("must contain RIDs");
+  }
+
+  @Test
+  void sqlVectorNeighborsFilterRejectsASubqueryRowWithSeveralNonRidColumns() {
+    assertThatThrownBy(() -> database.query("sql", """
+        SELECT `vector.neighbors`('Doc[embedding]', [1.0, 0.0, 0.0], 5, {
+          filter: (SELECT name, @rid AS r FROM Doc WHERE name IN ['docA', 'docB'])
+        }) AS neighbors""").next())
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("must contain RIDs");
+  }
+
+  @Test
+  void sqlVectorNeighborsFilterRejectsTwoLevelsOfNesting() {
+    assertThatThrownBy(() -> database.query("sql", """
+        SELECT `vector.neighbors`('Doc[embedding]', [1.0, 0.0, 0.0], 5, {
+          filter: [[(SELECT @rid FROM Doc WHERE name = 'docA').@rid]]
+        }) AS neighbors""").next())
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("must contain RIDs");
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<Map<String, Object>> neighbors(final String query) {
+    try (final ResultSet rs = database.query("sql", query)) {
+      return (List<Map<String, Object>>) rs.next().getProperty("neighbors");
+    }
+  }
+
+  private static void assertFilteredTo(final List<Map<String, Object>> neighbors, final List<RID> allowed) {
+    assertThat(neighbors).isNotNull().hasSize(allowed.size());
+    final Set<RID> returned = new HashSet<>();
+    for (final Map<String, Object> row : neighbors)
+      returned.add((RID) row.get("@rid"));
+    assertThat(returned).containsExactlyInAnyOrderElementsOf(allowed);
+  }
+
   private List<RID> collectRIDs(final String... names) {
     final List<RID> out = new ArrayList<>(names.length);
     for (final String name : names) {

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighborsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighborsTest.java
@@ -502,6 +502,18 @@ class SQLFunctionVectorNeighborsTest extends TestHelper {
         .hasMessageContaining("must contain RIDs");
   }
 
+  @Test
+  void sqlVectorNeighborsFilterRejectsAMalformedRidStringWithTheParsingException() {
+    // EVERY SHAPE OF MALFORMED STRING, NOT ONLY THE ONE RID(String) REPORTS AS AN ILLEGAL ARGUMENT
+    for (final String malformed : new String[] { "docA", "#1", "#", "#1:", "#a:b" })
+      assertThatThrownBy(() -> database.query("sql",
+          "SELECT `vector.neighbors`('Doc[embedding]', [1.0, 0.0, 0.0], 5, { filter: :f }) AS neighbors",
+          Map.of("f", List.of(malformed))).next())
+          .as(malformed)
+          .isInstanceOf(CommandSQLParsingException.class)
+          .hasMessageContaining("must contain RIDs");
+  }
+
   @SuppressWarnings("unchecked")
   private List<Map<String, Object>> neighbors(final String query) {
     try (final ResultSet rs = database.query("sql", query)) {

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/SparseNeighborsDuplicateSubIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/SparseNeighborsDuplicateSubIndexTest.java
@@ -110,6 +110,21 @@ class SparseNeighborsDuplicateSubIndexTest extends TestHelper {
     assertThat(new LinkedHashSet<>(uuids)).hasSize(6);
   }
 
+  @Test
+  void sparseNeighborsFilterAcceptsARidProjectingSubquery() {
+    // ISSUE #7125: parseRidFilter IS SHARED WITH vector.neighbors, SO THE SUBQUERY SHAPE MUST WORK HERE TOO
+    final List<String> uuids = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql", """
+        SELECT expand(`vector.sparseNeighbors`(?, ?, ?, ?, {
+          filter: (SELECT @rid FROM SparseDoc WHERE uuid IN ['d3', 'd10'])
+        }))""",
+        TYPE_NAME + "[tokens,weights]", new int[] { 3, 10, 16 }, new float[] { 1.0f, 0.5f, 0.25f }, 10)) {
+      while (rs.hasNext())
+        uuids.add(rs.next().getProperty("uuid"));
+    }
+    assertThat(uuids).containsExactlyInAnyOrder("d3", "d10");
+  }
+
   private List<String> topK(final int k) {
     final List<String> uuids = new ArrayList<>();
     try (final ResultSet rs = database.query("sql",

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7434MatchedAliasPropertyTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7434MatchedAliasPropertyTest.java
@@ -155,6 +155,26 @@ class Issue7434MatchedAliasPropertyTest extends TestHelper {
     }
   }
 
+  @Test
+  void correlatedLegAnsweringNoRowForSomeOuterTuplesSkipsThemAndGoesOn() {
+    // THE OUTER LEG BINDS s1 (a.ts), s2 (NO SUCH FILE) AND s3 (b.ts) IN THIS ORDER: THE CORRELATED LEG ANSWERS ONE ROW,
+    // THEN NONE, THEN ONE AGAIN, WHICH IS WHAT THE BACKTRACK-AND-RETRY LOOP OF THE PRODUCT EXISTS FOR
+    database.transaction(() -> {
+      database.command("sql", "INSERT INTO S SET id = 's2', filePath = 'none.ts'");
+      database.command("sql", "INSERT INTO S SET id = 's3', filePath = 'b.ts'");
+    });
+    final List<String> out = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql", """
+        MATCH {type: S, as: s}, {type: F, as: f, where: (path = $matched.s.filePath)}
+        RETURN s.id AS id, f.path AS p""")) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        out.add(row.getProperty("id") + "|" + row.getProperty("p"));
+      }
+    }
+    assertThat(out).containsExactlyInAnyOrder("s1|a.ts", "s3|b.ts");
+  }
+
   private static List<String> rows(final ResultSet rs) {
     final List<String> out = new ArrayList<>();
     while (rs.hasNext()) {

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7434MatchedAliasPropertyTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7434MatchedAliasPropertyTest.java
@@ -143,6 +143,27 @@ class Issue7434MatchedAliasPropertyTest extends TestHelper {
         .hasMessageContaining("circular dependency");
   }
 
+  @Test
+  void correlatedLegIsRunAgainForEveryRowOfAnIndependentLeg() {
+    // THREE LEGS, THE CORRELATED ONE LAST: IT MUST BE PLANNED AND RUN AGAIN FOR EVERY ROW OF THE INDEPENDENT LEG g. A
+    // RESET OF THE SAME SUB-PLAN IS NOT ENOUGH, SINCE THE FETCH AND FILTER STEPS OF ITS ROOT SELECT DO NOT RESTART: THE
+    // SECOND ROW OF g CAME BACK WITH NO f AND THE PRODUCT STOPPED AT ONE ROW
+    try (final ResultSet rs = database.query("sql", """
+        MATCH {type: S, as: s, where: (id = 's1')}, {type: F, as: f, where: (path = $matched.s.filePath)}, {type: F, as: g}
+        RETURN f.path AS p, g.path AS q, $matched.s.filePath AS sfp""")) {
+      assertThat(rows(rs)).containsExactlyInAnyOrder("a.ts|a.ts|a.ts", "a.ts|b.ts|a.ts");
+    }
+  }
+
+  private static List<String> rows(final ResultSet rs) {
+    final List<String> out = new ArrayList<>();
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      out.add(row.getProperty("p") + "|" + row.getProperty("q") + "|" + row.getProperty("sfp"));
+    }
+    return out;
+  }
+
   private List<Object> paths(final String query) {
     final List<Object> out = new ArrayList<>();
     try (final ResultSet rs = database.query("sql", query)) {

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7434MatchedAliasPropertyTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7434MatchedAliasPropertyTest.java
@@ -197,6 +197,17 @@ class Issue7434MatchedAliasPropertyTest extends TestHelper {
     assertThat(out).containsExactlyInAnyOrder("s1|a.ts", "s1|a.ts", "s2|b.ts", "s2|b.ts");
   }
 
+  @Test
+  void anIndependentLegWithNoRowEmptiesTheProduct() {
+    // WHETHER THE EMPTY LEG COMES FIRST OR AFTER OTHER LEGS, THE ANSWER IS EMPTY, WITH OR WITHOUT A CORRELATED LEG BEHIND IT
+    assertThat(paths("""
+        MATCH {type: F, as: g, where: (path = 'none')}, {type: S, as: s, where: (id = 's1')}
+        RETURN g.path AS p""")).isEmpty();
+    assertThat(paths("""
+        MATCH {type: S, as: s, where: (id = 's1')}, {type: F, as: g, where: (path = 'none')}, {type: F, as: f, where: (path = $matched.s.filePath)}
+        RETURN f.path AS p""")).isEmpty();
+  }
+
   private static List<String> rows(final ResultSet rs) {
     final List<String> out = new ArrayList<>();
     while (rs.hasNext()) {

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7434MatchedAliasPropertyTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7434MatchedAliasPropertyTest.java
@@ -175,6 +175,28 @@ class Issue7434MatchedAliasPropertyTest extends TestHelper {
     assertThat(out).containsExactlyInAnyOrder("s1|a.ts", "s3|b.ts");
   }
 
+  @Test
+  void correlatedLegWithSeveralMatchesForALaterOuterTupleKeepsThemAll() {
+    // TWO OUTER TUPLES, TWO MATCHES EACH. THE PRODUCT PREPARES THE NEXT ROW BEFORE HANDING OUT THE CURRENT ONE, AND THE
+    // BIND STEP DOWNSTREAM REBINDS $matched TO EVERY ROW IT HANDS OUT: THE SECOND MATCH FOR s2 IS PULLED FROM THE STILL
+    // OPEN LEG AFTER THAT REBINDING, SO ITS FILTER MUST NOT SEE THE PREVIOUS ROW'S s
+    database.transaction(() -> {
+      database.command("sql", "INSERT INTO F SET path = 'a.ts'");
+      database.command("sql", "INSERT INTO S SET id = 's2', filePath = 'b.ts'");
+      database.command("sql", "INSERT INTO F SET path = 'b.ts'");
+    });
+    final List<String> out = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql", """
+        MATCH {type: S, as: s}, {type: F, as: f, where: (path = $matched.s.filePath)}
+        RETURN s.id AS id, f.path AS p""")) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        out.add(row.getProperty("id") + "|" + row.getProperty("p"));
+      }
+    }
+    assertThat(out).containsExactlyInAnyOrder("s1|a.ts", "s1|a.ts", "s2|b.ts", "s2|b.ts");
+  }
+
   private static List<String> rows(final ResultSet rs) {
     final List<String> out = new ArrayList<>();
     while (rs.hasNext()) {

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7434MatchedAliasPropertyTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/Issue7434MatchedAliasPropertyTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandExecutionException;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7434: in a SQL MATCH, reading a property through {@code $matched.<alias>.<property>} answered {@code null}
+ * everywhere. In a pattern node's {@code where:} the predicate was false for every candidate, so the statement returned
+ * zero rows with no error; in {@code RETURN} the projection was {@code null}. Only the identity comparison
+ * {@code $matched.<alias> != $currentMatch} worked.
+ * <p>
+ * The schema and the six statements mirror the issue's repro table line for line.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7434MatchedAliasPropertyTest extends TestHelper {
+
+  @Override
+  public void beginTest() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE F");
+      database.command("sql", "CREATE VERTEX TYPE S");
+      database.command("sql", "CREATE EDGE TYPE CONTAINS");
+      database.command("sql", "INSERT INTO F SET path = 'a.ts'");
+      database.command("sql", "INSERT INTO F SET path = 'b.ts'");
+      database.command("sql", "INSERT INTO S SET id = 's1', filePath = 'a.ts'");
+      database.command("sql",
+          "CREATE EDGE CONTAINS FROM (SELECT FROM F WHERE path = 'a.ts') TO (SELECT FROM S WHERE id = 's1')");
+    });
+  }
+
+  @Test
+  void identityComparisonControlStillWorks() {
+    assertThat(paths("""
+        MATCH {type: S, as: s, where: (id = 's1')}<-CONTAINS-{type: F, as: f, where: ($matched.s != $currentMatch)}
+        RETURN f.path AS p""")).containsExactly("a.ts");
+  }
+
+  @Test
+  void matchedPropertyInConnectedPatternWhere() {
+    assertThat(paths("""
+        MATCH {type: S, as: s, where: (id = 's1')}<-CONTAINS-{type: F, as: f, where: (path = $matched.s.filePath)}
+        RETURN f.path AS p""")).containsExactly("a.ts");
+  }
+
+  @Test
+  void cartesianProductControlStillWorks() {
+    assertThat(paths("""
+        MATCH {type: S, as: s, where: (id = 's1')}, {type: F, as: f}
+        RETURN f.path AS p""")).containsExactlyInAnyOrder("a.ts", "b.ts");
+  }
+
+  @Test
+  void matchedPropertyInCartesianPatternWhere() {
+    assertThat(paths("""
+        MATCH {type: S, as: s, where: (id = 's1')}, {type: F, as: f, where: (path = $matched.s.filePath)}
+        RETURN f.path AS p""")).containsExactly("a.ts");
+  }
+
+  @Test
+  void tautologicalMatchedPropertyPredicateKeepsEveryRow() {
+    assertThat(paths("""
+        MATCH {type: S, as: s, where: (id = 's1')}, {type: F, as: f, where: ($matched.s.id = 's1')}
+        RETURN f.path AS p""")).containsExactlyInAnyOrder("a.ts", "b.ts");
+  }
+
+  @Test
+  void matchedPropertyInReturnProjection() {
+    final List<Object> sfp = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql", """
+        MATCH {type: S, as: s, where: (id = 's1')}, {type: F, as: f}
+        RETURN f.path AS p, $matched.s.filePath AS sfp""")) {
+      while (rs.hasNext())
+        sfp.add(rs.next().getProperty("sfp"));
+    }
+    assertThat(sfp).containsExactly("a.ts", "a.ts");
+  }
+
+  @Test
+  void matchedPropertyThroughAnAliasBoundLaterInTheSchedule() {
+    // THE PREDICATE READS THE ALIAS THAT IS NOT THE ROOT OF THE SCHEDULE: THE PLANNER MUST ORDER s BEFORE f EVEN
+    // THOUGH f IS LISTED FIRST AND HAS THE SMALLER ESTIMATE ONCE ITS FILTER IS IGNORED
+    assertThat(paths("""
+        MATCH {type: F, as: f, where: (path = $matched.s.filePath)}, {type: S, as: s, where: (id = 's1')}
+        RETURN f.path AS p""")).containsExactly("a.ts");
+  }
+
+  @Test
+  void correlatedSubPatternWithAHopKeepsTheOuterBindingForEveryCandidate() {
+    // THE CORRELATED SUB-PATTERN HAS ITS OWN HOP: THE ROWS ITS MatchStep EMITS MUST NOT SHADOW THE OUTER s WHILE THE
+    // ROOT'S FILTER IS STILL BEING EVALUATED FOR THE REMAINING F CANDIDATES
+    database.transaction(() -> database.command("sql",
+        "CREATE EDGE CONTAINS FROM (SELECT FROM F WHERE path = 'b.ts') TO (SELECT FROM S WHERE id = 's1')"));
+    assertThat(paths("""
+        MATCH {type: S, as: s, where: (id = 's1')}, {type: F, as: f, where: ($matched.s.id = 's1')}-CONTAINS->{type: S, as: t}
+        RETURN f.path AS p""")).containsExactlyInAnyOrder("a.ts", "b.ts");
+  }
+
+  @Test
+  void matchedPropertyInReturnSurvivesANotPatternAndOrderBy() {
+    final List<Object> sfp = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql", """
+        MATCH {type: S, as: s, where: (id = 's1')}, {type: F, as: f},
+        NOT {as: f}-CONTAINS->{type: S, where: (id = 'none')}
+        RETURN f.path AS p, $matched.s.filePath AS sfp ORDER BY p DESC""")) {
+      while (rs.hasNext())
+        sfp.add(rs.next().getProperty("sfp"));
+    }
+    assertThat(sfp).containsExactly("a.ts", "a.ts");
+  }
+
+  @Test
+  void circularMatchedDependencyAcrossSubPatternsIsRejected() {
+    assertThatThrownBy(() -> paths("""
+        MATCH {type: S, as: s, where: (id = $matched.f.path)}, {type: F, as: f, where: (path = $matched.s.filePath)}
+        RETURN f.path AS p"""))
+        .isInstanceOf(CommandExecutionException.class)
+        .hasMessageContaining("circular dependency");
+  }
+
+  private List<Object> paths(final String query) {
+    final List<Object> out = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql", query)) {
+      while (rs.hasNext())
+        out.add(rs.next().getProperty("p"));
+    }
+    return out;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/MatchGAVFusedStepDirectionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/MatchGAVFusedStepDirectionTest.java
@@ -23,6 +23,9 @@ import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.olap.GraphAnalyticalView;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -92,6 +95,52 @@ class MatchGAVFusedStepDirectionTest extends TestHelper {
       assertThat(row.<String>getProperty("cName")).isEqualTo("Eve");
       assertThat(row.<String>getProperty("dName")).isEqualTo("Dave");
       assertThat(rs.hasNext()).isFalse();
+      database.commit();
+    } finally {
+      gav.drop();
+    }
+  }
+
+  @Test
+  void aHopWithAWhereFilterIsNotFusedSoTheFilterIsHonoured() {
+    // THE FUSED CSR WALK BINDS THE ALIASES IT REACHES WITHOUT EVALUATING THEIR where:, SO A FILTERED HOP MUST STAY ON THE
+    // REGULAR MatchStep. HOPS 1-2 (KNOWS, KNOWS2) ARE A FUSIBLE CHAIN; THE FILTER ON c, WHICH READS $matched (ISSUE #7434),
+    // KEEPS EVE'S BRANCH ONLY, SO d IS FRANK AND NOT ALSO GINA
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+    database.getSchema().createEdgeType("KNOWS");
+    database.getSchema().createEdgeType("KNOWS2");
+
+    database.begin();
+    final MutableVertex alice = database.newVertex("Person").set("name", "Alice").set("wants", "Eve").save();
+    final MutableVertex bob = database.newVertex("Person").set("name", "Bob").save();
+    final MutableVertex eve = database.newVertex("Person").set("name", "Eve").save();
+    final MutableVertex dave = database.newVertex("Person").set("name", "Dave").save();
+    final MutableVertex frank = database.newVertex("Person").set("name", "Frank").save();
+    final MutableVertex gina = database.newVertex("Person").set("name", "Gina").save();
+    alice.newEdge("FOLLOWS", bob);
+    bob.newEdge("KNOWS", eve);
+    bob.newEdge("KNOWS", dave);
+    eve.newEdge("KNOWS2", frank);
+    dave.newEdge("KNOWS2", gina);
+    database.commit();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS", "KNOWS", "KNOWS2")
+        .build();
+    try {
+      database.begin();
+      final List<String> names = new ArrayList<>();
+      try (final ResultSet rs = database.query("sql",
+          """
+          MATCH {type: Person, as: a, where: (name = 'Alice')}.out('FOLLOWS'){as: b}\
+          .out('KNOWS'){as: c, where: (name = $matched.a.wants)}.out('KNOWS2'){as: d} \
+          RETURN d.name as dName""")) {
+        while (rs.hasNext())
+          names.add(rs.next().getProperty("dName"));
+      }
+      assertThat(names).containsExactly("Frank");
       database.commit();
     } finally {
       gav.drop();

--- a/engine/src/test/java/com/arcadedb/query/sql/method/Issue7114CollectionMethodsOnArrayReceiverTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/Issue7114CollectionMethodsOnArrayReceiverTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.method;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7114, follow-up to #7027: {@code keys()}, {@code values()}, {@code ifempty()}, {@code remove()} and
+ * {@code removeAll()} still hand-rolled their receiver type test instead of going through
+ * {@code AbstractSQLMethod.listReceiverOrNull()}, so an array-valued parameter or property met them as a scalar:
+ * {@code keys()}/{@code values()} answered {@code null}, {@code ifempty()} never saw an empty array, and
+ * {@code remove()}/{@code removeAll()} returned the array untouched.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@SuppressWarnings("unchecked")
+class Issue7114CollectionMethodsOnArrayReceiverTest extends TestHelper {
+
+  @Test
+  void removeHonoursAnArrayReceiver() {
+    assertThat(scalar("SELECT :p.remove(2) AS r", Map.of("p", new int[] { 3, 2, 1, 2 }))).isEqualTo(List.of(3, 1, 2));
+    assertThat(scalar("SELECT :p.remove('y') AS r", Map.of("p", new String[] { "x", "y", "z" }))).isEqualTo(List.of("x", "z"));
+    assertThat(scalar("SELECT :p.remove('y', 'z') AS r", Map.of("p", new String[] { "x", "y", "z" }))).isEqualTo(List.of("x"));
+    // THE LIST CONTROL ANSWERS THE SAME, AND A MAP RECEIVER KEEPS ITS OWN KIND
+    assertThat(scalar("SELECT [3,2,1,2].remove(2) AS r")).isEqualTo(List.of(3, 1, 2));
+    assertThat(scalar("SELECT {'a': 1, 'b': 2}.remove('a') AS r")).isEqualTo(Map.of("b", 2));
+  }
+
+  @Test
+  void removeAllHonoursAnArrayReceiver() {
+    assertThat(scalar("SELECT :p.removeAll(2) AS r", Map.of("p", new int[] { 3, 2, 1, 2 }))).isEqualTo(List.of(3, 1));
+    assertThat(scalar("SELECT :p.removeAll('y') AS r", Map.of("p", new String[] { "x", "y", "y" }))).isEqualTo(List.of("x"));
+    assertThat(scalar("SELECT [3,2,1,2].removeAll(2) AS r")).isEqualTo(List.of(3, 1));
+  }
+
+  @Test
+  void removeDoesNotMutateTheArrayParameter() {
+    final int[] source = { 3, 2, 1 };
+    assertThat(scalar("SELECT :p.remove(2) AS r", Map.of("p", source))).isEqualTo(List.of(3, 1));
+    assertThat(source).containsExactly(3, 2, 1);
+  }
+
+  @Test
+  void ifEmptyRecognisesAnEmptyArray() {
+    assertThat(scalar("SELECT :p.ifempty('none') AS r", Map.of("p", new String[0]))).isEqualTo("none");
+    assertThat(scalar("SELECT :p.ifempty('none') AS r", Map.of("p", new int[0]))).isEqualTo("none");
+    assertThat(scalar("SELECT :p.ifempty('none') AS r", Map.of("p", new int[] { 1 }))).isEqualTo(new int[] { 1 });
+    assertThat(scalar("SELECT [].ifempty('none') AS r")).isEqualTo("none");
+    assertThat(scalar("SELECT ''.ifempty('none') AS r")).isEqualTo("none");
+    assertThat(scalar("SELECT 'a'.ifempty('none') AS r")).isEqualTo("a");
+  }
+
+  @Test
+  void keysAndValuesSeeTheElementsOfAnArrayReceiver() {
+    final Object[] maps = { Map.of("a", 1), Map.of("b", 2) };
+    assertThat((List<Object>) scalar("SELECT :p.keys() AS r", Map.of("p", maps))).containsExactly("a", "b");
+    assertThat((List<Object>) scalar("SELECT :p.values() AS r", Map.of("p", maps))).containsExactly(1, 2);
+    // THE LIST CONTROL ANSWERS THE SAME
+    assertThat((List<Object>) scalar("SELECT :p.keys() AS r", Map.of("p", List.of(maps)))).containsExactly("a", "b");
+    assertThat((List<Object>) scalar("SELECT :p.values() AS r", Map.of("p", List.of(maps)))).containsExactly(1, 2);
+  }
+
+  @Test
+  void keysAndValuesOnAnArrayOfScalarsAnswerAnEmptyListLikeTheListForm() {
+    assertThat((List<Object>) scalar("SELECT :p.keys() AS r", Map.of("p", new int[] { 1, 2 }))).isEmpty();
+    assertThat((List<Object>) scalar("SELECT :p.values() AS r", Map.of("p", new int[] { 1, 2 }))).isEmpty();
+    assertThat((List<Object>) scalar("SELECT [1,2].keys() AS r")).isEmpty();
+    assertThat((List<Object>) scalar("SELECT [1,2].values() AS r")).isEmpty();
+  }
+
+  @Test
+  void removeOnAStoredArrayPropertyAnswersTheReducedList() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Issue7114");
+      database.command("sql", "CREATE PROPERTY Issue7114.tags LIST");
+      database.command("sql", "INSERT INTO Issue7114 SET tags = ['x','y','z']");
+    });
+    assertThat(scalar("SELECT tags.remove('y') AS r FROM Issue7114")).isEqualTo(List.of("x", "z"));
+    assertThat(scalar("SELECT tags.removeAll('y') AS r FROM Issue7114")).isEqualTo(List.of("x", "z"));
+    assertThat(scalar("SELECT tags.ifempty('none') AS r FROM Issue7114")).isEqualTo(List.of("x", "y", "z"));
+  }
+
+  private Object scalar(final String query) {
+    return scalar(query, Map.of());
+  }
+
+  private Object scalar(final String query, final Map<String, Object> params) {
+    try (final ResultSet rs = database.query("sql", query, params)) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result result = rs.next();
+      assertThat(rs.hasNext()).isFalse();
+      return result.getProperty("r");
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/method/Issue7114CollectionMethodsOnArrayReceiverTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/Issue7114CollectionMethodsOnArrayReceiverTest.java
@@ -72,6 +72,9 @@ class Issue7114CollectionMethodsOnArrayReceiverTest extends TestHelper {
     assertThat(scalar("SELECT [].ifempty('none') AS r")).isEqualTo("none");
     assertThat(scalar("SELECT ''.ifempty('none') AS r")).isEqualTo("none");
     assertThat(scalar("SELECT 'a'.ifempty('none') AS r")).isEqualTo("a");
+    // AN ITERATOR RECEIVER IS CONSUMED BY THE TEST FOR EMPTINESS, SO THE ANSWER IS WHAT IT HELD, NOT THE EXHAUSTED ITERATOR
+    assertThat(scalar("SELECT :p.ifempty('none') AS r", Map.of("p", List.of(1, 2).iterator()))).isEqualTo(List.of(1, 2));
+    assertThat(scalar("SELECT :p.ifempty('none') AS r", Map.of("p", List.of().iterator()))).isEqualTo("none");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/method/Issue7114CollectionMethodsOnArrayReceiverTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/Issue7114CollectionMethodsOnArrayReceiverTest.java
@@ -23,8 +23,10 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -48,6 +50,10 @@ class Issue7114CollectionMethodsOnArrayReceiverTest extends TestHelper {
     // THE LIST CONTROL ANSWERS THE SAME, AND A MAP RECEIVER KEEPS ITS OWN KIND
     assertThat(scalar("SELECT [3,2,1,2].remove(2) AS r")).isEqualTo(List.of(3, 1, 2));
     assertThat(scalar("SELECT {'a': 1, 'b': 2}.remove('a') AS r")).isEqualTo(Map.of("b", 2));
+    final Set<Integer> set = new LinkedHashSet<>(List.of(3, 2, 1));
+    assertThat(scalar("SELECT :p.remove(2) AS r", Map.of("p", set))).isInstanceOf(Set.class).isEqualTo(Set.of(3, 1));
+    assertThat(scalar("SELECT :p.removeAll(2) AS r", Map.of("p", set))).isInstanceOf(Set.class).isEqualTo(Set.of(3, 1));
+    assertThat(set).as("the source set is not mutated").containsExactly(3, 2, 1);
   }
 
   @Test


### PR DESCRIPTION
Fixes #7434, fixes #7114, fixes #7125.

## #7434 - SQL MATCH: `$matched.<alias>.<property>` always null

Three independent causes, each now with a regression test in `Issue7434MatchedAliasPropertyTest` (the issue's six statements plus a correlated sub-pattern with its own hop, a NOT pattern + ORDER BY, and a circular dependency):

- **Prefetch ran the predicate before any alias was bound.** A `where:` that reads `$matched` was pushed into the `PREFETCH` step of its node, so the predicate was false for every candidate and the statement silently answered nothing. Such nodes are no longer prefetched and their root estimate ignores the filter.
- **The match steps bound `matched` to the row they last emitted.** The pipeline is lazy, so a filter evaluated for the next candidate saw the previous emitted row instead of the partial match it belonged to. `MatchEdgeTraverser` now binds `matched` to the partial match the hop starts from while it evaluates a filter (and restores it), and a new `MatchBindMatchedStep` binds it to the row about to be projected, so `RETURN $matched.s.filePath` reads the right row regardless of what runs in between.
- **A comma pattern reading another pattern's alias was an independent leg of the cartesian product**, so `$matched.s` could never resolve inside it. The planner now orders the disjoint sub-patterns by their `$matched` dependencies (a cycle is rejected with the existing "circular dependency" message) and `CartesianProductStep` re-runs a correlated sub-plan for every tuple of the legs before it, seeding its root `MatchFirstStep` with that tuple. This turns `{S as s, where: (...)}, {F as f, where: (path = $matched.s.filePath)}` into a correlated nested loop instead of a full product.

Also fixed on the way: a multi-node sub-pattern could pick an alias belonging to another sub-pattern as its schedule root and fail with "This query contains MATCH conditions that cannot be evaluated".

## #7114 - five collection methods not routed through `listReceiverOrNull()`

`keys()`, `values()`, `ifempty()`, `remove()` and `removeAll()` now read their receiver through the shared helper, so an array-valued parameter or property is a collection to them too. `remove()`/`removeAll()` on an array used to throw `UnsupportedOperationException: Cannot execute remove() against an array`. A `Collection` or `Map` receiver keeps its own kind (a Set stays a Set, and the #4730 copy-before-mutate is preserved). Tests in `Issue7114CollectionMethodsOnArrayReceiverTest`.

## #7125 - `vector.neighbors` filter accepts a subquery result directly

`parseRidFilter` (shared by `vector.neighbors` and `vector.sparseNeighbors`) now accepts a record row (`SELECT FROM ...`), a single RID-valued projection (`SELECT @rid ...`), a `LET`-bound subquery, and one level of nesting (`(SELECT list(@rid) AS l ...).l`). A projection that is not a RID keeps throwing `CommandSQLParsingException` with a message that says which columns it saw, and a malformed RID string now throws the same exception instead of a bare `IllegalArgumentException`. Tests per accepted shape plus three negative ones in `SQLFunctionVectorNeighborsTest`, one in `SparseNeighborsDuplicateSubIndexTest`.

## Verification

- `mvn -o test -pl engine -Dtest='*Match*Test,...'`: 383 tests green
- SQL executor, SQL methods, SQL functions and vector function packages (excluding the `vector`/`slow`/`benchmark` lanes): 2632 tests green after fixing a Map-receiver regression the first run caught in `UpdateRemoveMapKeyTest`

Docs: `sql-match.adoc` (`$matched` row + correlation example) and `vector-search.adoc` (accepted filter shapes) updated in a local commit on arcadedb-docs, not pushed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MATCH queries now support correlated sub-patterns and `$matched` references across disjoint patterns.
  * Vector neighbor filters accept RID- and record-producing subqueries, including one level of collection nesting.
  * Collection methods including `keys()`, `values()`, `remove()`, `removeAll()`, and `ifempty()` now support arrays and other iterable values.

* **Bug Fixes**
  * Improved validation and error reporting for invalid vector filter values.
  * Preserved collection behavior when removing elements from sets, lists, arrays, and other iterable values.
  * Improved MATCH result correctness for correlated and empty sub-patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->