### PR TITLE
fix(#7384): serialise a restore against a backup, a restore and an import of the same database

### DIFF
--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
@@ -1104,9 +1104,11 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
     // because the request is well formed - it is the identity that is taken.
     if (e instanceof ServerControlPlane.AlreadyExistsException)
       return Status.ALREADY_EXISTS.withDescription(e.getMessage()).asException();
-    // A backup already running for the same database is HTTP's 409 on the other transport: the request
-    // is well formed and authorized, and retrying once the other run finishes is the fix.
-    if (e instanceof ServerControlPlane.BackupInProgressException)
+    // A backup, restore or import already running on the same database is HTTP's 409 on the other
+    // transport: the request is well formed and authorized, and retrying once the other operation
+    // finishes is the fix. The base type, so RestoreBackup, RestoreDatabase and ImportDatabase get the
+    // same status TriggerBackup already got (issue #7384) - BackupInProgressException extends it.
+    if (e instanceof ServerControlPlane.OperationInProgressException)
       return Status.ABORTED.withDescription(e.getMessage()).asException();
     // A rejected argument must not read as a server fault: an empty database name, an unparseable
     // setting value or a backup file name outside the backup directory are all the caller's to fix.

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7384GrpcRestoreSerialisationIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7384GrpcRestoreSerialisationIT.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.backup.AutoBackupSchedulerPlugin;
+import com.arcadedb.server.backup.BackupCoordinator;
+import com.arcadedb.server.backup.BackupCoordinator.Operation;
+import com.arcadedb.utility.FileUtils;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+/**
+ * The gRPC half of issue #7384: a restore, a backup or an import already running on a database refuses the next one,
+ * and the refusal reaches a gRPC client as {@code ABORTED} - HTTP's 409 on this transport.
+ * <p>
+ * Driven through the RPCs rather than through {@code ServerControlPlane}, because the thing this class exists to
+ * catch is a status mapping that only ever looked at {@code BackupInProgressException}: {@code TriggerBackup} was the
+ * one RPC that could raise it, so widening the slot to restores and imports without widening the mapping would have
+ * turned every refusal on {@code RestoreBackup}, {@code RestoreDatabase} and {@code ImportDatabase} into an
+ * {@code INTERNAL} - a server fault, which is exactly what it is not.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+public class Issue7384GrpcRestoreSerialisationIT extends BaseGraphServerTest {
+
+  private static final int    GRPC_PORT       = 50051;
+  private static final String BACKUP_DIR_NAME = "test-backups-7384-grpc";
+  private static final String BACKUP_CONFIG   = """
+      {
+        "version": 1,
+        "enabled": true,
+        "backupDirectory": "%s",
+        "defaults": {
+          "enabled": true,
+          "runOnServer": "*",
+          "schedule": { "type": "frequency", "frequencyMinutes": 9999 },
+          "retention": { "maxFiles": 50 }
+        }
+      }
+      """.formatted(BACKUP_DIR_NAME);
+
+  private File backupConfigFile;
+  private File backupDir;
+
+  private ManagedChannel                                            channel;
+  private ArcadeDbAdminServiceGrpc.ArcadeDbAdminServiceBlockingStub adminStub;
+
+  private final List<String> databasesToDrop = new ArrayList<>();
+
+  @Override
+  protected boolean isCreateDatabases() {
+    return true;
+  }
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+
+    try {
+      final File configDir = new File("./target/config");
+      configDir.mkdirs();
+
+      backupConfigFile = new File(configDir, "backup.json");
+      try (final FileWriter writer = new FileWriter(backupConfigFile)) {
+        writer.write(BACKUP_CONFIG);
+      }
+
+      backupDir = new File("./target/" + BACKUP_DIR_NAME);
+      if (backupDir.exists())
+        FileUtils.deleteRecursively(backupDir);
+      backupDir.mkdirs();
+    } catch (final IOException e) {
+      throw new RuntimeException("Failed to set up the backup configuration", e);
+    }
+
+    config.setValue(GlobalConfiguration.SERVER_ROOT_PATH, "./target");
+    config.setValue(GlobalConfiguration.SERVER_PLUGINS,
+        "GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin,auto-backup:" + AutoBackupSchedulerPlugin.class.getName());
+    config.setValue(GlobalConfiguration.SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS, true);
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    adminStub = ArcadeDbAdminServiceGrpc.newBlockingStub(channel);
+  }
+
+  @AfterEach
+  void teardown() throws InterruptedException {
+    final BackupCoordinator coordinator = getServer(0).getBackupCoordinator();
+    for (final Operation operation : Operation.values())
+      coordinator.end(getDatabaseName(), operation);
+
+    for (final String database : databasesToDrop) {
+      try {
+        for (final Operation operation : Operation.values())
+          coordinator.end(database, operation);
+        if (getServer(0).existsDatabase(database))
+          getServer(0).getDatabase(database).getEmbedded().drop();
+      } catch (final Exception ignore) {
+        // best-effort
+      }
+    }
+    databasesToDrop.clear();
+
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+
+    if (backupConfigFile != null && backupConfigFile.exists())
+      backupConfigFile.delete();
+    if (backupDir != null && backupDir.exists())
+      FileUtils.deleteRecursively(backupDir);
+  }
+
+  @Test
+  void everyRestoreAndImportRpcAnswersAbortedWhileARestoreOfTheTargetRuns() {
+    final String target = "grpc7384_target";
+    databasesToDrop.add(target);
+
+    final String archive = triggerBackupAndGetFileName();
+    final BackupCoordinator coordinator = getServer(0).getBackupCoordinator();
+
+    assertThat(coordinator.begin(target, Operation.RESTORE)).isNull();
+    try {
+      assertAborted(() -> drain(adminStub.restoreDatabase(RestoreDatabaseRequest.newBuilder().setCredentials(root())
+          .setDatabase(target).setUrl(archiveUrl(archive)).build())));
+
+      assertAborted(() -> drain(adminStub.restoreBackup(RestoreBackupRequest.newBuilder().setCredentials(root())
+          .setDatabase(getDatabaseName()).setFileName(archive).setTargetDatabase(target).setOverwrite(true).build())));
+
+      assertAborted(() -> drain(adminStub.importDatabase(ImportDatabaseRequest.newBuilder().setCredentials(root())
+          .setDatabase(target).setUrl(archiveUrl(archive)).build())));
+
+      assertAborted(() -> adminStub.triggerBackup(
+          TriggerBackupRequest.newBuilder().setCredentials(root()).setDatabase(target).build()));
+    } finally {
+      coordinator.end(target, Operation.RESTORE);
+    }
+
+    assertThat(getServer(0).existsDatabase(target)).isFalse();
+
+    // AND THE SAME RPC GOES THROUGH ONCE THE SLOT IS FREE: THE REFUSALS ABOVE ARE THE GUARD, NOT A CALL THAT COULD
+    // NEVER HAVE SUCCEEDED
+    drain(adminStub.restoreDatabase(RestoreDatabaseRequest.newBuilder().setCredentials(root())
+        .setDatabase(target).setUrl(archiveUrl(archive)).build()));
+    assertThat(getServer(0).existsDatabase(target)).isTrue();
+  }
+
+  @Test
+  void aBackupInFlightAnswersAbortedToARestoreOfTheSameDatabase() {
+    final String archive = triggerBackupAndGetFileName();
+    final BackupCoordinator coordinator = getServer(0).getBackupCoordinator();
+
+    assertThat(coordinator.begin(getDatabaseName(), Operation.BACKUP)).isNull();
+    try {
+      final StatusRuntimeException refused = assertAborted(
+          () -> drain(adminStub.restoreBackup(RestoreBackupRequest.newBuilder().setCredentials(root())
+              .setDatabase(getDatabaseName()).setFileName(archive).setTargetDatabase(getDatabaseName())
+              .setOverwrite(true).build())));
+
+      assertThat(refused).hasMessageContaining("a backup of it is already in progress");
+    } finally {
+      coordinator.end(getDatabaseName(), Operation.BACKUP);
+    }
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------------------------
+
+  private static StatusRuntimeException assertAborted(final Runnable call) {
+    final StatusRuntimeException failure = catchThrowableOfType(StatusRuntimeException.class, call::run);
+    assertThat(failure).isNotNull();
+    assertThat(failure.getStatus().getCode()).isEqualTo(Status.Code.ABORTED);
+    assertThat(failure.getStatus().getDescription()).contains("already in progress");
+    return failure;
+  }
+
+  private DatabaseCredentials root() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  private String triggerBackupAndGetFileName() {
+    adminStub.triggerBackup(TriggerBackupRequest.newBuilder().setCredentials(root()).setDatabase(getDatabaseName())
+        .build());
+
+    final ListBackupsResponse backups = adminStub.listBackups(
+        ListBackupsRequest.newBuilder().setCredentials(root()).setDatabase(getDatabaseName()).build());
+    assertThat(backups.getBackupsList()).isNotEmpty();
+    return backups.getBackups(backups.getBackupsCount() - 1).getFileName();
+  }
+
+  private String archiveUrl(final String fileName) {
+    final Path archive = Paths.get("./target", BACKUP_DIR_NAME, getDatabaseName(), fileName).toAbsolutePath().normalize();
+    return "file://" + archive;
+  }
+
+  private static <T> List<T> drain(final Iterator<T> stream) {
+    final List<T> events = new ArrayList<>();
+    while (stream.hasNext())
+      events.add(stream.next());
+    return events;
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -953,7 +953,7 @@ public class ServerControlPlane {
   }
 
   private static String refusal(final Operation refused, final String databaseName, final Operation running) {
-    return "Cannot " + refused.label() + " database '" + databaseName + "': " + running.phrase()
+    return "Cannot " + refused.verb() + " database '" + databaseName + "': " + running.phrase()
         + " of it is already in progress";
   }
 

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -33,6 +33,7 @@ import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.backup.AutoBackupConfig;
 import com.arcadedb.server.backup.AutoBackupSchedulerPlugin;
 import com.arcadedb.server.backup.BackupCoordinator;
+import com.arcadedb.server.backup.BackupCoordinator.Operation;
 import com.arcadedb.server.http.HttpAuthSession;
 import com.arcadedb.server.http.HttpAuthSessionManager;
 import com.arcadedb.server.http.HttpServer;
@@ -909,28 +910,51 @@ public class ServerControlPlane {
   /**
    * Runs a full backup inline and returns {@code {"result":"ok","backupFile":...}}.
    *
-   * @throws BackupInProgressException when another backup of the same database is already running.
-   *                                   This command runs the backup inline, so it is one of the entry points that can
-   *                                   have a database being backed up at the same time as the auto-backup schedule
-   *                                   does - down to resolving to the same archive name and writing into the same
-   *                                   file. Refusing outright is the honest answer to "back up a database that is
-   *                                   already being backed up": a second full backup of the same data produces
-   *                                   nothing the first one will not, and the caller gets told rather than silently
-   *                                   handed the other run's archive (issue #6753).
+   * @throws BackupInProgressException    when another backup of the same database is already running.
+   *                                      This command runs the backup inline, so it is one of the entry points that
+   *                                      can have a database being backed up at the same time as the auto-backup
+   *                                      schedule does - down to resolving to the same archive name and writing into
+   *                                      the same file. Refusing outright is the honest answer to "back up a database
+   *                                      that is already being backed up": a second full backup of the same data
+   *                                      produces nothing the first one will not, and the caller gets told rather
+   *                                      than silently handed the other run's archive (issue #6753).
+   * @throws OperationInProgressException when a restore of the same database is running instead. A restore drops and
+   *                                      replaces the database directory, so backing it up at the same time reads a
+   *                                      directory that is about to be deleted (issue #7384).
    */
   public JSONObject triggerBackup(final String databaseName) {
     requireBackupDatabaseName(databaseName);
 
-
     final BackupCoordinator coordinator = server.getBackupCoordinator();
-    if (!coordinator.begin(databaseName))
-      throw new BackupInProgressException("A backup of database '" + databaseName + "' is already in progress");
+    final Operation running = coordinator.begin(databaseName, Operation.BACKUP);
+    if (running != null)
+      // The pre-#7384 message, verbatim, for the pre-#7384 case: only a restore holding the slot is new.
+      throw running == Operation.BACKUP ?
+          new BackupInProgressException("A backup of database '" + databaseName + "' is already in progress") :
+          new OperationInProgressException(refusal(Operation.BACKUP, databaseName, running));
 
     try {
       return executeImmediateBackup(databaseName);
     } finally {
-      coordinator.end(databaseName);
+      coordinator.end(databaseName, Operation.BACKUP);
     }
+  }
+
+  /**
+   * Takes the per-database slot for {@code operation}, or refuses naming the operation that already holds it.
+   * <p>
+   * Every caller must release it with {@link BackupCoordinator#end(String, Operation)} from a {@code finally}: a
+   * leaked reservation blocks every later backup, restore and import of that database until the server restarts.
+   */
+  private void beginExclusive(final String databaseName, final Operation operation) {
+    final Operation running = server.getBackupCoordinator().begin(databaseName, operation);
+    if (running != null)
+      throw new OperationInProgressException(refusal(operation, databaseName, running));
+  }
+
+  private static String refusal(final Operation refused, final String databaseName, final Operation running) {
+    return "Cannot " + refused.label() + " database '" + databaseName + "': " + running.phrase()
+        + " of it is already in progress";
   }
 
   public JSONObject deleteBackup(final String databaseName, final String fileName) {
@@ -1111,10 +1135,26 @@ public class ServerControlPlane {
   }
 
   /**
-   * Raised by {@link #triggerBackup(String)} when the database is already being backed up. HTTP
-   * answers it with a 409 and gRPC with {@code ABORTED}; both carry this message verbatim.
+   * Raised when a backup, restore or import of a database is refused because another whole-database
+   * operation on it is already running - the per-database slot {@link BackupCoordinator} hands out.
+   * HTTP answers it with a 409 and gRPC with {@code ABORTED}; both carry this message verbatim.
+   * <p>
+   * The request is well formed and authorized, and retrying once the other operation finishes is the
+   * fix, which is what separates it from every other refusal these commands can produce (issue #7384).
    */
-  public static class BackupInProgressException extends RuntimeException {
+  public static class OperationInProgressException extends RuntimeException {
+    public OperationInProgressException(final String message) {
+      super(message);
+    }
+  }
+
+  /**
+   * The {@link OperationInProgressException} {@link #triggerBackup(String)} raises when it is another
+   * <i>backup</i> holding the slot - the only case that existed before restores took one too. Kept as
+   * its own type, and kept being thrown for that case, so code written against it before #7384 still
+   * catches what it always caught.
+   */
+  public static class BackupInProgressException extends OperationInProgressException {
     public BackupInProgressException(final String message) {
       super(message);
     }
@@ -1212,8 +1252,15 @@ public class ServerControlPlane {
    * The caller supplies the URL, so it is validated against
    * {@link GlobalConfiguration#SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS} first.
    *
-   * @throws IllegalArgumentException when the name is invalid or the database already exists
-   * @throws SecurityException        when the URL is not one this server accepts from a client
+   * Serialised against every other backup, restore and import of the same database by the per-database
+   * slot {@link BackupCoordinator} hands out. The slot is taken <b>before</b> the existence pre-check,
+   * which is the only thing that made the check meaningful: two restores could both pass it, both
+   * restore into their own temporary directory and both reach the swap, and the loser's caller was
+   * still told it had succeeded (issue #7384).
+   *
+   * @throws IllegalArgumentException     when the name is invalid or the database already exists
+   * @throws SecurityException            when the URL is not one this server accepts from a client
+   * @throws OperationInProgressException when a backup, restore or import of the same database is already running
    */
   public void restoreDatabase(final String databaseName, final String url, final ProgressListener listener) {
     if (databaseName == null || databaseName.isEmpty() || url == null || url.isEmpty())
@@ -1224,11 +1271,16 @@ public class ServerControlPlane {
     // Prevent path traversal via the caller-supplied database name (GHSA-qwgr-2c45-63xx).
     server.checkDatabaseNameIsValid(databaseName);
 
-    final String dbPath = databaseDirectory(databaseName);
-    if (new File(dbPath).exists())
-      throw new IllegalArgumentException("Database '" + databaseName + "' already exists");
+    beginExclusive(databaseName, Operation.RESTORE);
+    try {
+      final String dbPath = databaseDirectory(databaseName);
+      if (new File(dbPath).exists())
+        throw new IllegalArgumentException("Database '" + databaseName + "' already exists");
 
-    performRestore(databaseName, dbPath, url, listener);
+      performRestore(databaseName, dbPath, url, listener);
+    } finally {
+      server.getBackupCoordinator().end(databaseName, Operation.RESTORE);
+    }
   }
 
   /**
@@ -1240,8 +1292,14 @@ public class ServerControlPlane {
    * {@code overwrite} decides what happens when the target already exists. Even with it set, the
    * existing database is dropped only once the restore into a temporary directory has succeeded
    * (issue #5027).
+   * <p>
+   * The slot is taken on the <b>target</b>, which is the database this writes, and covers the
+   * overwrite pre-check as well as the restore itself (issue #7384). The source is only read - its
+   * archive is a file this server wrote, and a concurrent backup of it writes a different archive -
+   * so it is not reserved, which also keeps this from needing a lock order between two names.
    *
-   * @throws IllegalArgumentException when a name is invalid, or the target exists and {@code overwrite} is false
+   * @throws IllegalArgumentException     when a name is invalid, or the target exists and {@code overwrite} is false
+   * @throws OperationInProgressException when a backup, restore or import of the target is already running
    */
   public void restoreBackup(final String databaseName, final String fileName, final String targetDatabase,
       final boolean overwrite, final ProgressListener listener) {
@@ -1256,12 +1314,17 @@ public class ServerControlPlane {
 
     final Path backupFile = resolveBackupFile(databaseName, fileName);
 
-    final String dbPath = databaseDirectory(targetDatabase);
-    if ((server.existsDatabase(targetDatabase) || new File(dbPath).exists()) && !overwrite)
-      throw new IllegalArgumentException(
-          "Database '" + targetDatabase + "' already exists. Enable overwrite to replace it with the backup");
+    beginExclusive(targetDatabase, Operation.RESTORE);
+    try {
+      final String dbPath = databaseDirectory(targetDatabase);
+      if ((server.existsDatabase(targetDatabase) || new File(dbPath).exists()) && !overwrite)
+        throw new IllegalArgumentException(
+            "Database '" + targetDatabase + "' already exists. Enable overwrite to replace it with the backup");
 
-    performRestore(targetDatabase, dbPath, "file://" + backupFile.toAbsolutePath(), listener);
+      performRestore(targetDatabase, dbPath, "file://" + backupFile.toAbsolutePath(), listener);
+    } finally {
+      server.getBackupCoordinator().end(targetDatabase, Operation.RESTORE);
+    }
   }
 
   /**
@@ -1270,7 +1333,13 @@ public class ServerControlPlane {
    * has it before the import's transactions start replicating; a failure to create it on the
    * replicas drops the local one again so the operator can retry cleanly.
    *
-   * @throws SecurityException when the URL is not one this server accepts from a client
+   * The import holds the per-database slot for its whole duration, so a restore cannot drop and replace
+   * the directory it is loading into (issue #7384). It does <b>not</b> exclude a backup: an import is
+   * ordinary transactions against a live database, and backing a live database up is exactly what the
+   * auto-backup schedule does - see {@link Operation#conflictsWith}.
+   *
+   * @throws SecurityException            when the URL is not one this server accepts from a client
+   * @throws OperationInProgressException when a restore or another import of the same database is already running
    */
   public JSONObject importDatabase(final String databaseName, final String url, final ProgressListener listener) {
     if (databaseName == null || databaseName.isEmpty() || url == null || url.isEmpty())
@@ -1281,20 +1350,25 @@ public class ServerControlPlane {
 
     server.checkDatabaseNameIsValid(databaseName);
 
-    final ServerDatabase createdDb = server.createDatabase(databaseName, ComponentFile.MODE.READ_WRITE);
-    if (createdDb.getWrappedDatabaseInstance() instanceof HAReplicatedDatabase haDb) {
-      try {
-        haDb.createInReplicas();
-      } catch (final RuntimeException e) {
-        dropQuietly(createdDb, databaseName);
-        throw e;
+    beginExclusive(databaseName, Operation.IMPORT);
+    try {
+      final ServerDatabase createdDb = server.createDatabase(databaseName, ComponentFile.MODE.READ_WRITE);
+      if (createdDb.getWrappedDatabaseInstance() instanceof HAReplicatedDatabase haDb) {
+        try {
+          haDb.createInReplicas();
+        } catch (final RuntimeException e) {
+          dropQuietly(createdDb, databaseName);
+          throw e;
+        }
       }
-    }
 
-    // A failed import deliberately leaves the created database in place, as both HTTP branches do:
-    // dropping it would destroy whatever was imported before the failure, and the operator needs to
-    // see it to decide whether to retry or to drop it.
-    return runImport(createdDb, databaseName, url, listener);
+      // A failed import deliberately leaves the created database in place, as both HTTP branches do:
+      // dropping it would destroy whatever was imported before the failure, and the operator needs to
+      // see it to decide whether to retry or to drop it.
+      return runImport(createdDb, databaseName, url, listener);
+    } finally {
+      server.getBackupCoordinator().end(databaseName, Operation.IMPORT);
+    }
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/backup/BackupCoordinator.java
+++ b/server/src/main/java/com/arcadedb/server/backup/BackupCoordinator.java
@@ -20,8 +20,10 @@ package com.arcadedb.server.backup;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Set;
+import java.util.EnumSet;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -51,6 +53,20 @@ import java.util.regex.Pattern;
  * This is an admission policy, not the integrity guarantee. A backup started outside this server (the CLI, another
  * node writing into a shared directory) cannot be seen from here; what keeps THAT from corrupting an archive is
  * {@code FullBackupFormat} creating the target file atomically, so the loser of any race fails before it writes.
+ * <h2>Restores and imports</h2>
+ * The slot admits more than backups now. A restore is the one operation that <i>destroys</i> a database directory -
+ * it restores into a temporary sibling and then drops the target and moves the temporary one over it - and it used to
+ * take nothing at all, so two restores of one database both passed the existence pre-check and both reached the swap,
+ * and a restore could drop the directory a backup was reading (issue #7384). Restores and imports therefore take the
+ * same per-database slot, and {@link Operation} says which one holds it so the refusal can name it.
+ * <p>
+ * Two operations on one database conflict unless they are a backup and an import: those two coexist by construction,
+ * because an import is ordinary transactions against a live database and backing a live database up is what the
+ * auto-backup schedule does all day. Everything else is refused - see {@link Operation#conflictsWith}.
+ * <p>
+ * The class name predates restores and is kept so that the callers and tests written against
+ * {@code getBackupCoordinator()} keep compiling; what it coordinates is now every whole-database maintenance
+ * operation this server runs, not only backups.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -64,26 +80,132 @@ public class BackupCoordinator {
   private static final Pattern           ARCHIVE_NAME_PATTERN     = Pattern.compile(".*-backup-(\\d{8})-(\\d{6}(?:\\d{3})?)\\.zip$");
   private static final DateTimeFormatter ARCHIVE_TIMESTAMP_PARSER = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss[SSS]");
 
-  private final Set<String> inProgress = ConcurrentHashMap.newKeySet();
+  /**
+   * The whole-database maintenance operations that share one per-database slot.
+   * <p>
+   * {@link #conflictsWith} is the whole admission policy: two operations on one database exclude each other unless
+   * one is a {@link #BACKUP} and the other an {@link #IMPORT}. A restore excludes everything because it drops and
+   * replaces the database directory; a backup excludes another backup because two full backups of one database read
+   * and compress the same data twice for one usable archive (issue #6753); an import excludes another import because
+   * an import creates the database it loads into, so the second one could not have created it anyway.
+   */
+  public enum Operation {
+    BACKUP("backup", "a backup"), RESTORE("restore", "a restore"), IMPORT("import", "an import");
+
+    private final String label;
+    private final String phrase;
+
+    Operation(final String label, final String phrase) {
+      this.label = label;
+      this.phrase = phrase;
+    }
+
+    /** The operation's name as a verb, for "Cannot restore database 'x'". */
+    public String label() {
+      return label;
+    }
+
+    /**
+     * The operation's name with its indefinite article, for "... a restore of it is already in progress". Carried
+     * rather than derived, because "a import" is what deriving it produces.
+     */
+    public String phrase() {
+      return phrase;
+    }
+
+    /**
+     * Whether an operation of this kind, already running on a database, refuses one of kind {@code other} on the
+     * same database.
+     */
+    public boolean conflictsWith(final Operation other) {
+      return this == other || this == RESTORE || other == RESTORE;
+    }
+  }
 
   /**
-   * Reserves this database for a backup. Returns {@code false} when one is already running, in which case the caller
-   * must not start a backup and must not call {@link #end(String)}.
+   * The operations currently running per database. A value is never an empty set - the entry is removed instead -
+   * so {@code containsKey} answers "is anything running on it".
+   * <p>
+   * {@link EnumSet} is exact here rather than merely convenient: every kind conflicts with itself, so at most one
+   * operation of each kind is ever admitted for one database and a set needs no multiplicity.
+   * <p>
+   * Every value is replaced rather than mutated in place, so a set a reader has already been handed is never written
+   * to by another thread: {@code EnumSet} is not thread-safe, and {@link #isInProgress(String, Operation)} reads one
+   * outside the map's own per-entry lock.
+   */
+  private final Map<String, EnumSet<Operation>> inProgress = new ConcurrentHashMap<>();
+
+  /**
+   * Reserves this database for a backup. Returns {@code false} when a backup, restore or import of it is already
+   * running, in which case the caller must not start a backup and must not call {@link #end(String)}.
+   * <p>
+   * The shorthand every backup entry point uses. {@link #begin(String, Operation)} is the same reservation for a
+   * caller that wants to name the operation already holding the slot in its refusal.
    */
   public boolean begin(final String databaseName) {
-    return inProgress.add(databaseName);
+    return begin(databaseName, Operation.BACKUP) == null;
   }
 
   /**
-   * Releases the reservation taken by a successful {@link #begin(String)}. Always call it from a {@code finally}: a
-   * reservation leaked by a failed backup would block every later backup of that database until the server restarts.
+   * Reserves this database for {@code operation}.
+   *
+   * @return {@code null} when the reservation was taken - the caller must then release it with
+   * {@link #end(String, Operation)} from a {@code finally} - or the operation already running that refuses this one.
    */
-  public void end(final String databaseName) {
-    inProgress.remove(databaseName);
+  public Operation begin(final String databaseName, final Operation operation) {
+    final AtomicReference<Operation> conflict = new AtomicReference<>();
+
+    inProgress.compute(databaseName, (name, running) -> {
+      if (running == null)
+        return EnumSet.of(operation);
+
+      for (final Operation active : running)
+        if (active.conflictsWith(operation)) {
+          conflict.set(active);
+          return running;
+        }
+
+      final EnumSet<Operation> updated = EnumSet.copyOf(running);
+      updated.add(operation);
+      return updated;
+    });
+
+    return conflict.get();
   }
 
+  /**
+   * Releases the backup reservation taken by a successful {@link #begin(String)}. Always call it from a
+   * {@code finally}: a reservation leaked by a failed backup would block every later backup of that database until
+   * the server restarts.
+   */
+  public void end(final String databaseName) {
+    end(databaseName, Operation.BACKUP);
+  }
+
+  /**
+   * Releases the reservation a successful {@link #begin(String, Operation)} took. Always call it from a
+   * {@code finally}: a leaked reservation blocks every later operation of that database until the server restarts.
+   */
+  public void end(final String databaseName, final Operation operation) {
+    inProgress.computeIfPresent(databaseName, (name, running) -> {
+      if (!running.contains(operation))
+        return running;
+
+      final EnumSet<Operation> updated = EnumSet.copyOf(running);
+      updated.remove(operation);
+      return updated.isEmpty() ? null : updated;
+    });
+  }
+
+  /** Whether any backup, restore or import of this database is currently running. */
   public boolean isInProgress(final String databaseName) {
-    return inProgress.contains(databaseName);
+    return inProgress.containsKey(databaseName);
+  }
+
+  /** Whether an operation of this kind is currently running on this database. */
+  public boolean isInProgress(final String databaseName, final Operation operation) {
+    final EnumSet<Operation> running = inProgress.get(databaseName);
+    return running != null && running.contains(operation);
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/backup/BackupCoordinator.java
+++ b/server/src/main/java/com/arcadedb/server/backup/BackupCoordinator.java
@@ -90,19 +90,22 @@ public class BackupCoordinator {
    * an import creates the database it loads into, so the second one could not have created it anyway.
    */
   public enum Operation {
-    BACKUP("backup", "a backup"), RESTORE("restore", "a restore"), IMPORT("import", "an import");
+    BACKUP("back up", "a backup"), RESTORE("restore", "a restore"), IMPORT("import", "an import");
 
-    private final String label;
+    private final String verb;
     private final String phrase;
 
-    Operation(final String label, final String phrase) {
-      this.label = label;
+    Operation(final String verb, final String phrase) {
+      this.verb = verb;
       this.phrase = phrase;
     }
 
-    /** The operation's name as a verb, for "Cannot restore database 'x'". */
-    public String label() {
-      return label;
+    /**
+     * The operation as a verb, for "Cannot back up database 'x'". Carried rather than derived from the enum
+     * constant, because the verb for a backup is two words.
+     */
+    public String verb() {
+      return verb;
     }
 
     /**
@@ -148,6 +151,10 @@ public class BackupCoordinator {
 
   /**
    * Reserves this database for {@code operation}.
+   * <p>
+   * When more than one operation is running - which only {@link Operation#BACKUP} and {@link Operation#IMPORT}
+   * together can be - the one named is whichever the iteration reaches first, not a ranking: both refuse the caller
+   * equally, and the message is true of either.
    *
    * @return {@code null} when the reservation was taken - the caller must then release it with
    * {@link #end(String, Operation)} from a {@code finally} - or the operation already running that refuses this one.

--- a/server/src/main/java/com/arcadedb/server/backup/BackupTask.java
+++ b/server/src/main/java/com/arcadedb/server/backup/BackupTask.java
@@ -108,10 +108,15 @@ public class BackupTask implements Runnable {
     // and compress the same database twice for one usable archive - and, when they resolve to the same archive name,
     // write into the same file (issue #6753). A refused tick costs nothing: the schedule covers this database again
     // on the next one.
+    //
+    // The same slot now also refuses a tick while a RESTORE of this database runs, which is the case worth naming in
+    // the log: a restore drops and replaces the database directory, so a backup started alongside it reads a
+    // directory that is about to be deleted (issue #7384).
     final BackupCoordinator coordinator = server.getBackupCoordinator();
-    if (!coordinator.begin(databaseName)) {
+    final BackupCoordinator.Operation running = coordinator.begin(databaseName, BackupCoordinator.Operation.BACKUP);
+    if (running != null) {
       LogManager.instance().log(this, Level.WARNING,
-          "Skipping backup for database '%s' - a backup of it is already in progress", databaseName);
+          "Skipping backup for database '%s' - %s of it is already in progress", databaseName, running.phrase());
       return;
     }
 
@@ -145,7 +150,7 @@ public class BackupTask implements Runnable {
       server.getEventLog().reportEvent(ServerEventLog.EVENT_TYPE.CRITICAL, "Auto-Backup", databaseName,
           "Scheduled backup failed: " + e.getMessage());
     } finally {
-      coordinator.end(databaseName);
+      coordinator.end(databaseName, BackupCoordinator.Operation.BACKUP);
     }
   }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -743,6 +743,19 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
       return;
     }
 
+    // 409 Conflict: a backup, restore or import of this database is already running, and the per-database slot
+    // BackupCoordinator hands out refused this one. The request is well formed and authorized, and retrying once
+    // the other operation finishes is the fix - so it is a conflict, not a 500. 'trigger backup' answered this in
+    // its own handler long before; the arm is here so 'restore database', 'restore backup' and 'import database'
+    // answer it too rather than falling through to the generic internal-error arm (issue #7384).
+    final ServerControlPlane.OperationInProgressException inProgress = firstOf(e, cause,
+            ServerControlPlane.OperationInProgressException.class);
+    if (inProgress != null) {
+      logUserError(inProgress);
+      sendErrorResponse(exchange, 409, "Cannot execute command", inProgress, null);
+      return;
+    }
+
     // 409 Conflict (RFC 9110 15.5.10): a unique-constraint violation is a client data conflict, not a transient
     // server-availability problem. 503 told clients/load balancers the request was retry-worthy, amplifying the
     // bad write. See issue #4350.

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -306,15 +306,16 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
   }
 
   /**
-   * {@code trigger backup <database>}. A backup already running for the same database is a 409 here
-   * and an {@code ABORTED} on gRPC; both carry the message the shared implementation raised.
+   * {@code trigger backup <database>}. A backup - or, since #7384, a restore - already running for the
+   * same database is a 409 here and an {@code ABORTED} on gRPC; both carry the message the shared
+   * implementation raised.
    */
   private ExecutionResponse triggerBackup(final String databaseName) {
     try {
       final JSONObject result = controlPlane.triggerBackup(databaseName);
       Metrics.counter("http.trigger-backup").increment();
       return new ExecutionResponse(200, result.toString());
-    } catch (final ServerControlPlane.BackupInProgressException e) {
+    } catch (final ServerControlPlane.OperationInProgressException e) {
       return new ExecutionResponse(409, new JSONObject().put("error", e.getMessage()).toString());
     }
   }

--- a/server/src/test/java/com/arcadedb/server/backup/Issue7384ConcurrentRestoreIT.java
+++ b/server/src/test/java/com/arcadedb/server/backup/Issue7384ConcurrentRestoreIT.java
@@ -1,0 +1,450 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.backup;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.ServerControlPlane;
+import com.arcadedb.server.backup.BackupCoordinator.Operation;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A restore excludes every other backup, restore and import of the same database, and is excluded by them
+ * (issue #7384).
+ * <p>
+ * Before this, {@code triggerBackup} was the only one of the four that took the per-database slot
+ * {@link BackupCoordinator} hands out. {@code restoreDatabase}, {@code restoreBackup} and {@code importDatabase} took
+ * nothing, and the only guard a restore had was an existence pre-check that was not atomic with the directory swap
+ * that follows it: two restores of one database both passed it, both restored into their own temporary directory and
+ * both reached the swap, and the loser's caller was told it had succeeded. A restore could equally drop the directory
+ * a backup was reading, since the backup held a slot the restore never asked for.
+ * <p>
+ * The scope is one server, which is where the transports meet: HTTP and gRPC both run the same
+ * {@code ServerControlPlane}, and in HA every restore is refused anywhere but on the leader. Serialising this across a
+ * cluster is a separate change the issue puts out of scope.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue7384ConcurrentRestoreIT extends BaseGraphServerTest {
+  private static final String BACKUP_DIR_NAME = "test-backups-7384";
+  private static final String BACKUP_CONFIG   = """
+      {
+        "version": 1,
+        "enabled": true,
+        "backupDirectory": "%s",
+        "defaults": {
+          "enabled": true,
+          "runOnServer": "*",
+          "schedule": { "type": "frequency", "frequencyMinutes": 9999 },
+          "retention": { "maxFiles": 50 }
+        }
+      }
+      """.formatted(BACKUP_DIR_NAME);
+
+  private File backupConfigFile;
+  private File backupDir;
+
+  private final List<String> databasesToDrop = new ArrayList<>();
+
+  @Override
+  protected boolean isCreateDatabases() {
+    return true;
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+
+    try {
+      final File configDir = new File("./target/config");
+      configDir.mkdirs();
+
+      backupConfigFile = new File(configDir, "backup.json");
+      try (final FileWriter writer = new FileWriter(backupConfigFile)) {
+        writer.write(BACKUP_CONFIG);
+      }
+
+      backupDir = new File("./target/" + BACKUP_DIR_NAME);
+      if (backupDir.exists())
+        FileUtils.deleteRecursively(backupDir);
+      backupDir.mkdirs();
+    } catch (final IOException e) {
+      throw new RuntimeException("Failed to set up the backup configuration", e);
+    }
+
+    config.setValue(GlobalConfiguration.SERVER_ROOT_PATH, "./target");
+    config.setValue(GlobalConfiguration.SERVER_PLUGINS, "auto-backup:" + AutoBackupSchedulerPlugin.class.getName());
+    // The archives this fixture restores from live on disk, so the server has to be willing to fetch a file:// URL.
+    config.setValue(GlobalConfiguration.SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS, true);
+  }
+
+  @AfterEach
+  void cleanUp() {
+    final ArcadeDBServer server = getServer(0);
+
+    // NOTHING MAY OUTLIVE A TEST HOLDING THE SLOT: THE NEXT ONE WOULD BE REFUSED FOR THE WRONG REASON
+    for (final Operation operation : Operation.values())
+      server.getBackupCoordinator().end(getDatabaseName(), operation);
+
+    for (final String database : databasesToDrop) {
+      try {
+        for (final Operation operation : Operation.values())
+          server.getBackupCoordinator().end(database, operation);
+        if (server.existsDatabase(database))
+          server.getDatabase(database).getEmbedded().drop();
+      } catch (final Exception ignore) {
+        // best-effort
+      }
+    }
+    databasesToDrop.clear();
+
+    if (backupConfigFile != null && backupConfigFile.exists())
+      backupConfigFile.delete();
+    if (backupDir != null && backupDir.exists())
+      FileUtils.deleteRecursively(backupDir);
+  }
+
+  /**
+   * The one test that does not hold the slot by hand: a real restore is started through the shared implementation and
+   * every other operation on its target is attempted from inside its own progress stream, which is the only place
+   * "while the restore is running" can be observed from a single thread.
+   * <p>
+   * It is the test that fails against the pre-#7384 code for the reason the issue describes - nothing was refused,
+   * and a second restore would have run all the way to the swap.
+   */
+  @Test
+  void aRestoreInFlightRefusesEveryOtherOperationOnItsTarget() throws Exception {
+    final String target = getDatabaseName() + "_7384_inflight";
+    databasesToDrop.add(target);
+
+    final String archive = triggerBackupAndGetFileName();
+    final ServerControlPlane controlPlane = new ServerControlPlane(getServer(0));
+    final BackupCoordinator coordinator = getServer(0).getBackupCoordinator();
+
+    final List<String> failures = new ArrayList<>();
+    final AtomicBoolean probed = new AtomicBoolean();
+
+    controlPlane.restoreBackup(getDatabaseName(), archive, target, false, message -> {
+      // #6086 logs one line per archive entry from a worker pool, so probe exactly once, from whichever thread
+      // delivers the first event.
+      if (!probed.compareAndSet(false, true))
+        return;
+
+      record(failures, "the restore holds the slot while it runs",
+          () -> assertThat(coordinator.isInProgress(target, Operation.RESTORE)).isTrue());
+
+      record(failures, "a second restore of the target is refused",
+          () -> assertThatThrownBy(() -> controlPlane.restoreBackup(getDatabaseName(), archive, target, true,
+              ServerControlPlane.ProgressListener.NOOP))
+              .isInstanceOf(ServerControlPlane.OperationInProgressException.class)
+              .hasMessageContaining("a restore of it is already in progress"));
+
+      record(failures, "a backup of the target is refused",
+          () -> assertThatThrownBy(() -> controlPlane.triggerBackup(target))
+              .isInstanceOf(ServerControlPlane.OperationInProgressException.class)
+              .hasMessageContaining("a restore of it is already in progress"));
+
+      record(failures, "an import into the target is refused",
+          () -> assertThatThrownBy(() -> controlPlane.importDatabase(target, archiveUrl(archive),
+              ServerControlPlane.ProgressListener.NOOP))
+              .isInstanceOf(ServerControlPlane.OperationInProgressException.class)
+              .hasMessageContaining("a restore of it is already in progress"));
+
+      record(failures, "the source database is not held up by a restore of a different target",
+          () -> assertThat(coordinator.isInProgress(getDatabaseName())).isFalse());
+    });
+
+    assertThat(probed).isTrue();
+    assertThat(failures).isEmpty();
+
+    // THE SLOT IS RELEASED WHEN THE RESTORE ENDS, AND THE VERY SAME CALL GOES THROUGH: THE REFUSALS ABOVE ARE THE
+    // GUARD, NOT A RESTORE THAT COULD NEVER HAVE RUN
+    assertThat(coordinator.isInProgress(target)).isFalse();
+    assertThat(getServer(0).existsDatabase(target)).isTrue();
+
+    controlPlane.restoreBackup(getDatabaseName(), archive, target, true, ServerControlPlane.ProgressListener.NOOP);
+    assertThat(coordinator.isInProgress(target)).isFalse();
+  }
+
+  /**
+   * Issue #7384 cases 2 and 3: a restore that starts while a backup of the same database runs would drop and replace
+   * the directory the backup is reading. Whichever of the two arrives second is the one refused.
+   */
+  @Test
+  void aBackupInFlightRefusesARestoreOfTheSameDatabase() throws Exception {
+    final String archive = triggerBackupAndGetFileName();
+    final BackupCoordinator coordinator = getServer(0).getBackupCoordinator();
+
+    // SOMEBODY ELSE IS ALREADY BACKING THIS DATABASE UP - THE AUTO-BACKUP SCHEDULE OR ANOTHER TRANSPORT'S TRIGGER
+    assertThat(coordinator.begin(getDatabaseName(), Operation.BACKUP)).isNull();
+    try {
+      assertRefusedWith409("restore backup " + getDatabaseName() + " " + archive + " as " + getDatabaseName(),
+          true, "a backup of it is already in progress");
+      assertRefusedWith409("restore database " + getDatabaseName() + " " + archiveUrl(archive),
+          false, "a backup of it is already in progress");
+    } finally {
+      coordinator.end(getDatabaseName(), Operation.BACKUP);
+    }
+
+    // AND THE REFUSAL WAS THE GUARD, NOT A COMMAND THAT COULD NEVER HAVE RUN
+    final HttpResponse<String> admitted = postCommand(new JSONObject()
+        .put("command", "restore backup " + getDatabaseName() + " " + archive + " as " + getDatabaseName())
+        .put("overwrite", true));
+    assertThat(admitted.statusCode()).isEqualTo(200);
+  }
+
+  /**
+   * The three HTTP commands that take the slot, each driven through its own entry point. A refusal reaches the client
+   * as a 409 rather than the 500 an unmapped runtime failure would have produced: the request is well formed and
+   * authorized, and retrying once the other operation finishes is the fix.
+   */
+  @Test
+  void everyHttpRestoreAndImportCommandAnswers409WhileARestoreOfTheTargetRuns() throws Exception {
+    final String target = getDatabaseName() + "_7384_http";
+    databasesToDrop.add(target);
+
+    final String archive = triggerBackupAndGetFileName();
+    final BackupCoordinator coordinator = getServer(0).getBackupCoordinator();
+
+    assertThat(coordinator.begin(target, Operation.RESTORE)).isNull();
+    try {
+      assertRefusedWith409("restore database " + target + " " + archiveUrl(archive),
+          false, "a restore of it is already in progress");
+      assertRefusedWith409("restore backup " + getDatabaseName() + " " + archive + " as " + target,
+          true, "a restore of it is already in progress");
+      assertRefusedWith409("import database " + target + " " + archiveUrl(archive),
+          false, "a restore of it is already in progress");
+      assertRefusedWith409("trigger backup " + target,
+          false, "a restore of it is already in progress");
+    } finally {
+      coordinator.end(target, Operation.RESTORE);
+    }
+
+    // NOTHING WAS CREATED BY ANY OF THE REFUSALS
+    assertThat(getServer(0).existsDatabase(target)).isFalse();
+  }
+
+  /**
+   * Studio and every streaming client send {@code Accept: text/event-stream}, and a refusal there has to stay an HTTP
+   * status rather than becoming a 200 carrying an error frame. It does because the slot is taken before the operation
+   * produces its first progress line, so the stream has not started yet - the same property the existence and URL
+   * checks rely on.
+   */
+  @Test
+  void anSseClientGetsTheRefusalAsA409RatherThanAsAnErrorFrame() throws Exception {
+    final String target = getDatabaseName() + "_7384_sse";
+    databasesToDrop.add(target);
+
+    final String archive = triggerBackupAndGetFileName();
+    final BackupCoordinator coordinator = getServer(0).getBackupCoordinator();
+
+    assertThat(coordinator.begin(target, Operation.RESTORE)).isNull();
+    try {
+      final HttpResponse<String> response = postCommand(
+          new JSONObject().put("command", "restore database " + target + " " + archiveUrl(archive)), true);
+
+      assertThat(response.statusCode()).isEqualTo(409);
+      assertThat(response.body()).contains("a restore of it is already in progress");
+      assertThat(response.headers().firstValue("Content-Type").orElse("")).doesNotContain("text/event-stream");
+    } finally {
+      coordinator.end(target, Operation.RESTORE);
+    }
+  }
+
+  /**
+   * The third arm of the matrix: an import in flight refuses a restore of the same database, and the refusal names
+   * the import rather than defaulting to "a backup" the way the single-purpose message used to.
+   */
+  @Test
+  void anImportInFlightRefusesARestoreOfTheSameDatabaseAndNamesItself() throws Exception {
+    final String archive = triggerBackupAndGetFileName();
+    final BackupCoordinator coordinator = getServer(0).getBackupCoordinator();
+
+    assertThat(coordinator.begin(getDatabaseName(), Operation.IMPORT)).isNull();
+    try {
+      assertRefusedWith409("restore backup " + getDatabaseName() + " " + archive + " as " + getDatabaseName(),
+          true, "an import of it is already in progress");
+      assertRefusedWith409("import database " + getDatabaseName() + " " + archiveUrl(archive),
+          false, "an import of it is already in progress");
+    } finally {
+      coordinator.end(getDatabaseName(), Operation.IMPORT);
+    }
+  }
+
+  /** A scheduled tick is skipped rather than refused: the schedule covers the database again on the next one. */
+  @Test
+  void theScheduledBackupTaskSkipsWhileARestoreOfTheDatabaseRuns() {
+    final BackupCoordinator coordinator = getServer(0).getBackupCoordinator();
+    final File dbBackupDir = new File(backupDir, getDatabaseName());
+    final BackupTask task = new BackupTask(getServer(0), getDatabaseName(), backupConfig(),
+        backupDir.getAbsolutePath(), null);
+
+    assertThat(coordinator.begin(getDatabaseName(), Operation.RESTORE)).isNull();
+    try {
+      task.run();
+      assertThat(archives(dbBackupDir)).isEmpty();
+    } finally {
+      coordinator.end(getDatabaseName(), Operation.RESTORE);
+    }
+
+    // AND THE VERY SAME TASK GOES THROUGH ONCE THE RESTORE IS DONE
+    task.run();
+    assertThat(archives(dbBackupDir)).hasSize(1);
+  }
+
+  /**
+   * An import is ordinary transactions against a live database, and backing a live database up is what the auto-backup
+   * schedule does all day, so the two coexist deliberately. Taking the slot for an import must not starve the
+   * schedule for as long as a multi-hour load runs.
+   */
+  @Test
+  void anImportInFlightDoesNotHoldUpABackupOfTheSameDatabase() throws Exception {
+    final BackupCoordinator coordinator = getServer(0).getBackupCoordinator();
+
+    assertThat(coordinator.begin(getDatabaseName(), Operation.IMPORT)).isNull();
+    try {
+      final HttpResponse<String> response = postCommand("trigger backup " + getDatabaseName());
+      assertThat(response.statusCode()).isEqualTo(200);
+    } finally {
+      coordinator.end(getDatabaseName(), Operation.IMPORT);
+    }
+  }
+
+  /**
+   * A reservation leaked by a failed restore would block every later backup, restore and import of that database
+   * until the server restarts, which would turn one bad URL into an outage.
+   */
+  @Test
+  void aFailedRestoreReleasesTheSlot() throws Exception {
+    final String target = getDatabaseName() + "_7384_failed";
+    databasesToDrop.add(target);
+
+    final HttpResponse<String> failed = postCommand(
+        "restore database " + target + " file:///no/such/archive-7384.zip");
+    assertThat(failed.statusCode()).isNotEqualTo(200);
+
+    assertThat(getServer(0).getBackupCoordinator().isInProgress(target)).isFalse();
+
+    // AND THE SLOT IS GENUINELY FREE, NOT MERELY REPORTED FREE
+    final String archive = triggerBackupAndGetFileName();
+    final HttpResponse<String> retried = postCommand("restore database " + target + " " + archiveUrl(archive));
+    assertThat(retried.statusCode()).isEqualTo(200);
+    assertThat(getServer(0).existsDatabase(target)).isTrue();
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------------------------
+
+  private static void record(final List<String> failures, final String what, final Runnable assertion) {
+    try {
+      assertion.run();
+    } catch (final Throwable t) {
+      failures.add(what + ": " + t.getMessage());
+    }
+  }
+
+  private void assertRefusedWith409(final String command, final boolean overwrite, final String expectedMessage)
+      throws Exception {
+    final JSONObject payload = new JSONObject().put("command", command);
+    if (overwrite)
+      payload.put("overwrite", true);
+
+    final HttpResponse<String> response = postCommand(payload);
+    assertThat(response.statusCode()).as("status of: %s", command).isEqualTo(409);
+    assertThat(response.body()).as("body of: %s", command).contains(expectedMessage);
+  }
+
+  private String triggerBackupAndGetFileName() throws Exception {
+    final HttpResponse<String> triggered = postCommand("trigger backup " + getDatabaseName());
+    assertThat(triggered.statusCode()).isEqualTo(200);
+
+    final HttpResponse<String> listed = postCommand("list backups " + getDatabaseName());
+    assertThat(listed.statusCode()).isEqualTo(200);
+
+    final JSONArray backups = new JSONObject(listed.body()).getJSONArray("backups");
+    assertThat(backups.length()).isPositive();
+    return backups.getJSONObject(backups.length() - 1).getString("fileName");
+  }
+
+  private String archiveUrl(final String fileName) {
+    final Path archive = Paths.get(backupDir.getAbsolutePath(), getDatabaseName(), fileName).toAbsolutePath().normalize();
+    return "file://" + archive;
+  }
+
+  private DatabaseBackupConfig backupConfig() {
+    final DatabaseBackupConfig config = new DatabaseBackupConfig(getDatabaseName());
+    final DatabaseBackupConfig.ScheduleConfig schedule = new DatabaseBackupConfig.ScheduleConfig();
+    schedule.setType(DatabaseBackupConfig.ScheduleConfig.Type.FREQUENCY);
+    schedule.setFrequencyMinutes(9999);
+    config.setSchedule(schedule);
+    return config;
+  }
+
+  private String[] archives(final File directory) {
+    if (!directory.exists())
+      return new String[0];
+    final String[] names = directory.list((dir, name) -> name.endsWith(".zip"));
+    return names != null ? names : new String[0];
+  }
+
+  private HttpResponse<String> postCommand(final String command) throws Exception {
+    return postCommand(new JSONObject().put("command", command));
+  }
+
+  private HttpResponse<String> postCommand(final JSONObject payload) throws Exception {
+    return postCommand(payload, false);
+  }
+
+  private HttpResponse<String> postCommand(final JSONObject payload, final boolean sse) throws Exception {
+    final HttpClient client = HttpClient.newHttpClient();
+    final HttpRequest.Builder request = HttpRequest.newBuilder()
+        .uri(new URI("http://127.0.0.1:" + getServer(0).getHttpServer().getPort() + "/api/v1/server"))
+        .header("Authorization",
+            "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()))
+        .header("Content-Type", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString(payload.toString()));
+    if (sse)
+      request.header("Accept", "text/event-stream");
+    return client.send(request.build(), HttpResponse.BodyHandlers.ofString());
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/backup/Issue7384ConcurrentRestoreIT.java
+++ b/server/src/test/java/com/arcadedb/server/backup/Issue7384ConcurrentRestoreIT.java
@@ -253,8 +253,9 @@ class Issue7384ConcurrentRestoreIT extends BaseGraphServerTest {
           true, "a restore of it is already in progress");
       assertRefusedWith409("import database " + target + " " + archiveUrl(archive),
           false, "a restore of it is already in progress");
+      // AND THE VERB IS THE ONE A HUMAN WOULD WRITE: "back up", NOT "backup", WHICH IS THE NOUN
       assertRefusedWith409("trigger backup " + target,
-          false, "a restore of it is already in progress");
+          false, "Cannot back up database '" + target + "': a restore of it is already in progress");
     } finally {
       coordinator.end(target, Operation.RESTORE);
     }

--- a/server/src/test/java/com/arcadedb/server/backup/Issue7384OperationAdmissionTest.java
+++ b/server/src/test/java/com/arcadedb/server/backup/Issue7384OperationAdmissionTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.backup;
+
+import com.arcadedb.server.backup.BackupCoordinator.Operation;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The admission policy the per-database slot applies once it admits restores and imports as well as backups
+ * (issue #7384).
+ * <p>
+ * A restore drops and replaces the database directory, so it has to exclude - and be excluded by - everything else
+ * that touches it. A backup and an import are the one pair that coexists: an import is ordinary transactions against
+ * a live database, and backing a live database up is what the auto-backup schedule does all day.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue7384OperationAdmissionTest {
+
+  @Test
+  void aRestoreExcludesEveryOtherOperationOnTheSameDatabase() {
+    for (final Operation other : Operation.values()) {
+      final BackupCoordinator coordinator = new BackupCoordinator();
+
+      assertThat(coordinator.begin("db", Operation.RESTORE)).isNull();
+      assertThat(coordinator.begin("db", other)).isEqualTo(Operation.RESTORE);
+
+      coordinator.end("db", Operation.RESTORE);
+      assertThat(coordinator.isInProgress("db")).isFalse();
+    }
+  }
+
+  @Test
+  void everyOtherOperationExcludesARestoreOfTheSameDatabase() {
+    for (final Operation holder : Operation.values()) {
+      final BackupCoordinator coordinator = new BackupCoordinator();
+
+      assertThat(coordinator.begin("db", holder)).isNull();
+      assertThat(coordinator.begin("db", Operation.RESTORE)).isEqualTo(holder);
+
+      coordinator.end("db", holder);
+      assertThat(coordinator.begin("db", Operation.RESTORE)).isNull();
+      coordinator.end("db", Operation.RESTORE);
+    }
+  }
+
+  @Test
+  void aBackupAndAnImportOfOneDatabaseRunTogether() {
+    final BackupCoordinator coordinator = new BackupCoordinator();
+
+    assertThat(coordinator.begin("db", Operation.BACKUP)).isNull();
+    assertThat(coordinator.begin("db", Operation.IMPORT)).isNull();
+
+    // AND NEITHER OF THEM LET A RESTORE IN WHILE BOTH ARE HELD
+    assertThat(coordinator.begin("db", Operation.RESTORE)).isIn(Operation.BACKUP, Operation.IMPORT);
+
+    // RELEASING ONE DOES NOT RELEASE THE OTHER: THE SLOT IS PER OPERATION, NOT A SINGLE FLAG
+    coordinator.end("db", Operation.BACKUP);
+    assertThat(coordinator.isInProgress("db")).isTrue();
+    assertThat(coordinator.isInProgress("db", Operation.IMPORT)).isTrue();
+    assertThat(coordinator.isInProgress("db", Operation.BACKUP)).isFalse();
+    assertThat(coordinator.begin("db", Operation.RESTORE)).isEqualTo(Operation.IMPORT);
+
+    coordinator.end("db", Operation.IMPORT);
+    assertThat(coordinator.isInProgress("db")).isFalse();
+    assertThat(coordinator.begin("db", Operation.RESTORE)).isNull();
+  }
+
+  @Test
+  void anOperationAlwaysExcludesASecondOneOfItsOwnKind() {
+    for (final Operation operation : Operation.values()) {
+      final BackupCoordinator coordinator = new BackupCoordinator();
+
+      assertThat(coordinator.begin("db", operation)).isNull();
+      assertThat(coordinator.begin("db", operation)).isEqualTo(operation);
+
+      coordinator.end("db", operation);
+      assertThat(coordinator.begin("db", operation)).isNull();
+      coordinator.end("db", operation);
+    }
+  }
+
+  @Test
+  void aDifferentDatabaseIsNeverHeldUpByARestore() {
+    final BackupCoordinator coordinator = new BackupCoordinator();
+
+    assertThat(coordinator.begin("db1", Operation.RESTORE)).isNull();
+    assertThat(coordinator.begin("db2", Operation.RESTORE)).isNull();
+    assertThat(coordinator.begin("db2", Operation.BACKUP)).isEqualTo(Operation.RESTORE);
+
+    coordinator.end("db1", Operation.RESTORE);
+    coordinator.end("db2", Operation.RESTORE);
+    assertThat(coordinator.isInProgress("db1")).isFalse();
+    assertThat(coordinator.isInProgress("db2")).isFalse();
+  }
+
+  @Test
+  void releasingAnOperationThatIsNotHeldLeavesTheOthersAlone() {
+    final BackupCoordinator coordinator = new BackupCoordinator();
+
+    assertThat(coordinator.begin("db", Operation.RESTORE)).isNull();
+
+    // A CALLER THAT WAS REFUSED MUST NOT CALL end(), BUT IF IT DOES IT MUST NOT FREE SOMEBODY ELSE'S SLOT
+    coordinator.end("db", Operation.BACKUP);
+    coordinator.end("db", Operation.IMPORT);
+
+    assertThat(coordinator.isInProgress("db", Operation.RESTORE)).isTrue();
+    assertThat(coordinator.begin("db", Operation.BACKUP)).isEqualTo(Operation.RESTORE);
+
+    coordinator.end("db", Operation.RESTORE);
+    assertThat(coordinator.isInProgress("db")).isFalse();
+  }
+
+  @Test
+  void theLegacyBackupShorthandIsTheSameSlot() {
+    final BackupCoordinator coordinator = new BackupCoordinator();
+
+    // begin(db) IS begin(db, BACKUP): A RESTORE MUST SEE IT AND IT MUST SEE A RESTORE
+    assertThat(coordinator.begin("db")).isTrue();
+    assertThat(coordinator.begin("db", Operation.RESTORE)).isEqualTo(Operation.BACKUP);
+    coordinator.end("db");
+
+    assertThat(coordinator.begin("db", Operation.RESTORE)).isNull();
+    assertThat(coordinator.begin("db")).isFalse();
+    coordinator.end("db", Operation.RESTORE);
+  }
+
+  @Test
+  // PLAIN HANG DETECTOR, NOT A LATENCY BOUND: EVERY CALLER DOES ONE ConcurrentHashMap.compute, SO ANY REAL RUN
+  // FINISHES IN MICROSECONDS AND ONLY A DEADLOCK COULD REACH THIS
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
+  void concurrentCallersNeverBothHoldConflictingOperations() throws Exception {
+    final BackupCoordinator coordinator = new BackupCoordinator();
+    final int callers = 12;
+    final CountDownLatch startTogether = new CountDownLatch(1);
+    final CountDownLatch done = new CountDownLatch(callers);
+    final Set<Operation> admitted = ConcurrentHashMap.newKeySet();
+
+    final ExecutorService executor = Executors.newFixedThreadPool(callers);
+    try {
+      for (int i = 0; i < callers; i++) {
+        final Operation operation = Operation.values()[i % Operation.values().length];
+        executor.submit(() -> {
+          try {
+            startTogether.await();
+            if (coordinator.begin("db", operation) == null)
+              admitted.add(operation);
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+          } finally {
+            done.countDown();
+          }
+          return null;
+        });
+      }
+
+      startTogether.countDown();
+      done.await();
+    } finally {
+      executor.shutdownNow();
+    }
+
+    // WHATEVER WON, NO TWO CONFLICTING OPERATIONS ARE HOLDING THE DATABASE AT THE SAME TIME
+    assertThat(admitted).isNotEmpty();
+    for (final Operation one : admitted)
+      for (final Operation two : admitted)
+        if (one != two)
+          assertThat(one.conflictsWith(two)).isFalse();
+
+    // AND THE ONLY SET THAT CAN SURVIVE TOGETHER IS THE BACKUP/IMPORT PAIR
+    assertThat(admitted).isIn(EnumSet.of(Operation.BACKUP), EnumSet.of(Operation.RESTORE), EnumSet.of(Operation.IMPORT),
+        EnumSet.of(Operation.BACKUP, Operation.IMPORT));
+  }
+}


### PR DESCRIPTION
Closes #7384

## Summary

`ServerControlPlane.triggerBackup` took a per-database slot from `BackupCoordinator`. `restoreDatabase`, `restoreBackup` and `importDatabase` took nothing, and the only guard a restore had was an existence pre-check that is not atomic with the directory swap that follows it - so two restores of one database both passed it, both restored into their own temporary directory and both reached the swap, and the loser's caller was told it had succeeded. A restore could equally drop the directory a `trigger backup` or an auto-backup tick was reading. The slot now carries an `Operation` (`BACKUP`, `RESTORE`, `IMPORT`) and restores and imports take it, so a restore excludes - and is excluded by - everything else touching the same database, and the refusal names what is holding it.

A backup and an import are the one pair that deliberately coexists: an import is ordinary transactions against a live database, and backing a live database up is what the auto-backup schedule does all day, so excluding them would starve the schedule for the whole duration of a multi-hour load.

## Invariant

> On one server, for one database, a restore never overlaps a backup, another restore or an import of that same database: whichever arrives second is refused with an `OperationInProgressException` rather than being allowed to interleave.

## Root cause

```java
// ServerControlPlane.restoreDatabase, before this change
if (new File(dbPath).exists())
  throw new IllegalArgumentException("Database '" + databaseName + "' already exists");
performRestore(databaseName, dbPath, url, listener);   // ... then swaps a directory into place
```

The race predates #7308, but #7308 made all three commands reachable over gRPC as well as HTTP, so the two racers no longer have to be two callers of one endpoint.

## What changed

**`BackupCoordinator`**
* new `Operation` enum with `conflictsWith`: two operations on one database exclude each other unless one is a `BACKUP` and the other an `IMPORT`.
* the in-progress set becomes `Map<String, EnumSet<Operation>>`. Values are replaced, never mutated in place, so a set already handed to a reader is never written to by another thread. `EnumSet` is exact because every kind conflicts with itself, so at most one of each kind is ever admitted.
* `begin(db, Operation)` returns the *blocking* operation (`null` when admitted) so a refusal can name it. `begin(db)` / `end(db)` stay as the `BACKUP` shorthand, unchanged for `BackupTask`, `triggerBackup` and the existing tests.
* the class is deliberately **not** renamed. The issue notes the name would want revisiting; renaming would force edits to `BackupCoordinatorTest` and `Issue6753ConcurrentBackupIT`, and this change adds tests rather than modifying them. The Javadoc says what it now coordinates instead.

**`ServerControlPlane`**
* new `OperationInProgressException`. `BackupInProgressException` now extends it and is *still* what `triggerBackup` raises when another backup holds the slot, with the same message, so anything written against it catches what it always caught.
* `restoreDatabase`, `restoreBackup` (on the **target**) and `importDatabase` take the slot through a `beginExclusive` helper and release it in a `finally`. The slot is taken before the existence / overwrite pre-check, which is the only thing that makes that check meaningful.

**Transports** - widening these was required, not incidental: both status mappings keyed on `BackupInProgressException`, the one exception only `trigger backup` could raise, so a refused restore would otherwise have been a `500` / `INTERNAL`.
* `AbstractServerHttpHandler`: new 409 arm for `OperationInProgressException`, with the other 409s.
* `PostServerCommandHandler.triggerBackup`: catch widened to the base type.
* `ArcadeDbGrpcAdminService.toStatus`: `instanceof` widened to the base type, so the three streaming RPCs get the `ABORTED` `TriggerBackup` already got.
* `BackupTask`: the skip log names the operation holding the slot instead of always saying "a backup".

## Coverage

| # | Entry point | Transport(s) | Covered by fix? | Covered by a test? |
|---|---|---|---|---|
| 1 | `ServerControlPlane.restoreDatabase` | HTTP `restore database`, gRPC `RestoreDatabase` | yes - `RESTORE` slot before the existence pre-check | yes, through both transports |
| 2 | `ServerControlPlane.restoreBackup` | HTTP `restore backup`, gRPC `RestoreBackup` | yes - `RESTORE` slot on the target, covering the overwrite pre-check | yes, plus the in-flight probe |
| 3 | `ServerControlPlane.importDatabase` | HTTP `import database`, gRPC `ImportDatabase` | yes - `IMPORT` slot around `createDatabase` + the import | yes, through both transports |
| 4 | `ServerControlPlane.triggerBackup` | HTTP `trigger backup`, gRPC `TriggerBackup` | yes - already took the slot; now refuses a restore too, and names it | yes, through both transports |
| 5 | `BackupTask.run` (auto-backup tick + immediate trigger) | scheduler | yes - now skips on a restore and logs which operation holds it | yes - `theScheduledBackupTaskSkipsWhileARestoreOfTheDatabaseRuns` |
| 6 | HTTP status of a refusal | `AbstractServerHttpHandler` ladder | yes - new 409 arm (was a 500) | yes, plain and SSE mode |
| 7 | gRPC status of a refusal | `ArcadeDbGrpcAdminService.toStatus` | yes - widened to the base type (was `INTERNAL`) | yes |
| 8 | `ArcadeDBServer` startup `defaultDatabases` `restore:` | startup only | **argued** - see below | n/a |
| 9 | SQL `BACKUP DATABASE` / `IMPORT DATABASE` | SQL over any transport | **filed as #7443** | n/a |
| 10 | Leader-side restore vs a follower's scheduled backup | HA | **filed as #7444** | n/a |

### Known gaps

* **#7443** - SQL `BACKUP DATABASE` and `IMPORT DATABASE` are executed by the engine, which cannot reference a server class, so they take no slot. Closing it needs a way for engine-side statement execution to reach a server-side admission policy, which is a design decision rather than a missing `begin`/`end` pair.
* **#7444** - the slot is per server instance (deliberately: HA tests and co-located nodes run several servers with the same database names in one process). Restores are leader-only, so restore-vs-restore is already serialised cluster-wide, but a follower running its own scheduled backup of a replicated database is not. #7384 itself puts cluster-wide serialisation out of scope.

### Row 8, argued with evidence

The startup restore runs inside `loadDatabases()`, called at `ArcadeDBServer:373` - before `httpServer = new HttpServer(this)` (382), `httpServer.startService()` (386) and every `startPlugins(...)` call (384, 390, 413). Nothing it could race with is running yet.

## Test plan

- [ ] `mvn -o -pl server -am -Dtest='Issue7384OperationAdmissionTest' test` - the admission policy: the conflict matrix in both directions, the backup/import pair, self-conflict, per-database isolation, a stray `end()`, the legacy shorthand, and 12 concurrent callers.
- [ ] `mvn -o -pl server -am -Dtest='Issue7384ConcurrentRestoreIT' -DskipITs=false test` - 8 tests. The first starts a **real** restore and probes from inside its own progress stream that it holds the slot and that a second restore, a backup and an import of its target are all refused while it runs. Then: the HTTP 409s for all four commands in plain and SSE mode, a refusal blocked by an import, the `BackupTask` skip, the deliberate import/backup coexistence, and that a failed restore releases the slot.
- [ ] `mvn -o -pl grpcw -am -Dtest='Issue7384GrpcRestoreSerialisationIT' -DskipITs=false test` - the same refusals through the gRPC RPCs, asserting `ABORTED` and the message.
- [ ] Regression: `-pl server -Dtest='com.arcadedb.server.backup.*'` (BUILD SUCCESS); `Issue6753ConcurrentBackupIT,BackupCoordinatorTest,BackupRestoreDeleteApiIT,Issue7308RestoreTargetNameIT,RestoreImportSecurityDurabilityIT,Issue7392*,AutoBackupSchedulerPluginIT,BackupTaskCompressionOverrideTest,ServerBackupDatabaseIT` (51 tests, 0 failures); `PostServerCommandHandler*,*HttpHandler*,*ErrorResponse*` (79 tests, 0 failures); `-pl grpcw -Dtest='Issue7308*,Issue7304*,GrpcAdminServiceIT'` (118 tests, 0 failures); `-pl grpc-client -Dtest='Issue7308RemoteGrpcServerRestoreImportIT'` (6 tests, 0 failures).

### The tests were proved able to fail

Neutralising `beginExclusive` to an empty body turns three of the eight `Issue7384ConcurrentRestoreIT` tests red:

```
[ERROR] Tests run: 6, Failures: 3
  aRestoreInFlightRefusesEveryOtherOperationOnItsTarget
  aBackupInFlightRefusesARestoreOfTheSameDatabase
  everyHttpRestoreAndImportCommandAnswers409WhileARestoreOfTheTargetRuns
```

Reverting the gRPC mapping to `BackupInProgressException` turns both `Issue7384GrpcRestoreSerialisationIT` tests red with `expected: ABORTED but was: INTERNAL`.

## Reachability

`ServerControlPlane` is constructed by `PostServerCommandHandler` (HTTP) and injected into `ArcadeDbGrpcAdminService` (gRPC); the ITs reach the changed methods over real HTTP and real gRPC rather than by calling the class directly. `BackupCoordinator` is an unconditional field of `ArcadeDBServer` (`:161`), so the slot exists whether or not the auto-backup plugin is configured. Nothing new is behind a flag.

## Adversarial pass

Phase 1.5's isolated subagent was unavailable in this session (no `Task` tool), so the pass was run against the tree by the author - weaker, and recorded as such.

| Finding | Disposition |
|---|---|
| A refusal reaching an **SSE** client could become a 200 carrying an error frame rather than a status - the mode Studio uses | **Real, in scope.** It does not, because the slot is taken before the first progress line, so `streamOrRun`'s `sink.started()` is false. Now asserted by `anSseClientGetsTheRefusalAsA409RatherThanAsAnErrorFrame` |
| The refusal message built its article by hand and rendered **"a import"** | **Real, fixed.** `Operation` now carries the phrase with its article. Caught by a test that was red until the message was fixed |
| `EnumSet` is not thread-safe and `isInProgress(db, op)` reads a value outside the map's per-entry lock | **Real, fixed during implementation.** `begin`/`end` replace the value with a fresh `EnumSet` |
| A *refused* caller that wrongly calls `end()` releases the holder's slot | **Real, not changed.** The same contract `begin`/`end` has had since #6753; the cross-kind case is covered by a test. Making it token-based would change every call site for a hazard no caller in the tree has |
| `restoreBackup` with source == target deadlocks or loses the archive | **Not real.** The slot is taken once, on the target, and `begin` refuses rather than blocks. The archive lives under the backup directory, not the database directory. Exercised by `aBackupInFlightRefusesARestoreOfTheSameDatabase`, which restores `graph` over `graph` |
| `BackupTask`'s new two-argument log call binds its first argument as a `Throwable` | **Not real.** `LogManager:252` declares `log(Object, Level, String, Object, Object)`; the `Throwable` overloads are not applicable to two `String`s |
| The Raft apply path re-enters the control plane's restore | **Not real.** `grep -rn "restoreDatabase\|restoreBackup\|beginExclusive" server/src/main/java/com/arcadedb/server/ha/` returns nothing |
| Retention could delete the archive a `restore backup` is reading | **Real, out of scope, not filed.** A different invariant (archive lifetime vs its reader), not an entry point that starts a whole-database operation. On POSIX an unlinked file an open handle is reading stays readable; on Windows the delete fails rather than the read, so neither corrupts the restore |

## Residual risk

1. Anything that backs a database up without going through the control plane: the SQL statements (#7443), and the CLI or a second process writing into a shared backup directory, which were already outside this admission policy - `FullBackupFormat` creating its target file atomically is what stops those from corrupting an archive.
2. Cluster-wide serialisation (#7444).
3. A plain `create database` racing a restore of the same name: `swapRestoredDatabase` already deletes whatever is in the final directory under `databasesLock`, so the restore wins rather than producing a half-swapped directory. Unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4kKMPe6TUwc36ZCZr6iBR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented conflicting backup, restore, and import operations on the same database.
  * Added clear HTTP 409 and gRPC `ABORTED` responses for operations already in progress.
  * Scheduled backups now skip databases undergoing restore operations.
  * Operation locks are released correctly after failed restores, allowing subsequent operations to proceed.
  * Backups and imports may run concurrently when no restore operation is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review cycles

| Cycle | Head | Outcome | Applied |
|---|---|---|---|
| 1 | `66800957` | No blocking issues. Reviewer independently re-verified the `LogManager:252` overload binding, the `firstOf(...)` arm's placement in the status ladder, and that `BackupCoordinator` is a single per-server field. Two non-blocking nits | Both. `Operation.label()` was used in exactly one place - `"Cannot <label> database 'x'"` - so it was always a verb, and "backup" is the noun: renamed to `verb()` with `BACKUP` now `"back up"`, pinned by an IT assertion so the noun cannot creep back. And `begin(String, Operation)`'s javadoc now says that when both a `BACKUP` and an `IMPORT` hold the slot, the one named in the refusal is whichever the iteration reaches first rather than a ranking - both refuse equally |
| 2 | `1942524f` | Clean approval: "Nothing here blocks merging." Two observations, both explicitly agreed as out of scope | None needed. (a) The refusal message shape is not uniform across the two causes in `triggerBackup` - deliberate, so that anything written against `BackupInProgressException` before #7384 still gets its verbatim pre-existing message; changing it would trade a documented backward-compatibility guarantee for cosmetic uniformity. (b) `restoreBackup` takes no slot on the *source*, so a retention sweep could delete the archive mid-read - reviewer agreed with the residual-risk reasoning above and that it is a different invariant |

No deferred items: every comment across both cycles was either applied or is recorded above with its rationale.
