### PR TITLE
fix(#7441): reserve a restore's target name for the whole restore

### DIFF
--- a/docs/7441-restore-target-reservation.md
+++ b/docs/7441-restore-target-reservation.md
@@ -163,9 +163,13 @@ carry `overwrite`. The tests drive the control plane and the HTTP endpoint direc
 2. `restoreDatabase` and `restoreBackup` take the reservation **in the same `databasesLock`
    section as the existence check** and release it in a `finally` around the whole restore, so the
    check and the swap are two ends of one reservation rather than two independent samples.
-3. `swapRestoredDatabase` re-asks `databaseNameIsTaken` **inside the same `databasesLock` section
-   that deletes and moves**, unless the caller passed `overwrite`. A name that appeared anyway
-   fails the restore instead of being destroyed.
+3. `swapRestoredDatabase` splits on `replaceExisting`. With it, the old behaviour: delete the
+   target, `ATOMIC_MOVE` over it. Without it, **the branch contains no destructive call at all** -
+   it re-asks `existsDatabase` inside the lock for the registry half, and for the filesystem half
+   it moves with neither `ATOMIC_MOVE` nor `REPLACE_EXISTING`, so a target that appeared anyway
+   fails the move with `FileAlreadyExistsException` rather than being deleted. The filesystem is
+   not *checked*, because any check is a sample and a directory can appear between it and the
+   move; the move is the filesystem answering the question instead of being asked it.
 4. The HA-aware `dropDatabaseForRestore` is gated on the same flag. It has to run outside
    `databasesLock` (an HA drop round-trips through Raft and the apply thread takes that lock -
    issue #4832), so a database registered during the restore would have been dropped there,
@@ -183,11 +187,15 @@ than parked behind a multi-minute download.
   lock file, not an in-memory set.
 - The reservation is per `ArcadeDBServer` instance, deliberately: an HA test and a co-located pair
   of nodes run several servers with the same database names in one process.
-- The pre-swap re-check is a tripwire, not a second claim. It is atomic with the delete-and-move
-  it guards - both are in one `databasesLock` section - but it only answers the question at that
-  instant, and for anything outside this JVM the answer can be stale the moment it is read. For
-  every creator that goes through `ArcadeDBServer` it is the reservation, not the re-check, that
-  carries the invariant.
+- The registry re-check in the swap is a tripwire, not a second claim: it answers only for that
+  instant, and for anything outside this JVM the answer can be stale the moment it is read. What
+  makes that survivable is that the non-overwrite branch it guards cannot destroy anything even if
+  the answer *is* stale - there is no delete on it and the move does not replace. For every creator
+  that goes through `ArcadeDBServer` it is the reservation, not the re-check, that carries the
+  invariant.
+- `restore backup ... overwrite` still deletes and replaces, by design. An out-of-band directory
+  appearing during an overwrite restore is still destroyed - the caller said to replace whatever is
+  at that name.
 
 ## Changes
 
@@ -318,3 +326,36 @@ changing behaviour:
    of `reserveDatabaseNameForRestore` so the next reader does not have to relitigate it.
 
 The review's remaining sections (correctness, tests, security) were confirmations with nothing to act on.
+
+### Cycle 3 - 8c8ed6d
+
+`coderabbitai` left one inline finding on `ServerControlPlane.java:1679`, and it was right:
+the non-overwrite branch still ran `FileUtils.deleteRecursively(finalDir)` between the re-check and
+the move, and fell back to `REPLACE_EXISTING`. Holding `databasesLock` binds creators that go
+through `ArcadeDBServer`; it does not stop a directory appearing on disk, so the check-to-delete gap
+was microseconds of exposure that ended in a deletion - on the one command whose contract is that it
+never replaces anything.
+
+Fixed as suggested, and the shape is better than a tighter check would have been: the non-overwrite
+branch now has no destructive call on it. `existsDatabase` covers the registry half; the filesystem
+half is left to `Files.move` with no options, which fails with `FileAlreadyExistsException` if the
+target is there. `ATOMIC_MOVE` is deliberately not set on that branch - with no `REPLACE_EXISTING`
+its behaviour over an existing target is implementation-specific and POSIX `rename(2)` would clobber
+silently, which is the outcome being prevented. The move is a single rename either way, `tempDir`
+being a sibling of `finalDir`.
+
+Both halves were already under test, and the split makes which is which explicit:
+`aDatabaseDirectoryThatAppearsDuringARestoreFailsTheSwapInsteadOfBeingDestroyed` plants a directory
+that is registered nowhere, so it now exercises the move; `aDatabaseRegisteredDuringARestoreIsNotDroppedByTheSwap`
+exercises the registry check. Both javadocs now say so.
+
+Re-run: `Issue7441` 7/7, the restore/backup/import neighbours 19/19, and the server suite
+1052/1052 green.
+
+`claude` reviewed the same head and found no bugs - it re-derived the lock ordering
+(`BackupCoordinator` slot, then `databasesLock`, identically at every call site, so no inversion),
+confirmed the guard really is inside the critical section in both creators rather than sampled
+outside it, and confirmed the 409/`ABORTED` wiring exists rather than taking the PR body's word for
+it. One actionable line: the tripwire is skipped entirely under `overwrite`, which the adversarial
+table argued was not a defect but which only the tracking doc said. It is now said in
+`swapRestoredDatabase`'s own javadoc, where the next reader is.

--- a/docs/7441-restore-target-reservation.md
+++ b/docs/7441-restore-target-reservation.md
@@ -48,7 +48,7 @@ re-check immediately before the swap catches anything that did not.
 
 ### Every creator of a database on a server
 
-```
+```text
 $ grep -rn "\.createDatabase(" --include='*.java' . | grep -v /target/ | grep -v /src/test/ \
     | grep -v "DatabaseFactory\|createDatabases\|createDatabaseInReplicas"
 ha-raft/.../ArcadeStateMachine.java:2986:    server.createDatabase(databaseName, ComponentFile.MODE.READ_WRITE);
@@ -85,7 +85,7 @@ A server-side database therefore comes into existence at exactly two places, bot
 
 ### Every restore that swaps a directory into place
 
-```
+```text
 $ grep -rn "performRestore\|restoreDatabase(\|restoreBackup(" --include='*.java' . \
     | grep -v /target/ | grep -v /src/test/
 server/.../ServerControlPlane.java:1289 restoreDatabase   -> performRestore:1304
@@ -122,7 +122,7 @@ so it is not the window this issue describes.
 `ArcadeDbGrpcService` keeps a `databasePool` of its own and, on a miss, opens or creates through a bare
 `DatabaseFactory`. That call is unreachable on a server:
 
-```
+```text
 $ grep -rn "new ArcadeDbGrpcService(" --include='*.java' . | grep -v /target/ | grep -v /src/test/
 grpcw/.../GrpcServerPlugin.java:262:      this.grpcService = new ArcadeDbGrpcService(databasePath, arcadeServer, ...)
 ```
@@ -222,7 +222,7 @@ than parked behind a multi-minute download.
 
 ## Test results
 
-```
+```text
 $ mvn -o -pl server test -Dtest=Issue7441RestoreNameReservationIT
 Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
 ```
@@ -231,7 +231,7 @@ The tests can fail. With the two `checkDatabaseNameIsNotBeingRestored` calls and
 re-check disabled - the fix's three load-bearing lines, everything else left in place - the same
 run is:
 
-```
+```text
 Tests run: 6, Failures: 4, Errors: 0
   aCreateDatabaseOfTheRestoreTargetIsRefusedWhileTheRestoreRuns
   theHttpCreateDatabaseCommandAnswers409WhileTheNameIsReservedForARestore   expected: 409
@@ -243,7 +243,7 @@ The two that stay green are the ones that assert the claim is released, which it
 
 Regression runs:
 
-```
+```text
 $ mvn -o -pl server test -Dtest='Issue7441...,Issue7384ConcurrentRestoreIT,ServerRestoreDatabaseIT,
     ServerBackupDatabaseIT,ServerImportDatabaseIT,ServerControlPlane*Test,BackupCoordinatorTest,
     ReservedInternalDatabaseTest,ServerDefaultDatabasesIT,Issue6778DatabaseNotAvailableExceptionTest'
@@ -359,3 +359,25 @@ outside it, and confirmed the 409/`ABORTED` wiring exists rather than taking the
 it. One actionable line: the tripwire is skipped entirely under `overwrite`, which the adversarial
 table argued was not a defect but which only the tracking doc said. It is now said in
 `swapRestoredDatabase`'s own javadoc, where the next reader is.
+
+### Cycle 4 - ea0210d
+
+`claude` reviewed the rewritten swap and reported **no blocking findings**, having re-traced both
+`checkDatabaseNameIsNotBeingRestored` call sites in the current file rather than in the diff
+context, re-run the `registerDatabase` grep behind coverage row 7 itself, checked that the
+non-overwrite branch leaves no temp directory on the `FileAlreadyExistsException` path, and agreed
+with the row 10 argument. Its remaining notes - the `HashSet` under the lock, the exception's
+upward dependency, the doc's overlap with the PR body - were each recorded as already weighed and
+asked for no change.
+
+`coderabbitai` left one markdownlint nit on this file: code fences with no language. Applied - the
+six shell/output fences are now `text`. Nothing in the repo lints Markdown (`markdownlint` appears
+in neither `.github/workflows/` nor `.pre-commit-config.yaml`), so it is cosmetic, but it is free.
+
+That is the fourth and last cycle `--max-cycles=4` allows. The final commit is documentation only.
+
+## Final state
+
+`max-cycles-reached`, with the loop having exhausted its budget rather than having failed: the
+gating reviewer's verdict on the last reviewed head was clean, and the only change after it was
+this file's code fences.

--- a/docs/7441-restore-target-reservation.md
+++ b/docs/7441-restore-target-reservation.md
@@ -115,6 +115,35 @@ so it is not the window this issue describes.
 | 7 | `ArcadeDBServer.registerDatabase` | n/a | **argued**: no `src/main` caller - the grep above finds only test classes in `ha-raft` |
 | 8 | a database appearing out of band: an embedded `DatabaseFactory` in the same JVM, an operator's `mkdir`, a half-finished operation | yes, and not reservable | **fixed here** by the second clause: the swap's own lock section re-checks and turns the silent destruction into a failed restore. Tests `aDatabaseDirectoryThatAppearsDuringARestoreFailsTheSwapInsteadOfBeingDestroyed` (directory) and `aDatabaseRegisteredDuringARestoreIsNotDroppedByTheSwap` (registered database) |
 | 9 | another server process sharing the same database directory | yes | **not covered** - see Residual risk. Nothing in this JVM can see it, the same limit `BackupCoordinator` documents for backups |
+| 10 | `ArcadeDbGrpcService.getDatabase(String, DatabaseCredentials)` -> its own `DatabaseFactory.create()` and private `databasePool`, bypassing `ArcadeDBServer` entirely | no | **argued** - see below. Raised in review on PR #7452; the sweep above missed it because it greps `ArcadeDBServer`'s creators and this path has its own factory |
+
+### Row 10: the gRPC service's own factory
+
+`ArcadeDbGrpcService` keeps a `databasePool` of its own and, on a miss, opens or creates through a bare
+`DatabaseFactory`. That call is unreachable on a server:
+
+```
+$ grep -rn "new ArcadeDbGrpcService(" --include='*.java' . | grep -v /target/ | grep -v /src/test/
+grpcw/.../GrpcServerPlugin.java:262:      this.grpcService = new ArcadeDbGrpcService(databasePath, arcadeServer, ...)
+```
+
+The single production construction site passes the `ArcadeDBServer` the plugin was configured with, so
+`arcadeServer` is non-null, and the branch that runs first is:
+
+```java
+if (arcadeServer != null) {
+  Database db = arcadeServer.getDatabase(databaseName);   // (name, createIfNotExists=false, allowLoad=true)
+  ...
+  if (db != null) { ...; return db; }
+}
+```
+
+`ArcadeDBServer.getDatabase` has no `return null` for a missing database - it opens from disk, and
+`LocalDatabase.open()` raises `DatabaseOperationException("Database '...' does not exist")`
+(`engine/.../LocalDatabase.java:291`). So `db != null` never falls through on a server, and the raw
+`DatabaseFactory.create()` below it runs only when `arcadeServer == null`, which is a standalone or
+embedded use of the class with no server registry to reserve a name in. A comment at that line now says
+so, so the next person auditing creators does not have to re-derive it.
 
 ### Reachability
 
@@ -251,3 +280,21 @@ uncontaminated reviewer. That is a weaker pass than the skill asks for and is re
 
 No follow-up issue was filed: every row of the coverage table is fixed here or argued, and the one
 uncovered row (9, a second process) is the limit `BackupCoordinator` already documents for backups.
+
+## Review cycles
+
+### Cycle 1 - 8c1203a
+
+`claude` reviewed and found no bugs: it independently re-traced the reservation's atomicity, the
+release-in-finally on both restore entry points, the HA leader-only argument for row 4, the
+409/`ABORTED` mapping and the `replaceExisting` gating, and confirmed each.
+
+One non-blocking observation, and it was a real hole in the *sweep* even though it is not a hole in
+the fix: `ArcadeDbGrpcService.getDatabase(String, DatabaseCredentials)` creates through a
+`DatabaseFactory` of its own, which the "every creator" grep did not reach because that grep is
+scoped to `ArcadeDBServer`. Verified rather than taken on trust - `GrpcServerPlugin` is the only
+production construction site and always passes a non-null server, and `ArcadeDBServer.getDatabase`
+throws rather than returning null for a missing database - and recorded as row 10 with the
+evidence, plus a comment at the call site itself.
+
+Nothing else in the review asked for a change; the style and test notes were confirmations.

--- a/docs/7441-restore-target-reservation.md
+++ b/docs/7441-restore-target-reservation.md
@@ -298,3 +298,23 @@ throws rather than returning null for a missing database - and recorded as row 1
 evidence, plus a comment at the call site itself.
 
 Nothing else in the review asked for a change; the style and test notes were confirmations.
+
+### Cycle 2 - fb5b3f1
+
+`claude` reviewed again, re-derived the core mechanism, the HA row-4 argument, the
+`restoringDatabaseNames` synchronisation and the `replaceExisting` drop gate, and found no bugs.
+Two optional items, both answered by writing the decision down where the code is rather than by
+changing behaviour:
+
+1. *The exception type reaches up into `ServerControlPlane` from `ArcadeDBServer`.* Fair reading,
+   and the tidier arrangement would be to hoist `OperationInProgressException` somewhere neutral.
+   Not done here: it is public API that `BackupInProgressException` extends and that handlers and
+   tests in `server`, `grpcw` and `ha-raft` already catch under that name, so moving it is its own
+   change rather than something to ride along with a bug fix. The reason is now in the javadoc of
+   `checkDatabaseNameIsNotBeingRestored` instead of only in this file.
+2. *`databaseNameIsTaken`'s `File.exists()` now runs under `databasesLock`.* True, and deliberate -
+   sampling the name outside the lock is the bug. It is one stat, once per restore, on a monitor
+   `createDatabase` already holds across the creation of a whole database. Recorded in the javadoc
+   of `reserveDatabaseNameForRestore` so the next reader does not have to relitigate it.
+
+The review's remaining sections (correctness, tests, security) were confirmations with nothing to act on.

--- a/docs/7441-restore-target-reservation.md
+++ b/docs/7441-restore-target-reservation.md
@@ -1,0 +1,253 @@
+# #7441 - restore's "target already exists" check is not atomic with the swap that replaces it
+
+## Problem
+
+`ServerControlPlane.restoreDatabase` and `restoreBackup` sample the target name up front:
+
+```java
+final String dbPath = databaseDirectory(databaseName);
+if (databaseNameIsTaken(databaseName, dbPath))      // <- registry + filesystem, no lock held
+  throw new IllegalArgumentException("Database '" + databaseName + "' already exists");
+
+performRestore(databaseName, dbPath, url, "restore database", listener);
+```
+
+and act on it minutes later, in `swapRestoredDatabase`:
+
+```java
+if (server.existsDatabase(databaseName))
+  dropDatabaseForRestore(databaseName);
+
+synchronized (server.getDatabasesLock()) {
+  if (finalDir.exists())
+    FileUtils.deleteRecursively(finalDir);
+  Files.move(tempDir.toPath(), finalDir.toPath(), ...);
+}
+```
+
+`ArcadeDBServer.createDatabase` takes `databasesLock` for its own check-then-act, but the restore
+check never takes it, and the window between check and swap is the whole duration of the download.
+A `create database X` that lands inside that window is dropped and overwritten without a word - by
+the one command whose contract is "I will never replace an existing database".
+
+Issue #7384 already closed the restore-vs-restore, restore-vs-backup and restore-vs-import halves
+of this with the per-database `BackupCoordinator` slot. What it did not close is create-vs-restore:
+`createDatabase` asks the coordinator nothing.
+
+## Invariant
+
+**Once a restore has passed its "target already exists" check, no database can be created on this
+server under that name until the restore has finished - and if one appears anyway, the restore
+fails instead of destroying it.**
+
+Two clauses, because they are enforced by two different mechanisms and one of them cannot be
+exhaustive: a name reservation binds every creator that goes through `ArcadeDBServer`, and a
+re-check immediately before the swap catches anything that did not.
+
+## Completeness
+
+### Every creator of a database on a server
+
+```
+$ grep -rn "\.createDatabase(" --include='*.java' . | grep -v /target/ | grep -v /src/test/ \
+    | grep -v "DatabaseFactory\|createDatabases\|createDatabaseInReplicas"
+ha-raft/.../ArcadeStateMachine.java:2986:    server.createDatabase(databaseName, ComponentFile.MODE.READ_WRITE);
+grpc-client/.../RemoteGrpcServer.java:478:          .createDatabase(CreateDatabaseRequest...)      # client side, not a server creator
+server/.../ServerControlPlane.java:298:    final ServerDatabase database = server.createDatabase(databaseName, ...);
+server/.../ServerControlPlane.java:1399:      final ServerDatabase createdDb = server.createDatabase(databaseName, ...);
+server/.../http/handler/PostServerCommandHandler.java:394:    controlPlane.createDatabase(databaseName);
+grpcw/.../ArcadeDbGrpcAdminService.java:1219:    return controlPlane.createDatabase(name);
+
+$ grep -rn "getDatabase([^)]*, *true" --include='*.java' . | grep -v /target/ | grep -v /src/test/
+gremlin/.../GremlinServerPlugin.java:245:          server.getDatabase(dbName, true, true);
+server/.../ArcadeDBServer.java:964:    return getDatabase(databaseName, false, true);
+server/.../ArcadeDBServer.java:968:    return getDatabase(databaseName, true, true);
+
+$ grep -rn "factory.create()" server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+1016:      DatabaseInternal embeddedDatabase = (DatabaseInternal) factory.create();     # createDatabase
+1288:          embDatabase = ... (factory.exists() ? factory.open(...) : factory.create());  # getDatabase
+
+$ grep -rn "\.registerDatabase(" --include='*.java' . | grep -v /target/ \
+    | grep -v Profiler | grep -v Retention | grep -v AutoBackup
+ha-raft/src/test/java/...Issue7011BootstrapSourceRaceTest.java:75
+ha-raft/src/test/java/...Issue7221ForceSnapshotGuardMissingDatabaseTest.java:74
+ha-raft/src/test/java/...ArcadeStateMachineAppliedIndexPerDatabaseTest.java:103,132
+ha-raft/src/test/java/...Issue7143ForceSnapshotReplayGuardTest.java:69
+ha-raft/src/test/java/...ArcadeStateMachineBootstrapBaselinePersistenceTest.java:73
+ha-raft/src/test/java/...ArcadeStateMachineBootstrapDivergenceTest.java:76
+ha-raft/src/test/java/...ArcadeStateMachineDeferredDropTest.java:79
+# no src/main caller
+```
+
+A server-side database therefore comes into existence at exactly two places, both inside
+`ArcadeDBServer` and both already under `databasesLock`: `createDatabase` (line 1016) and the
+`createIfNotExists` arm of `getDatabase` (line 1288). That is where the reservation is checked.
+
+### Every restore that swaps a directory into place
+
+```
+$ grep -rn "performRestore\|restoreDatabase(\|restoreBackup(" --include='*.java' . \
+    | grep -v /target/ | grep -v /src/test/
+server/.../ServerControlPlane.java:1289 restoreDatabase   -> performRestore:1304
+server/.../ServerControlPlane.java:1328 restoreBackup     -> performRestore:1348
+server/.../http/handler/PostServerCommandHandler.java:424,458 -> the two control-plane methods
+grpcw/.../ArcadeDbGrpcAdminService.java:803,827                -> the two control-plane methods
+ha-raft/.../SnapshotInstaller.java:686,795,1402,1417  -> a PRIVATE restoreBackup(Path,Path) of its own
+integration/.../restore/Restore.java, format/*                -> the CLI/library restore, no server registry
+grpc-client/.../RemoteGrpcServer.java:861,879                  -> client side
+```
+
+Both transports funnel into the same two control-plane methods, which is where the reservation is
+taken and released. `SnapshotInstaller` is the HA snapshot path: it is a different method with the
+same name that already holds `databasesLock` across its whole close->swap->reopen (issue #4832),
+so it is not the window this issue describes.
+
+### Coverage table
+
+| # | Entry point | Reaches the window? | Outcome |
+|---|---|---|---|
+| 1 | `create database` over HTTP (`PostServerCommandHandler` -> `ServerControlPlane.createDatabase` -> `ArcadeDBServer.createDatabase`) | yes | **fixed here**, test `aCreateDatabaseOfTheRestoreTargetIsRefusedWhileTheRestoreRuns`, `theHttpCreateDatabaseCommandAnswers409WhileTheNameIsReserved` |
+| 2 | `create database` over gRPC (`ArcadeDbGrpcAdminService` -> the same control-plane method) | yes | **fixed here** - same chokepoint; driven in test through `ServerControlPlane.createDatabase`, which is the whole of what the gRPC RPC calls |
+| 3 | `ArcadeDBServer.getDatabase(name, createIfNotExists=true, ...)` -> `factory.create()` (`GremlinServerPlugin`, `getOrCreateDatabase`) | yes | **fixed here**, test `getOrCreateDatabaseIsRefusedWhileTheNameIsReservedForARestore` |
+| 4 | HA Raft apply `ArcadeStateMachine.applyInstallDatabaseEntry` -> `server.createDatabase` | yes | **fixed here** - same chokepoint. It already has to handle the two `IllegalArgumentException`s `createDatabase` throws for an existing name; this adds a third condition to an existing failure mode rather than a new one. In HA a restore only runs on the leader, and on the leader the create that would have produced the entry is refused before the entry is submitted |
+| 5 | `import database` (`ServerControlPlane.importDatabase` -> `server.createDatabase`) | no | **argued**: IMPORT conflicts with RESTORE in `BackupCoordinator.Operation.conflictsWith`, so the import is refused before it reaches `createDatabase` (issue #7384, test `everyHttpRestoreAndImportCommandAnswers409WhileARestoreOfTheTargetRuns`) |
+| 6 | a second `restore database` / `restore backup` of the same target | no | **argued**: RESTORE conflicts with everything, same slot, same #7384 test |
+| 7 | `ArcadeDBServer.registerDatabase` | n/a | **argued**: no `src/main` caller - the grep above finds only test classes in `ha-raft` |
+| 8 | a database appearing out of band: an embedded `DatabaseFactory` in the same JVM, an operator's `mkdir`, a half-finished operation | yes, and not reservable | **fixed here** by the second clause: the swap's own lock section re-checks and turns the silent destruction into a failed restore. Tests `aDatabaseDirectoryThatAppearsDuringARestoreFailsTheSwapInsteadOfBeingDestroyed` (directory) and `aDatabaseRegisteredDuringARestoreIsNotDroppedByTheSwap` (registered database) |
+| 9 | another server process sharing the same database directory | yes | **not covered** - see Residual risk. Nothing in this JVM can see it, the same limit `BackupCoordinator` documents for backups |
+
+### Reachability
+
+`ArcadeDBServer.createDatabase` is called on every `create database` this server serves (HTTP line
+394, gRPC line 1219, both through `ServerControlPlane.createDatabase`); the reservation is taken
+by `restoreDatabase`/`restoreBackup`, which are the only two methods either transport calls to
+restore. No flag gates either. The pre-swap re-check runs on every `performRestore` that does not
+carry `overwrite`. The tests drive the control plane and the HTTP endpoint directly, not a mock.
+
+## Fix
+
+1. `ArcadeDBServer` grows a set of database names reserved for an in-flight restore, guarded by
+   the same `databasesLock` that already guards the registry's check-then-act. `createDatabase`
+   and the `createIfNotExists` arm of `getDatabase` refuse a reserved name with
+   `OperationInProgressException`, which HTTP already answers with 409 and gRPC with `ABORTED` -
+   the request is well formed, and retrying once the restore finishes is the fix.
+2. `restoreDatabase` and `restoreBackup` take the reservation **in the same `databasesLock`
+   section as the existence check** and release it in a `finally` around the whole restore, so the
+   check and the swap are two ends of one reservation rather than two independent samples.
+3. `swapRestoredDatabase` re-asks `databaseNameIsTaken` **inside the same `databasesLock` section
+   that deletes and moves**, unless the caller passed `overwrite`. A name that appeared anyway
+   fails the restore instead of being destroyed.
+4. The HA-aware `dropDatabaseForRestore` is gated on the same flag. It has to run outside
+   `databasesLock` (an HA drop round-trips through Raft and the apply thread takes that lock -
+   issue #4832), so a database registered during the restore would have been dropped there,
+   before the guard in (3) ever ran. A restore that promised not to replace anything has nothing
+   to drop by definition: the target did not exist when the command was accepted.
+
+A reservation is not a lock a creator waits on: `createDatabase` is refused immediately rather
+than parked behind a multi-minute download.
+
+## Residual risk
+
+- Row 9: a second process (another server instance, the CLI `restore`) writing the same database
+  directory cannot be seen from this JVM. `BackupCoordinator`'s class javadoc already states this
+  limit for backups; the reservation inherits it. Out of scope here - closing it needs an on-disk
+  lock file, not an in-memory set.
+- The reservation is per `ArcadeDBServer` instance, deliberately: an HA test and a co-located pair
+  of nodes run several servers with the same database names in one process.
+- The pre-swap re-check is a tripwire, not a second claim. It is atomic with the delete-and-move
+  it guards - both are in one `databasesLock` section - but it only answers the question at that
+  instant, and for anything outside this JVM the answer can be stale the moment it is read. For
+  every creator that goes through `ArcadeDBServer` it is the reservation, not the re-check, that
+  carries the invariant.
+
+## Changes
+
+- `server/src/main/java/com/arcadedb/server/ArcadeDBServer.java`
+  - `restoringDatabaseNames`, a `Set<String>` guarded by `databasesLock`, plus
+    `reserveDatabaseNameForRestore` / `releaseDatabaseNameReservedForRestore` /
+    `isDatabaseNameReservedForRestore` and the private
+    `checkDatabaseNameIsNotBeingRestored`.
+  - `createDatabase` and the `createIfNotExists` arm of `getDatabase` - the only two callers of
+    `DatabaseFactory.create()` in the class - ask it before creating anything. The refusal is
+    `ServerControlPlane.OperationInProgressException`, which HTTP already answers with 409 and
+    gRPC with `ABORTED`.
+  - The `factory.exists()` arm of `getDatabase` is deliberately untouched: opening a directory
+    that is already there is what `restore backup ... overwrite` means to replace, and refusing it
+    would take a live database away from its readers for the length of the restore.
+- `server/src/main/java/com/arcadedb/server/ServerControlPlane.java`
+  - `reserveRestoreTarget` runs the existence check and the claim inside one
+    `synchronized (server.getDatabasesLock())` block; `restoreDatabase` and `restoreBackup` call
+    it and release the claim from a `finally` around the whole restore.
+  - `performRestore` and `swapRestoredDatabase` take a `replaceExisting` flag. When it is false,
+    the swap re-asks `databaseNameIsTaken` under `databasesLock` before dropping anything and
+    fails the restore if the answer has changed.
+- `server/src/test/java/com/arcadedb/server/backup/Issue7441RestoreNameReservationIT.java` - new.
+
+## Test results
+
+```
+$ mvn -o -pl server test -Dtest=Issue7441RestoreNameReservationIT
+Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
+```
+
+The tests can fail. With the two `checkDatabaseNameIsNotBeingRestored` calls and the pre-swap
+re-check disabled - the fix's three load-bearing lines, everything else left in place - the same
+run is:
+
+```
+Tests run: 6, Failures: 4, Errors: 0
+  aCreateDatabaseOfTheRestoreTargetIsRefusedWhileTheRestoreRuns
+  theHttpCreateDatabaseCommandAnswers409WhileTheNameIsReservedForARestore   expected: 409
+  getOrCreateDatabaseIsRefusedWhileTheNameIsReservedForARestore
+  aDatabaseDirectoryThatAppearsDuringARestoreFailsTheSwapInsteadOfBeingDestroyed
+```
+
+The two that stay green are the ones that assert the claim is released, which it is either way.
+
+Regression runs:
+
+```
+$ mvn -o -pl server test -Dtest='Issue7441...,Issue7384ConcurrentRestoreIT,ServerRestoreDatabaseIT,
+    ServerBackupDatabaseIT,ServerImportDatabaseIT,ServerControlPlane*Test,BackupCoordinatorTest,
+    ReservedInternalDatabaseTest,ServerDefaultDatabasesIT,Issue6778DatabaseNotAvailableExceptionTest'
+Tests run: 33, Failures: 0, Errors: 0, Skipped: 0
+
+$ mvn -o -pl server test -DexcludedGroups=benchmark,vector,slow
+Tests run: 1052, Failures: 0, Errors: 0, Skipped: 0
+
+$ mvn -o -pl ha-raft test -Dtest='ArcadeStateMachine*Test,Issue7011*,Issue7143*,Issue7221*'
+Tests run: 108, Failures: 0, Errors: 0, Skipped: 0
+
+$ mvn -o install -DskipTests
+BUILD SUCCESS   (full reactor)
+```
+
+An earlier pass of that same suite reported 7 failures, all in `PostClusterAuthSessionHandlerTest`,
+and they were environmental rather than a regression: that class hardcodes `http://localhost:2480`,
+and a locally installed ArcadeDB 26.9.1 (`/opt/homebrew/Cellar/arcadedb/26.9.1`) is holding it, so
+which server that client reaches is not the test's to decide - both runs log `HTTP Port 2480 not
+available` dozens of times. The tell is `missingTokenAndUnknownActionAnswer400` getting a **404**
+from `/api/v1/cluster/auth-session`, a route 26.9.1 does not have, which puts those requests
+outside the test JVM. The class is green in the run above with the same 1052 tests and nothing else
+changed, and it touches neither restore nor database creation.
+
+The suite count is 1052 in both runs because Surefire's default includes do not match `*IT`: the
+new class runs under Failsafe (and under the explicit `-Dtest=` runs above), as
+`Issue7384ConcurrentRestoreIT` does.
+
+## Adversarial pass
+
+No `Task` tool is available in this session - this agent is itself a subagent and cannot spawn
+one - so the pass was run by re-reading the diff cold against the issue rather than by an
+uncontaminated reviewer. That is a weaker pass than the skill asks for and is recorded as such.
+
+| Finding | Disposition |
+|---|---|
+| The re-check was placed before `dropDatabaseForRestore`, which runs outside `databasesLock` and takes an HA Raft round-trip. A database registered during the restore was therefore still dropped - by the drop, before the guard could refuse. The guard only caught the *directory* case, which is the weaker one. | **Real, fixed here.** The re-check moved inside the swap's own lock section and the drop was gated on `replaceExisting`. New test `aDatabaseRegisteredDuringARestoreIsNotDroppedByTheSwap`; with only the drop gate reverted it fails at line 316 (`existsDatabase` false - the database had been dropped). |
+| `restore backup ... overwrite` skips the re-check entirely, so a directory appearing out of band during an overwrite restore is still destroyed. | **Not a defect.** `overwrite` is the caller stating that the target is replaced; refusing it would break the command's only purpose. Recorded rather than argued away silently. |
+| gRPC `CreateDatabase` could create on a replica while the leader restores, putting the create outside the leader's claim. | **Not real.** `ArcadeDbGrpcAdminService` line 1175 gates the RPC on `ha.isLeader()`, and `PostServerCommandHandler` forwards `create database` to the leader (`forwardToLeaderIfReplica`) - the same "everything lands on the leader" argument issue #7384 relies on. |
+| The claim could leak if something threw between `reserveRestoreTarget` returning and the `try` being entered. | **Not real.** There is no statement between them in either caller; `reserveRestoreTarget(...)` is immediately followed by `try {`. Also covered by `aFailedRestoreReleasesTheNameReservation`. |
+| A new lock-ordering hazard: `reserveRestoreTarget` holds `databasesLock` across the existence check. | **Not real.** Under the lock it does a `ConcurrentHashMap.containsKey` and one `File.exists()`, and calls nothing that can take another lock. `createDatabase` already holds the same monitor across a whole database creation. |
+
+No follow-up issue was filed: every row of the coverage table is fixed here or argued, and the one
+uncovered row (9, a second process) is the limit `BackupCoordinator` already documents for backups.

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -5394,6 +5394,13 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       }
     }
 
+    // Below this line the service is running WITHOUT an ArcadeDBServer, which only a standalone or embedded use of
+    // this class does - GrpcServerPlugin, the single production construction site, always passes one. The branch
+    // above returns or throws in that case: ArcadeDBServer.getDatabase(name) opens from disk and raises
+    // DatabaseOperationException("... does not exist") rather than returning null, so `db != null` never falls
+    // through on a real server. That is what keeps the raw DatabaseFactory.create() below outside the set of
+    // database creators the restore name reservation has to bind (issue #7441).
+
     // Check if database is already in the pool
     String poolKey = databaseName;
     Database database = databasePool.get(poolKey);

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -165,6 +165,13 @@ public class ArcadeDBServer {
   // half-swapped directory or reopens it from disk mid-swap (issue #4832). Kept distinct from the map so it can be
   // exposed via getDatabasesLock() without leaking the registry itself.
   private final       Object                                databasesLock                        = new Object();
+  // Database names an in-flight restore has claimed, guarded by databasesLock (issue #7441). A restore checks its
+  // target up front and replaces it minutes later, in swapRestoredDatabase; without a claim held across that window
+  // a database created inside it was dropped and overwritten with no error reported to either caller. Sampling the
+  // name a second time would not have helped - the two samples are not atomic with each other either - so the name
+  // is reserved in the same databasesLock section as the pre-check and released when the restore ends. Creators are
+  // refused, not parked: waiting here would block a create behind a multi-GB download.
+  private final       Set<String>                           restoringDatabaseNames               = new HashSet<>();
   // Serialises start() and stop(). Deliberately an explicit lock rather than `synchronized` on the
   // instance: the JVM shutdown hook must be able to give up on it (see stopFromShutdownHook), because a
   // startup failure that calls System.exit() from inside start() would otherwise deadlock the JVM
@@ -995,11 +1002,67 @@ public class ArcadeDBServer {
     return databasesLock;
   }
 
+  /**
+   * Claims {@code databaseName} for a restore that is about to start, so that no database can be created under that
+   * name until the restore has swapped its result into place (issue #7441).
+   * <p>
+   * The caller takes this in the same {@link #getDatabasesLock()} section as its own "does the target already exist"
+   * check and releases it from a {@code finally} around the whole restore - {@link ServerControlPlane#restoreDatabase}
+   * and {@link ServerControlPlane#restoreBackup} are the two that do. Taking it separately would leave the same
+   * window the claim exists to close, only narrower.
+   * <p>
+   * A claim is not a lock a creator waits on. {@link #createDatabase} is refused immediately with
+   * {@link ServerControlPlane.OperationInProgressException}, which HTTP answers with a 409 and gRPC with
+   * {@code ABORTED}: parking a create behind a multi-GB download would be a worse answer than telling the caller to
+   * retry. It is also per server instance rather than per JVM, matching {@link BackupCoordinator}: an HA test and a
+   * co-located pair of nodes run several servers with the same database names in one process.
+   * <p>
+   * Re-claiming a name already claimed is not rejected here. Two restores of one database cannot get this far - the
+   * {@link BackupCoordinator} slot refuses the second one before it reaches the pre-check (issue #7384) - so a
+   * rejection would be unreachable code standing in for an invariant that is enforced elsewhere.
+   */
+  public void reserveDatabaseNameForRestore(final String databaseName) {
+    synchronized (databasesLock) {
+      restoringDatabaseNames.add(databaseName);
+    }
+  }
+
+  /**
+   * Releases the claim {@link #reserveDatabaseNameForRestore} took. Always call it from a {@code finally}: a claim
+   * leaked by a failed restore would refuse every later create of that name until the server restarts, turning one
+   * bad URL into an outage.
+   */
+  public void releaseDatabaseNameReservedForRestore(final String databaseName) {
+    synchronized (databasesLock) {
+      restoringDatabaseNames.remove(databaseName);
+    }
+  }
+
+  /** Whether a restore on this server currently holds {@code databaseName}. */
+  public boolean isDatabaseNameReservedForRestore(final String databaseName) {
+    synchronized (databasesLock) {
+      return restoringDatabaseNames.contains(databaseName);
+    }
+  }
+
+  /**
+   * Refuses to bring a database into existence under a name an in-flight restore has claimed. Called from the two
+   * places in this class that reach {@code DatabaseFactory.create()}, both already holding {@link #databasesLock},
+   * which is what makes the refusal atomic with the claim rather than another unsynchronised sample.
+   */
+  private void checkDatabaseNameIsNotBeingRestored(final String databaseName) {
+    if (restoringDatabaseNames.contains(databaseName))
+      throw new ServerControlPlane.OperationInProgressException(
+          "Cannot create database '" + databaseName + "': a restore of it is already in progress");
+  }
+
   public ServerDatabase createDatabase(final String databaseName, final ComponentFile.MODE mode) {
     checkDatabaseNameIsValid(databaseName);
 
     ServerDatabase serverDatabase;
     synchronized (databasesLock) {
+      checkDatabaseNameIsNotBeingRestored(databaseName);
+
       serverDatabase = databases.get(databaseName);
       if (serverDatabase != null)
         throw new IllegalArgumentException("Database '" + databaseName + "' already exists");
@@ -1284,9 +1347,18 @@ public class ArcadeDBServer {
           defaultDbMode = READ_WRITE;
 
         DatabaseInternal embDatabase;
-        if (createIfNotExists)
-          embDatabase = (DatabaseInternal) (factory.exists() ? factory.open(defaultDbMode) : factory.create());
-        else {
+        if (createIfNotExists) {
+          if (factory.exists())
+            embDatabase = (DatabaseInternal) factory.open(defaultDbMode);
+          else {
+            // The second of the two places a database comes into existence on a server - createDatabase above is the
+            // other - so the restore claim has to be honoured here too (issue #7441). Only the create arm asks: an
+            // OPEN of a directory that is already there is what 'restore backup ... overwrite' means to replace, and
+            // refusing it would take a live database away from its readers for the duration of the restore.
+            checkDatabaseNameIsNotBeingRestored(databaseName);
+            embDatabase = (DatabaseInternal) factory.create();
+          }
+        } else {
           final Collection<Database> activeDatabases = DatabaseFactory.getActiveDatabaseInstances();
           if (!activeDatabases.isEmpty()) {
             embDatabase = null;

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -1011,6 +1011,11 @@ public class ArcadeDBServer {
    * and {@link ServerControlPlane#restoreBackup} are the two that do. Taking it separately would leave the same
    * window the claim exists to close, only narrower.
    * <p>
+   * The caller's existence check runs inside that same lock section, which puts a {@code File.exists()} stat under
+   * the monitor every open and create on this server contends on. That is deliberate - sampling the name outside the
+   * lock is the bug - and it is one stat on a path taken once per restore, against a lock that
+   * {@link #createDatabase} already holds across the creation of a whole database.
+   * <p>
    * A claim is not a lock a creator waits on. {@link #createDatabase} is refused immediately with
    * {@link ServerControlPlane.OperationInProgressException}, which HTTP answers with a 409 and gRPC with
    * {@code ABORTED}: parking a create behind a multi-GB download would be a worse answer than telling the caller to
@@ -1049,6 +1054,15 @@ public class ArcadeDBServer {
    * Refuses to bring a database into existence under a name an in-flight restore has claimed. Called from the two
    * places in this class that reach {@code DatabaseFactory.create()}, both already holding {@link #databasesLock},
    * which is what makes the refusal atomic with the claim rather than another unsynchronised sample.
+   * <p>
+   * The exception type is {@link ServerControlPlane.OperationInProgressException} rather than a new one of this
+   * class's own because it is what the transports already translate - {@code AbstractServerHttpHandler} answers it
+   * with a 409 and {@code ArcadeDbGrpcAdminService} with {@code ABORTED} - and because it is the same answer a
+   * caller gets when the {@link BackupCoordinator} slot refuses them: "well formed, and it will work once the other
+   * operation finishes". Naming the outer class here reads as this class reaching up into the one that wraps it, and
+   * it is: hoisting the type out of {@code ServerControlPlane} would be the tidier arrangement, but it is public API
+   * that {@code BackupInProgressException} extends and that handlers and tests across three modules already catch by
+   * that name, so moving it belongs in its own change rather than riding along with a bug fix.
    */
   private void checkDatabaseNameIsNotBeingRestored(final String databaseName) {
     if (restoringDatabaseNames.contains(databaseName))

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -1281,6 +1281,11 @@ public class ServerControlPlane {
    * which is the only thing that made the check meaningful: two restores could both pass it, both
    * restore into their own temporary directory and both reach the swap, and the loser's caller was
    * still told it had succeeded (issue #7384).
+   * <p>
+   * The name itself is claimed for the duration - see {@link #reserveRestoreTarget} - so the existence check and the
+   * swap that acts on it are two ends of one reservation rather than two independent samples taken a download apart
+   * (issue #7441). A {@code create database} of the same name inside that window is refused rather than created and
+   * then silently destroyed.
    *
    * @throws IllegalArgumentException     when the name is invalid or the database already exists
    * @throws SecurityException            when the URL is not one this server accepts from a client
@@ -1298,10 +1303,12 @@ public class ServerControlPlane {
     beginExclusive(databaseName, Operation.RESTORE);
     try {
       final String dbPath = databaseDirectory(databaseName);
-      if (databaseNameIsTaken(databaseName, dbPath))
-        throw new IllegalArgumentException("Database '" + databaseName + "' already exists");
-
-      performRestore(databaseName, dbPath, url, "restore database", listener);
+      reserveRestoreTarget(databaseName, dbPath, false, "Database '" + databaseName + "' already exists");
+      try {
+        performRestore(databaseName, dbPath, url, "restore database", false, listener);
+      } finally {
+        server.releaseDatabaseNameReservedForRestore(databaseName);
+      }
     } finally {
       server.getBackupCoordinator().end(databaseName, Operation.RESTORE);
     }
@@ -1321,6 +1328,11 @@ public class ServerControlPlane {
    * overwrite pre-check as well as the restore itself (issue #7384). The source is only read - its
    * archive is a file this server wrote, and a concurrent backup of it writes a different archive -
    * so it is not reserved, which also keeps this from needing a lock order between two names.
+   * <p>
+   * The target name is claimed for the duration as {@link #restoreDatabase} claims its own (issue #7441). Without
+   * {@code overwrite} this command makes {@code restore database}'s promise and keeps it the same way; with it, the
+   * claim still stands - the caller accepted that the target is replaced, not that something else may create one
+   * underneath the restore.
    *
    * @throws IllegalArgumentException     when a name is invalid, or the target exists and {@code overwrite} is false
    * @throws OperationInProgressException when a backup, restore or import of the target is already running
@@ -1341,13 +1353,43 @@ public class ServerControlPlane {
     beginExclusive(targetDatabase, Operation.RESTORE);
     try {
       final String dbPath = databaseDirectory(targetDatabase);
-      if (databaseNameIsTaken(targetDatabase, dbPath) && !overwrite)
-        throw new IllegalArgumentException(
-            "Database '" + targetDatabase + "' already exists. Enable overwrite to replace it with the backup");
-
-      performRestore(targetDatabase, dbPath, "file://" + backupFile.toAbsolutePath(), "restore backup", listener);
+      reserveRestoreTarget(targetDatabase, dbPath, overwrite,
+          "Database '" + targetDatabase + "' already exists. Enable overwrite to replace it with the backup");
+      try {
+        performRestore(targetDatabase, dbPath, "file://" + backupFile.toAbsolutePath(), "restore backup", overwrite,
+            listener);
+      } finally {
+        server.releaseDatabaseNameReservedForRestore(targetDatabase);
+      }
     } finally {
       server.getBackupCoordinator().end(targetDatabase, Operation.RESTORE);
+    }
+  }
+
+  /**
+   * Decides whether this restore may go ahead against its target and, in the same breath, claims the name for as
+   * long as the restore runs (issue #7441).
+   * <p>
+   * The two halves are one step on purpose. Asking the question and acting on the answer minutes later, in
+   * {@link #swapRestoredDatabase}, is what let a {@code create database} of the same name land in between and be
+   * dropped and overwritten without a word - by the command whose whole contract is that it never replaces an
+   * existing database. Both run under {@link ArcadeDBServer#getDatabasesLock()}, the monitor
+   * {@link ArcadeDBServer#createDatabase} already holds for its own check-then-act, so a creator either loses the
+   * race before the check and is seen by it, or arrives after the claim and is refused by it.
+   * <p>
+   * {@code overwrite} does not skip the claim, only the refusal: {@code restore backup ... overwrite} means the
+   * caller accepts that the target is replaced, not that anything else may create one underneath it.
+   *
+   * @param refusal the message for the caller when the target is taken and {@code overwrite} is not set - the two
+   *                commands word it differently, because only one of them has an overwrite flag to point at
+   */
+  private void reserveRestoreTarget(final String databaseName, final String dbPath, final boolean overwrite,
+      final String refusal) {
+    synchronized (server.getDatabasesLock()) {
+      if (databaseNameIsTaken(databaseName, dbPath) && !overwrite)
+        throw new IllegalArgumentException(refusal);
+
+      server.reserveDatabaseNameForRestore(databaseName);
     }
   }
 
@@ -1518,14 +1560,18 @@ public class ServerControlPlane {
    * {@code loadDatabases()} skips the orphan at next startup instead of opening it as a user
    * database.
    * <p>
-   * The caller is responsible for the pre-restore existence and overwrite checks.
+   * The caller is responsible for the pre-restore existence and overwrite checks, and for holding the name
+   * reservation that keeps the answer true until the swap.
    *
-   * @param operation the label the operation is published under - the command the operator typed, so that a
-   *                  reader of the progress endpoint sees {@code restore backup} or {@code restore database}
-   *                  rather than one name standing for both
+   * @param operation       the label the operation is published under - the command the operator typed, so that a
+   *                        reader of the progress endpoint sees {@code restore backup} or {@code restore database}
+   *                        rather than one name standing for both
+   * @param replaceExisting whether the caller has already accepted that an existing target is destroyed, which only
+   *                        {@code restore backup ... overwrite} does. When it is false the swap re-checks the target
+   *                        and fails rather than replace one that appeared meanwhile (issue #7441)
    */
   private void performRestore(final String databaseName, final String dbPath, final String url,
-      final String operation, final ProgressListener listener) {
+      final String operation, final boolean replaceExisting, final ProgressListener listener) {
     final File finalDir = new File(dbPath);
     final File tempDir = new File(finalDir.getParentFile(),
         ArcadeDBServer.RESERVED_DATABASE_PREFIX + "restore-tmp-" + databaseName + "-" + System.nanoTime());
@@ -1562,7 +1608,7 @@ public class ServerControlPlane {
       }
 
       progress.onProgress(RESTORE_STEP_ACTIVATE, 2, RESTORE_STEPS, 0, -1);
-      swapRestoredDatabase(databaseName, finalDir, tempDir);
+      swapRestoredDatabase(databaseName, finalDir, tempDir, replaceExisting);
 
       // A no-op outside HA, and minutes inside it: forceSnapshot makes every replica pull the restored files.
       progress.onProgress(RESTORE_STEP_REPLICATE, 3, RESTORE_STEPS, 0, -1);
@@ -1598,19 +1644,40 @@ public class ServerControlPlane {
    * Swaps a freshly-restored temporary directory into the final database directory. The existing
    * target database (if any) is dropped only now that the restore into {@code tempDir} has
    * succeeded, so a failed restore never destroys the original data (issue #5027).
+   * <p>
+   * {@code replaceExisting} is the caller saying it accepted, when the command was issued, that an existing target is
+   * destroyed - only {@code restore backup ... overwrite} does. Without it, nothing here may destroy anything: the
+   * target did not exist when the command was accepted, and this is where that answer is finally acted on
+   * (issue #7441).
    */
-  private void swapRestoredDatabase(final String databaseName, final File finalDir, final File tempDir) {
+  private void swapRestoredDatabase(final String databaseName, final File finalDir, final File tempDir,
+      final boolean replaceExisting) {
     try {
       // Drop the previous target (HA-aware) BEFORE taking the registry lock and only after a
       // successful restore into tempDir. In HA mode dropDatabase() round-trips through Raft and the
       // apply thread itself acquires databasesLock, so holding that lock here would deadlock; only the
       // pure-local file swap below runs under the lock, matching the snapshot-installer pattern (#4832).
-      if (server.existsDatabase(databaseName))
+      //
+      // Gated on replaceExisting (issue #7441): a restore that promised not to replace anything has nothing here to
+      // drop, because the target did not exist when the command was accepted. A registered database at this point is
+      // therefore one that appeared during the restore - exactly what the guard below refuses to destroy - and
+      // dropping it here, outside the lock and before that guard runs, would destroy it first.
+      if (replaceExisting && server.existsDatabase(databaseName))
         dropDatabaseForRestore(databaseName);
 
       // Serialise the on-disk swap against concurrent getDatabase / createDatabase so no concurrent
       // open observes the transient half-swapped directory.
       synchronized (server.getDatabasesLock()) {
+        // Ask the pre-check's own question one last time, in the same lock section that does the destroying, so the
+        // answer cannot go stale between the two the way it did between the pre-check and here (issue #7441). The
+        // name reservation already refuses every creator that goes through ArcadeDBServer; what this catches is what
+        // an in-memory claim cannot see - a directory appearing out of band, from an embedded DatabaseFactory in
+        // this JVM, an operator's mkdir, or a half-finished operation. Failing the restore is the honest outcome for
+        // a command that promised not to replace anything; deleting the directory was not.
+        if (!replaceExisting && databaseNameIsTaken(databaseName, finalDir.getPath()))
+          throw new CommandExecutionException("Cannot activate the restored database '" + databaseName
+              + "': a database by that name appeared while the restore was running");
+
         if (finalDir.exists())
           FileUtils.deleteRecursively(finalDir);
 

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -53,6 +53,7 @@ import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
 import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -1647,8 +1648,13 @@ public class ServerControlPlane {
    * <p>
    * {@code replaceExisting} is the caller saying it accepted, when the command was issued, that an existing target is
    * destroyed - only {@code restore backup ... overwrite} does. Without it, nothing here may destroy anything: the
-   * target did not exist when the command was accepted, and this is where that answer is finally acted on
-   * (issue #7441).
+   * target did not exist when the command was accepted, so the branch below neither drops, nor deletes, nor moves
+   * with {@code REPLACE_EXISTING}, and a target that appeared since fails the restore instead (issue #7441).
+   * <p>
+   * With it there is no tripwire at all, deliberately and not by omission: a database that appeared out of band
+   * during an {@code overwrite} restore is destroyed without a word, because replacing whatever is at that name is
+   * the entire content of the flag. Reserving the name still keeps every creator that goes through
+   * {@link ArcadeDBServer} out of the way; what is unprotected here is only what a reservation cannot see.
    */
   private void swapRestoredDatabase(final String databaseName, final File finalDir, final File tempDir,
       final boolean replaceExisting) {
@@ -1668,23 +1674,40 @@ public class ServerControlPlane {
       // Serialise the on-disk swap against concurrent getDatabase / createDatabase so no concurrent
       // open observes the transient half-swapped directory.
       synchronized (server.getDatabasesLock()) {
-        // Ask the pre-check's own question one last time, in the same lock section that does the destroying, so the
-        // answer cannot go stale between the two the way it did between the pre-check and here (issue #7441). The
-        // name reservation already refuses every creator that goes through ArcadeDBServer; what this catches is what
-        // an in-memory claim cannot see - a directory appearing out of band, from an embedded DatabaseFactory in
-        // this JVM, an operator's mkdir, or a half-finished operation. Failing the restore is the honest outcome for
-        // a command that promised not to replace anything; deleting the directory was not.
-        if (!replaceExisting && databaseNameIsTaken(databaseName, finalDir.getPath()))
-          throw new CommandExecutionException("Cannot activate the restored database '" + databaseName
-              + "': a database by that name appeared while the restore was running");
+        if (replaceExisting) {
+          // The caller asked for the target to be replaced, so replace it.
+          if (finalDir.exists())
+            FileUtils.deleteRecursively(finalDir);
 
-        if (finalDir.exists())
-          FileUtils.deleteRecursively(finalDir);
+          try {
+            Files.move(tempDir.toPath(), finalDir.toPath(), StandardCopyOption.ATOMIC_MOVE);
+          } catch (final AtomicMoveNotSupportedException e) {
+            Files.move(tempDir.toPath(), finalDir.toPath(), StandardCopyOption.REPLACE_EXISTING);
+          }
+        } else {
+          // Nothing on this branch may destroy anything: the target did not exist when the command was accepted,
+          // and this command has no way for the caller to say they meant to replace one (issue #7441). So it does
+          // not delete and it does not move with REPLACE_EXISTING - it asks, and then it lets the move be the
+          // second half of the answer.
+          //
+          // The two halves are split that way because a name is taken on two independent registers and only one of
+          // them can be tested and acted on in a single step. The server registry is checked here; the filesystem
+          // is not checked at all, because a check would be a sample and a directory can appear between it and the
+          // move however tightly they are written - the monitor held here binds every creator that goes through
+          // ArcadeDBServer, not an embedded DatabaseFactory elsewhere in this JVM or another process. A move with
+          // no options fails with FileAlreadyExistsException instead, which is the filesystem answering the
+          // question rather than being asked it. ATOMIC_MOVE is deliberately not set: combined with no
+          // REPLACE_EXISTING its behaviour over an existing target is implementation-specific, and on POSIX
+          // rename(2) would silently clobber - the exact outcome this branch exists to prevent. The move is a
+          // single rename regardless, tempDir being a sibling of finalDir and so always on the same filesystem.
+          if (server.existsDatabase(databaseName))
+            throw new CommandExecutionException(restoreTargetAppeared(databaseName));
 
-        try {
-          Files.move(tempDir.toPath(), finalDir.toPath(), StandardCopyOption.ATOMIC_MOVE);
-        } catch (final AtomicMoveNotSupportedException e) {
-          Files.move(tempDir.toPath(), finalDir.toPath(), StandardCopyOption.REPLACE_EXISTING);
+          try {
+            Files.move(tempDir.toPath(), finalDir.toPath());
+          } catch (final FileAlreadyExistsException e) {
+            throw new CommandExecutionException(restoreTargetAppeared(databaseName), e);
+          }
         }
       }
     } catch (final CommandExecutionException e) {
@@ -1694,6 +1717,15 @@ public class ServerControlPlane {
       FileUtils.deleteRecursively(tempDir);
       throw new CommandExecutionException("Error activating restored database '" + databaseName + "'", e);
     }
+  }
+
+  /**
+   * What a restore that promised not to replace anything says when it finds something there anyway - from either of
+   * the two registers a name can be taken on, so a caller cannot tell which one answered and does not need to.
+   */
+  private static String restoreTargetAppeared(final String databaseName) {
+    return "Cannot activate the restored database '" + databaseName
+        + "': a database by that name appeared while the restore was running";
   }
 
   /**

--- a/server/src/test/java/com/arcadedb/server/backup/Issue7441RestoreNameReservationIT.java
+++ b/server/src/test/java/com/arcadedb/server/backup/Issue7441RestoreNameReservationIT.java
@@ -1,0 +1,411 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.backup;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.ServerControlPlane;
+import com.arcadedb.server.backup.BackupCoordinator.Operation;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A restore reserves its target name for as long as it runs, and refuses to activate over a database that
+ * appeared anyway (issue #7441).
+ * <p>
+ * Issue #7384 gave every restore a per-database slot, which serialised it against the other restores, backups and
+ * imports of the same database. {@code create database} asks that slot nothing, so the window between the restore's
+ * "target already exists" pre-check and the directory swap minutes later was still wide open to it: a
+ * {@code create database X} landing inside it was dropped and overwritten without a word, by the one command whose
+ * contract is that it never replaces an existing database.
+ * <p>
+ * Two mechanisms close it, and both are exercised here. A name reservation, taken in the same {@code databasesLock}
+ * section as the pre-check and released when the restore ends, binds every creator that goes through
+ * {@link ArcadeDBServer} - which, {@code factory.create()} being called in exactly two places, is all of them. A
+ * re-check immediately before the swap catches what a reservation cannot see: a directory that appeared out of band.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue7441RestoreNameReservationIT extends BaseGraphServerTest {
+  private static final String BACKUP_DIR_NAME = "test-backups-7441";
+  private static final String BACKUP_CONFIG   = """
+      {
+        "version": 1,
+        "enabled": true,
+        "backupDirectory": "%s",
+        "defaults": {
+          "enabled": true,
+          "runOnServer": "*",
+          "schedule": { "type": "frequency", "frequencyMinutes": 9999 },
+          "retention": { "maxFiles": 50 }
+        }
+      }
+      """.formatted(BACKUP_DIR_NAME);
+
+  private File backupConfigFile;
+  private File backupDir;
+
+  private final List<String> databasesToDrop = new ArrayList<>();
+
+  @Override
+  protected boolean isCreateDatabases() {
+    return true;
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+
+    try {
+      final File configDir = new File("./target/config");
+      configDir.mkdirs();
+
+      backupConfigFile = new File(configDir, "backup.json");
+      try (final FileWriter writer = new FileWriter(backupConfigFile)) {
+        writer.write(BACKUP_CONFIG);
+      }
+
+      backupDir = new File("./target/" + BACKUP_DIR_NAME);
+      if (backupDir.exists())
+        FileUtils.deleteRecursively(backupDir);
+      backupDir.mkdirs();
+    } catch (final IOException e) {
+      throw new RuntimeException("Failed to set up the backup configuration", e);
+    }
+
+    config.setValue(GlobalConfiguration.SERVER_ROOT_PATH, "./target");
+    config.setValue(GlobalConfiguration.SERVER_PLUGINS, "auto-backup:" + AutoBackupSchedulerPlugin.class.getName());
+    // The archives this fixture restores from live on disk, so the server has to be willing to fetch a file:// URL.
+    config.setValue(GlobalConfiguration.SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS, true);
+  }
+
+  @AfterEach
+  void cleanUp() {
+    final ArcadeDBServer server = getServer(0);
+
+    for (final Operation operation : Operation.values())
+      server.getBackupCoordinator().end(getDatabaseName(), operation);
+
+    for (final String database : databasesToDrop) {
+      try {
+        // NOTHING MAY OUTLIVE A TEST HOLDING EITHER CLAIM: THE NEXT ONE WOULD BE REFUSED FOR THE WRONG REASON
+        server.releaseDatabaseNameReservedForRestore(database);
+        for (final Operation operation : Operation.values())
+          server.getBackupCoordinator().end(database, operation);
+        if (server.existsDatabase(database))
+          server.getDatabase(database).getEmbedded().drop();
+      } catch (final Exception ignore) {
+        // best-effort
+      }
+      FileUtils.deleteRecursively(databaseDirectory(database));
+    }
+    databasesToDrop.clear();
+
+    if (backupConfigFile != null && backupConfigFile.exists())
+      backupConfigFile.delete();
+    if (backupDir != null && backupDir.exists())
+      FileUtils.deleteRecursively(backupDir);
+  }
+
+  /**
+   * Coverage-table rows 1 and 2: the create both transports run. HTTP's {@code create database} and gRPC's
+   * {@code CreateDatabase} RPC each call {@link ServerControlPlane#createDatabase(String)} and nothing else, so
+   * driving that method is driving both.
+   * <p>
+   * The probe runs from inside the restore's own progress stream, which is the only place "while the restore is
+   * running" can be observed from one thread. Against the pre-#7441 code the create SUCCEEDS here, and the database
+   * it creates is gone by the time the method returns - which is the whole of the bug.
+   */
+  @Test
+  void aCreateDatabaseOfTheRestoreTargetIsRefusedWhileTheRestoreRuns() throws Exception {
+    final String target = getDatabaseName() + "_7441_inflight";
+    databasesToDrop.add(target);
+
+    final String archive = triggerBackupAndGetFileName();
+    final ServerControlPlane controlPlane = new ServerControlPlane(getServer(0));
+
+    final List<String> failures = new ArrayList<>();
+    final AtomicBoolean probed = new AtomicBoolean();
+
+    controlPlane.restoreBackup(getDatabaseName(), archive, target, false, message -> {
+      // #6086 logs one line per archive entry from a worker pool, so probe exactly once, from whichever thread
+      // delivers the first event.
+      if (!probed.compareAndSet(false, true))
+        return;
+
+      record(failures, "the restore holds the name while it runs",
+          () -> assertThat(getServer(0).isDatabaseNameReservedForRestore(target)).isTrue());
+
+      record(failures, "a create of the target is refused",
+          () -> assertThatThrownBy(() -> controlPlane.createDatabase(target))
+              .isInstanceOf(ServerControlPlane.OperationInProgressException.class)
+              .hasMessageContaining("Cannot create database '" + target + "': a restore of it is already in progress"));
+
+      record(failures, "a create of a DIFFERENT name is not held up by this restore",
+          () -> assertThat(getServer(0).isDatabaseNameReservedForRestore(target + "_other")).isFalse());
+    });
+
+    assertThat(probed).isTrue();
+    assertThat(failures).isEmpty();
+
+    // THE RESTORE FINISHED AND ITS OWN DATA IS WHAT IS THERE - NOT AN EMPTY DATABASE SOMEBODY ELSE CREATED
+    assertThat(getServer(0).existsDatabase(target)).isTrue();
+    assertThat(getServer(0).getDatabase(target).countType(VERTEX1_TYPE_NAME, false)).isEqualTo(1);
+
+    // AND THE NAME IS FREE AGAIN: THE REFUSAL ABOVE WAS THE GUARD, NOT A PERMANENT CLAIM
+    assertThat(getServer(0).isDatabaseNameReservedForRestore(target)).isFalse();
+  }
+
+  /**
+   * The same refusal as seen by an HTTP client. It is a 409 and not a 500: the request is well formed and
+   * authorized, and retrying once the restore finishes is the fix - the same status {@code restore database} and
+   * {@code trigger backup} already answer for the slot they share (issue #7384).
+   */
+  @Test
+  void theHttpCreateDatabaseCommandAnswers409WhileTheNameIsReservedForARestore() throws Exception {
+    final String target = getDatabaseName() + "_7441_http";
+    databasesToDrop.add(target);
+
+    getServer(0).reserveDatabaseNameForRestore(target);
+    try {
+      final HttpResponse<String> refused = postCommand("create database " + target);
+      assertThat(refused.statusCode()).isEqualTo(409);
+      assertThat(refused.body()).contains("a restore of it is already in progress");
+    } finally {
+      getServer(0).releaseDatabaseNameReservedForRestore(target);
+    }
+
+    // NOTHING WAS CREATED BY THE REFUSAL, AND THE VERY SAME COMMAND GOES THROUGH ONCE THE NAME IS FREE
+    assertThat(getServer(0).existsDatabase(target)).isFalse();
+
+    final HttpResponse<String> admitted = postCommand("create database " + target);
+    assertThat(admitted.statusCode()).isEqualTo(200);
+    assertThat(getServer(0).existsDatabase(target)).isTrue();
+  }
+
+  /**
+   * Coverage-table row 3. {@code factory.create()} is reached from two places in {@link ArcadeDBServer}:
+   * {@code createDatabase}, which the test above drives, and the {@code createIfNotExists} arm of
+   * {@code getDatabase} that {@code getOrCreateDatabase} and the Gremlin plugin use. Both are guarded.
+   */
+  @Test
+  void getOrCreateDatabaseIsRefusedWhileTheNameIsReservedForARestore() {
+    final String target = getDatabaseName() + "_7441_getorcreate";
+    databasesToDrop.add(target);
+
+    final ArcadeDBServer server = getServer(0);
+    server.reserveDatabaseNameForRestore(target);
+    try {
+      assertThatThrownBy(() -> server.getOrCreateDatabase(target))
+          .isInstanceOf(ServerControlPlane.OperationInProgressException.class)
+          .hasMessageContaining("a restore of it is already in progress");
+
+      assertThatThrownBy(() -> server.createDatabase(target, ComponentFile.MODE.READ_WRITE))
+          .isInstanceOf(ServerControlPlane.OperationInProgressException.class)
+          .hasMessageContaining("a restore of it is already in progress");
+    } finally {
+      server.releaseDatabaseNameReservedForRestore(target);
+    }
+
+    assertThat(server.existsDatabase(target)).isFalse();
+    assertThat(databaseDirectory(target)).doesNotExist();
+  }
+
+  /**
+   * Coverage-table row 8: the half a reservation cannot cover. A directory appearing under the target's name - an
+   * embedded {@code DatabaseFactory} in the same JVM, an operator's {@code mkdir}, a half-finished operation - is
+   * invisible to an in-memory claim, so the swap re-asks the pre-check's own question before it drops anything.
+   * <p>
+   * The restore fails and the directory is still there. Before this, {@code swapRestoredDatabase} deleted it.
+   */
+  @Test
+  void aDatabaseDirectoryThatAppearsDuringARestoreFailsTheSwapInsteadOfBeingDestroyed() throws Exception {
+    final String target = getDatabaseName() + "_7441_outofband";
+    databasesToDrop.add(target);
+
+    final String archive = triggerBackupAndGetFileName();
+    final ServerControlPlane controlPlane = new ServerControlPlane(getServer(0));
+
+    final File targetDir = databaseDirectory(target);
+    final File marker = new File(targetDir, "appeared-out-of-band.txt");
+    final AtomicBoolean planted = new AtomicBoolean();
+
+    assertThatThrownBy(() -> controlPlane.restoreBackup(getDatabaseName(), archive, target, false, message -> {
+      if (!planted.compareAndSet(false, true))
+        return;
+      try {
+        assertThat(targetDir.mkdirs()).isTrue();
+        try (final FileWriter writer = new FileWriter(marker)) {
+          writer.write("not the restore's to delete");
+        }
+      } catch (final IOException e) {
+        throw new RuntimeException(e);
+      }
+    })).hasMessageContaining("appeared while the restore was running");
+
+    assertThat(planted).isTrue();
+    assertThat(marker).exists();
+    assertThat(getServer(0).existsDatabase(target)).isFalse();
+
+    // AND THE FAILED RESTORE LEFT NEITHER CLAIM BEHIND
+    assertThat(getServer(0).isDatabaseNameReservedForRestore(target)).isFalse();
+    assertThat(getServer(0).getBackupCoordinator().isInProgress(target)).isFalse();
+  }
+
+  /**
+   * The other half of row 8, and the half that decides whether the tripwire is worth having: a database that is
+   * REGISTERED - not merely a directory on disk - when the swap comes round.
+   * <p>
+   * The restore drops its predecessor through {@code dropDatabaseForRestore}, which has to run outside
+   * {@code databasesLock} because an HA drop round-trips through Raft and the apply thread takes that lock
+   * (issue #4832). A guard placed after it would therefore have been checking whether a database still existed
+   * immediately after dropping it. So the drop is gated on the caller having asked for a replacement, and the
+   * re-check runs inside the swap's own lock section.
+   * <p>
+   * The registered database is planted by releasing the claim, creating, and re-claiming - standing in for a creator
+   * an in-memory claim cannot bind: another process, or anything that reaches the directory without going through
+   * this {@link ArcadeDBServer}.
+   */
+  @Test
+  void aDatabaseRegisteredDuringARestoreIsNotDroppedByTheSwap() throws Exception {
+    final String target = getDatabaseName() + "_7441_registered";
+    databasesToDrop.add(target);
+
+    final String archive = triggerBackupAndGetFileName();
+    final ArcadeDBServer server = getServer(0);
+    final ServerControlPlane controlPlane = new ServerControlPlane(server);
+    final AtomicBoolean planted = new AtomicBoolean();
+
+    assertThatThrownBy(() -> controlPlane.restoreBackup(getDatabaseName(), archive, target, false, message -> {
+      if (!planted.compareAndSet(false, true))
+        return;
+      server.releaseDatabaseNameReservedForRestore(target);
+      try {
+        controlPlane.createDatabase(target);
+      } finally {
+        server.reserveDatabaseNameForRestore(target);
+      }
+    })).hasMessageContaining("appeared while the restore was running");
+
+    assertThat(planted).isTrue();
+
+    // THE DATABASE THAT WAS THERE IS STILL THERE, AND STILL USABLE - NOT DROPPED AND NOT HALF-SWAPPED
+    assertThat(server.existsDatabase(target)).isTrue();
+    assertThat(server.getDatabase(target).isOpen()).isTrue();
+    assertThat(databaseDirectory(target)).exists();
+  }
+
+  /**
+   * A reservation leaked by a failed restore would block every later create of that name until the server restarts,
+   * turning one bad URL into an outage - the same hazard {@code aFailedRestoreReleasesTheSlot} guards for the slot.
+   */
+  @Test
+  void aFailedRestoreReleasesTheNameReservation() throws Exception {
+    final String target = getDatabaseName() + "_7441_failed";
+    databasesToDrop.add(target);
+
+    final HttpResponse<String> failed = postCommand(
+        "restore database " + target + " file:///no/such/archive-7441.zip");
+    assertThat(failed.statusCode()).isNotEqualTo(200);
+
+    assertThat(getServer(0).isDatabaseNameReservedForRestore(target)).isFalse();
+
+    // AND THE NAME IS GENUINELY FREE, NOT MERELY REPORTED FREE
+    final HttpResponse<String> created = postCommand("create database " + target);
+    assertThat(created.statusCode()).isEqualTo(200);
+  }
+
+  /**
+   * The pre-swap re-check must not break the case it does not apply to: {@code overwrite} is the caller saying they
+   * meant it, so a target that exists at swap time is replaced rather than refused (issue #5027).
+   */
+  @Test
+  void restoreBackupWithOverwriteStillReplacesAnExistingTarget() throws Exception {
+    final String archive = triggerBackupAndGetFileName();
+    final ServerControlPlane controlPlane = new ServerControlPlane(getServer(0));
+
+    controlPlane.restoreBackup(getDatabaseName(), archive, getDatabaseName(), true,
+        ServerControlPlane.ProgressListener.NOOP);
+
+    assertThat(getServer(0).existsDatabase(getDatabaseName())).isTrue();
+    assertThat(getServer(0).getDatabase(getDatabaseName()).countType(VERTEX1_TYPE_NAME, false)).isEqualTo(1);
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------------------------
+
+  private static void record(final List<String> failures, final String what, final Runnable assertion) {
+    try {
+      assertion.run();
+    } catch (final Throwable t) {
+      failures.add(what + ": " + t.getMessage());
+    }
+  }
+
+  private File databaseDirectory(final String databaseName) {
+    return new File(getServer(0).getConfiguration().getValueAsString(GlobalConfiguration.SERVER_DATABASE_DIRECTORY)
+        + File.separator + databaseName);
+  }
+
+  private String triggerBackupAndGetFileName() throws Exception {
+    final HttpResponse<String> triggered = postCommand("trigger backup " + getDatabaseName());
+    assertThat(triggered.statusCode()).isEqualTo(200);
+
+    final HttpResponse<String> listed = postCommand("list backups " + getDatabaseName());
+    assertThat(listed.statusCode()).isEqualTo(200);
+
+    final JSONArray backups = new JSONObject(listed.body()).getJSONArray("backups");
+    assertThat(backups.length()).isPositive();
+    return backups.getJSONObject(backups.length() - 1).getString("fileName");
+  }
+
+  private HttpResponse<String> postCommand(final String command) throws Exception {
+    final HttpClient client = HttpClient.newHttpClient();
+    final HttpRequest request = HttpRequest.newBuilder()
+        .uri(new URI("http://127.0.0.1:" + getServer(0).getHttpServer().getPort() + "/api/v1/server"))
+        .header("Authorization",
+            "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()))
+        .header("Content-Type", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString(new JSONObject().put("command", command).toString()))
+        .build();
+    return client.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/backup/Issue7441RestoreNameReservationIT.java
+++ b/server/src/test/java/com/arcadedb/server/backup/Issue7441RestoreNameReservationIT.java
@@ -251,9 +251,16 @@ class Issue7441RestoreNameReservationIT extends BaseGraphServerTest {
   /**
    * Coverage-table row 8: the half a reservation cannot cover. A directory appearing under the target's name - an
    * embedded {@code DatabaseFactory} in the same JVM, an operator's {@code mkdir}, a half-finished operation - is
-   * invisible to an in-memory claim, so the swap re-asks the pre-check's own question before it drops anything.
+   * invisible to an in-memory claim.
    * <p>
-   * The restore fails and the directory is still there. Before this, {@code swapRestoredDatabase} deleted it.
+   * This is the <b>filesystem</b> half of the swap's guard, and nothing checks for it: the directory is registered
+   * nowhere, so {@code existsDatabase} says no, and what refuses the restore is the move itself, which on this
+   * branch carries neither {@code ATOMIC_MOVE} nor {@code REPLACE_EXISTING} and so fails with
+   * {@code FileAlreadyExistsException}. A check could not have done the job - a directory can appear between any
+   * check and the move that follows it.
+   * <p>
+   * The restore fails and the directory is still there, marker and all. Before this,
+   * {@code swapRestoredDatabase} deleted it.
    */
   @Test
   void aDatabaseDirectoryThatAppearsDuringARestoreFailsTheSwapInsteadOfBeingDestroyed() throws Exception {
@@ -293,11 +300,11 @@ class Issue7441RestoreNameReservationIT extends BaseGraphServerTest {
    * The other half of row 8, and the half that decides whether the tripwire is worth having: a database that is
    * REGISTERED - not merely a directory on disk - when the swap comes round.
    * <p>
-   * The restore drops its predecessor through {@code dropDatabaseForRestore}, which has to run outside
-   * {@code databasesLock} because an HA drop round-trips through Raft and the apply thread takes that lock
-   * (issue #4832). A guard placed after it would therefore have been checking whether a database still existed
-   * immediately after dropping it. So the drop is gated on the caller having asked for a replacement, and the
-   * re-check runs inside the swap's own lock section.
+   * This is the <b>registry</b> half, the one a check does answer: the restore drops its predecessor through
+   * {@code dropDatabaseForRestore}, which has to run outside {@code databasesLock} because an HA drop round-trips
+   * through Raft and the apply thread takes that lock (issue #4832). A guard placed after it would therefore have
+   * been asking whether a database still existed immediately after dropping it. So the drop is gated on the caller
+   * having asked for a replacement, and {@code existsDatabase} is re-asked inside the swap's own lock section.
    * <p>
    * The registered database is planted by releasing the claim, creating, and re-claiming - standing in for a creator
    * an in-memory claim cannot bind: another process, or anything that reaches the directory without going through


### PR DESCRIPTION
Closes #7441

`restoreDatabase` and `restoreBackup` sampled the target name up front and acted on the answer minutes later, in `swapRestoredDatabase`. `ArcadeDBServer.createDatabase` takes `databasesLock` for its own check-then-act; the restore check took nothing at all, so the window between the two was the whole duration of the download, and a `create database X` that landed inside it was dropped and overwritten without a word - by the one command whose contract is that it never replaces an existing database. Issue #7384 closed the restore-vs-restore, restore-vs-backup and restore-vs-import halves of this with the per-database `BackupCoordinator` slot; `createDatabase` asks that slot nothing.

The name is now claimed in the same `databasesLock` section as the existence check and released in a `finally` around the whole restore, so the check and the swap are two ends of one reservation rather than two independent samples. `ArcadeDBServer` refuses to create under a claimed name from both places it reaches `DatabaseFactory.create()`, with `OperationInProgressException` - already a 409 on HTTP and `ABORTED` on gRPC, so no new status plumbing. A creator is refused, never parked: waiting would block a `create database` behind a multi-GB download.

For what a claim cannot bind, the **non-overwrite swap branch now has no destructive call on it at all**. `existsDatabase` answers the registry half under the lock; the filesystem half is left to `Files.move` with no options, which fails with `FileAlreadyExistsException` rather than being asked a question whose answer goes stale before the move. `ATOMIC_MOVE` is deliberately unset there - with no `REPLACE_EXISTING` its behaviour over an existing target is implementation-specific and POSIX `rename(2)` clobbers silently. The HA-aware drop is gated on the same flag, because it must run outside `databasesLock` (#4832) and would otherwise destroy a mid-restore database before any guard ran.

## Test plan

- [x] `mvn -o -pl server test -Dtest=Issue7441RestoreNameReservationIT` - 7 tests, green
- [x] The tests can fail: with the two `checkDatabaseNameIsNotBeingRestored` calls and the swap guard disabled, 4 of the 7 fail; with only the `replaceExisting` gate on `dropDatabaseForRestore` reverted, `aDatabaseRegisteredDuringARestoreIsNotDroppedByTheSwap` fails
- [x] `mvn -o -pl server test -Dtest='Issue7384ConcurrentRestoreIT,ServerRestoreDatabaseIT,ServerBackupDatabaseIT,ServerImportDatabaseIT'` - 19/19 with the new class
- [x] `mvn -o -pl server test -DexcludedGroups=benchmark,vector,slow` - 1052 tests, green
- [x] `mvn -o -pl ha-raft test -Dtest='ArcadeStateMachine*Test,Issue7011*,Issue7143*,Issue7221*'` - 108 tests, green (the Raft apply is the third caller of `createDatabase`)
- [x] `mvn -o install -DskipTests` - full reactor
- [ ] By hand: start a restore of a large archive and `create database <target>` while it runs - a 409 naming the restore, instead of a database that vanishes when the restore lands

## Coverage

Every path that can bring a database into existence on a server, from the sweep in `docs/7441-restore-target-reservation.md`:

| Entry point | Outcome |
|---|---|
| `create database` over HTTP (`PostServerCommandHandler` -> `ServerControlPlane.createDatabase`) | fixed, tested through the control plane and through the HTTP endpoint |
| `create database` over gRPC (`ArcadeDbGrpcAdminService`) | fixed - it calls the same control-plane method and nothing else |
| `ArcadeDBServer.getDatabase(name, createIfNotExists=true, ...)` (`getOrCreateDatabase`, `GremlinServerPlugin`) | fixed, tested |
| HA Raft apply `ArcadeStateMachine` -> `server.createDatabase` | fixed - same chokepoint, and it already has to handle the two `IllegalArgumentException`s `createDatabase` throws for a taken name |
| `import database`, and a second restore of the same target | argued: the `BackupCoordinator` slot refuses both before they reach `createDatabase` (#7384) |
| `ArcadeDBServer.registerDatabase` | argued: no `src/main` caller - the grep finds only `ha-raft` test classes |
| `ArcadeDbGrpcService`'s own `databasePool` + `DatabaseFactory` | argued: reachable only with no `ArcadeDBServer` at all, and `GrpcServerPlugin` is the single production construction site. Raised in review; the sweep had missed it, and the reachability fact is now stated at the call site |
| a database appearing out of band (embedded `DatabaseFactory` in this JVM, an operator's `mkdir`) | fixed by the non-destructive swap branch, tested for both the bare-directory (the move) and registered-database (the registry check) case |

**Known gaps:** None filed as follow-ups. Two rows are argued in the tracking doc rather than fixed, and both are stated in the code as well as here:

1. A **second OS process** writing the same database directory (another server instance, the CLI `restore`) cannot be seen from this JVM. That is the limit `BackupCoordinator`'s own class javadoc already states for backups, and closing it needs an on-disk lock file - a different change from this one. The reservation is per `ArcadeDBServer` instance for the same reason the slot is: an HA test and a co-located pair of nodes run several servers with the same database names in one process.
2. `restore backup ... overwrite` has **no tripwire at all**, deliberately: replacing whatever is at that name is the entire content of the flag. Now said in `swapRestoredDatabase`'s javadoc rather than only in the tracking doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1vgWQXZoDXYq7TqAwLYXY