### PR TITLE
fix(#7395): ask one question about whether a restore target already exists

### DIFF
--- a/docs/7395-restore-target-exists-predicate.md
+++ b/docs/7395-restore-target-exists-predicate.md
@@ -238,3 +238,25 @@ weaker version of the same check and is recorded as such rather than claimed as 
 - The check is not atomic with the swap: [#7441](https://github.com/ArcadeData/arcadedb/issues/7441).
 - Case-sensitivity between the two halves of the predicate is whatever `ArcadeDBServer`'s registry and the
   host filesystem already made it; this fix neither widens nor narrows it.
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/7442
+
+## Review cycles
+
+| # | Head | Changes | Bot outcome |
+|---|---|---|---|
+| 1 | `a9a1d9b` | the fix, both IT classes, this doc | `claude`: "Nothing here blocks merging." Three nits, none a defect - a javadoc `{@link}` label used as a mid-sentence verb, this doc skipping section 4, and the gRPC IT's hardcoded port. First two applied, third skipped with evidence (see below). |
+| 2 | `115ff5d0` | the two applied nits plus `docs/review-deferred-a9a1d9b.md` | `claude`: "Overall this looks ready to merge." No actionable items; the port nit re-raised only to agree it is out of scope and already answered. |
+
+Final state: **clean-approval** after 2 of a permitted 4 cycles.
+
+## Deferred items
+
+[`docs/review-deferred-a9a1d9b.md`](review-deferred-a9a1d9b.md) - one skipped review point, the gRPC
+IT's hardcoded `GRPC_PORT = 50051`. Not deferred for want of a decision: 43 IT classes in `grpcw`
+share that constant and the module runs one JVM per class in sequence, so changing this one class
+alone would make it the odd one out rather than make the package concurrency-safe. The `server`-module
+half of this PR does derive its port from `getServer(0).getHttpServer().getPort()`, which is the
+pattern that base class supports. Nothing here is waiting on the developer.

--- a/docs/7395-restore-target-exists-predicate.md
+++ b/docs/7395-restore-target-exists-predicate.md
@@ -1,0 +1,224 @@
+# #7395 - `restore database` and `restore backup` disagree on what "the target already exists" means
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/7395
+Type: bug (labels `bug`, `server`, `backup-restore`)
+Branch: `fix/7395-restore-existence-check-parity`
+
+## Finding ledger
+
+- [x] 1. `ServerControlPlane.restoreDatabase` asks only the filesystem; `ServerControlPlane.restoreBackup` asks the
+  registry *and* the filesystem. Unify on the stricter predicate, keeping `restore database`'s unconditional refusal
+  and `restore backup`'s `overwrite` gate.
+
+## Analysis
+
+`server/src/main/java/com/arcadedb/server/ServerControlPlane.java`, as of `main`:
+
+```java
+// restoreDatabase (line 1227)
+final String dbPath = databaseDirectory(databaseName);
+if (new File(dbPath).exists())
+  throw new IllegalArgumentException("Database '" + databaseName + "' already exists");
+
+// restoreBackup (line 1259)
+final String dbPath = databaseDirectory(targetDatabase);
+if ((server.existsDatabase(targetDatabase) || new File(dbPath).exists()) && !overwrite)
+  throw new IllegalArgumentException("Database '" + targetDatabase + "' already exists. ...");
+```
+
+The divergence is only observable in one state: **registered in `ArcadeDBServer.databases` but no directory on
+disk**. That state is reachable out of band (the directory removed under a running server) and through the server's
+own API - `LocalDatabase.drop()` closes the database and deletes the directory but does **not** unregister it;
+`ServerControlPlane.dropQuietly` has to call `server.removeDatabase(name)` as a separate second step, which is the
+proof that the two halves are independent:
+
+```java
+private void dropQuietly(final ServerDatabase database, final String databaseName) {
+  try {
+    database.getEmbedded().drop();
+    server.removeDatabase(databaseName);   // <- separate step
+```
+
+In that state `restore database` proceeds, restores into a temp directory and reaches `swapRestoredDatabase`, which
+drops the registered database and moves the new directory into place. `restore backup` refuses unless `overwrite`.
+
+### Which predicate is "intended"
+
+`ArcadeDBServer.createDatabase` - the third place on the server that asks the same question - already asks the
+stricter one, registry first and then the files:
+
+```java
+synchronized (databasesLock) {
+  serverDatabase = databases.get(databaseName);
+  if (serverDatabase != null)
+    throw new IllegalArgumentException("Database '" + databaseName + "' already exists");
+  ...
+  if (factory.exists())
+    throw new IllegalArgumentException("Database '" + databaseName + "' already exists");
+```
+
+So the stricter predicate is the server-wide norm, and `restoreDatabase` was the outlier. That settles the question
+the issue leaves open: `restore database` refuses a registered-but-absent database rather than silently replacing it.
+
+## Completeness
+
+### 1. Invariant
+
+> `restore database` and `restore backup` answer "does the target already exist?" with one and the same predicate -
+> the name is registered in the server's database registry **or** a directory of that name is present under
+> `SERVER_DATABASE_DIRECTORY` - with `restore database` refusing unconditionally and `restore backup` refusing
+> unless `overwrite` is set.
+
+### 2. Ways to violate it
+
+```
+$ grep -rn "existsDatabase(" --include="*.java" server/src/main/java grpcw/src/main/java
+server/.../ServerControlPlane.java:318:    if (!server.existsDatabase(databaseName))          # dropDatabase guard, not a restore target check
+server/.../ServerControlPlane.java:1260:   if ((server.existsDatabase(targetDatabase) || new File(dbPath).exists()) && !overwrite)
+server/.../ServerControlPlane.java:1450:   if (server.existsDatabase(databaseName))           # swapRestoredDatabase, post-restore
+server/.../ArcadeDBServer.java:983:       public boolean existsDatabase(...)                 # the accessor itself
+server/.../ArcadeDBServer.java:1369, SchemaInfo:130, AbstractServerHttpHandler:1147/1235,
+  BackupTask:84, AutoBackupSchedulerPlugin:244, grpcw/ArcadeDbGrpcAdminService:140/147/166/199/225
+                                                                                     # unrelated existence lookups
+```
+
+```
+$ grep -rn "databaseDirectory(\|new File(dbPath)" --include="*.java" server/src/main/java
+server/.../ServerControlPlane.java:1227:  final String dbPath = databaseDirectory(databaseName);
+server/.../ServerControlPlane.java:1228:  if (new File(dbPath).exists())                       # <- the outlier
+server/.../ServerControlPlane.java:1259:  final String dbPath = databaseDirectory(targetDatabase);
+server/.../ServerControlPlane.java:1260:  if ((server.existsDatabase(targetDatabase) || ...
+server/.../ServerControlPlane.java:1407:  final File finalDir = new File(dbPath);              # performRestore, post-check
+server/.../ServerControlPlane.java:1510:  private String databaseDirectory(...)                # the accessor itself
+```
+
+```
+$ grep -rn "controlPlane.restoreDatabase(\|controlPlane.restoreBackup(" --include="*.java" .
+server/.../PostServerCommandHandler.java:423:  controlPlane.restoreDatabase(databaseName, url, listener);
+server/.../PostServerCommandHandler.java:457:  controlPlane.restoreBackup(databaseName, fileName, targetDatabase, overwrite, listener);
+grpcw/.../ArcadeDbGrpcAdminService.java:803:  controlPlane.restoreBackup(req.getDatabase(), req.getFileName(), req.getTargetDatabase(), req.getOverwrite(), listener);
+grpcw/.../ArcadeDbGrpcAdminService.java:827:  controlPlane.restoreDatabase(req.getDatabase(), req.getUrl(), listener);
+```
+
+```
+$ grep -rni "RESTORE_DATABASE\|RESTORE_BACKUP\|\"restore database" --include="*.java" */src/main/java
+# the only command dispatchers are PostServerCommandHandler:77/79/122/163-168 and the two gRPC RPCs above.
+# console/src/main/java has no restore command; there is no RESTORE SQL statement.
+# ha-raft SnapshotInstaller.restoreBackup is a private static Path->Path file copy, unrelated to this predicate.
+```
+
+Four transports, two shared implementations. No transport repeats the check for itself.
+
+### 3. Coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| HTTP `POST /api/v1/server` `restore database <n> <url>` -> `ServerControlPlane.restoreDatabase` | yes | yes - `Issue7395RestoreTargetExistsIT` |
+| HTTP `POST /api/v1/server` `restore backup <db> <f> as <t>` -> `ServerControlPlane.restoreBackup` | yes (predicate now shared, behaviour unchanged) | yes - `Issue7395RestoreTargetExistsIT` |
+| gRPC `RestoreDatabase` -> `ServerControlPlane.restoreDatabase` | yes | yes - `Issue7395GrpcRestoreTargetExistsIT` |
+| gRPC `RestoreBackup` -> `ServerControlPlane.restoreBackup` | yes (unchanged) | yes - `Issue7395GrpcRestoreTargetExistsIT` |
+| `ServerControlPlane.importDatabase` -> `ArcadeDBServer.createDatabase` | n/a - argued | argued: `createDatabase` already applies registry-then-`factory.exists()`, the stricter predicate (`ArcadeDBServer.java:1002-1014`). It is the norm this fix aligns restore with, not a violator of it. |
+| `ha-raft` `SnapshotInstaller.restoreBackup(Path, Path)` | n/a - argued | argued: `private static void restoreBackup(final Path dbDir, final Path backupDir)` - a file-copy helper taking two paths, no database name, no registry. Same method name, different question. |
+
+### 5. Reachability
+
+`ServerControlPlane` is constructed by `ArcadeDBServer` and reached on every restore command; the two methods are
+the only implementation behind all four transports (grep C above). Nothing gates the changed lines behind a flag.
+The new tests drive the changed lines over real HTTP and real gRPC against a live server.
+
+## Residual risk
+
+`restore database` now refuses, rather than silently replacing, a database that is registered but whose directory is
+gone. An operator who was relying on `restore database` to repair that state has to `drop database <name>` first, or
+use `restore backup ... as <name>` with `overwrite`. That is the behaviour change the issue asks for, and the error
+message names the database so the required step is obvious.
+
+Nothing else is left uncovered: the four transports in the table are the complete set of restore entry points per
+grep C, and both remaining rows are argued with evidence rather than left blank.
+
+
+## Changes
+
+`server/src/main/java/com/arcadedb/server/ServerControlPlane.java`
+
+- New private `databaseNameIsTaken(databaseName, dbPath)` - `server.existsDatabase(name) || new File(dbPath).exists()` -
+  with the javadoc that says why the two halves are independent and which command used to ask only one of them.
+- `restoreDatabase` now calls it in place of its filesystem-only check. Its refusal stays unconditional, and its
+  javadoc now says so and names the two ways out (`restore backup ... as <name>` with `overwrite`, or `drop database`).
+- `restoreBackup` now calls it in place of its inline copy of the same expression. Behaviour unchanged: the
+  `overwrite` gate still sits over the predicate.
+
+Tests:
+
+- `server/src/test/java/com/arcadedb/server/backup/Issue7395RestoreTargetExistsIT` (HTTP, 7 tests)
+- `grpcw/src/test/java/com/arcadedb/server/grpc/Issue7395GrpcRestoreTargetExistsIT` (gRPC, 6 tests)
+
+Both build the divergent state through the server's own API - `createDatabase`, then `getEmbedded().drop()`, which
+deletes the directory and leaves the registry entry - rather than by deleting files under an open database.
+
+## Test results
+
+Both new classes were run against the unfixed tree first. In each, the one test that asserts the new behaviour failed
+and the other five passed, which is what pins the existing behaviour rather than re-asserting it:
+
+```
+# before the fix, server module
+[ERROR] Tests run: 6, Failures: 1 -- Issue7395RestoreTargetExistsIT
+[ERROR]   restoreDatabaseRefusesATargetRegisteredOnTheServerWhoseDirectoryIsGone:165
+          [{"error":"Cannot execute command", ... "detail":"Error restoring database -> ...
+            The backup file '...nonexistent-7395.zip' does not exist ..."}]
+
+# before the fix, grpcw module (predicate temporarily reverted to `new File(dbPath).exists()`)
+[ERROR] Tests run: 6, Failures: 1 -- Issue7395GrpcRestoreTargetExistsIT
+[ERROR]   restoreDatabaseRefusesATargetRegisteredOnTheServerWhoseDirectoryIsGone:172
+```
+
+After the fix, the new classes and every connected suite:
+
+```
+$ mvn -o verify -DskipITs=false -pl server \
+    -Dit.test='BackupRestoreDeleteApiIT,BackupApiCommandsIT,Issue7308RestoreTargetNameIT,\
+               RestoreImportSecurityDurabilityIT,Issue7392OnDemandBackupWithoutAutoBackupIT,\
+               Issue7395RestoreTargetExistsIT,PostServerCommandHandlerIT' \
+    -Dtest='ServerControlPlaneProgressAndSessionsTest'
+Tests run: 4,  Failures: 0  (ServerControlPlaneProgressAndSessionsTest)
+Tests run: 50, Failures: 0  (the seven ITs above)
+BUILD SUCCESS
+
+$ mvn -o verify -DskipTests -DskipITs=false -pl grpcw \
+    -Dit.test='Issue7308GrpcRestoreImportIT,Issue7308GrpcRestoreImportUrlGuardIT,\
+               Issue7308GrpcRestoreImportAuthorizationIT,Issue7395GrpcRestoreTargetExistsIT,\
+               Issue7304GrpcControlPlaneIT'
+Tests run: 53, Failures: 0
+BUILD SUCCESS
+```
+
+## Impact
+
+Four transports, one behaviour change, in one state only: `restore database` against a name the server still has
+registered but whose directory is gone now answers `400 Database '<name>' already exists` (gRPC `INVALID_ARGUMENT`)
+instead of restoring over it. Every other input to either command behaves exactly as before - the five pre-existing
+assertions in each new class, and the 103 tests of the connected suites, are the evidence.
+
+## Adversarial pass
+
+The orchestrator's Phase 1.5 asks for a `general-purpose` subagent that has not seen the author's
+reasoning. **No subagent-spawning tool is available in this session** (`ListAgents`/`SendMessage` exist,
+`Task` does not), so the pass was run against the diff directly instead of by a fresh reader. That is a
+weaker version of the same check and is recorded as such rather than claimed as the real thing.
+
+| Finding | Disposition |
+|---|---|
+| The new `restoreDatabase` javadoc tells the operator to `drop database` or `restore backup ... overwrite`. Does that escape hatch hold? `restore database` now refuses a state it used to repair, so a wrong hatch would be a comment the code does not honour. | **Real, fixed here.** Verified rather than assumed: `aTargetRefusedBecauseItIsOnlyRegisteredCanStillBeDroppedSoTheOperatorCanRetry` builds the state the way it is actually reached - the directory removed from under a database that is still open - then asserts the refusal *and* that `drop database` clears it (200, no longer registered). Green. |
+| `drop database` throws `DatabaseIsClosedException` in the other variant of the state, where the database was dropped through `getEmbedded().drop()` without `removeDatabase` (what this fixture's helper does, and what `Issue7308GrpcRestoreImportIT`'s teardown does). | **Not real** as a product defect. `LocalDatabase.drop()` -> `closeForDrop()` -> `checkDatabaseIsOpen` does throw on an already-closed database, but no server code reaches that state: `dropQuietly` and `dropDatabaseClusterWide` are the only two callers of `getEmbedded().drop()` in `server/src/main/java`, and both pair it with `server.removeDatabase`. Only test teardown leaves the pair half-done. The realistic route into the state is the out-of-band directory removal, and the test above proves that one recovers. |
+| The existence check is not atomic with the swap that acts on it: nothing holds `databasesLock` between them, and the window is the whole duration of the restore, so a `create database` that lands inside it is silently dropped by `swapRestoredDatabase`. | **Real, out of scope - filed as [#7441](https://github.com/ArcadeData/arcadedb/issues/7441).** Predates this fix and is untouched by it (both commands had the window before and after); closing it means reserving the name for the restore's duration, which is a different change from agreeing on the predicate. |
+| The registry is a case-sensitive `Map`, `new File(dbPath).exists()` is case-insensitive on macOS and Windows, so `restore database GRAPH` and `restore database graph` can disagree about which half answers. | **Not real** as a new gap: both halves were already in `restoreBackup`'s predicate before this fix, so the behaviour is unchanged on every input. Recorded under residual risk rather than filed - it is a property of `ArcadeDBServer`'s registry, not of restore. |
+
+## Residual risk (updated)
+
+- `restore database` now refuses, rather than silently replacing, a database that is registered but whose
+  directory is gone. The way out is `drop database <name>` - asserted, not assumed - or
+  `restore backup ... as <name>` with `overwrite`.
+- The check is not atomic with the swap: [#7441](https://github.com/ArcadeData/arcadedb/issues/7441).
+- Case-sensitivity between the two halves of the predicate is whatever `ArcadeDBServer`'s registry and the
+  host filesystem already made it; this fix neither widens nor narrows it.

--- a/docs/7395-restore-target-exists-predicate.md
+++ b/docs/7395-restore-target-exists-predicate.md
@@ -120,6 +120,22 @@ Four transports, two shared implementations. No transport repeats the check for 
 | `ServerControlPlane.importDatabase` -> `ArcadeDBServer.createDatabase` | n/a - argued | argued: `createDatabase` already applies registry-then-`factory.exists()`, the stricter predicate (`ArcadeDBServer.java:1002-1014`). It is the norm this fix aligns restore with, not a violator of it. |
 | `ha-raft` `SnapshotInstaller.restoreBackup(Path, Path)` | n/a - argued | argued: `private static void restoreBackup(final Path dbDir, final Path backupDir)` - a file-copy helper taking two paths, no database name, no registry. Same method name, different question. |
 
+### 4. Test per entry point
+
+One test per **fixed** row, driven through that row's own transport rather than through the shared
+implementation - a test that called `ServerControlPlane` directly would pass against a transport that
+never wired the method up.
+
+| Fixed row | Tests |
+|---|---|
+| HTTP `restore database` | `restoreDatabaseRefusesATargetRegisteredOnTheServerWhoseDirectoryIsGone` (the new behaviour), `restoreDatabaseStillRefusesATargetWhoseDirectoryIsPresentButUnregistered` (the other half of the predicate), `aTargetRefusedBecauseItIsOnlyRegisteredCanStillBeDroppedSoTheOperatorCanRetry` (the state reached the way it is really reached, plus the way out), `restoreDatabaseWithAFreeNameGetsPastTheExistenceCheckAndFailsOnTheArchive` (the control) |
+| HTTP `restore backup` | `restoreBackupRefusesATargetRegisteredOnTheServerWhoseDirectoryIsGone`, `restoreBackupRefusesATargetWhoseDirectoryIsPresentButUnregistered`, `restoreBackupWithAFreeTargetNameGetsPastTheExistenceCheckAndFailsOnTheArchive` (the control) |
+| gRPC `RestoreDatabase` | the same three shapes in `Issue7395GrpcRestoreTargetExistsIT` |
+| gRPC `RestoreBackup` | the same three shapes in `Issue7395GrpcRestoreTargetExistsIT` |
+
+The controls are what stop the refusal tests passing against a check that refuses every name; the
+"directory present but unregistered" tests are what stop the fix being written as a registry-only check.
+
 ### 5. Reachability
 
 `ServerControlPlane` is constructed by `ArcadeDBServer` and reached on every restore command; the two methods are

--- a/docs/review-deferred-a9a1d9b.md
+++ b/docs/review-deferred-a9a1d9b.md
@@ -1,0 +1,33 @@
+# Review notes - PR #7442, head `a9a1d9b`
+
+Cycle 1, `claude` review. Nothing in it blocked merging; the disposition of each point is below.
+
+## Applied
+
+- **Javadoc link used as a mid-sentence verb.** `{@link #databaseNameIsTaken is taken}` at
+  `ServerControlPlane.java:1216` and `:1245` used the link *label* to carry the sentence's verb, a
+  convention that appears nowhere else in the class. Reworded to "A target name that is already taken -
+  see `{@link #databaseNameIsTaken}` - ..." and "... already taken, as `{@link #databaseNameIsTaken}`
+  defines it", so the link is a reference and the sentence reads on its own.
+- **Tracking doc skipped section 4.** It numbered 1, 2, 3, then 5. Section 4 of
+  `completeness-checklist.md` is "test per entry point, not per issue" and it had been folded into the
+  coverage table instead of written out. Added as its own section, listing which test drives which
+  fixed row.
+
+## Skipped, with rationale
+
+- **`Issue7395GrpcRestoreTargetExistsIT` hardcodes `GRPC_PORT = 50051`.** Not changed, and the reviewer
+  says so too ("matching the existing pattern across most other `grpcw` IT classes in this package, so
+  it is not a new issue"). Verified rather than assumed:
+
+  ```
+  $ grep -rln "GRPC_PORT *= *50051" grpcw/src/test/java | wc -l
+  43
+  ```
+
+  Forty-three IT classes in this package share that constant, and the module's ITs run one JVM per class
+  in sequence. Picking a different port for this one class alone would not make the package
+  concurrency-safe - it would only make this class the odd one out - and moving all seventeen to a
+  free-port helper is a change to the `grpcw` test fixture, not to this fix. The `server`-module half of
+  this PR does derive its port from `getServer(0).getHttpServer().getPort()`, which is the pattern that
+  base class actually supports.

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7395GrpcRestoreTargetExistsIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7395GrpcRestoreTargetExistsIT.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.backup.AutoBackupSchedulerPlugin;
+import com.arcadedb.utility.FileUtils;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7395, gRPC half. {@code RestoreDatabase} and {@code RestoreBackup} reach the same two
+ * {@code ServerControlPlane} methods the HTTP commands do, so they inherited the divergence this
+ * issue is about: {@code restore backup} consulted the server's database registry and the filesystem,
+ * {@code restore database} only the filesystem.
+ * <p>
+ * The HTTP half lives in {@code Issue7395RestoreTargetExistsIT} in the {@code server} module. This
+ * class drives the same states through the RPCs rather than through the shared implementation,
+ * because a test that called the implementation directly would pass against a transport that never
+ * wired it up.
+ *
+ * @see Issue7308GrpcRestoreImportIT for the fixture this one follows
+ */
+public class Issue7395GrpcRestoreTargetExistsIT extends BaseGraphServerTest {
+
+  private static final int    GRPC_PORT       = 50051;
+  private static final String BACKUP_DIR_NAME = "test-backups-7395-grpc";
+  private static final String ARCHIVE_NAME    = "graph-backup-7395000000.zip";
+  private static final String BACKUP_CONFIG   = """
+      {
+        "version": 1,
+        "enabled": true,
+        "backupDirectory": "%s",
+        "defaults": {
+          "enabled": true,
+          "runOnServer": "*",
+          "schedule": { "type": "frequency", "frequencyMinutes": 9999 },
+          "retention": { "maxFiles": 50 }
+        }
+      }
+      """.formatted(BACKUP_DIR_NAME);
+
+  private File backupConfigFile;
+  private File backupDir;
+
+  private ManagedChannel                                            channel;
+  private ArcadeDbAdminServiceGrpc.ArcadeDbAdminServiceBlockingStub adminStub;
+
+  private final List<String> registeredToUnregister = new ArrayList<>();
+  private final List<File>   directoriesToDelete    = new ArrayList<>();
+
+  @Override
+  protected boolean isCreateDatabases() {
+    return true;
+  }
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+
+    try {
+      final File configDir = new File("./target/config");
+      configDir.mkdirs();
+
+      backupConfigFile = new File(configDir, "backup.json");
+      try (final FileWriter writer = new FileWriter(backupConfigFile)) {
+        writer.write(BACKUP_CONFIG);
+      }
+
+      backupDir = new File("./target/" + BACKUP_DIR_NAME);
+      if (backupDir.exists())
+        FileUtils.deleteRecursively(backupDir);
+      backupDir.mkdirs();
+    } catch (final IOException e) {
+      throw new RuntimeException("Failed to set up the backup configuration", e);
+    }
+
+    config.setValue(GlobalConfiguration.SERVER_ROOT_PATH, "./target");
+    config.setValue(GlobalConfiguration.SERVER_PLUGINS,
+        "GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin,auto-backup:" + AutoBackupSchedulerPlugin.class.getName());
+    // RestoreDatabase validates the caller's URL before it looks at the target at all, so without this
+    // every test here would fail the SSRF guard instead of reaching the existence check.
+    config.setValue(GlobalConfiguration.SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS, true);
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    adminStub = ArcadeDbAdminServiceGrpc.newBlockingStub(channel);
+  }
+
+  @AfterEach
+  void teardown() throws InterruptedException {
+    for (final String database : registeredToUnregister)
+      getServer(0).removeDatabase(database);
+    registeredToUnregister.clear();
+
+    for (final File directory : directoriesToDelete)
+      if (directory.exists())
+        FileUtils.deleteRecursively(directory);
+    directoriesToDelete.clear();
+
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  @AfterAll
+  static void cleanUpBackupFixture() {
+    final File config = new File("./target/config/backup.json");
+    if (config.exists())
+      config.delete();
+    final File backups = new File("./target/" + BACKUP_DIR_NAME);
+    if (backups.exists())
+      FileUtils.deleteRecursively(backups);
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // RestoreDatabase
+  // -----------------------------------------------------------------------------------------------
+
+  @Test
+  void restoreDatabaseRefusesATargetRegisteredOnTheServerWhoseDirectoryIsGone() {
+    final String target = registeredWithoutADirectory("grpc7395_regonly_restore_db");
+
+    assertThatThrownBy(() -> drain(adminStub.restoreDatabase(RestoreDatabaseRequest.newBuilder().setCredentials(root())
+        .setDatabase(target).setUrl(missingArchiveUrl()).build())))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("INVALID_ARGUMENT")
+        .hasMessageContaining("already exists");
+  }
+
+  @Test
+  void restoreDatabaseStillRefusesATargetWhoseDirectoryIsPresentButUnregistered() {
+    final String target = directoryWithoutARegistration("grpc7395_dironly_restore_db");
+
+    assertThatThrownBy(() -> drain(adminStub.restoreDatabase(RestoreDatabaseRequest.newBuilder().setCredentials(root())
+        .setDatabase(target).setUrl(missingArchiveUrl()).build())))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("INVALID_ARGUMENT")
+        .hasMessageContaining("already exists");
+  }
+
+  /** The control: a free name gets past the existence check and fails on the archive instead. */
+  @Test
+  void restoreDatabaseWithAFreeNameGetsPastTheExistenceCheckAndFailsOnTheArchive() {
+    assertThatThrownBy(() -> drain(adminStub.restoreDatabase(RestoreDatabaseRequest.newBuilder().setCredentials(root())
+        .setDatabase("grpc7395_free_restore_db").setUrl(missingArchiveUrl()).build())))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageNotContaining("already exists");
+
+    assertThat(getServer(0).existsDatabase("grpc7395_free_restore_db")).isFalse();
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // RestoreBackup
+  // -----------------------------------------------------------------------------------------------
+
+  @Test
+  void restoreBackupRefusesATargetRegisteredOnTheServerWhoseDirectoryIsGone() throws IOException {
+    final String target = registeredWithoutADirectory("grpc7395_regonly_restore_backup");
+
+    assertThatThrownBy(() -> drain(adminStub.restoreBackup(RestoreBackupRequest.newBuilder().setCredentials(root())
+        .setDatabase(getDatabaseName()).setFileName(placeholderArchive()).setTargetDatabase(target).build())))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("INVALID_ARGUMENT")
+        .hasMessageContaining("already exists");
+  }
+
+  @Test
+  void restoreBackupRefusesATargetWhoseDirectoryIsPresentButUnregistered() throws IOException {
+    final String target = directoryWithoutARegistration("grpc7395_dironly_restore_backup");
+
+    assertThatThrownBy(() -> drain(adminStub.restoreBackup(RestoreBackupRequest.newBuilder().setCredentials(root())
+        .setDatabase(getDatabaseName()).setFileName(placeholderArchive()).setTargetDatabase(target).build())))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("INVALID_ARGUMENT")
+        .hasMessageContaining("already exists");
+  }
+
+  @Test
+  void restoreBackupWithAFreeTargetNameGetsPastTheExistenceCheckAndFailsOnTheArchive() throws IOException {
+    assertThatThrownBy(() -> drain(adminStub.restoreBackup(RestoreBackupRequest.newBuilder().setCredentials(root())
+        .setDatabase(getDatabaseName()).setFileName(placeholderArchive())
+        .setTargetDatabase("grpc7395_free_restore_backup").build())))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageNotContaining("already exists");
+
+    assertThat(getServer(0).existsDatabase("grpc7395_free_restore_backup")).isFalse();
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // Fixture helpers
+  // -----------------------------------------------------------------------------------------------
+
+  /**
+   * Creates a database and then drops it through the embedded instance, which deletes the directory
+   * and leaves the registry entry behind - the one state in which the two checks disagreed.
+   */
+  private String registeredWithoutADirectory(final String databaseName) {
+    getServer(0).createDatabase(databaseName, ComponentFile.MODE.READ_WRITE);
+    getServer(0).getDatabase(databaseName).getEmbedded().drop();
+    registeredToUnregister.add(databaseName);
+
+    assertThat(getServer(0).existsDatabase(databaseName)).isTrue();
+    assertThat(databaseDirectory(databaseName)).doesNotExist();
+    return databaseName;
+  }
+
+  private String directoryWithoutARegistration(final String databaseName) {
+    final File directory = databaseDirectory(databaseName);
+    assertThat(directory.mkdirs()).isTrue();
+    directoriesToDelete.add(directory);
+
+    assertThat(getServer(0).existsDatabase(databaseName)).isFalse();
+    return databaseName;
+  }
+
+  private File databaseDirectory(final String databaseName) {
+    return new File(
+        getServer(0).getConfiguration().getValueAsString(GlobalConfiguration.SERVER_DATABASE_DIRECTORY), databaseName);
+  }
+
+  private String missingArchiveUrl() {
+    return "file://" + new File("./target/nonexistent-7395-grpc.zip").getAbsolutePath();
+  }
+
+  /**
+   * {@code RestoreBackup} resolves its archive before it looks at the target, so the file has to
+   * exist; its contents never matter here - every test either refuses before the restore starts, or
+   * is the control that asserts the restore itself fails.
+   */
+  private String placeholderArchive() throws IOException {
+    final File dbBackupDir = new File(backupDir, getDatabaseName());
+    dbBackupDir.mkdirs();
+    final File archive = new File(dbBackupDir, ARCHIVE_NAME);
+    if (!archive.exists())
+      Files.writeString(archive.toPath(), "not a real archive");
+    return ARCHIVE_NAME;
+  }
+
+  private DatabaseCredentials root() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  private static <T> List<T> drain(final Iterator<T> stream) {
+    final List<T> events = new ArrayList<>();
+    while (stream.hasNext())
+      events.add(stream.next());
+    return events;
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -1213,9 +1213,10 @@ public class ServerControlPlane {
    * {@link GlobalConfiguration#SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS} first.
    *
    * <p>
-   * A target that {@link #databaseNameIsTaken is taken} is refused outright: this command has no
-   * {@code overwrite} flag, so there is no way for the caller to say they meant it. Use
-   * {@code restore backup ... as &lt;name&gt;} with {@code overwrite}, or drop the database first.
+   * A target name that is already taken - see {@link #databaseNameIsTaken} - is refused outright:
+   * this command has no {@code overwrite} flag, so there is no way for the caller to say they meant
+   * it. Use {@code restore backup ... as &lt;name&gt;} with {@code overwrite}, or drop the database
+   * first.
    *
    * @throws IllegalArgumentException when the name is invalid or the database already exists
    * @throws SecurityException        when the URL is not one this server accepts from a client
@@ -1242,9 +1243,9 @@ public class ServerControlPlane {
    * {@link #resolveBackupFile}, so the caller never supplies a filesystem path and the resulting
    * {@code file://} URL needs no SSRF check.
    * <p>
-   * {@code overwrite} decides what happens when the target {@link #databaseNameIsTaken is taken}.
-   * Even with it set, the existing database is dropped only once the restore into a temporary
-   * directory has succeeded (issue #5027).
+   * {@code overwrite} decides what happens when the target name is already taken, as
+   * {@link #databaseNameIsTaken} defines it. Even with it set, the existing database is dropped only
+   * once the restore into a temporary directory has succeeded (issue #5027).
    *
    * @throws IllegalArgumentException when a name is invalid, or the target exists and {@code overwrite} is false
    */

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -1212,6 +1212,11 @@ public class ServerControlPlane {
    * The caller supplies the URL, so it is validated against
    * {@link GlobalConfiguration#SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS} first.
    *
+   * <p>
+   * A target that {@link #databaseNameIsTaken is taken} is refused outright: this command has no
+   * {@code overwrite} flag, so there is no way for the caller to say they meant it. Use
+   * {@code restore backup ... as &lt;name&gt;} with {@code overwrite}, or drop the database first.
+   *
    * @throws IllegalArgumentException when the name is invalid or the database already exists
    * @throws SecurityException        when the URL is not one this server accepts from a client
    */
@@ -1225,7 +1230,7 @@ public class ServerControlPlane {
     server.checkDatabaseNameIsValid(databaseName);
 
     final String dbPath = databaseDirectory(databaseName);
-    if (new File(dbPath).exists())
+    if (databaseNameIsTaken(databaseName, dbPath))
       throw new IllegalArgumentException("Database '" + databaseName + "' already exists");
 
     performRestore(databaseName, dbPath, url, listener);
@@ -1237,9 +1242,9 @@ public class ServerControlPlane {
    * {@link #resolveBackupFile}, so the caller never supplies a filesystem path and the resulting
    * {@code file://} URL needs no SSRF check.
    * <p>
-   * {@code overwrite} decides what happens when the target already exists. Even with it set, the
-   * existing database is dropped only once the restore into a temporary directory has succeeded
-   * (issue #5027).
+   * {@code overwrite} decides what happens when the target {@link #databaseNameIsTaken is taken}.
+   * Even with it set, the existing database is dropped only once the restore into a temporary
+   * directory has succeeded (issue #5027).
    *
    * @throws IllegalArgumentException when a name is invalid, or the target exists and {@code overwrite} is false
    */
@@ -1257,11 +1262,31 @@ public class ServerControlPlane {
     final Path backupFile = resolveBackupFile(databaseName, fileName);
 
     final String dbPath = databaseDirectory(targetDatabase);
-    if ((server.existsDatabase(targetDatabase) || new File(dbPath).exists()) && !overwrite)
+    if (databaseNameIsTaken(targetDatabase, dbPath) && !overwrite)
       throw new IllegalArgumentException(
           "Database '" + targetDatabase + "' already exists. Enable overwrite to replace it with the backup");
 
     performRestore(targetDatabase, dbPath, "file://" + backupFile.toAbsolutePath(), listener);
+  }
+
+  /**
+   * The single question both restore entry points ask about their target: is the name already taken
+   * on this server? It is taken when the server has a database of that name registered <b>or</b> when
+   * a directory of that name is present under {@code SERVER_DATABASE_DIRECTORY}.
+   * <p>
+   * The two halves are independent. A registered database whose directory has gone - removed out of
+   * band, or dropped through the embedded instance without {@link ArcadeDBServer#removeDatabase},
+   * which {@link #dropQuietly} has to call as a separate second step - satisfies the first and not
+   * the second. A directory left behind by a half-finished operation satisfies the second and not the
+   * first.
+   * <p>
+   * Until issue #7395 the two commands disagreed here: {@code restore backup} asked both halves and
+   * {@code restore database} only the filesystem, so a registered-but-absent database was "not there"
+   * to one and "there" to the other. Both now ask the same question, which is also the one
+   * {@link ArcadeDBServer#createDatabase} already asked - the registry first, then the files.
+   */
+  private boolean databaseNameIsTaken(final String databaseName, final String dbPath) {
+    return server.existsDatabase(databaseName) || new File(dbPath).exists();
   }
 
   /**

--- a/server/src/test/java/com/arcadedb/server/backup/Issue7395RestoreTargetExistsIT.java
+++ b/server/src/test/java/com/arcadedb/server/backup/Issue7395RestoreTargetExistsIT.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.backup;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7395: {@code restore database} and {@code restore backup} asked a different question about
+ * whether their target already existed. {@code restore backup} consulted the server's database
+ * registry <b>and</b> the filesystem; {@code restore database} consulted only the filesystem.
+ * <p>
+ * The two answers differ in exactly one state - a database that is registered on the server but whose
+ * directory is gone. That state is reachable out of band (the directory removed under a running
+ * server) and through the server's own API: {@code LocalDatabase.drop()} closes the database and
+ * deletes its directory but does not unregister it, which is why
+ * {@code ServerControlPlane.dropQuietly} has to call {@code server.removeDatabase()} as a separate
+ * second step. This fixture builds the state that way rather than by deleting files under an open
+ * database.
+ * <p>
+ * Both entry points now ask {@code registered || directory present} - the stricter of the two, and
+ * the predicate {@code ArcadeDBServer.createDatabase} already applied. {@code restore database} keeps
+ * its unconditional refusal, {@code restore backup} keeps its {@code overwrite} gate over the same
+ * predicate.
+ * <p>
+ * The gRPC transports of the same two commands are asserted by
+ * {@code Issue7395GrpcRestoreTargetExistsIT} in the {@code grpcw} module. Both transports reach the
+ * same {@code ServerControlPlane} methods, but a test that called those methods directly would pass
+ * against a transport that never wired them up.
+ */
+class Issue7395RestoreTargetExistsIT extends BaseGraphServerTest {
+  private static final String BACKUP_DIR_NAME = "test-backups-7395-target-exists";
+  private static final String ARCHIVE_NAME    = "graph-backup-7395000000.zip";
+  private static final String BACKUP_CONFIG   = """
+      {
+        "version": 1,
+        "enabled": true,
+        "backupDirectory": "%s",
+        "defaults": {
+          "enabled": true,
+          "runOnServer": "*",
+          "schedule": { "type": "frequency", "frequencyMinutes": 9999 },
+          "retention": { "maxFiles": 50 }
+        }
+      }
+      """.formatted(BACKUP_DIR_NAME);
+
+  private File backupConfigFile;
+  private File backupDir;
+
+  private final List<String> registeredToUnregister = new ArrayList<>();
+  private final List<File>   directoriesToDelete    = new ArrayList<>();
+
+  @Override
+  protected boolean isCreateDatabases() {
+    return true;
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+
+    try {
+      final File configDir = new File("./target/config");
+      configDir.mkdirs();
+
+      backupConfigFile = new File(configDir, "backup.json");
+      try (final FileWriter writer = new FileWriter(backupConfigFile)) {
+        writer.write(BACKUP_CONFIG);
+      }
+
+      backupDir = new File("./target/" + BACKUP_DIR_NAME);
+      if (backupDir.exists())
+        FileUtils.deleteRecursively(backupDir);
+      backupDir.mkdirs();
+    } catch (final IOException e) {
+      throw new RuntimeException("Failed to set up the backup configuration", e);
+    }
+
+    config.setValue(GlobalConfiguration.SERVER_ROOT_PATH, "./target");
+    config.setValue(GlobalConfiguration.SERVER_PLUGINS, "auto-backup:" + AutoBackupSchedulerPlugin.class.getName());
+    // 'restore database' validates the caller's URL before it looks at the target at all, so without
+    // this every test here would fail the SSRF guard instead of reaching the existence check.
+    config.setValue(GlobalConfiguration.SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS, true);
+  }
+
+  @AfterEach
+  void cleanUpPerTestState() {
+    for (final String database : registeredToUnregister)
+      getServer(0).removeDatabase(database);
+    registeredToUnregister.clear();
+
+    for (final File directory : directoriesToDelete)
+      if (directory.exists())
+        FileUtils.deleteRecursively(directory);
+    directoriesToDelete.clear();
+  }
+
+  /**
+   * Cleaned up once, after the whole class: per-test cleanup would delete the backup configuration
+   * out from under the server fixture the remaining tests still share.
+   */
+  @AfterAll
+  static void cleanUp() {
+    final File config = new File("./target/config/backup.json");
+    if (config.exists())
+      config.delete();
+    final File backups = new File("./target/" + BACKUP_DIR_NAME);
+    if (backups.exists())
+      FileUtils.deleteRecursively(backups);
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // restore database
+  // -----------------------------------------------------------------------------------------------
+
+  /**
+   * The regression this issue is about. Before the fix the filesystem-only check saw nothing, let the
+   * restore run, and reached {@code swapRestoredDatabase} - which would have dropped the registered
+   * database out from under whoever still held it.
+   */
+  @Test
+  void restoreDatabaseRefusesATargetRegisteredOnTheServerWhoseDirectoryIsGone() throws Exception {
+    final String target = registeredWithoutADirectory("regonly7395_restore_db");
+
+    final HttpResponse<String> response = postCommand("restore database " + target + " " + missingArchiveUrl());
+
+    assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
+    assertThat(new JSONObject(response.body()).getString("detail")).contains("already exists").contains(target);
+  }
+
+  /** The other half of the predicate, unchanged by this fix: a directory with nobody registered. */
+  @Test
+  void restoreDatabaseStillRefusesATargetWhoseDirectoryIsPresentButUnregistered() throws Exception {
+    final String target = directoryWithoutARegistration("dironly7395_restore_db");
+
+    final HttpResponse<String> response = postCommand("restore database " + target + " " + missingArchiveUrl());
+
+    assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
+    assertThat(new JSONObject(response.body()).getString("detail")).contains("already exists").contains(target);
+  }
+
+  /**
+   * The state the issue describes reached the way it is actually reached - the directory removed from
+   * under a database that is still open and registered - rather than the way the other tests build
+   * it. And the refusal has to leave the operator a way out, because {@code restore database} has no
+   * {@code overwrite} flag: {@code drop database} is the way out this fix's javadoc names, so it is
+   * asserted here rather than assumed.
+   */
+  @Test
+  void aTargetRefusedBecauseItIsOnlyRegisteredCanStillBeDroppedSoTheOperatorCanRetry() throws Exception {
+    final String target = "outofband7395_restore_db";
+    getServer(0).createDatabase(target, ComponentFile.MODE.READ_WRITE);
+    registeredToUnregister.add(target);
+    FileUtils.deleteRecursively(databaseDirectory(target));
+
+    assertThat(getServer(0).existsDatabase(target)).isTrue();
+    assertThat(databaseDirectory(target)).doesNotExist();
+
+    final HttpResponse<String> refused = postCommand("restore database " + target + " " + missingArchiveUrl());
+    assertThat(refused.statusCode()).as(refused.body()).isEqualTo(400);
+    assertThat(new JSONObject(refused.body()).getString("detail")).contains("already exists");
+
+    final HttpResponse<String> dropped = postCommand("drop database " + target);
+    assertThat(dropped.statusCode()).as(dropped.body()).isEqualTo(200);
+    assertThat(getServer(0).existsDatabase(target)).isFalse();
+    registeredToUnregister.remove(target);
+  }
+
+  /**
+   * The control. Without it every test above would pass against a check that refused every name: a
+   * target that is neither registered nor on disk gets past the existence check and fails on the
+   * archive instead.
+   */
+  @Test
+  void restoreDatabaseWithAFreeNameGetsPastTheExistenceCheckAndFailsOnTheArchive() throws Exception {
+    final HttpResponse<String> response = postCommand("restore database free7395_restore_db " + missingArchiveUrl());
+
+    assertThat(response.statusCode()).as(response.body()).isNotEqualTo(200);
+    assertThat(response.body()).doesNotContain("already exists");
+    assertThat(getServer(0).existsDatabase("free7395_restore_db")).isFalse();
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // restore backup
+  // -----------------------------------------------------------------------------------------------
+
+  /** Unchanged by this fix, and now expressed through the shared predicate rather than its own copy. */
+  @Test
+  void restoreBackupRefusesATargetRegisteredOnTheServerWhoseDirectoryIsGone() throws Exception {
+    final String target = registeredWithoutADirectory("regonly7395_restore_backup");
+
+    final HttpResponse<String> response = postCommand(
+        "restore backup " + getDatabaseName() + " " + placeholderArchive() + " as " + target);
+
+    assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
+    assertThat(new JSONObject(response.body()).getString("detail")).contains("already exists").contains(target);
+  }
+
+  @Test
+  void restoreBackupRefusesATargetWhoseDirectoryIsPresentButUnregistered() throws Exception {
+    final String target = directoryWithoutARegistration("dironly7395_restore_backup");
+
+    final HttpResponse<String> response = postCommand(
+        "restore backup " + getDatabaseName() + " " + placeholderArchive() + " as " + target);
+
+    assertThat(response.statusCode()).as(response.body()).isEqualTo(400);
+    assertThat(new JSONObject(response.body()).getString("detail")).contains("already exists").contains(target);
+  }
+
+  /**
+   * The control for {@code restore backup}: a free target name gets past the existence check and
+   * fails on the archive, which here is a placeholder that is not a backup at all.
+   */
+  @Test
+  void restoreBackupWithAFreeTargetNameGetsPastTheExistenceCheckAndFailsOnTheArchive() throws Exception {
+    final HttpResponse<String> response = postCommand(
+        "restore backup " + getDatabaseName() + " " + placeholderArchive() + " as free7395_restore_backup");
+
+    assertThat(response.statusCode()).as(response.body()).isNotEqualTo(200);
+    assertThat(response.body()).doesNotContain("already exists");
+    assertThat(getServer(0).existsDatabase("free7395_restore_backup")).isFalse();
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // Fixture helpers
+  // -----------------------------------------------------------------------------------------------
+
+  /**
+   * Creates a database and then drops it through the embedded instance, which deletes the directory
+   * and leaves the registry entry behind - the divergent state, built with the server's own API.
+   */
+  private String registeredWithoutADirectory(final String databaseName) {
+    getServer(0).createDatabase(databaseName, ComponentFile.MODE.READ_WRITE);
+    getServer(0).getDatabase(databaseName).getEmbedded().drop();
+    registeredToUnregister.add(databaseName);
+
+    assertThat(getServer(0).existsDatabase(databaseName)).isTrue();
+    assertThat(databaseDirectory(databaseName)).doesNotExist();
+    return databaseName;
+  }
+
+  private String directoryWithoutARegistration(final String databaseName) {
+    final File directory = databaseDirectory(databaseName);
+    assertThat(directory.mkdirs()).isTrue();
+    directoriesToDelete.add(directory);
+
+    assertThat(getServer(0).existsDatabase(databaseName)).isFalse();
+    return databaseName;
+  }
+
+  private File databaseDirectory(final String databaseName) {
+    return new File(
+        getServer(0).getConfiguration().getValueAsString(GlobalConfiguration.SERVER_DATABASE_DIRECTORY), databaseName);
+  }
+
+  /**
+   * A {@code file://} URL for an archive that is not there. The existence check runs before the
+   * restore, so a target that is taken never gets far enough for the missing file to matter - and a
+   * target that is free fails on it, which is what the control tests assert.
+   */
+  private String missingArchiveUrl() {
+    return "file://" + new File("./target/nonexistent-7395.zip").getAbsolutePath();
+  }
+
+  /**
+   * {@code restore backup} resolves its archive out of the backup directory before it looks at the
+   * target, so the file has to be there; {@code resolveBackupFile} only requires a regular file whose
+   * name looks like an archive. Its contents never matter here - every test either refuses before the
+   * restore starts, or is the control that asserts the restore itself fails.
+   */
+  private String placeholderArchive() throws IOException {
+    final File dbBackupDir = new File(backupDir, getDatabaseName());
+    dbBackupDir.mkdirs();
+    final File archive = new File(dbBackupDir, ARCHIVE_NAME);
+    if (!archive.exists())
+      Files.writeString(archive.toPath(), "not a real archive");
+    return ARCHIVE_NAME;
+  }
+
+  private HttpResponse<String> postCommand(final String command) throws Exception {
+    final HttpRequest request = HttpRequest.newBuilder()
+        .uri(new URI("http://localhost:" + getServer(0).getHttpServer().getPort() + "/api/v1/server"))
+        .header("Authorization",
+            "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()))
+        .header("Content-Type", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString(new JSONObject().put("command", command).toString()))
+        .build();
+    return HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+  }
+}


### PR DESCRIPTION
Closes #7395

`ServerControlPlane.restoreDatabase` asked only the filesystem whether its target already existed;
`ServerControlPlane.restoreBackup` asked the server's database registry as well. The two answers
differ in exactly one state - a database that is registered on the server but whose directory is
gone, reachable when the directory is removed out of band under a running server - and there
`restore database` would proceed, restore into a temp directory and reach `swapRestoredDatabase`,
which drops the registered database and moves the new directory into place. Both entry points now
call a single `databaseNameIsTaken()` helper, the stricter of the two predicates and the one
`ArcadeDBServer.createDatabase` already applied (registry first, then the files): `restore database`
keeps its unconditional refusal, `restore backup` keeps its `overwrite` gate over the same
predicate. The one behaviour change is that `restore database` against a registered-but-absent
database now answers `400 Database '<name>' already exists` instead of restoring over it; `drop
database <name>` clears that state and is asserted to, so the refusal leaves the operator a way out.

## Test plan

- [x] `mvn -o verify -DskipITs=false -pl server -Dit.test=Issue7395RestoreTargetExistsIT` - 7 tests, HTTP transport
- [x] `mvn -o verify -DskipTests -DskipITs=false -pl grpcw -Dit.test=Issue7395GrpcRestoreTargetExistsIT` - 6 tests, gRPC transport
- [x] Both new classes run against the unfixed tree first: in each, the one test asserting the new behaviour fails and the other five pass, so the class pins existing behaviour rather than re-asserting it
- [x] Connected suites, server: `BackupRestoreDeleteApiIT`, `BackupApiCommandsIT`, `Issue7308RestoreTargetNameIT`, `RestoreImportSecurityDurabilityIT`, `Issue7392OnDemandBackupWithoutAutoBackupIT`, `PostServerCommandHandlerIT`, `ServerControlPlaneProgressAndSessionsTest` - 50 tests, 0 failures
- [x] Connected suites, grpcw: `Issue7308GrpcRestoreImportIT`, `Issue7308GrpcRestoreImportUrlGuardIT`, `Issue7308GrpcRestoreImportAuthorizationIT`, `Issue7304GrpcControlPlaneIT` - 53 tests, 0 failures

Both new fixtures build the divergent state through the server's own API (`createDatabase`, then
`getEmbedded().drop()`, which deletes the directory and leaves the registry entry) rather than by
deleting files under an open database. One test additionally builds it the way it is really reached
- the directory removed from under a still-open database - and asserts both the refusal and that
`drop database` then clears it.

## Coverage

| Entry point | Covered | Test |
|---|---|---|
| HTTP `POST /api/v1/server` `restore database <n> <url>` | yes | `Issue7395RestoreTargetExistsIT` |
| HTTP `POST /api/v1/server` `restore backup <db> <f> as <t>` | yes (predicate now shared, behaviour unchanged) | `Issue7395RestoreTargetExistsIT` |
| gRPC `RestoreDatabase` | yes | `Issue7395GrpcRestoreTargetExistsIT` |
| gRPC `RestoreBackup` | yes (unchanged) | `Issue7395GrpcRestoreTargetExistsIT` |
| `ServerControlPlane.importDatabase` -> `ArcadeDBServer.createDatabase` | n/a | argued: `createDatabase` already applies registry-then-`factory.exists()`. It is the norm this fix aligns restore with, not a violator of it |
| `ha-raft` `SnapshotInstaller.restoreBackup(Path, Path)` | n/a | argued: a private static file-copy helper taking two paths, no database name and no registry. Same method name, different question |

Four transports, two shared implementations, and no transport repeats the check for itself - so the
table is the complete set of restore entry points. The greps behind that claim are in the tracking
doc, `docs/7395-restore-target-exists-predicate.md`.

### Known gaps

- **#7441** - the existence check is not atomic with the swap that acts on it. Nothing holds
  `databasesLock` between them and the window is the whole duration of the restore, so a
  `create database` landing inside it is silently dropped by `swapRestoredDatabase`. Predates this
  fix and is untouched by it: both commands had the window before and after, and closing it means
  reserving the name for the restore's duration rather than agreeing on the predicate. Found by this
  PR's adversarial pass and filed before it opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4kKMPe6TUwc36ZCZr6iBR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restore operations now consistently recognize a target as existing when it is registered or its directory is present.
  - Database restores refuse existing targets.
  - Backup restores continue to honor the overwrite option while preventing unintended replacement by default.

- **Tests**
  - Added coverage for registered targets, existing directories, and available target names across server and gRPC restore workflows.

- **Documentation**
  - Added detailed documentation describing restore target checks, supported scenarios, and validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->