### PR TITLE
fix(#7448): GraphBatch wrote the header end offset one byte short on property-less edges

### DIFF
--- a/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
@@ -1126,9 +1126,13 @@ public class GraphBatch implements AutoCloseable {
     buffer.putNumber(inPos);
 
     if (propCount == 0) {
-      // No properties — write empty header
-      buffer.putInt(buffer.position() + Binary.INT_SERIALIZED_SIZE);
+      // No properties: the header is the count alone and the header end offset points PAST it, where the values section
+      // would start, the same layout BinarySerializer.serializeProperties() writes. Pointing at the count instead (one
+      // byte short) made the reader's property-count validation reject every such edge as corrupted (#7448)
+      final int headerSizePos = buffer.position();
+      buffer.putInt(0);
       buffer.putUnsignedNumber(0);
+      buffer.putInt(headerSizePos, buffer.position());
       buffer.flip();
       return buffer;
     }

--- a/engine/src/main/java/com/arcadedb/serializer/BinarySerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinarySerializer.java
@@ -84,6 +84,12 @@ import java.util.logging.Level;
  * TODO: efficient, because it doesn't need to unmarshall all the values first.
  */
 public class BinarySerializer {
+  /**
+   * Header bytes a property-less record written by {@code GraphBatch} before #7448 is short of: its header end offset
+   * points at the property count instead of past it. See {@link #checkPropertyCount}.
+   */
+  private static final int LEGACY_EMPTY_HEADER_SHORTFALL = -1;
+
   private final BinaryComparator comparator = new BinaryComparator();
   private       Class<?>         dateImplementation;
   private       Class<?>         dateTimeImplementation;
@@ -980,11 +986,19 @@ public class BinarySerializer {
     final int properties = checkDeserializedCount(buffer.getUnsignedNumber(), buffer);
 
     final int headerBytesLeft = headerEndOffset - buffer.position();
-    if (headerBytesLeft < properties * 2L)
+    if (headerBytesLeft < properties * 2L) {
+      // Property-less edges written by GraphBatch before #7448 carry a header end offset that points AT the count byte
+      // rather than past it: exactly one byte short, with exactly zero properties. Nothing is read past the count of
+      // such a record, so it is well-formed for every purpose but this check, and databases bulk-loaded before the fix
+      // keep that layout on disk. Accept that one shape; any other shortfall is still corruption
+      if (properties == 0 && headerBytesLeft == LEGACY_EMPTY_HEADER_SHORTFALL)
+        return 0;
+
       throw new SerializationException(
           "Error on deserialize record. It may be corrupted (properties=" + properties + " do not fit in the "
               + headerBytesLeft + " header bytes before headerEndOffset=" + headerEndOffset + " at position " + initialPosition
               + ")");
+    }
 
     return properties;
   }

--- a/engine/src/test/java/com/arcadedb/graph/Issue7448GraphBatchEmptyEdgeHeaderTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue7448GraphBatchEmptyEdgeHeaderTest.java
@@ -23,16 +23,13 @@ import com.arcadedb.database.BaseRecord;
 import com.arcadedb.database.Binary;
 import com.arcadedb.database.DocumentInternal;
 import com.arcadedb.database.RID;
-import com.arcadedb.log.LogManager;
-import com.arcadedb.log.Logger;
+import com.arcadedb.log.WarningCapture;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.logging.Level;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -65,89 +62,32 @@ class Issue7448GraphBatchEmptyEdgeHeaderTest extends TestHelper {
       batch.newEdge(vertices[0], "Cite7448", vertices[1]);
     }
 
-    final List<String> reported = new CopyOnWriteArrayList<>();
-    final Logger originalLogger = LogManager.instance().getLogger();
-    LogManager.instance().setLogger(new CapturingLogger(reported, originalLogger));
-    try {
-      database.transaction(() -> {
-        try (final ResultSet rs = database.query("sql", "select from Cite7448")) {
-          assertThat(rs.hasNext()).isTrue();
-          final Result row = rs.next();
-          final Edge edge = row.toElement().asEdge();
+    final List<String> reported = WarningCapture.captureWarnings(() -> database.transaction(() -> {
+      try (final ResultSet rs = database.query("sql", "select from Cite7448")) {
+        assertThat(rs.hasNext()).isTrue();
+        final Result row = rs.next();
+        final Edge edge = row.toElement().asEdge();
 
-          assertThat(edge.getOut()).isEqualTo(vertices[0]);
-          assertThat(edge.getIn()).isEqualTo(vertices[1]);
-          assertThat(edge.getPropertyNames()).isEmpty();
-          assertThat(edge.toMap(false)).isEmpty();
-          assertThat(edge.toJSON().has("@rid")).isTrue();
-          assertThat(row.getPropertyNames()).isEmpty();
-          assertThat(rs.hasNext()).isFalse();
+        assertThat(edge.getOut()).isEqualTo(vertices[0]);
+        assertThat(edge.getIn()).isEqualTo(vertices[1]);
+        assertThat(edge.getPropertyNames()).isEmpty();
+        assertThat(edge.toMap(false)).isEmpty();
+        assertThat(edge.toJSON().has("@rid")).isTrue();
+        assertThat(row.getPropertyNames()).isEmpty();
+        assertThat(rs.hasNext()).isFalse();
 
-          // The accessors above materialised the record: its header end offset must point right past the property
-          // count, where the values section starts, the same layout BinarySerializer.serializeProperties() writes
-          final Binary buffer = ((BaseRecord) edge).getBuffer();
-          buffer.position(((DocumentInternal) edge).getPropertiesStartingPosition());
-          final int headerEndOffset = buffer.getInt();
-          assertThat(buffer.getUnsignedNumber()).isZero();
-          assertThat(headerEndOffset).as("header end offset must follow the property count").isEqualTo(buffer.position());
-        }
-      });
-
-      assertThat(reported.stream().filter(m -> m.contains("Possible corrupted record")).toList())
-          .as("a property-less batch edge must not be reported as corrupted (captured=%s)", reported)
-          .isEmpty();
-    } finally {
-      LogManager.instance().setLogger(originalLogger);
-    }
-  }
-
-  /**
-   * Captures WARNING-and-above messages into a list while forwarding every record to the production logger.
-   */
-  private static final class CapturingLogger implements Logger {
-    private final List<String> messages;
-    private final Logger       delegate;
-
-    CapturingLogger(final List<String> messages, final Logger delegate) {
-      this.messages = messages;
-      this.delegate = delegate;
-    }
-
-    private void capture(final Level level, final String message, final Object... args) {
-      if (message == null || level.intValue() < Level.WARNING.intValue())
-        return;
-      String formatted = message;
-      if (args != null && args.length > 0) {
-        try {
-          formatted = message.formatted(args);
-        } catch (final Exception ignored) {
-          // Fall back to the raw template, good enough for the substring matching above.
-        }
+        // The accessors above materialised the record: its header end offset must point right past the property
+        // count, where the values section starts, the same layout BinarySerializer.serializeProperties() writes
+        final Binary buffer = ((BaseRecord) edge).getBuffer();
+        buffer.position(((DocumentInternal) edge).getPropertiesStartingPosition());
+        final int headerEndOffset = buffer.getInt();
+        assertThat(buffer.getUnsignedNumber()).isZero();
+        assertThat(headerEndOffset).as("header end offset must follow the property count").isEqualTo(buffer.position());
       }
-      messages.add(formatted);
-    }
+    }));
 
-    @Override
-    public void log(final Object requester, final Level level, final String message, final Throwable exception,
-        final String context, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5,
-        final Object arg6, final Object arg7, final Object arg8, final Object arg9, final Object arg10, final Object arg11,
-        final Object arg12, final Object arg13, final Object arg14, final Object arg15, final Object arg16, final Object arg17) {
-      capture(level, message, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15,
-          arg16, arg17);
-      delegate.log(requester, level, message, exception, context, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10,
-          arg11, arg12, arg13, arg14, arg15, arg16, arg17);
-    }
-
-    @Override
-    public void log(final Object requester, final Level level, final String message, final Throwable exception,
-        final String context, final Object... args) {
-      capture(level, message, args);
-      delegate.log(requester, level, message, exception, context, args);
-    }
-
-    @Override
-    public void flush() {
-      delegate.flush();
-    }
+    assertThat(reported.stream().filter(m -> m.contains("Possible corrupted record")).toList())
+        .as("a property-less batch edge must not be reported as corrupted (captured=%s)", reported)
+        .isEmpty();
   }
 }

--- a/engine/src/test/java/com/arcadedb/graph/Issue7448GraphBatchEmptyEdgeHeaderTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue7448GraphBatchEmptyEdgeHeaderTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.BaseRecord;
+import com.arcadedb.database.Binary;
+import com.arcadedb.database.DocumentInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.log.Logger;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression for issue #7448 (discussion #7439): every edge written by {@link GraphBatch} without properties was reported
+ * as corrupted the first time its properties were read. The bulk writer stored the header end offset one byte short,
+ * pointing at the property count instead of past it, and the property-count validation added for #5774 rejects that.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7448GraphBatchEmptyEdgeHeaderTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Work7448");
+      database.getSchema().createEdgeType("Cite7448");
+    });
+  }
+
+  @Test
+  void propertyLessEdgeFromGraphBatchReadsBackClean() {
+    final RID[] vertices = new RID[2];
+    database.transaction(() -> {
+      for (int i = 0; i < vertices.length; i++)
+        vertices[i] = database.newVertex("Work7448").set("id", i).save().getIdentity();
+    });
+
+    try (final GraphBatch batch = GraphBatch.builder(database).withLightEdges(false).build()) {
+      batch.newEdge(vertices[0], "Cite7448", vertices[1]);
+    }
+
+    final List<String> reported = new CopyOnWriteArrayList<>();
+    final Logger originalLogger = LogManager.instance().getLogger();
+    LogManager.instance().setLogger(new CapturingLogger(reported, originalLogger));
+    try {
+      database.transaction(() -> {
+        try (final ResultSet rs = database.query("sql", "select from Cite7448")) {
+          assertThat(rs.hasNext()).isTrue();
+          final Result row = rs.next();
+          final Edge edge = row.toElement().asEdge();
+
+          assertThat(edge.getOut()).isEqualTo(vertices[0]);
+          assertThat(edge.getIn()).isEqualTo(vertices[1]);
+          assertThat(edge.getPropertyNames()).isEmpty();
+          assertThat(edge.toMap(false)).isEmpty();
+          assertThat(edge.toJSON().has("@rid")).isTrue();
+          assertThat(row.getPropertyNames()).isEmpty();
+          assertThat(rs.hasNext()).isFalse();
+
+          // The accessors above materialised the record: its header end offset must point right past the property
+          // count, where the values section starts, the same layout BinarySerializer.serializeProperties() writes
+          final Binary buffer = ((BaseRecord) edge).getBuffer();
+          buffer.position(((DocumentInternal) edge).getPropertiesStartingPosition());
+          final int headerEndOffset = buffer.getInt();
+          assertThat(buffer.getUnsignedNumber()).isZero();
+          assertThat(headerEndOffset).as("header end offset must follow the property count").isEqualTo(buffer.position());
+        }
+      });
+
+      assertThat(reported.stream().filter(m -> m.contains("Possible corrupted record")).toList())
+          .as("a property-less batch edge must not be reported as corrupted (captured=%s)", reported)
+          .isEmpty();
+    } finally {
+      LogManager.instance().setLogger(originalLogger);
+    }
+  }
+
+  /**
+   * Captures WARNING-and-above messages into a list while forwarding every record to the production logger.
+   */
+  private static final class CapturingLogger implements Logger {
+    private final List<String> messages;
+    private final Logger       delegate;
+
+    CapturingLogger(final List<String> messages, final Logger delegate) {
+      this.messages = messages;
+      this.delegate = delegate;
+    }
+
+    private void capture(final Level level, final String message, final Object... args) {
+      if (message == null || level.intValue() < Level.WARNING.intValue())
+        return;
+      String formatted = message;
+      if (args != null && args.length > 0) {
+        try {
+          formatted = message.formatted(args);
+        } catch (final Exception ignored) {
+          // Fall back to the raw template, good enough for the substring matching above.
+        }
+      }
+      messages.add(formatted);
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5,
+        final Object arg6, final Object arg7, final Object arg8, final Object arg9, final Object arg10, final Object arg11,
+        final Object arg12, final Object arg13, final Object arg14, final Object arg15, final Object arg16, final Object arg17) {
+      capture(level, message, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15,
+          arg16, arg17);
+      delegate.log(requester, level, message, exception, context, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10,
+          arg11, arg12, arg13, arg14, arg15, arg16, arg17);
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object... args) {
+      capture(level, message, args);
+      delegate.log(requester, level, message, exception, context, args);
+    }
+
+    @Override
+    public void flush() {
+      delegate.flush();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/serializer/BinarySerializerTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/BinarySerializerTest.java
@@ -1008,6 +1008,59 @@ class BinarySerializerTest extends TestHelper {
   }
 
   /**
+   * Regression for #7448: {@code GraphBatch} used to write property-less edges with the header end offset pointing at
+   * the property count instead of past it, one byte short. Nothing is read past the count of such a record, so it is
+   * well-formed for every purpose but the #5774 count validation. Databases loaded before the fix keep that layout on
+   * disk, and the reader has to keep accepting exactly that shape, silently, while still reporting anything else.
+   */
+  @Test
+  void deserializeAcceptsLegacyEmptyHeaderOneByteShortButNothingElse() {
+    final BinarySerializer serializer = new BinarySerializer(database.getConfiguration());
+    final List<String> reported = new CopyOnWriteArrayList<>();
+    final Logger originalLogger = LogManager.instance().getLogger();
+    LogManager.instance().setLogger(new CapturingLogger(reported, originalLogger));
+    try {
+      // Legacy shape: [headerEndOffset = position of the count][count = 0]
+      final Binary legacy = new Binary();
+      legacy.putInt(legacy.position() + Binary.INT_SERIALIZED_SIZE);
+      legacy.putUnsignedNumber(0);
+      legacy.flip();
+
+      assertThat(serializer.deserializeProperties(database, bufferPositionedAt(legacy.toByteArray(), 0), null, null)).isEmpty();
+      assertThat(serializer.getPropertyNames(database, bufferPositionedAt(legacy.toByteArray(), 0), null)).isEmpty();
+      assertThat(reported.stream().filter(m -> m.contains("Possible corrupted record")).toList())
+          .as("the legacy property-less layout must read back silently (captured=%s)", reported)
+          .isEmpty();
+
+      // One byte short with one property is still corruption: the pair cannot fit in the header
+      final Binary oneProperty = new Binary();
+      oneProperty.putInt(oneProperty.position() + Binary.INT_SERIALIZED_SIZE);
+      oneProperty.putUnsignedNumber(1);
+      oneProperty.putUnsignedNumber(0);
+      oneProperty.putUnsignedNumber(0);
+      oneProperty.flip();
+      assertThat(serializer.deserializeProperties(database, bufferPositionedAt(oneProperty.toByteArray(), 0), null, null))
+          .isEmpty();
+      assertThat(reported.stream().filter(m -> m.contains("Possible corrupted record")).toList())
+          .as("a header end offset before a non-empty property list must still be reported (captured=%s)", reported)
+          .hasSize(1);
+
+      // Two bytes short with zero properties is not the legacy shape either
+      final Binary twoShort = new Binary();
+      twoShort.putInt(twoShort.position() + Binary.INT_SERIALIZED_SIZE - 1);
+      twoShort.putUnsignedNumber(0);
+      twoShort.flip();
+      assertThat(serializer.deserializeProperties(database, bufferPositionedAt(twoShort.toByteArray(), 0), null, null))
+          .isEmpty();
+      assertThat(reported.stream().filter(m -> m.contains("Possible corrupted record")).toList())
+          .as("only the exact one-byte-short empty header is legacy, anything else is corruption (captured=%s)", reported)
+          .hasSize(2);
+    } finally {
+      LogManager.instance().setLogger(originalLogger);
+    }
+  }
+
+  /**
    * Wraps a serialized record in a fresh {@link Binary} whose size is exactly the record size, positioned at the given
    * offset. A separate copy per call keeps each accessor under test independent of the others.
    */


### PR DESCRIPTION
Fixes #7448, reported in discussion #7439.

## What was wrong

After a `GraphImporter` load of ~4.2M vertices and ~75M edges, `SELECT FROM CITE` returned rows but the server logged a `SerializationException` for **every** edge:

```
Possible corrupted record #7:0, returning 0 properties read so far
SerializationException: Error on deserialize record. It may be corrupted (properties=0 do not fit in the -1 header bytes before headerEndOffset=13 at position 9)
```

`GraphBatch.serializeEdgeDirect()` has a fast path for edges without properties that wrote the header end offset as the position right after the 4-byte size field, i.e. pointing **at** the property-count byte instead of past it. `BinarySerializer.serializeProperties()` writes the offset **after** the count. The reader never noticed the one-byte gap (nothing is read past the count of a property-less record) until #5774 added `checkPropertyCount()`, which now sees `headerBytesLeft = -1` and rejects the record. The out/in RIDs and the (empty) property set are intact; only the validation fails.

Every property-less, non-lightweight edge written by `GraphBatch` or `GraphImporter` since the fast path was introduced (March 2026) is affected. Edges with at least one property use the two-pass path and are well-formed.

## Fix

- `GraphBatch` writes the header end offset after the property count, matching `BinarySerializer.serializeProperties()`.
- `BinarySerializer.checkPropertyCount()` accepts the exact legacy shape (zero properties, offset exactly one byte short) so databases already bulk-loaded keep reading their edges without a reload. Any other shortfall is still reported as corruption, so the #5774 guarantee holds.

## Tests

- `Issue7448GraphBatchEmptyEdgeHeaderTest`: a property-less `GraphBatch` edge reads back through `SELECT`, `toMap()`, `getPropertyNames()` and `toJSON()` with nothing logged, and its header end offset is asserted to follow the count byte (fails against the old writer even with the reader shim in place).
- `BinarySerializerTest.deserializeAcceptsLegacyEmptyHeaderOneByteShortButNothingElse`: a hand-crafted legacy header reads back silently as empty, while one-byte-short-with-one-property and two-bytes-short-with-zero-properties are still reported.

Ran: all `GraphBatch*`/`Issue566x*` engine tests, `CheckDatabase*`, `BinarySerializerTest`, `JsonSerializerTest`, `JsonGraphSerializerTest`, and every `GraphImporter*` test in `integration`. All green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where edges created without properties could be incorrectly reported as corrupted when read.
  - Property-less edges now load correctly, including their endpoints, identifiers, and empty property sets.
  - Existing records written with the earlier layout remain readable without generating corruption warnings.
  - Validation continues to reject genuinely malformed records, helping preserve protection against invalid data.
  - Reading and querying property-less edges now completes without false corruption warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->