### PR TITLE
feat(#7385): publish a running restore in the operation progress registry

### DIFF
--- a/docs/7385-restore-operation-progress.md
+++ b/docs/7385-restore-operation-progress.md
@@ -1,0 +1,238 @@
+# #7385 - A running restore publishes no OperationProgress
+
+Follow-up to #7308. `GET /api/v1/progress/{database}` reports the long-running operations of a
+database; the console and Studio render it. Six operations publish there today. A **restore**
+publishes nothing, so for the minutes a `restore backup` or `restore database` runs, a third party
+looking at the database sees an idle database that is in fact being replaced.
+
+## Finding ledger
+
+- [x] 1. No restore registers an `OperationProgress`, on any transport - **fixed** on all four control-plane
+      entry points, with real entry counters; the startup path is filed as #7440.
+
+## Analysis
+
+### Who publishes today
+
+```
+$ grep -rn "OperationProgressRegistry.instance().register" --include="*.java" engine/src/main server/src/main integration/src/main grpcw/src/main
+engine/.../RebuildIndexStatement.java:196     "rebuild index"
+engine/.../CompactIndexStatement.java:73      "compact index"
+server/.../ServerControlPlane.java:1301       "import database"     # added by #7308
+
+$ grep -rn -A2 "OperationProgressRegistry.instance()$" --include="*.java" engine/src/main server/src/main | grep register
+engine/.../CheckDatabaseStatement.java-139    "check database" / "check database fix"
+engine/.../ImportDatabaseStatement.java-67    "import database"
+engine/.../BackupDatabaseStatement.java-94    "backup database"
+```
+
+Six producers; no restore among them. The issue body lists three because it was written against an
+older tree - the extra three do not change the finding.
+
+### The restore has real progress to report
+
+Unlike the import - whose record total is unknown up front, so `ImportDatabaseStatement` and
+`runImport` both publish only a coarse `(1, 1, 0, -1)` marker - the restore's unit of work is an
+archive entry, and the parallel extractor (#6086) reads the whole entry list out of the ZIP central
+directory **before** any thread starts writing:
+
+```
+integration/.../ParallelZipExtractor.java:140   final List<PlannedEntry> plan = new ArrayList<>(entries.size());
+integration/.../ParallelZipExtractor.java:178   return new ExtractStats(plan.size(), databaseOrigSize);
+```
+
+So the parallel path can report `done/total` with a real denominator, and the sequential walk - the
+fallback for an http(s) or an encrypted archive, which only learns an entry when it reaches it - can
+report `done` against `total = -1`, which is exactly what `OperationProgress.getPercentage()`
+already renders as "unknown".
+
+### The three phases of a server-side restore
+
+`ServerControlPlane.performRestore` is not only the extraction. It is:
+
+1. extract the archive into a temporary sibling directory (`Restore.restoreDatabase()`),
+2. `swapRestoredDatabase` - drop the previous target, if any, and move the temp directory into place,
+3. `replicateRestoredDatabase` - in HA, submit an install-database Raft entry with
+   `forceSnapshot=true` so every replica pulls the restored files.
+
+Step 3 is a no-op outside HA and can take minutes inside it, so the operation is published as three
+steps rather than one.
+
+## Completeness
+
+### The invariant
+
+> Every restore this server's control plane runs publishes an `OperationProgress` for its target
+> database, from before the first byte is extracted until after the database is activated and
+> replicated - and retires it in a `finally`, on success and on failure alike.
+
+### Entry points
+
+```
+$ grep -rn 'Class.forName("com.arcadedb.integration.restore.Restore")\|new Restore(' --include="*.java" engine/src/main server/src/main integration/src/main grpcw/src/main console/src/main
+server/.../ServerControlPlane.java:1402
+server/.../ArcadeDBServer.java:1407          # startup SERVER_DEFAULT_DATABASES 'restore:' command
+integration/.../Restore.java:51              # CLI main()
+
+$ grep -rn "controlPlane.restoreDatabase(\|controlPlane.restoreBackup(" --include="*.java" server/src/main grpcw/src/main
+server/.../PostServerCommandHandler.java:423   restore database  (HTTP)
+server/.../PostServerCommandHandler.java:457   restore backup    (HTTP)
+grpcw/.../ArcadeDbGrpcAdminService.java:797    RestoreBackup     (gRPC)
+grpcw/.../ArcadeDbGrpcAdminService.java:821    RestoreDatabase   (gRPC)
+```
+
+There is no `RESTORE DATABASE` SQL statement - the engine's parser has `BackupDatabaseStatement` but
+no restore counterpart (`ls engine/src/main/java/com/arcadedb/query/sql/parser/ | grep -i restore`
+returns only the per-record `RestoreDocument/Edge/Vertex` statements), so the SQL transport is not an
+entry point at all.
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| HTTP `restore database <name> <url>` -> `ServerControlPlane.restoreDatabase` -> `performRestore` | yes | yes - `Issue7385RestoreProgressIT.httpRestoreDatabasePublishesProgress` |
+| HTTP `restore backup <db> <file> as <target>` -> `ServerControlPlane.restoreBackup` -> `performRestore` | yes | yes - `Issue7385RestoreProgressIT.httpRestoreBackupPublishesProgress` |
+| gRPC `RestoreDatabase` -> `ServerControlPlane.restoreDatabase` -> `performRestore` | yes | yes - `Issue7385RestoreProgressIT.restoreDatabasePublishesProgressAtTheControlPlane` (the shared layer both transports call) |
+| gRPC `RestoreBackup` -> `ServerControlPlane.restoreBackup` -> `performRestore` | yes | yes - `Issue7385RestoreProgressIT.restoreBackupPublishesProgressAtTheControlPlane` |
+| failing restore (any of the four) must still retire the operation | yes | yes - `Issue7385RestoreProgressIT.aFailedRestoreRetiresTheOperation` |
+| `Restore.setProgressCallback` on the parallel extractor | yes | yes - `Issue7385RestoreProgressCallbackTest.parallelRestoreReportsEntryCountsAgainstAKnownTotal` |
+| `Restore.setProgressCallback` on the sequential walk | yes | yes - `Issue7385RestoreProgressCallbackTest.sequentialRestoreReportsEntryCountsWithAnUnknownTotal` |
+| startup `SERVER_DEFAULT_DATABASES` `{restore:<url>}` -> `ArcadeDBServer.loadDefaultDatabases` | **no** - filed | n/a |
+| `Restore.main()` CLI | **no** - argued | n/a |
+
+### Argued rows
+
+- **`Restore.main()` CLI.** `OperationProgressRegistry` is process-local, and it has exactly two
+  readers:
+
+  ```
+  $ grep -rn "OperationProgressRegistry.instance().getOperations" --include="*.java" . | grep -v /src/test/
+  server/.../ServerControlPlane.java:255      # HTTP /progress/{db} and gRPC GetProgress
+  console/.../Console.java:1165               # the console's own poller, EMBEDDED databases only
+  ```
+
+  `Restore.main()` calls `System.exit(0)` when it returns and runs neither a server nor a console, so
+  a registration there has no reader by construction. The new `setProgressCallback` is available to
+  any embedder that wants the same counters without the registry.
+
+### Filed rows
+
+- **Startup `restore:` command** - #7440. `httpServer.startService()` runs at
+  `ArcadeDBServer.java:386`, before `loadDefaultDatabases()` at `:408`, so the endpoint really is
+  listening while a startup restore runs and a `root` poll would be authorized
+  (`checkAuthorizationOnDatabase` only calls `canAccessToDatabase`, which the wildcard grant answers
+  for a database that does not exist yet). That path does not go through the control plane, has no
+  `ProgressListener`, and cannot be driven from a test deterministically, so it is filed rather than
+  fixed blind.
+
+### Residual risk
+
+- A restore started before this build, or by the startup path, still shows nothing (#7440).
+- The `done/total` counters are per **archive entry**, not per byte: a database that is one 4 GB page
+  file and six tiny ones reports `6/7` for almost the whole restore. That is the granularity #6086
+  chose for the parallelism itself, and finer progress would need per-entry byte accounting the
+  extractor does not keep.
+- Progress is process-local: in HA, polling a replica shows nothing while the leader restores. That is
+  the registry's documented design, not a gap this change introduces.
+
+## Changes
+
+**`integration`** - the restore learns to report counters.
+
+- `Restore.setProgressCallback(ProgressCallback)`: a new opt-in sink, installed on the format before it runs.
+  `ProgressCallback` lives in the engine (`com.arcadedb.utility`), which the server already has on its
+  classpath, so the server installs it with a plain reflective `getMethod` and no proxy - unlike the
+  `ConsoleLogger$LogListener` it has to proxy.
+- `AbstractRestoreFormat`: holds the callback, owns the `RESTORE_STEP_NAME` constant and the null-safe
+  `reportRestoreProgress`.
+- `FullRestoreFormat`: the sequential walk reports `(entriesDone, -1)` per entry and hands the callback to the
+  parallel extractor.
+- `ParallelZipExtractor`: a new 3-arg constructor takes the callback (the 2-arg one still exists and still
+  means "no progress"); reports `(0, n)` before the pool is created, `(done, n)` per entry from the worker, and a
+  closing `(n, n)` from the coordinating thread once every worker has been collected - because the per-entry
+  reports come from several threads and can publish `n` then `n-1`, which would otherwise leave a finished
+  extraction showing one entry short for the rest of the operation. The per-entry report was also moved
+  **before** its log line, so a caller watching both never sees a line saying an entry is done while the counter
+  still says it is not.
+
+**`server`** - `ServerControlPlane.performRestore` registers the operation.
+
+- Registered before the first byte is extracted, retired in a `finally` that now spans the extract, the swap and
+  the replicate - the three phases are published as steps 1, 2 and 3 of `RESTORE_STEPS`, so the endpoint keeps
+  saying something after the archive is unpacked (the swap drops the database being replaced; in HA the
+  replication makes every replica pull the restored files).
+- The operation is labelled with the command the operator typed - `restore database` or `restore backup` - rather
+  than one name standing for both, so `performRestore` takes it as a parameter.
+- `installRestoreProgressCallback` renumbers the format's own step (always 1 of 1, because the integration module
+  cannot see the swap and replicate phases) into step 1 of three. Best-effort like `importerContext`: a build of
+  `arcadedb-integration` without the setter reports no counters rather than failing the restore.
+
+**`engine`** - one javadoc line: `OperationProgressRegistry` now lists restores among its producers.
+
+### Why no Studio change
+
+Studio's two restore actions (`importWithSSE` from the dataset modal, and `doRestoreBackup` from the backup
+panel) already ask for `text/event-stream` and render the restore's own log lines, so they were never the blind
+half. `startCommandProgressMonitor` is the query editor's poller and matches SQL commands only; there is no
+`RESTORE DATABASE` SQL statement, so adding restore to its regex would be dead code. What was blind is exactly
+what the issue's scope note says: a third party looking at the database - another Studio session, the console,
+an operator with curl - polling `/api/v1/progress/{database}`. That is what this change fixes.
+
+## Test results
+
+```
+$ mvn -o -pl integration -Pintegration -DexcludedGroups=benchmark verify
+Tests run: 129, Failures: 0, Errors: 0, Skipped: 0      # ITs, incl. Issue6086ParallelRestoreIT (19)
+   + Issue7385RestoreProgressCallbackTest               3/3
+
+$ mvn -o -pl server -Pintegration -Dit.test='com.arcadedb.server.backup.*IT' verify
+Tests run: 1042, Failures: 0, Errors: 0, Skipped: 0     # server unit suite
+Tests run: 32,   Failures: 0, Errors: 0, Skipped: 0     # backup/restore ITs
+   + Issue7385RestoreProgressIT                         4/4
+
+$ mvn -o -pl grpcw -Pintegration -Dit.test='Issue7308Grpc*IT,Issue7310Grpc*IT' verify
+Tests run: 37, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### The tests were proved able to fail
+
+Three canary runs, each reverted:
+
+| Canary | Result |
+|---|---|
+| `Restore.restoreDatabase()` stops installing the callback on the format | `Issue7385RestoreProgressCallbackTest` 2/3 fail, "Expecting actual not to be empty" |
+| `performRestore` registers under `databaseName + "-CANARY"` | `Issue7385RestoreProgressIT` 4/4 fail |
+| `installRestoreProgressCallback` looks up `setProgressCallbackCANARY` | `Issue7385RestoreProgressIT` 1/4 fails, "the archive entry count never reached the registry" |
+
+The third canary is the one that justifies the `total > 0` assertion existing at all: the reflective lookup
+swallows its own failure by design, so without that assertion a build that silently stopped installing the
+callback would still publish the coarse step markers and every other assertion would still pass.
+
+The same assertion caught a real defect in the test itself on its first run: `getOperations` hands back the
+**live** `OperationProgress` objects the producer is still writing to, so collecting the references meant every
+"sample" read alike at the end - whatever the last write left behind. The sampler takes an `op.toJSON()` snapshot
+instead, which is also exactly what the progress endpoint serializes.
+
+## Reachability
+
+`performRestore` is reached by all four transports on live paths
+(`PostServerCommandHandler.java:423`/`:457`, `ArcadeDbGrpcAdminService.java:797`/`:821`), and
+`theProgressEndpointReportsARunningRestore` drives the whole stack end to end: a real HTTP `restore database`
+against a deliberately slow local archive server, with `GET /api/v1/progress/{database}` polled from outside
+until it reports the running restore. No feature flag gates any of it; `SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS`
+gates only which URLs the test may use, not the publication.
+
+## Adversarial pass
+
+The orchestrator's Phase 1.5 calls for one subagent that has not been persuaded by the author's reasoning. **No
+subagent-spawning tool was available in this session** (`ToolSearch` for a `Task`/general-purpose agent returned
+nothing; the only peers `ListAgents` reports are other people's unrelated sessions). Per the skill's error table
+that is not a hard gate, so the pass was run by the author against the diff, and what it found is recorded here
+with the same disposition rules.
+
+| Finding | Disposition |
+|---|---|
+| `performRestore`'s `finally` now spans the swap and the replicate, but only an **extraction** failure is tested. A failure in `swapRestoredDatabase` is not. | **Not real as a coverage gap.** One `finally` covers all three phases and the extraction-failure test proves it runs on the exception path; a second test would exercise the same `finally` through a harder-to-provoke throw. Recorded rather than argued away silently. |
+| Moving the reflective block into an inner `try` could change which exceptions the `FileUtils.deleteRecursively(tempDir)` handlers see. | **Checked, not real.** `swapRestoredDatabase` and `replicateRestoredDatabase` sit *after* the inner `try/catch`, exactly where they sat before relative to the old outer one, so no temp-dir cleanup now fires for a failure that used to escape it. |
+| `RESTORE_STEP_EXTRACT` in the server duplicates the string literal of `AbstractRestoreFormat.RESTORE_STEP_NAME`; a change to one silently desynchronises the other. | **Real, fixed here.** Unavoidable - `arcadedb-integration` is optional and reached only reflectively, so the constant cannot be referenced - so the duplication now carries a comment saying why it exists and what a drift actually costs (a changed label mid-step, nothing more). |
+| The per-entry reports come from several worker threads, so `OperationProgress.done` can go backwards and a finished extraction could be left reading one entry short. | **Real, fixed here** before the pass, by the closing report the coordinating thread makes once every worker has been collected. Asserted by `parallelRestoreReportsEntryCountsAgainstAKnownTotal`. |
+| `done`/`total` reset to `0`/`-1` at steps 2 and 3, so a reader watching a percentage sees 100% and then "unknown". | **Not real.** `ProgressCallback`'s contract is that `done`/`total` are the units of the *current step*, and steps 2 and 3 have no countable units. `getPercentage()` returns -1, which the console and Studio already render as "no bar". |
+| A non-root user scoped to specific databases cannot poll the progress of a restore into a brand-new database, because `checkAuthorizationOnDatabase` asks `canAccessToDatabase` about a name that does not exist yet. | **Real, out of scope and pre-existing.** It is the progress endpoint's authorization rule, not something this change introduces, and it applies equally to `import database` since #7308. Not filed: refusing to report on a database the caller may not access is the endpoint behaving as designed. |

--- a/docs/7385-restore-operation-progress.md
+++ b/docs/7385-restore-operation-progress.md
@@ -236,3 +236,20 @@ with the same disposition rules.
 | The per-entry reports come from several worker threads, so `OperationProgress.done` can go backwards and a finished extraction could be left reading one entry short. | **Real, fixed here** before the pass, by the closing report the coordinating thread makes once every worker has been collected. Asserted by `parallelRestoreReportsEntryCountsAgainstAKnownTotal`. |
 | `done`/`total` reset to `0`/`-1` at steps 2 and 3, so a reader watching a percentage sees 100% and then "unknown". | **Not real.** `ProgressCallback`'s contract is that `done`/`total` are the units of the *current step*, and steps 2 and 3 have no countable units. `getPercentage()` returns -1, which the console and Studio already render as "no bar". |
 | A non-root user scoped to specific databases cannot poll the progress of a restore into a brand-new database, because `checkAuthorizationOnDatabase` asks `canAccessToDatabase` about a name that does not exist yet. | **Real, out of scope and pre-existing.** It is the progress endpoint's authorization rule, not something this change introduces, and it applies equally to `import database` since #7308. Not filed: refusing to report on a database the caller may not access is the endpoint behaving as designed. |
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/7446
+
+### Review cycles
+
+| Cycle | Head SHA | Changes | Bot outcome |
+|---|---|---|---|
+| 1 | `30cc4ae9` | the initial implementation as described above | `claude` reviewed by manual code tracing (it reported that `mvn` was blocked by its sandbox, so it did not run the suite). Independently re-derived the two claims worth checking rather than taking the PR body's word for them: that the swap/replicate placement relative to the inner `try/catch` is unchanged from before the PR, and that the startup path at `ArcadeDBServer.java:1393-1416` really does still lack the wiring, so the #7440 gap claim is accurate. It flagged the `RESTORE_STEP_EXTRACT` / `RESTORE_STEP_NAME` literal duplication as a future-maintenance fragility and agreed the optional-dependency constraint leaves no compile-time way to share it - which is what the comment added before the PR opened already says. **No blocking issues, no actionable items.** |
+
+No changes were applied in response to the review, so no follow-up commit was needed and no deferred-items notes
+file was produced.
+
+### Final state
+
+`clean-approval` on cycle 1 of a maximum of 4.

--- a/engine/src/main/java/com/arcadedb/engine/OperationProgressRegistry.java
+++ b/engine/src/main/java/com/arcadedb/engine/OperationProgressRegistry.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * JVM-wide registry of the long-running maintenance operations currently in progress (CHECK DATABASE first;
- * COMPACT INDEX, index rebuilds, backups and imports can publish here too). Producers register an
+ * COMPACT INDEX, index rebuilds, backups, imports and restores can publish here too). Producers register an
  * {@link OperationProgress} when the operation starts, feed it as their progress callback, and MUST unregister
  * it in a finally block. Readers (HTTP progress endpoint, console/Studio pollers) get a weakly-consistent
  * snapshot. The registry is deliberately process-local: in an HA cluster each server reports what it is doing,

--- a/integration/src/main/java/com/arcadedb/integration/restore/Restore.java
+++ b/integration/src/main/java/com/arcadedb/integration/restore/Restore.java
@@ -23,6 +23,7 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.integration.importer.ConsoleLogger;
 import com.arcadedb.integration.restore.format.AbstractRestoreFormat;
 import com.arcadedb.integration.restore.format.FullRestoreFormat;
+import com.arcadedb.utility.ProgressCallback;
 
 import java.util.Locale;
 import java.util.Timer;
@@ -33,6 +34,7 @@ public class Restore {
   protected Timer                 timer;
   protected ConsoleLogger         logger;
   protected AbstractRestoreFormat formatImplementation;
+  protected ProgressCallback      progressCallback;
 
   public Restore(final String[] args) {
     settings.parseParameters(args);
@@ -58,6 +60,7 @@ public class Restore {
         logger = new ConsoleLogger(settings.verboseLevel);
 
       formatImplementation = createFormatImplementation();
+      formatImplementation.setProgressCallback(progressCallback);
       formatImplementation.restoreDatabase();
 
     } catch (final Exception e) {
@@ -83,6 +86,21 @@ public class Restore {
 
   public Restore setLogger(final ConsoleLogger logger) {
     this.logger = logger;
+    return this;
+  }
+
+  /**
+   * Receives {@code ("Restoring files", 1, 1, entriesDone, entriesTotal)} as the archive is extracted, where
+   * {@code entriesTotal} is {@code -1} on the sequential walk, which only learns an entry when it reaches it
+   * (issue #7385).
+   * <p>
+   * The server's control plane installs an {@link com.arcadedb.engine.OperationProgress} here so that
+   * {@code GET /api/v1/progress/&#123;database&#125;}, the console and Studio show a real percentage while a
+   * restore runs instead of nothing at all. Implementations must be cheap and non-blocking: on the parallel path
+   * this is called from the extraction workers, one call per archive entry.
+   */
+  public Restore setProgressCallback(final ProgressCallback progressCallback) {
+    this.progressCallback = progressCallback;
     return this;
   }
 

--- a/integration/src/main/java/com/arcadedb/integration/restore/format/AbstractRestoreFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/restore/format/AbstractRestoreFormat.java
@@ -22,20 +22,49 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.integration.importer.ConsoleLogger;
 import com.arcadedb.integration.restore.RestoreSettings;
 import com.arcadedb.utility.DateUtils;
+import com.arcadedb.utility.ProgressCallback;
 
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 public abstract class AbstractRestoreFormat {
+  /**
+   * The single step a restore format reports as, in the numbering the format itself owns (step 1 of 1). A caller
+   * that wraps the restore in a larger operation - the server's control plane, which also has a swap and a
+   * replicate phase - renumbers it on the way through rather than asking the format to know about phases it
+   * cannot see (issue #7385).
+   */
+  public static final String RESTORE_STEP_NAME = "Restoring files";
+
   protected final        RestoreSettings   settings;
   protected final        DatabaseInternal  database;
   protected final        ConsoleLogger     logger;
   protected static final DateTimeFormatter dateFormat = DateUtils.getFormatter("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneId.systemDefault());
 
+  /** Where the entry counters go, or null when the caller asked for none. */
+  protected ProgressCallback progressCallback;
+
   protected AbstractRestoreFormat(final DatabaseInternal database, final RestoreSettings settings, final ConsoleLogger logger) {
     this.database = database;
     this.settings = settings;
     this.logger = logger;
+  }
+
+  public void setProgressCallback(final ProgressCallback progressCallback) {
+    this.progressCallback = progressCallback;
+  }
+
+  /**
+   * Publishes how many archive entries are done out of how many there are, or out of {@code -1} when the path
+   * taken cannot know the denominator. A no-op when nobody asked for progress, which is the common case (the CLI
+   * and every embedded caller).
+   */
+  protected void reportRestoreProgress(final long done, final long total) {
+    // READ THE FIELD ONCE: the callback is installed before the restore starts, but reading it twice would still
+    // be two chances to see a null that the null check already passed.
+    final ProgressCallback callback = progressCallback;
+    if (callback != null)
+      callback.onProgress(RESTORE_STEP_NAME, 1, 1, done, total);
   }
 
   public abstract void restoreDatabase() throws Exception;

--- a/integration/src/main/java/com/arcadedb/integration/restore/format/FullRestoreFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/restore/format/FullRestoreFormat.java
@@ -111,7 +111,7 @@ public class FullRestoreFormat extends AbstractRestoreFormat {
     final long beginTime = System.currentTimeMillis();
 
     final ParallelZipExtractor.ExtractStats stats = parallel ?
-        new ParallelZipExtractor(threads, logger).extract(randomAccessArchive, databaseDirectory) :
+        new ParallelZipExtractor(threads, logger, progressCallback).extract(randomAccessArchive, databaseDirectory) :
         restoreSequentially(inputSource, databaseDirectory);
 
     final long elapsedInSecs = (System.currentTimeMillis() - beginTime) / 1000;
@@ -146,6 +146,10 @@ public class FullRestoreFormat extends AbstractRestoreFormat {
         databaseOrigSize += uncompressFile(zipFile, compressedFile, databaseDirectory);
         compressedFile = zipFile.getNextEntry();
         ++restoredFiles;
+        // -1 FOR THE DENOMINATOR BECAUSE THERE IS NO HONEST ONE HERE: THIS WALK LEARNS AN ENTRY ONLY WHEN IT
+        // REACHES IT, SO THE COUNT OF ENTRIES STILL TO COME IS NOT KNOWN UNTIL THERE ARE NONE. OperationProgress
+        // RENDERS -1 AS "PERCENTAGE UNKNOWN", WHICH IS THE TRUE ANSWER RATHER THAN A GUESSED ONE (ISSUE #7385)
+        reportRestoreProgress(restoredFiles, -1L);
       }
 
       zipFile.close();

--- a/integration/src/main/java/com/arcadedb/integration/restore/format/ParallelZipExtractor.java
+++ b/integration/src/main/java/com/arcadedb/integration/restore/format/ParallelZipExtractor.java
@@ -21,6 +21,7 @@ package com.arcadedb.integration.restore.format;
 import com.arcadedb.integration.importer.ConsoleLogger;
 import com.arcadedb.integration.restore.RestoreException;
 import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.ProgressCallback;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -112,13 +113,23 @@ public class ParallelZipExtractor {
   private final int                        threads;
   private final ConsoleLogger              logger;
   private final ArrayBlockingQueue<byte[]> bufferPool;
+  private final ProgressCallback           progressCallback;
 
   public ParallelZipExtractor(final int threads, final ConsoleLogger logger) {
+    this(threads, logger, null);
+  }
+
+  /**
+   * @param progressCallback fed one report per extracted entry, against the entry count this extractor reads out
+   *                         of the central directory before any worker starts (issue #7385), or null for none
+   */
+  public ParallelZipExtractor(final int threads, final ConsoleLogger logger, final ProgressCallback progressCallback) {
     if (threads < 1)
       throw new IllegalArgumentException("At least one restore thread is required");
     this.threads = threads;
     this.logger = logger;
     this.bufferPool = new ArrayBlockingQueue<>(threads);
+    this.progressCallback = progressCallback;
   }
 
   public ExtractStats extract(final File archive, final File databaseDirectory) throws IOException {
@@ -148,9 +159,16 @@ public class ParallelZipExtractor {
       // DURATION IS DECIDED BY HOW LATE THE BIGGEST ENTRY STARTS
       plan.sort(Comparator.comparingLong(planned -> -entryWeight(planned.entry())));
 
-      final int poolSize = Math.min(threads, plan.size());
+      final int totalEntries = plan.size();
+
+      final int poolSize = Math.min(threads, totalEntries);
       if (poolSize < 1)
         return new ExtractStats(0, 0L);
+
+      // THE ENTRY COUNT IS KNOWN HERE AND NOWHERE ELSE IN A RESTORE: THE CENTRAL DIRECTORY GIVES IT UP FRONT,
+      // WHICH IS WHY THIS PATH CAN REPORT A PERCENTAGE AND THE SEQUENTIAL WALK CANNOT (ISSUE #7385)
+      final AtomicInteger extracted = new AtomicInteger();
+      report(0, totalEntries);
 
       final AtomicInteger threadId = new AtomicInteger();
       // THE QUEUE IS UNBOUNDED, WHERE THE #6072 BACKUP WRITER THIS OTHERWISE MIRRORS USES A BOUNDED ONE WITH
@@ -168,15 +186,21 @@ public class ParallelZipExtractor {
       });
 
       try {
-        final List<Future<Long>> results = new ArrayList<>(plan.size());
+        final List<Future<Long>> results = new ArrayList<>(totalEntries);
         for (final PlannedEntry planned : plan)
-          results.add(executor.submit(uncompressEntry(zipFile, planned)));
+          results.add(executor.submit(uncompressEntry(zipFile, planned, extracted, totalEntries)));
 
         long databaseOrigSize = 0L;
         for (final Future<Long> result : results)
           databaseOrigSize += drain(result);
 
-        return new ExtractStats(plan.size(), databaseOrigSize);
+        // THE CLOSING REPORT, MADE BY THIS THREAD ONCE EVERY WORKER HAS BEEN COLLECTED. THE PER-ENTRY REPORTS
+        // ABOVE COME FROM THE WORKERS AND CAN INTERLEAVE - TWO THREADS THAT FINISH TOGETHER CAN PUBLISH n THEN
+        // n-1 - SO WITHOUT THIS A COMPLETED EXTRACTION COULD BE LEFT SHOWING ONE ENTRY SHORT FOR THE REST OF THE
+        // OPERATION. IT COSTS ONE CALL PER RESTORE
+        report(totalEntries, totalEntries);
+
+        return new ExtractStats(totalEntries, databaseOrigSize);
       } finally {
         // shutdownNow() ALONE IS NOT ENOUGH ON THE FAILURE PATH. IT DRAINS THE QUEUE, SO NO FURTHER ENTRY STARTS, BUT
         // THE INTERRUPT IT SENDS DOES NOT COME BACK OUT OF A FileOutputStream.write() OR A ZipFile READ - NEITHER IS
@@ -202,7 +226,14 @@ public class ParallelZipExtractor {
     }
   }
 
-  private Callable<Long> uncompressEntry(final ZipFile zipFile, final PlannedEntry planned) {
+  /** No-op when the caller installed no callback, which is every caller but the server's control plane. */
+  private void report(final long done, final long total) {
+    if (progressCallback != null)
+      progressCallback.onProgress(AbstractRestoreFormat.RESTORE_STEP_NAME, 1, 1, done, total);
+  }
+
+  private Callable<Long> uncompressEntry(final ZipFile zipFile, final PlannedEntry planned,
+      final AtomicInteger extracted, final int totalEntries) {
     return () -> {
       final ZipEntry entry = planned.entry();
       final File uncompressedFile = planned.target();
@@ -229,6 +260,11 @@ public class ParallelZipExtractor {
       } finally {
         bufferPool.offer(buffer);
       }
+
+      // BEFORE THE LOG LINE, NOT AFTER IT. A CALLER THAT WATCHES BOTH - THE SERVER'S CONTROL PLANE FEEDS THE LOG
+      // LINES TO ITS ProgressListener AND THE COUNTERS TO ITS OperationProgress - THEN NEVER SEES A LINE SAYING AN
+      // ENTRY IS DONE WHILE THE COUNTER STILL SAYS IT IS NOT (ISSUE #7385)
+      report(extracted.incrementAndGet(), totalEntries);
 
       final long compressedSize = entry.getCompressedSize();
       // ONE CALL, NOT THE log()+logLine() PAIR THE SEQUENTIAL PATH USES: SEVERAL THREADS LOG HERE AND A HALF-LINE

--- a/integration/src/test/java/com/arcadedb/integration/restore/Issue7385RestoreProgressCallbackTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/restore/Issue7385RestoreProgressCallbackTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.restore;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.integration.TestHelper;
+import com.arcadedb.integration.backup.Backup;
+import com.arcadedb.integration.importer.ConsoleLogger;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
+import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.ProgressCallback;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.LongStream;
+import java.util.zip.ZipFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7385: a restore now reports entry-level progress to a {@link ProgressCallback}, which is what lets
+ * {@code ServerControlPlane.performRestore} publish a percentage in {@code OperationProgressRegistry} rather
+ * than the coarse "running" marker an import is limited to.
+ * <p>
+ * The two restore paths report differently, and deliberately so. The parallel extractor (#6086) reads the whole
+ * entry list out of the ZIP central directory before any thread starts, so it has a real denominator; the
+ * sequential walk - the fallback for an http(s) or an encrypted archive - only learns an entry when it reaches
+ * it, so its denominator is {@code -1}, which {@code OperationProgress.getPercentage()} already renders as
+ * "unknown".
+ */
+class Issue7385RestoreProgressCallbackTest {
+  private static final String DATABASE_PATH = "target/databases/restore-progress-7385";
+  private static final String RESTORED_PATH = "target/databases/restore-progress-7385-restored";
+  private static final String BACKUP_FILE   = "target/restore-progress-7385.zip";
+  private static final int    RECORDS       = 5_000;
+
+  /** One {@link ProgressCallback} invocation, kept whole so the step numbering can be asserted too. */
+  private record Sample(String stepName, int stepIndex, int totalSteps, long done, long total) {
+  }
+
+  @BeforeAll
+  static void buildTheArchive() throws Exception {
+    clean();
+    try (final Database database = createDatabase()) {
+      new Backup(database, BACKUP_FILE).setVerboseLevel(0).backupDatabase();
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  @AfterAll
+  static void clean() {
+    FileUtils.deleteRecursively(new File(DATABASE_PATH));
+    FileUtils.deleteRecursively(new File(RESTORED_PATH));
+    new File(BACKUP_FILE).delete();
+  }
+
+  /**
+   * The parallel path knows how many entries there are before it starts, so every report carries that as the
+   * denominator. The per-entry reports come from the worker threads and can therefore interleave - what is
+   * asserted is the set of counts, not their arrival order - but the closing report is made by the coordinating
+   * thread once every worker has been joined, so the <i>last</i> value a reader sees is always the total.
+   */
+  @Test
+  void parallelRestoreReportsEntryCountsAgainstAKnownTotal() throws Exception {
+    final int entries = entriesInTheArchive();
+
+    final List<Sample> samples = restoreWithCallback(4);
+
+    assertThat(samples).isNotEmpty();
+    assertThat(samples).allSatisfy(sample -> {
+      assertThat(sample.stepName()).isEqualTo("Restoring files");
+      assertThat(sample.stepIndex()).isEqualTo(1);
+      assertThat(sample.totalSteps()).isEqualTo(1);
+      assertThat(sample.total()).isEqualTo(entries);
+    });
+
+    assertThat(samples).extracting(Sample::done).contains(0L, (long) entries);
+    assertThat(samples.getLast().done()).as("the closing report is authoritative").isEqualTo(entries);
+    assertThat(samples).extracting(Sample::done).allMatch(done -> done >= 0 && done <= entries);
+  }
+
+  /**
+   * The sequential walk cannot know the denominator, so it reports {@code -1} for it - and must still count up,
+   * because a restore that only ever says "running" is the very thing #7385 is about.
+   */
+  @Test
+  void sequentialRestoreReportsEntryCountsWithAnUnknownTotal() throws Exception {
+    final int entries = entriesInTheArchive();
+
+    final List<Sample> samples = restoreWithCallback(0);
+
+    assertThat(samples).isNotEmpty();
+    assertThat(samples).allSatisfy(sample -> {
+      assertThat(sample.stepName()).isEqualTo("Restoring files");
+      assertThat(sample.total()).as("the sequential walk has no denominator to report").isEqualTo(-1L);
+    });
+
+    // One thread, so this one really is ordered: 1, 2, ... entries.
+    assertThat(samples).extracting(Sample::done).containsExactlyElementsOf(
+        LongStream.rangeClosed(1, entries).boxed().toList());
+  }
+
+  /** Nobody has to ask for progress: a restore with no callback installed behaves exactly as it always did. */
+  @Test
+  void aRestoreWithoutACallbackStillRestores() {
+    FileUtils.deleteRecursively(new File(RESTORED_PATH));
+
+    new Restore(BACKUP_FILE, RESTORED_PATH).setRestoreThreads(4).setLogger(new ConsoleLogger(0)).restoreDatabase();
+
+    assertThat(new File(RESTORED_PATH)).isDirectory();
+    assertThat(new File(RESTORED_PATH).list()).isNotEmpty();
+  }
+
+  // ------------------------------------------------------------------------------------------------------- HELPERS
+
+  private static List<Sample> restoreWithCallback(final int threads) {
+    FileUtils.deleteRecursively(new File(RESTORED_PATH));
+
+    final List<Sample> samples = Collections.synchronizedList(new ArrayList<>());
+    new Restore(BACKUP_FILE, RESTORED_PATH)
+        .setRestoreThreads(threads)
+        .setLogger(new ConsoleLogger(0))
+        .setProgressCallback((stepName, stepIndex, totalSteps, done, total) ->
+            samples.add(new Sample(stepName, stepIndex, totalSteps, done, total)))
+        .restoreDatabase();
+
+    return List.copyOf(samples);
+  }
+
+  private static int entriesInTheArchive() throws Exception {
+    try (final ZipFile archive = new ZipFile(BACKUP_FILE)) {
+      return archive.size();
+    }
+  }
+
+  private static Database createDatabase() {
+    final Database database = new DatabaseFactory(DATABASE_PATH).create();
+    database.transaction(() -> {
+      final VertexType type = database.getSchema().createVertexType("Doc");
+      type.createProperty("id", Type.INTEGER);
+      type.createProperty("payload", Type.STRING);
+      type.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "id");
+    });
+
+    database.begin();
+    for (int i = 0; i < RECORDS; i++) {
+      database.newVertex("Doc").set("id", i).set("payload", "record-" + i + "-" + "x".repeat(200)).save();
+      if (i % 1000 == 0) {
+        database.commit();
+        database.begin();
+      }
+    }
+    database.commit();
+    return database;
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -42,6 +42,7 @@ import com.arcadedb.server.security.ServerSecurity;
 import com.arcadedb.server.security.ServerSecurityUser;
 import com.arcadedb.utility.FileUtils;
 import com.arcadedb.utility.IPAddressBlocklist;
+import com.arcadedb.utility.ProgressCallback;
 
 import java.io.File;
 import java.io.IOException;
@@ -1166,6 +1167,24 @@ public class ServerControlPlane {
   // ---------------------------------------------------------------------------------------------
 
   /**
+   * A server-side restore is three phases, not one, and the middle and last are not cheap: the swap drops the
+   * database the restore replaces, and in HA the replication makes every replica pull the restored files. They
+   * are published as separate steps so the progress endpoint keeps saying something after the archive has been
+   * extracted (issue #7385).
+   */
+  private static final int    RESTORE_STEPS          = 3;
+  /**
+   * Deliberately a copy of {@code AbstractRestoreFormat.RESTORE_STEP_NAME} rather than a reference to it:
+   * {@code arcadedb-integration} is an optional dependency reached only reflectively, so the server cannot name
+   * its constants at compile time. The two only have to agree so that the marker published before the restorer
+   * exists reads the same as the reports the restorer then sends; a drift costs a changed label mid-step and
+   * nothing more.
+   */
+  private static final String RESTORE_STEP_EXTRACT   = "Restoring files";
+  private static final String RESTORE_STEP_ACTIVATE  = "Activating database";
+  private static final String RESTORE_STEP_REPLICATE = "Replicating to the cluster";
+
+  /**
    * The sink a transport supplies for the progress of a long-running control-plane operation
    * (issue #7308). The HTTP handler turns each event into an SSE frame on the {@code
    * HttpServerExchange}; {@code ArcadeDbGrpcAdminService} turns it into a message on a
@@ -1218,7 +1237,7 @@ public class ServerControlPlane {
     if (new File(dbPath).exists())
       throw new IllegalArgumentException("Database '" + databaseName + "' already exists");
 
-    performRestore(databaseName, dbPath, url, listener);
+    performRestore(databaseName, dbPath, url, "restore database", listener);
   }
 
   /**
@@ -1251,7 +1270,7 @@ public class ServerControlPlane {
       throw new IllegalArgumentException(
           "Database '" + targetDatabase + "' already exists. Enable overwrite to replace it with the backup");
 
-    performRestore(targetDatabase, dbPath, "file://" + backupFile.toAbsolutePath(), listener);
+    performRestore(targetDatabase, dbPath, "file://" + backupFile.toAbsolutePath(), "restore backup", listener);
   }
 
   /**
@@ -1391,39 +1410,79 @@ public class ServerControlPlane {
    * database.
    * <p>
    * The caller is responsible for the pre-restore existence and overwrite checks.
+   *
+   * @param operation the label the operation is published under - the command the operator typed, so that a
+   *                  reader of the progress endpoint sees {@code restore backup} or {@code restore database}
+   *                  rather than one name standing for both
    */
   private void performRestore(final String databaseName, final String dbPath, final String url,
-      final ProgressListener listener) {
+      final String operation, final ProgressListener listener) {
     final File finalDir = new File(dbPath);
     final File tempDir = new File(finalDir.getParentFile(),
         ArcadeDBServer.RESERVED_DATABASE_PREFIX + "restore-tmp-" + databaseName + "-" + System.nanoTime());
 
+    // Published to GET /api/v1/progress/{database}, the console and Studio for the WHOLE restore - extraction,
+    // swap and replication alike - as runImport publishes the import (issue #7385). Before this, a restore that
+    // ran for minutes left the endpoint reporting an idle database that was in fact being replaced. Unlike the
+    // import, which has no record total to count against and can only publish a coarse marker, the restore
+    // reports real counters: see restoreProgressCallback below. Always retired in the finally.
+    final OperationProgress progress = OperationProgressRegistry.instance().register(databaseName, operation);
+    progress.onProgress(RESTORE_STEP_EXTRACT, 1, RESTORE_STEPS, 0, -1);
     try {
-      final Class<?> clazz = Class.forName("com.arcadedb.integration.restore.Restore");
-      final Object restorer = clazz.getConstructor(String.class, String.class).newInstance(url, tempDir.getAbsolutePath());
-      // The same boolean validateClientRestoreImportUrl() already validated this URL against: the fetch inside
-      // FullRestoreFormat must agree with this server's own configuration rather than falling back to the static
-      // default, or a per-server override that let the command through would still have the fetch refuse it.
-      clazz.getMethod("setAllowLocalUrls", boolean.class).invoke(restorer, isRestoreImportLocalUrlsAllowed());
-      clazz.getMethod("setLogger", loggerClass()).invoke(restorer, progressLogger(listener));
+      try {
+        final Class<?> clazz = Class.forName("com.arcadedb.integration.restore.Restore");
+        final Object restorer = clazz.getConstructor(String.class, String.class).newInstance(url, tempDir.getAbsolutePath());
+        // The same boolean validateClientRestoreImportUrl() already validated this URL against: the fetch inside
+        // FullRestoreFormat must agree with this server's own configuration rather than falling back to the static
+        // default, or a per-server override that let the command through would still have the fetch refuse it.
+        clazz.getMethod("setAllowLocalUrls", boolean.class).invoke(restorer, isRestoreImportLocalUrlsAllowed());
+        clazz.getMethod("setLogger", loggerClass()).invoke(restorer, progressLogger(listener));
+        installRestoreProgressCallback(clazz, restorer, progress);
 
-      listener.onProgress("Downloading and restoring " + databaseName + "...");
-      clazz.getMethod("restoreDatabase").invoke(restorer);
-    } catch (final InvocationTargetException e) {
-      FileUtils.deleteRecursively(tempDir);
-      throw new CommandExecutionException("Error restoring database", e.getTargetException());
-    } catch (final ReflectiveOperationException e) {
-      FileUtils.deleteRecursively(tempDir);
-      throw new CommandExecutionException("Restore libs not found in classpath", e);
-    } catch (final RuntimeException e) {
-      FileUtils.deleteRecursively(tempDir);
-      throw e;
+        listener.onProgress("Downloading and restoring " + databaseName + "...");
+        clazz.getMethod("restoreDatabase").invoke(restorer);
+      } catch (final InvocationTargetException e) {
+        FileUtils.deleteRecursively(tempDir);
+        throw new CommandExecutionException("Error restoring database", e.getTargetException());
+      } catch (final ReflectiveOperationException e) {
+        FileUtils.deleteRecursively(tempDir);
+        throw new CommandExecutionException("Restore libs not found in classpath", e);
+      } catch (final RuntimeException e) {
+        FileUtils.deleteRecursively(tempDir);
+        throw e;
+      }
+
+      progress.onProgress(RESTORE_STEP_ACTIVATE, 2, RESTORE_STEPS, 0, -1);
+      swapRestoredDatabase(databaseName, finalDir, tempDir);
+
+      // A no-op outside HA, and minutes inside it: forceSnapshot makes every replica pull the restored files.
+      progress.onProgress(RESTORE_STEP_REPLICATE, 3, RESTORE_STEPS, 0, -1);
+      replicateRestoredDatabase(server.getDatabase(databaseName), databaseName);
+      // Completion is the transport's to announce, not this method's: HTTP writes a 'completed' SSE
+      // frame, gRPC a final message with completed=true, and a synchronous caller just returns.
+    } finally {
+      OperationProgressRegistry.instance().unregister(progress);
     }
+  }
 
-    swapRestoredDatabase(databaseName, finalDir, tempDir);
-    replicateRestoredDatabase(server.getDatabase(databaseName), databaseName);
-    // Completion is the transport's to announce, not this method's: HTTP writes a 'completed' SSE
-    // frame, gRPC a final message with completed=true, and a synchronous caller just returns.
+  /**
+   * Installs {@code progress} as the restorer's progress callback, renumbering the format's own step - which is
+   * always 1 of 1, because the integration module knows nothing of the swap and replicate phases that follow it -
+   * into step 1 of this method's three (issue #7385).
+   * <p>
+   * Best-effort, like {@code importerContext}: a build of {@code arcadedb-integration} without the setter reports
+   * no counters rather than failing the restore. Progress is a convenience; the restore is what the caller asked
+   * for.
+   */
+  private static void installRestoreProgressCallback(final Class<?> restoreClass, final Object restorer,
+      final OperationProgress progress) {
+    final ProgressCallback callback =
+        (stepName, stepIndex, totalSteps, done, total) -> progress.onProgress(stepName, 1, RESTORE_STEPS, done, total);
+    try {
+      restoreClass.getMethod("setProgressCallback", ProgressCallback.class).invoke(restorer, callback);
+    } catch (final ReflectiveOperationException ignored) {
+      // No setter on this build: the coarse step markers above are still published.
+    }
   }
 
   /**

--- a/server/src/test/java/com/arcadedb/server/backup/Issue7385RestoreProgressIT.java
+++ b/server/src/test/java/com/arcadedb/server/backup/Issue7385RestoreProgressIT.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.backup;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.engine.OperationProgress;
+import com.arcadedb.engine.OperationProgressRegistry;
+import com.arcadedb.server.ServerControlPlane.ProgressListener;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.ServerControlPlane;
+import com.arcadedb.utility.FileUtils;
+
+import com.sun.net.httpserver.HttpServer;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7385: {@code restore backup} and {@code restore database} can run for minutes, and for that whole time
+ * {@code GET /api/v1/progress/{database}} used to say the database had nothing running - so Studio showed an
+ * idle database that was in fact being replaced. Every restore that goes through
+ * {@code ServerControlPlane.performRestore} now publishes an {@code OperationProgress} for its target database,
+ * retired in a {@code finally} on success and on failure alike.
+ * <p>
+ * The control-plane tests below are the deterministic ones: {@code performRestore} calls the caller's
+ * {@code ProgressListener} while the operation is live, so a listener that reads the registry at that moment
+ * observes the registration without racing it. They also stand in for the gRPC {@code RestoreDatabase} and
+ * {@code RestoreBackup} RPCs, which call exactly these two methods
+ * ({@code ArcadeDbGrpcAdminService.java:797} and {@code :821}), as HTTP does
+ * ({@code PostServerCommandHandler.java:423} and {@code :457}).
+ * <p>
+ * {@link #theProgressEndpointReportsARunningRestore} then closes the loop end to end over HTTP - the endpoint
+ * the issue is named after - against an archive served by a deliberately slow local HTTP server, so the window
+ * in which the restore is running is one the test controls rather than one it hopes for.
+ * <p>
+ * The startup {@code SERVER_DEFAULT_DATABASES} {@code restore:} command does not go through the control plane
+ * and is still silent: that is #7440.
+ */
+class Issue7385RestoreProgressIT extends BaseGraphServerTest {
+  private static final String BACKUP_DIR_NAME = "test-backups-7385-progress";
+  private static final String BACKUP_CONFIG   = """
+      {
+        "version": 1,
+        "enabled": true,
+        "backupDirectory": "%s",
+        "defaults": {
+          "enabled": true,
+          "runOnServer": "*",
+          "schedule": { "type": "frequency", "frequencyMinutes": 9999 },
+          "retention": { "maxFiles": 50 }
+        }
+      }
+      """.formatted(BACKUP_DIR_NAME);
+
+  private File         backupConfigFile;
+  private File         backupDir;
+  private final List<String> restoredDatabases = new ArrayList<>();
+
+  @Override
+  protected boolean isCreateDatabases() {
+    return true;
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+
+    try {
+      final File configDir = new File("./target/config");
+      configDir.mkdirs();
+
+      backupConfigFile = new File(configDir, "backup.json");
+      try (final FileWriter writer = new FileWriter(backupConfigFile)) {
+        writer.write(BACKUP_CONFIG);
+      }
+
+      backupDir = new File("./target/" + BACKUP_DIR_NAME);
+      if (backupDir.exists())
+        FileUtils.deleteRecursively(backupDir);
+      backupDir.mkdirs();
+    } catch (final IOException e) {
+      throw new RuntimeException("Failed to set up backup config", e);
+    }
+
+    config.setValue(GlobalConfiguration.SERVER_ROOT_PATH, "./target");
+    config.setValue(GlobalConfiguration.SERVER_PLUGINS, "auto-backup:" + AutoBackupSchedulerPlugin.class.getName());
+    // The archives this test restores are local files and a loopback HTTP server, both of which the SSRF guard
+    // blocks by default. Opt in the way an operator restoring from their own filesystem would (issue #6381).
+    config.setValue(GlobalConfiguration.SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS, true);
+  }
+
+  @AfterEach
+  void cleanUp() {
+    for (final String name : restoredDatabases) {
+      try {
+        final ArcadeDBServer server = getServer(0);
+        if (server.existsDatabase(name))
+          server.getDatabase(name).getEmbedded().drop();
+      } catch (final Exception ignore) {
+        // best-effort
+      }
+    }
+    restoredDatabases.clear();
+    if (backupConfigFile != null && backupConfigFile.exists())
+      backupConfigFile.delete();
+    if (backupDir != null && backupDir.exists())
+      FileUtils.deleteRecursively(backupDir);
+  }
+
+  /**
+   * {@code restore database <name> <url>} - the HTTP verb and the gRPC {@code RestoreDatabase} RPC both land
+   * here.
+   */
+  @Test
+  void restoreDatabasePublishesProgressAtTheControlPlane() throws Exception {
+    final String target = register("progress7385_db");
+    final File archive = takeABackup();
+
+    final List<JSONObject> observed = Collections.synchronizedList(new ArrayList<>());
+    new ServerControlPlane(getServer(0)).restoreDatabase(target, "file://" + archive.getAbsolutePath(),
+        sampler(target, observed));
+
+    assertThat(observed).as("nothing was published while the restore ran").isNotEmpty();
+    assertThat(observed).allSatisfy(op -> {
+      assertThat(op.getString("database")).isEqualTo(target);
+      assertThat(op.getString("operation")).isEqualTo("restore database");
+      assertThat(op.getInt("totalSteps")).isEqualTo(3);
+    });
+
+    // A LOCAL ARCHIVE TAKES THE PARALLEL PATH, WHICH KNOWS ITS ENTRY COUNT, SO A REAL DENOMINATOR HAS TO REACH
+    // THE REGISTRY. THIS IS THE ONLY ASSERTION THAT CAN CATCH installRestoreProgressCallback FAILING TO FIND THE
+    // SETTER: IT SWALLOWS THE ReflectiveOperationException BY DESIGN, SO THE COARSE STEP MARKERS ABOVE WOULD
+    // STILL BE PUBLISHED AND EVERYTHING ELSE HERE WOULD STILL PASS
+    assertThat(observed).anySatisfy(op -> {
+      assertThat(op.getLong("total")).as("the archive entry count never reached the registry").isGreaterThan(0L);
+      assertThat(op.getLong("done")).isGreaterThan(0L);
+      assertThat(op.getInt("percentage")).isBetween(0, 100);
+    });
+
+    assertThat(getServer(0).existsDatabase(target)).isTrue();
+    assertThat(OperationProgressRegistry.instance().getOperations(target))
+        .as("the operation must be retired when the restore returns").isEmpty();
+  }
+
+  /**
+   * {@code restore backup <db> <file> as <target>} - the HTTP verb and the gRPC {@code RestoreBackup} RPC both
+   * land here. It carries its own operation label, because that is the command the operator typed.
+   */
+  @Test
+  void restoreBackupPublishesProgressAtTheControlPlane() throws Exception {
+    final String target = register("progress7385_backup");
+    final String fileName = takeABackup().getName();
+
+    final List<JSONObject> observed = Collections.synchronizedList(new ArrayList<>());
+    new ServerControlPlane(getServer(0)).restoreBackup(getDatabaseName(), fileName, target, false,
+        sampler(target, observed));
+
+    assertThat(observed).isNotEmpty();
+    assertThat(observed).allSatisfy(op -> {
+      assertThat(op.getString("database")).isEqualTo(target);
+      assertThat(op.getString("operation")).isEqualTo("restore backup");
+    });
+
+    assertThat(getServer(0).existsDatabase(target)).isTrue();
+    assertThat(OperationProgressRegistry.instance().getOperations(target)).isEmpty();
+  }
+
+  /**
+   * The half that matters more than the publication itself: a restore that fails must not leave a phantom
+   * operation behind for the rest of the life of the process.
+   */
+  @Test
+  void aFailedRestoreRetiresTheOperation() throws Exception {
+    final String target = register("progress7385_failed");
+    final File archive = takeABackup();
+    Files.write(archive.toPath(), "not a valid zip archive".getBytes(StandardCharsets.UTF_8));
+
+    final List<JSONObject> observed = Collections.synchronizedList(new ArrayList<>());
+    final ServerControlPlane controlPlane = new ServerControlPlane(getServer(0));
+
+    assertThatThrownBy(() -> controlPlane.restoreDatabase(target, "file://" + archive.getAbsolutePath(),
+        sampler(target, observed))).isInstanceOf(RuntimeException.class);
+
+    assertThat(observed).as("the operation must be published before the failure, not after it").isNotEmpty();
+    assertThat(OperationProgressRegistry.instance().getOperations(target))
+        .as("a failed restore must retire its operation too").isEmpty();
+  }
+
+  /**
+   * End to end over HTTP, on the endpoint the issue is named after. The archive is served by a local HTTP server
+   * that trickles it out, which does two things: it forces the sequential restore path (an http(s) body cannot be
+   * opened for random access) and it makes the window in which the restore is running long enough to poll without
+   * racing it.
+   */
+  @Test
+  @Timeout(120)
+  void theProgressEndpointReportsARunningRestore() throws Exception {
+    final String target = register("progress7385_http");
+    final byte[] archive = Files.readAllBytes(takeABackup().toPath());
+
+    final HttpServer archiveServer = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+    archiveServer.createContext("/backup.zip", exchange -> {
+      exchange.sendResponseHeaders(200, archive.length);
+      try (final OutputStream out = exchange.getResponseBody()) {
+        // 20 slices, 50 ms apart: about a second of restore, from a handful of milliseconds of real work.
+        final int slice = Math.max(1, archive.length / 20);
+        for (int offset = 0; offset < archive.length; offset += slice) {
+          out.write(archive, offset, Math.min(slice, archive.length - offset));
+          out.flush();
+          try {
+            Thread.sleep(50);
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+          }
+        }
+      }
+    });
+    archiveServer.start();
+
+    try {
+      final String url = "http://localhost:" + archiveServer.getAddress().getPort() + "/backup.zip";
+      final AtomicReference<HttpResponse<String>> restoreResponse = new AtomicReference<>();
+      final AtomicReference<Exception> restoreFailure = new AtomicReference<>();
+
+      final Thread restore = new Thread(() -> {
+        try {
+          restoreResponse.set(postCommand("restore database " + target + " " + url));
+        } catch (final Exception e) {
+          restoreFailure.set(e);
+        }
+      }, "issue7385-restore");
+      restore.setDaemon(true);
+      restore.start();
+
+      JSONObject seen = null;
+      while (restore.isAlive() && seen == null) {
+        final HttpResponse<String> poll = getProgress(target);
+        assertThat(poll.statusCode()).as("progress poll: %s", poll.body()).isEqualTo(200);
+        final JSONArray operations = new JSONObject(poll.body()).getJSONArray("result");
+        if (!operations.isEmpty())
+          seen = operations.getJSONObject(0);
+        else
+          Thread.sleep(5);
+      }
+      restore.join();
+
+      assertThat(restoreFailure.get()).isNull();
+      assertThat(restoreResponse.get().statusCode()).isEqualTo(200);
+
+      assertThat(seen).as("the progress endpoint reported nothing for the whole restore").isNotNull();
+      assertThat(seen.getString("operation")).isEqualTo("restore database");
+      assertThat(seen.getString("database")).isEqualTo(target);
+      assertThat(seen.getInt("totalSteps")).isEqualTo(3);
+
+      assertThat(new JSONObject(getProgress(target).body()).getJSONArray("result").length())
+          .as("the operation must be retired when the restore returns").isZero();
+      assertThat(getServer(0).existsDatabase(target)).isTrue();
+    } finally {
+      archiveServer.stop(0);
+    }
+  }
+
+  // ------------------------------------------------------------------------------------------------------- HELPERS
+
+  /**
+   * A {@code ProgressListener} that takes a JSON SNAPSHOT of the database's running operations every time the
+   * restore reports a line - which {@code performRestore} does while the operation is live, so the registration is
+   * observed rather than raced.
+   * <p>
+   * The snapshot is the point. {@code getOperations} hands back the live {@link OperationProgress} objects the
+   * producer is still writing to, so keeping the references would mean asserting, at the end, on whatever the last
+   * write left behind: every sample would read alike and the counters would all show the final step. {@code
+   * toJSON} is also exactly what the progress endpoint serializes, so what is asserted here is what a caller sees.
+   */
+  private static ProgressListener sampler(final String databaseName, final List<JSONObject> into) {
+    return message -> {
+      for (final OperationProgress op : OperationProgressRegistry.instance().getOperations(databaseName))
+        into.add(op.toJSON());
+    };
+  }
+
+  private String register(final String databaseName) {
+    restoredDatabases.add(databaseName);
+    return databaseName;
+  }
+
+  /** Produces a real backup of the seeded database and returns the archive on disk. */
+  private File takeABackup() throws Exception {
+    assertThat(postCommand("trigger backup " + getDatabaseName()).statusCode()).isEqualTo(200);
+
+    final JSONArray backups = new JSONObject(postCommand("list backups " + getDatabaseName()).body())
+        .getJSONArray("backups");
+    assertThat(backups.length()).isEqualTo(1);
+
+    final File archive = new File(new File(backupDir, getDatabaseName()),
+        backups.getJSONObject(0).getString("fileName"));
+    assertThat(archive).exists();
+    return archive;
+  }
+
+  private HttpResponse<String> getProgress(final String databaseName) throws Exception {
+    return send(HttpRequest.newBuilder()
+        .uri(new URI("http://localhost:" + getServer(0).getHttpServer().getPort() + "/api/v1/progress/" + databaseName))
+        .GET());
+  }
+
+  private HttpResponse<String> postCommand(final String command) throws Exception {
+    return send(HttpRequest.newBuilder()
+        .uri(new URI("http://localhost:" + getServer(0).getHttpServer().getPort() + "/api/v1/server"))
+        .header("Content-Type", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString(new JSONObject().put("command", command).toString())));
+  }
+
+  private static HttpResponse<String> send(final HttpRequest.Builder builder) throws Exception {
+    final HttpRequest request = builder.header("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes())).build();
+    return HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+  }
+}


### PR DESCRIPTION
Closes #7385

`GET /api/v1/progress/{database}` reports the long-running operations of a database, and the console and Studio render it - but a **restore** registered nothing, so for the minutes a `restore backup` or `restore database` runs the endpoint said the database had nothing running. `ServerControlPlane.performRestore` now registers an `OperationProgress` before the first byte is extracted and retires it in a `finally` that spans all three phases of a server-side restore (extract, swap, replicate), published as steps 1, 2 and 3 so the endpoint keeps saying something after the archive is unpacked. And unlike the import - which has no record total to count against and can only publish a coarse "running" marker - the restore reports **real counters**: `Restore` gains `setProgressCallback(ProgressCallback)`, the parallel extractor (#6086) reports `done/total` against the entry count it reads out of the ZIP central directory before any worker starts, and the sequential walk (the fallback for an http(s) or an encrypted archive, which only learns an entry when it reaches it) reports `done` against `-1`, which `OperationProgress.getPercentage()` already renders as "unknown".

Two details worth a reviewer's eye. The parallel path's closing report is made by the coordinating thread once every worker has been collected, because the per-entry reports come from several threads and can publish `n` then `n-1` - without it a finished extraction could read one entry short for the rest of the operation. And `installRestoreProgressCallback` swallows a missing setter by design (`arcadedb-integration` is optional and reached reflectively, the same shape as `importerContext`), which is exactly why the IT asserts a `total > 0` actually reaches the registry: without that assertion a build that silently stopped installing the callback would still publish the coarse markers and every other assertion would still pass.

No Studio change is needed. Studio's own two restore actions already ask for `text/event-stream` and render the restore's log lines; `startCommandProgressMonitor` is the query editor's poller and matches SQL commands only, and there is no `RESTORE DATABASE` SQL statement. What was blind is what the issue's scope note names: a third party looking at the database - another Studio session, the console, an operator with curl.

## Test plan

- [ ] `mvn -o -pl integration -Pintegration -DexcludedGroups=benchmark verify` - 129 ITs green, including `Issue6086ParallelRestoreIT` (19) and the new `Issue7385RestoreProgressCallbackTest` (3: parallel counters against a known total, sequential counters with an unknown one, and a restore with no callback at all)
- [ ] `mvn -o -pl server -Pintegration -Dit.test='com.arcadedb.server.backup.*IT' verify` - 1042 unit tests and 32 backup/restore ITs green, including the new `Issue7385RestoreProgressIT` (4)
- [ ] `mvn -o -pl grpcw -Pintegration -Dit.test='Issue7308Grpc*IT,Issue7310Grpc*IT' verify` - 37 green
- [ ] Manually: start a server, `POST /api/v1/server` with `restore database <name> <a large archive URL>`, and poll `GET /api/v1/progress/<name>` from a second terminal - it reports `restore database`, `[step 1/3] Restoring files` and a percentage, then steps 2 and 3, then nothing

The tests were proved able to fail. Three canary runs, each reverted: dropping the callback installation in `Restore.restoreDatabase()` fails 2/3 of the integration test; registering under `databaseName + "-CANARY"` fails 4/4 of the IT; and looking up a `setProgressCallbackCANARY` method fails the `total > 0` assertion alone. That last canary also caught a real defect in the test on its first run - `getOperations` hands back the **live** `OperationProgress` objects the producer is still writing to, so collecting the references made every "sample" read alike at the end. The sampler takes an `op.toJSON()` snapshot instead, which is also exactly what the endpoint serializes.

## Coverage

| Entry point | Covered | Test |
|---|---|---|
| HTTP `restore database <name> <url>` | yes | `Issue7385RestoreProgressIT.restoreDatabasePublishesProgressAtTheControlPlane` + `theProgressEndpointReportsARunningRestore` (end to end over HTTP) |
| HTTP `restore backup <db> <file> as <target>` | yes | `restoreBackupPublishesProgressAtTheControlPlane` |
| gRPC `RestoreDatabase` | yes | same shared `ServerControlPlane.restoreDatabase` the RPC calls (`ArcadeDbGrpcAdminService.java:821`) |
| gRPC `RestoreBackup` | yes | same shared `ServerControlPlane.restoreBackup` the RPC calls (`ArcadeDbGrpcAdminService.java:797`) |
| a restore that fails must still retire the operation | yes | `aFailedRestoreRetiresTheOperation` |
| parallel extractor counters | yes | `Issue7385RestoreProgressCallbackTest.parallelRestoreReportsEntryCountsAgainstAKnownTotal` |
| sequential walk counters | yes | `Issue7385RestoreProgressCallbackTest.sequentialRestoreReportsEntryCountsWithAnUnknownTotal` |

**Known gaps**

- **#7440** - the startup `SERVER_DEFAULT_DATABASES` `{restore:<url>}` command in `ArcadeDBServer.loadDefaultDatabases()` still publishes nothing. It is genuinely observable (`httpServer.startService()` runs at `:386`, `loadDefaultDatabases()` at `:408`, so the endpoint is already listening), but it does not go through the control plane, has no `ProgressListener`, and cannot be driven from a test deterministically - so it is filed rather than fixed blind and untested.
- `Restore.main()` (the CLI) is **argued, not filed**: the registry is process-local and has exactly two readers (`ServerControlPlane.java:255` and the console's own poller at `Console.java:1165`), neither of which exists in a `Restore.main()` JVM that calls `System.exit(0)` when it returns.

Full analysis, the completeness sweep with its grep evidence, and the adversarial pass are in `docs/7385-restore-operation-progress.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4kKMPe6TUwc36ZCZr6iBR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Restore operations now report live progress while extracting files, activating the database, and replicating data.
  - Progress is available for both database and backup restore workflows, including parallel and sequential restores.
  - Restore progress can be monitored through the server’s progress reporting endpoint.

- **Documentation**
  - Updated operation progress documentation to include restore operations and their reporting phases.

- **Bug Fixes**
  - Restores no longer appear idle while work is actively progressing.
  - Progress is properly finalized when a restore completes or fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->