### PR TITLE
fix(#7444): exclude a follower's backup from the snapshot install that replaces the database

### DIFF
--- a/docs/7444-follower-backup-vs-snapshot-install.md
+++ b/docs/7444-follower-backup-vs-snapshot-install.md
@@ -1,0 +1,234 @@
+# #7444 - A leader-side restore does not exclude a follower's scheduled backup of the same replicated database
+
+Follow-up to #7384. That issue gave every whole-database maintenance operation a per-database
+admission slot (`BackupCoordinator`), deliberately scoped **per server instance**: an HA test - and
+a co-located pair of nodes - runs several servers with the same database names in one process, and
+their backups are genuinely independent.
+
+## The gap as reported
+
+A restore is leader-only on both transports, so restore-versus-restore of one database is already
+serialised cluster-wide. A backup is not: `runOnServer` in `backup.json` defaults to `"*"`, so every
+node runs its own scheduled backup.
+
+After a successful restore the leader calls `ServerControlPlane.replicateRestoredDatabase`, which
+submits an install-database entry with `forceSnapshot=true`. Every follower applies it and
+**replaces its own copy of the database directory** from the leader's snapshot. A follower running
+its own scheduled backup of that database at that moment has the directory reinstalled underneath
+the backup, and its own `BackupCoordinator` slot is the wrong one to consult - the restore happened
+on a different JVM.
+
+## Root cause
+
+The slot is taken by every operation that replaces a database directory **except one**: the HA
+snapshot install. `ServerControlPlane.performRestore` takes `Operation.RESTORE` (#7384);
+`SnapshotInstaller.install` - which closes the live database, swaps its directory for the leader's
+snapshot and reopens it - takes nothing.
+
+The reporter offered two shapes of fix and named the smaller one: "the install-database apply path
+on a follower takes the local slot before it reinstalls and the follower's backup task waits for or
+is refused by it." That is what this change does, one level lower than the apply path so that
+*every* install driver is covered rather than only the one the issue named.
+
+## Completeness
+
+### 1. The invariant
+
+> On any one server, a snapshot install of a database and a backup of that same database can never
+> be in flight at the same time: the install holds the node's per-database maintenance slot for its
+> whole duration, so a backup that has not started is refused, and a backup already running is
+> waited for (bounded) before the files are replaced.
+
+### 2. Every way to violate it
+
+Every driver that replaces a local database directory from the leader:
+
+```
+$ grep -rn "SnapshotInstaller\.\(install\|acquireNewDatabase\|recoverPendingSnapshotSwaps\)(" --include='*.java' */src/main
+ha-raft/.../ArcadeStateMachine.java:615   -> recoverPendingSnapshotSwaps
+ha-raft/.../ArcadeStateMachine.java:2970  -> install   (applyInstallDatabaseEntry, forceSnapshot arm - the reported path)
+ha-raft/.../ArcadeStateMachine.java:3269  -> install   (installFromLeaderForBootstrap)
+ha-raft/.../ArcadeStateMachine.java:3327  -> install
+ha-raft/.../ArcadeStateMachine.java:4238  -> install
+ha-raft/.../ArcadeStateMachine.java:4463  -> install
+ha-raft/.../DatabaseReconciler.java:274   -> acquireNewDatabase
+ha-raft/.../DatabaseReconciler.java:280   -> install
+ha-raft/.../DatabaseReconciler.java:423   -> install
+```
+
+Every caller that takes the slot today (the readers/holders the install has to exclude):
+
+```
+$ grep -rn "getBackupCoordinator()\.begin\|coordinator.begin(" --include='*.java' */src/main
+server/.../ServerControlPlane.java:930   coordinator.begin(databaseName, Operation.BACKUP)   (HTTP/gRPC trigger backup)
+server/.../ServerControlPlane.java:951   begin(databaseName, operation)                      (RESTORE / IMPORT admission)
+server/.../backup/BackupTask.java:116    coordinator.begin(databaseName, Operation.BACKUP)   (scheduled tick)
+```
+
+Same-shape siblings - everything in `src/main` that starts a full backup:
+
+```
+$ grep -rn "backupDatabase\|new Backup(" --include='*.java' */src/main
+engine/.../BackupDatabaseStatement.java:151   SQL BACKUP DATABASE - takes no slot (already filed as #7443)
+server/.../ServerControlPlane.java:1027       HTTP trigger backup - under the slot taken at :930
+server/.../backup/BackupTask.java:246         scheduled backup   - under the slot taken at :116
+```
+
+### 3. Coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| `ArcadeStateMachine.applyInstallDatabaseEntry` (forceSnapshot) -> `install` - the reported path | yes | yes |
+| `ArcadeStateMachine:3269` / `:3327` / `:4238` / `:4463` -> `install` | yes (slot taken inside `install`, not at the call site) | yes - the test drives `install` itself, which is the single choke point all five share |
+| `DatabaseReconciler:280` / `:423` -> `install` | yes (same choke point) | yes - same |
+| `DatabaseReconciler:274` -> `acquireNewDatabase` (database never seen locally) | argued, see below | n/a |
+| `ArcadeStateMachine:615` -> `recoverPendingSnapshotSwaps` (startup crash recovery) | **no** - filed as #7449 | no |
+| `BackupTask.run` scheduled tick - the loser side the issue describes | yes (already takes `BACKUP`; `RESTORE` now excludes it) | yes |
+| HTTP/gRPC "trigger backup" -> `ServerControlPlane:930` | yes (same slot, same `Operation.BACKUP`) | yes (unit) |
+| SQL `BACKUP DATABASE` / `IMPORT DATABASE` | **no** - already filed as #7443 | no |
+| Leader takes the slot on every peer before it starts | **no** - the larger of the two options the issue offers; argued below | n/a |
+
+### Argued rows
+
+- **`acquireNewDatabase`.** It only publishes under the final name when the database is *not*
+  registered on this node, and it re-checks that immediately before publishing. Both arms where the
+  database *is* registered delegate to `install` (SnapshotInstaller.java:410 and :443), which takes
+  the slot. A backup cannot be running on a database that is not registered:
+  `BackupTask.run` returns at its first line when `!server.existsDatabase(databaseName)`, and
+  `performBackup` resolves it with `getDatabase(name, false, false)` - `allowLoad=false` - so it can
+  never be the thing that opens it (#6752). The `deleteDirectoryIfExists(dbPath)` before the rename
+  runs only on the not-registered arm.
+- **Cluster-wide serialisation.** The issue names it as the larger option and says of the smaller
+  one that it "may be enough on its own". It is: the hazard is a follower replacing its own files,
+  and the follower replaces them only from inside `SnapshotInstaller.install`, which now holds that
+  follower's own slot. A cluster-wide slot would additionally cover a backup on a peer that the
+  leader's restore never reaches an install for - but there is no such peer, because
+  `replicateRestoredDatabase` submits the entry to every replica.
+
+### 5. Reachability
+
+`SnapshotInstaller.install` is on the live follower path: `applyInstallDatabaseEntry` calls it
+directly from the Ratis apply thread (ArcadeStateMachine.java:2970), and the whole download runs on
+that same thread. `server` is dereferenced unconditionally inside `install`
+(`server.getConfiguration()` at the retry-count read), so `getBackupCoordinator()` cannot see a null
+server there. No feature flag gates the change off: the new setting only sizes the *wait*, and the
+exclusion happens whatever its value.
+
+### 7. Residual risk
+
+- A snapshot install that runs while a backup started before it is **not** prevented; it is waited
+  for, for at most `arcadedb.ha.snapshotInstallBackupWaitMs` (default 60s), and then proceeds with a
+  WARNING. Blocking indefinitely is not an option: a committed Raft entry has to be applied.
+- Startup crash recovery (`recoverPendingSnapshotSwaps`) still takes no slot - #7449.
+- SQL `BACKUP DATABASE` still takes no slot - #7443, unchanged by this PR.
+
+## The change
+
+| File | What |
+|---|---|
+| `server/.../backup/BackupCoordinator.java` | `begin(database, operation, timeoutMs)` - the same reservation, but it waits out a conflicting operation for a bounded time instead of refusing immediately. `end` notifies the waiters. |
+| `ha-raft/.../SnapshotInstaller.java` | `install` takes `Operation.RESTORE` for its whole duration through that bounded wait, and releases it in a `finally`. The body moved unchanged into a private `installHoldingMaintenanceSlot`. |
+| `engine/.../GlobalConfiguration.java` | `arcadedb.ha.snapshotInstallBackupWaitMs` (`SCOPE.SERVER`, default 60 000) sizes that wait. |
+
+Why a waiting form at all: every other holder of the slot may simply be refused - a scheduled
+backup is covered again on the next tick, a restore or an import is an operator command that can be
+retried. An install cannot. It applies a committed Raft entry, and a follower that declines to apply
+one diverges from the cluster, so an in-flight backup may delay the install but must not veto it.
+The wait expiring is therefore not an error: the install proceeds and says so at WARNING, naming the
+setting to raise.
+
+Sixty seconds is proportionate rather than cautious. The download already runs on the same Ratis
+apply thread and takes minutes for a large database, so the wait is small beside what that thread is
+already committed to.
+
+## Test results
+
+```
+$ mvn -o -pl server test -Dtest='com.arcadedb.server.backup.*Test'
+Tests run: 169, Failures: 0, Errors: 0, Skipped: 0
+
+$ mvn -o -pl ha-raft test -Dtest='Snapshot*Test,Issue7*Test,Issue6*Test,Issue4*Test,ArcadeStateMachine*Test'
+Tests run: 659, Failures: 0, Errors: 0, Skipped: 0
+
+$ mvn -o -pl engine test -Dtest='GlobalConfigurationTest,Issue7124...,Issue7163...'
+Tests run: 29, Failures: 0, Errors: 0, Skipped: 0
+```
+
+New tests:
+
+- `server/.../backup/Issue7444MaintenanceSlotWaitTest` - 6 cases on the bounded wait: a free slot is
+  taken without spending the timeout, the slot is taken the instant the holder releases it, the wait
+  expires and names the operation still in the way without reserving anything, a zero or negative
+  timeout is exactly the non-waiting form, a release on an unrelated database does not hand the
+  waiter a slot, and the backup/import pair still coexists through the waiting form.
+- `ha-raft/.../Issue7444SnapshotInstallExcludesBackupTest` - 3 cases driving the real
+  `SnapshotInstaller.install` against a real `ArcadeDBServer` and a local HTTP server standing in for
+  the leader's snapshot endpoint: a backup is refused while the swap is in progress (paused on the
+  existing `swapBarrierForTesting` seam), an install waits for a backup already running and the live
+  database is untouched while it waits, and a backup that never ends does not block the install past
+  the configured wait.
+
+### Both new tests were shown to fail without the fix
+
+With the reservation in `install` replaced by a constant and the waiting `begin` short-circuited to
+the non-waiting one:
+
+```
+Issue7444MaintenanceSlotWaitTest: Tests run: 6, Failures: 2
+  aWaitOnOneDatabaseIsNotWokenByAnUnrelatedOne:128
+  theSlotIsTakenAsSoonAsTheOperationInTheWayReleasesIt:72 [the install waits instead of replacing the files under a running backup]
+
+Issue7444SnapshotInstallExcludesBackupTest: Tests run: 3, Failures: 2
+  aBackupIsRefusedWhileThisNodeIsReinstallingTheDatabase:146 [the install holds this node's maintenance slot while it replaces the files]
+  anInstallWaitsForABackupThatIsAlreadyRunning:195 [the install waited instead of replacing the files under a running backup]
+```
+
+The third case in each class pins a safety property rather than the bug (the wait must stay bounded;
+a zero timeout must behave like the non-waiting form), so it passes either way by design.
+
+## Impact
+
+- HA followers: a scheduled backup is now refused - and logged as skipped by `BackupTask`, which
+  already names the operation in the way - while the node reinstalls that database from the leader.
+  The schedule covers it again on the next tick.
+- No change outside HA: `install` only runs on a node pulling a snapshot.
+- No hot path is touched. The reservation is one `ConcurrentHashMap.compute` per install, and the
+  new monitor in `end` is uncontended except while an install is actually waiting.
+- An existing unit test (`Issue7139RetainedBackupNotDestroyedTest`) drives `install` with a
+  partially-stubbed `ArcadeDBServer` whose `getBackupCoordinator()` returns null. Rather than change
+  that test, the reservation tolerates a null coordinator, the way `downloadSnapshot` and
+  `purgeRaftLogBeforeInstall` in the same class already tolerate a partially-stubbed server.
+
+## Adversarial pass
+
+The orchestrator's Phase 1.5 spawns a subagent that has not seen this document. The `Task` tool was
+disabled in this session (`Error: No such tool available: Task`), so the pass was run by the author
+against the tree instead - which is weaker, and is recorded as such. Findings:
+
+1. **`acquireNewDatabase`'s publish arm still deletes `dbPath` without the slot.** Real, argued
+   above rather than fixed: that arm runs only while `!server.existsDatabase(databaseName)`, both
+   arms where it is registered delegate to `install`, and `BackupTask` returns at its first line for
+   an unregistered database. Not fixed because fixing it needs the reservation released before each
+   delegation to `install` (the slot is not reentrant), which is complexity for a path the reported
+   scenario never reaches: a restore replicates as a `forceSnapshot` entry, which lands in
+   `applyInstallDatabaseEntry` -> `install`, never in `acquireNewDatabase`.
+2. **The reservation changed install-versus-install behaviour, not only install-versus-backup.**
+   Real, and an improvement: a second install of the same database on the same server now waits for
+   the first instead of overlapping it and logging `INSTALLS_IN_FLIGHT`'s WARNING. Written down on
+   that field, together with why the WARNING is still reachable (the wait is bounded).
+3. **`Operation.RESTORE` is reused rather than a new `SNAPSHOT_INSTALL` constant.** Deliberate. A
+   follower's log will read "a restore of it is already in progress" for a backup skipped by an
+   install, which is true - the node is restoring its own copy - but is not the word an operator who
+   issued no restore would predict. A fourth constant would read better and would pass #7384's
+   `Operation.values()` loops unchanged; it was not added because the whole point is that an install
+   must be admitted exactly as a restore is, and a second constant that must never diverge from the
+   first is a thing to keep in sync rather than a distinction. Named here so a reviewer can disagree.
+4. **A stale line reference in a comment.** Real, fixed: the null-coordinator comment cited
+   `ArcadeDBServer:161`, which drifts. It now names the field instead of the line.
+5. **Does any caller pass a null `server` into `install`?** Checked, no:
+   `grep -rn "SnapshotInstaller.install(" */src/test` returns seven call sites, five with a real
+   `ArcadeDBServer` and two (`Issue7139RetainedBackupNotDestroyedTest`) with a Mockito mock whose
+   `getBackupCoordinator()` is unstubbed - the case the null tolerance covers.
+6. **Port binding in the new ha-raft test.** Each case starts a real `ArcadeDBServer`, which binds
+   the 2480-2489 HTTP range. Not new: `SnapshotInstallSwapLockTest` in the same package does exactly
+   the same, and the range auto-increments.

--- a/docs/7444-follower-backup-vs-snapshot-install.md
+++ b/docs/7444-follower-backup-vs-snapshot-install.md
@@ -232,3 +232,38 @@ against the tree instead - which is weaker, and is recorded as such. Findings:
 6. **Port binding in the new ha-raft test.** Each case starts a real `ArcadeDBServer`, which binds
    the 2480-2489 HTTP range. Not new: `SnapshotInstallSwapLockTest` in the same package does exactly
    the same, and the range auto-increments.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/7453
+
+## Review cycles
+
+### Cycle 1 - `d72d88fe` - clean approval
+
+The `claude` reviewer traced the diff against the tree rather than against the write-up: it
+re-derived the `wait`/`notify` ordering in `BackupCoordinator` ("that ordering closes the classic
+'release lands between check and wait' race correctly - no missed wakeups"), independently confirmed
+the leadership-change deadlock scenario is real by walking `restoreDatabase` -> `performRestore` ->
+`replicateRestoredDatabase`, and confirmed by grep that neither `ArcadeStateMachine` nor
+`DatabaseReconciler` calls `getBackupCoordinator()` directly - so `install` really is the single
+choke point. Verdict: "Nothing blocking found."
+
+Two nits, both declined with reasons rather than applied:
+
+1. **The waiting `begin` calls the non-waiting one twice on the conflict path** - once outside the
+   monitor as the fast path, once as the `while` condition inside it. Declined, and the reviewer's
+   own verdict was "not worth restructuring": collapsing them means taking the monitor before the
+   fast path, which makes the common uncontended case worse to save one `ConcurrentHashMap.compute`
+   on a path that runs a handful of times a day.
+2. **`Operation.RESTORE` reuse rather than a fourth `SNAPSHOT_INSTALL` constant** - the reviewer
+   raised it "only so it's visible outside the doc" and said it would "lean toward agreeing it's
+   fine as-is". Declined for the reason already in the adversarial pass above: a second constant that
+   must never diverge from the first is a thing to keep in sync, not a distinction.
+
+No code changed in this cycle, and nothing was deferred - both items were technically assessed and
+declined, which is a decision rather than a deferral.
+
+## Final state
+
+`clean-approval` on cycle 1 of a maximum of 4.

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2012,6 +2012,10 @@ public enum GlobalConfiguration {
       "Base delay in milliseconds for exponential backoff between snapshot download retries. Actual delay is baseMs * 2^attempt.",
       Long.class, 5000L),
 
+  HA_SNAPSHOT_INSTALL_BACKUP_WAIT_MS("arcadedb.ha.snapshotInstallBackupWaitMs", SCOPE.SERVER,
+      "Milliseconds a snapshot install waits for a backup or an import of the same database, already running on this node, to finish before it replaces the database files anyway. An install applies a committed Raft entry, so the wait has to be bounded: when it expires the install proceeds and logs a warning. 0 refuses to wait at all.",
+      Long.class, 60_000L),
+
   HA_PROXY_READ_TIMEOUT("arcadedb.ha.proxyReadTimeout", SCOPE.SERVER,
       "Read timeout in milliseconds for the leader proxy in AbstractServerHttpHandler. Covers long-running queries proxied from a follower to the leader.",
       Long.class, 30000L),

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
@@ -26,6 +26,7 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.engine.ComponentFile;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.backup.BackupCoordinator;
 import com.arcadedb.utility.FileUtils;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -162,6 +163,12 @@ public final class SnapshotInstaller {
    * a violation of that assumption from a silent double-close into a logged WARNING so it is
    * diagnosable after the fact. Keyed by resolved path (not database name) so two logical servers in
    * the same JVM - which use distinct database directories - never raise a spurious overlap warning.
+   * <p>
+   * Since issue #7444 the per-database maintenance slot {@link #install} takes usually prevents the overlap
+   * outright rather than only reporting it: a second install of the same database on the same server waits for the
+   * first. This set still earns its keep, because that wait is bounded - an install that outlasts
+   * {@code arcadedb.ha.snapshotInstallBackupWaitMs} can still be joined by a second one, and that is exactly the
+   * case worth a WARNING.
    */
   private static final Set<String> INSTALLS_IN_FLIGHT = ConcurrentHashMap.newKeySet();
 
@@ -206,6 +213,63 @@ public final class SnapshotInstaller {
    * again, giving leader election time to complete.
    */
   public static void install(final String databaseName, final String databasePath,
+      final Supplier<String> leaderHttpAddrSupplier, final Supplier<String> leaderHttpsAddrSupplier,
+      final String clusterToken, final ArcadeDBServer server) throws IOException {
+
+    // An install REPLACES this node's copy of the database - it closes the live one, swaps its directory for the
+    // leader's snapshot and reopens it - so it is a restore of this node's copy, and it takes the same per-database
+    // maintenance slot a restore takes (issue #7384). Without this, a backup running on THIS node had its directory
+    // reinstalled underneath it: the restore that produced the entry ran on the leader, a different JVM, so the
+    // leader's slot could not be the one that excluded it (issue #7444).
+    //
+    // Taken here rather than at any call site because this method is the choke point every install driver shares:
+    // the forceSnapshot arm of applyInstallDatabaseEntry, the bootstrap installs, the reconciler's resync, and
+    // acquireNewDatabase on both arms where it finds the database already registered and delegates here.
+    //
+    // The wait is bounded, and expiry is not fatal. An install applies a committed Raft entry and a follower that
+    // declines to apply one diverges, so an in-flight backup can delay the install but must not veto it. The default
+    // is proportionate rather than cautious: the download below runs on this same thread and takes minutes for a
+    // large database, so the wait is small beside what the caller is already committed to.
+    //
+    // Bounding it also keeps one narrow circular wait from becoming a deadlock. A leader-side restore holds this
+    // database's RESTORE slot on its request thread while replicateRestoredDatabase blocks waiting for the entry to
+    // commit and apply; applyInstallDatabaseEntry normally returns early on a leader and never reaches here, but a
+    // node that lost leadership between the submit and the apply does reach here, on the apply thread, with its own
+    // request thread still holding the slot and waiting on it. The reservation is not reentrant and these are two
+    // different threads, so an unbounded wait would be a cycle. Bounded, it costs the timeout and a warning.
+    //
+    // A null coordinator is not a production state - ArcadeDBServer's field is final and initialised inline - but
+    // the unit tests that drive this method directly hand it a partially-stubbed server,
+    // which is the same reason downloadSnapshot and purgeRaftLogBeforeInstall below already tolerate one. No
+    // coordinator means no slot to take, and therefore none to release.
+    final BackupCoordinator coordinator = server.getBackupCoordinator();
+    final BackupCoordinator.Operation refusedBy = coordinator == null ? null
+        : coordinator.begin(databaseName, BackupCoordinator.Operation.RESTORE,
+            server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_SNAPSHOT_INSTALL_BACKUP_WAIT_MS));
+    final boolean slotHeld = coordinator != null && refusedBy == null;
+    if (refusedBy != null)
+      LogManager.instance().log(SnapshotInstaller.class, Level.WARNING,
+          "Reinstalling database '%s' from the leader while %s of it is still running on this node: the install "
+              + "applies a committed Raft entry and cannot be declined, so it proceeds and that operation will fail "
+              + "or produce an incomplete result. Raise '%s' to give it longer to finish", null,
+          databaseName, refusedBy.phrase(), GlobalConfiguration.HA_SNAPSHOT_INSTALL_BACKUP_WAIT_MS.getKey());
+
+    try {
+      installHoldingMaintenanceSlot(databaseName, databasePath, leaderHttpAddrSupplier, leaderHttpsAddrSupplier,
+          clusterToken, server);
+    } finally {
+      // Only what was actually reserved: a wait that expired took nothing, and releasing then would drop the
+      // reservation the operation still in flight is holding.
+      if (slotHeld)
+        coordinator.end(databaseName, BackupCoordinator.Operation.RESTORE);
+    }
+  }
+
+  /**
+   * The install itself, with this node's per-database maintenance slot already held (or deliberately given up on)
+   * by {@link #install(String, String, Supplier, Supplier, String, ArcadeDBServer)}.
+   */
+  private static void installHoldingMaintenanceSlot(final String databaseName, final String databasePath,
       final Supplier<String> leaderHttpAddrSupplier, final Supplier<String> leaderHttpsAddrSupplier,
       final String clusterToken, final ArcadeDBServer server) throws IOException {
 

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7444SnapshotInstallExcludesBackupTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7444SnapshotInstallExcludesBackupTest.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.ServerDatabase;
+import com.arcadedb.server.backup.BackupCoordinator;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7444.
+ * <p>
+ * A restore is leader-only, so restore-versus-restore of one database is already serialised cluster-wide. A backup is
+ * not: {@code runOnServer} defaults to {@code "*"}, so every node runs its own scheduled backup. After a restore the
+ * leader submits an install-database entry with {@code forceSnapshot=true} and every follower answers it by replacing
+ * its own copy of the database directory from the leader's snapshot - while that follower's own scheduled backup may
+ * be reading it. The follower's {@link BackupCoordinator} slot was the wrong one to consult only because nothing on
+ * the install path ever took it: the restore happened on a different JVM, but the <i>reinstall</i> happens right here.
+ * <p>
+ * {@link SnapshotInstaller#install} is the single choke point every install driver goes through - the forceSnapshot
+ * arm of {@code applyInstallDatabaseEntry}, the bootstrap installs, the reconciler's resync - so the slot is taken
+ * there rather than at any one call site. These tests drive the real {@code install}, with a local HTTP server
+ * standing in for the leader's snapshot endpoint, and pin both directions of the exclusion.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue7444SnapshotInstallExcludesBackupTest {
+
+  private static final String DB_NAME        = "snap7444";
+  private static final String PASSWORD       = "DefaultPasswordForTests";
+  private static final int    LIVE_COUNT     = 12;
+  private static final int    SNAPSHOT_COUNT = 27;
+
+  private HttpServer     leader;
+  private int            leaderPort;
+  private ArcadeDBServer server;
+
+  @BeforeEach
+  void startLeaderEndpoint() throws IOException {
+    leader = HttpServer.create(new InetSocketAddress(0), 0);
+    leaderPort = leader.getAddress().getPort();
+  }
+
+  @AfterEach
+  void stopEverything() {
+    SnapshotInstaller.swapBarrierForTesting = null;
+    if (server != null) {
+      try {
+        if (server.existsDatabase(DB_NAME))
+          ((DatabaseInternal) server.getDatabase(DB_NAME)).getEmbedded().drop();
+      } catch (final Exception ignore) {
+        // best-effort cleanup; the @TempDir is removed regardless
+      }
+      server.stop();
+      server = null;
+    }
+    if (leader != null) {
+      leader.stop(0);
+      leader = null;
+    }
+  }
+
+  /**
+   * The bug as reported: while this node replaces its copy of the database, a backup of it must not be admitted.
+   * The install is paused inside the registry-locked swap - the exact moment the directory is being replaced - and a
+   * backup is attempted from the test thread, standing in for the scheduled tick {@code BackupTask.run} would fire.
+   * <p>
+   * Without the fix the reservation succeeds and the tick goes on to read a directory that is being deleted.
+   */
+  @Test
+  @Timeout(120)
+  void aBackupIsRefusedWhileThisNodeIsReinstallingTheDatabase(@TempDir final Path root) throws Exception {
+    server = startServer(root, 60_000);
+    final Path dbPath = createLiveDatabase();
+    serveSnapshot(root);
+
+    final CountDownLatch insideSwap = new CountDownLatch(1);
+    final CountDownLatch releaseSwap = new CountDownLatch(1);
+    SnapshotInstaller.swapBarrierForTesting = () -> {
+      insideSwap.countDown();
+      try {
+        releaseSwap.await();
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    };
+
+    final AtomicBoolean installDone = new AtomicBoolean(false);
+    final AtomicReference<Throwable> installError = new AtomicReference<>();
+    final Thread installer = new Thread(() -> {
+      try {
+        SnapshotInstaller.install(DB_NAME, dbPath.toString(), "localhost:" + leaderPort, null, null, server);
+        installDone.set(true);
+      } catch (final Throwable t) {
+        installError.set(t);
+      }
+    }, "snapshot-installer");
+    installer.start();
+
+    try {
+      assertThat(insideSwap.await(60, TimeUnit.SECONDS)).as("the install reached the in-swap barrier").isTrue();
+
+      final BackupCoordinator coordinator = server.getBackupCoordinator();
+      assertThat(coordinator.isInProgress(DB_NAME, BackupCoordinator.Operation.RESTORE))
+          .as("the install holds this node's maintenance slot while it replaces the files").isTrue();
+      assertThat(coordinator.begin(DB_NAME, BackupCoordinator.Operation.BACKUP))
+          .as("a scheduled backup of a database being reinstalled from the leader is refused")
+          .isEqualTo(BackupCoordinator.Operation.RESTORE);
+    } finally {
+      releaseSwap.countDown();
+    }
+
+    installer.join(60_000);
+    assertThat(installError.get()).as("the install completed without error").isNull();
+    assertThat(installDone.get()).isTrue();
+
+    // The slot is released when the install ends, whatever the outcome: a leaked reservation would block every later
+    // backup of this database until the server restarts.
+    assertThat(server.getBackupCoordinator().isInProgress(DB_NAME)).as("the install released the slot").isFalse();
+    assertThat(server.getBackupCoordinator().begin(DB_NAME, BackupCoordinator.Operation.BACKUP)).isNull();
+    server.getBackupCoordinator().end(DB_NAME, BackupCoordinator.Operation.BACKUP);
+
+    assertThat(server.getDatabase(DB_NAME).countType("Node", true)).isEqualTo(SNAPSHOT_COUNT);
+  }
+
+  /**
+   * The other direction: a backup already running when the entry arrives. The install waits for it rather than
+   * pulling the directory out from under it, and proceeds the moment it is released.
+   */
+  @Test
+  @Timeout(120)
+  void anInstallWaitsForABackupThatIsAlreadyRunning(@TempDir final Path root) throws Exception {
+    server = startServer(root, 60_000);
+    final Path dbPath = createLiveDatabase();
+    serveSnapshot(root);
+
+    final BackupCoordinator coordinator = server.getBackupCoordinator();
+    assertThat(coordinator.begin(DB_NAME, BackupCoordinator.Operation.BACKUP)).isNull();
+
+    final AtomicBoolean installDone = new AtomicBoolean(false);
+    final AtomicReference<Throwable> installError = new AtomicReference<>();
+    final Thread installer = new Thread(() -> {
+      try {
+        SnapshotInstaller.install(DB_NAME, dbPath.toString(), "localhost:" + leaderPort, null, null, server);
+        installDone.set(true);
+      } catch (final Throwable t) {
+        installError.set(t);
+      }
+    }, "snapshot-installer");
+    installer.start();
+
+    // The install must not have replaced anything yet: the live database is still the one the backup is reading.
+    installer.join(2_000);
+    assertThat(installDone.get()).as("the install waited instead of replacing the files under a running backup").isFalse();
+    assertThat(server.getDatabase(DB_NAME).countType("Node", true))
+        .as("the database the backup is reading is untouched while the install waits").isEqualTo(LIVE_COUNT);
+
+    coordinator.end(DB_NAME, BackupCoordinator.Operation.BACKUP);
+
+    installer.join(60_000);
+    assertThat(installError.get()).as("the install completed without error once the backup released the slot").isNull();
+    assertThat(installDone.get()).isTrue();
+    assertThat(server.getDatabase(DB_NAME).countType("Node", true)).isEqualTo(SNAPSHOT_COUNT);
+  }
+
+  /**
+   * The wait is bounded, and that is not a detail: an install applies a committed Raft entry, and a follower that
+   * blocks on it forever stops applying <i>every</i> database's entries - one state machine multiplexes them all.
+   * With the wait configured short, a backup that never ends does not stop the install; it only makes it loud.
+   */
+  @Test
+  @Timeout(120)
+  void aBackupThatNeverEndsDoesNotBlockTheInstallForever(@TempDir final Path root) throws Exception {
+    server = startServer(root, 500);
+    final Path dbPath = createLiveDatabase();
+    serveSnapshot(root);
+
+    final BackupCoordinator coordinator = server.getBackupCoordinator();
+    assertThat(coordinator.begin(DB_NAME, BackupCoordinator.Operation.BACKUP)).isNull();
+    try {
+      SnapshotInstaller.install(DB_NAME, dbPath.toString(), "localhost:" + leaderPort, null, null, server);
+
+      assertThat(server.getDatabase(DB_NAME).countType("Node", true))
+          .as("the committed entry was applied even though the wait expired").isEqualTo(SNAPSHOT_COUNT);
+      // The install never took the slot, so it must not have released the backup's reservation either.
+      assertThat(coordinator.isInProgress(DB_NAME, BackupCoordinator.Operation.BACKUP))
+          .as("a timed-out install leaves the reservation it never took alone").isTrue();
+    } finally {
+      coordinator.end(DB_NAME, BackupCoordinator.Operation.BACKUP);
+    }
+  }
+
+  private ArcadeDBServer startServer(final Path root, final long backupWaitMs) throws IOException {
+    final Path databasesDir = root.resolve("databases");
+    Files.createDirectories(databasesDir);
+
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.SERVER_NAME, "ArcadeDB_7444");
+    config.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, databasesDir.toString());
+    config.setValue(GlobalConfiguration.SERVER_ROOT_PATH, root.toString());
+    config.setValue(GlobalConfiguration.SERVER_ROOT_PASSWORD, PASSWORD);
+    config.setValue(GlobalConfiguration.SERVER_HTTP_INCOMING_HOST, "localhost");
+    config.setValue(GlobalConfiguration.HA_ENABLED, false);
+    config.setValue(GlobalConfiguration.HA_SNAPSHOT_INSTALL_BACKUP_WAIT_MS, backupWaitMs);
+
+    final ArcadeDBServer started = new ArcadeDBServer(config);
+    started.start();
+    return started;
+  }
+
+  private Path createLiveDatabase() {
+    final ServerDatabase live = server.getOrCreateDatabase(DB_NAME);
+    live.transaction(() -> {
+      live.getSchema().createVertexType("Node");
+      for (int i = 0; i < LIVE_COUNT; i++)
+        live.newVertex("Node").set("v", i).save();
+    });
+    return Path.of(((DatabaseInternal) live).getDatabasePath());
+  }
+
+  /**
+   * Publishes a real, loadable database with a DIFFERENT record count on the leader's snapshot endpoint, so a
+   * successful install is observable as a count change rather than only as the absence of an exception.
+   */
+  private void serveSnapshot(final Path root) throws IOException {
+    final Path source = root.resolve("leader-copy").resolve(DB_NAME);
+    try (final Database snap = new DatabaseFactory(source.toString()).create()) {
+      snap.transaction(() -> {
+        snap.getSchema().createVertexType("Node");
+        for (int i = 0; i < SNAPSHOT_COUNT; i++)
+          snap.newVertex("Node").set("v", i).save();
+      });
+    }
+
+    final byte[] zip = zipDirectory(source);
+    leader.createContext("/api/v1/ha/snapshot/" + DB_NAME, exchange -> {
+      exchange.sendResponseHeaders(200, zip.length);
+      exchange.getResponseBody().write(zip);
+      exchange.close();
+    });
+    leader.start();
+  }
+
+  private static byte[] zipDirectory(final Path dir) throws IOException {
+    final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (final ZipOutputStream zip = new ZipOutputStream(bytes); final Stream<Path> files = Files.walk(dir)) {
+      for (final Path file : files.filter(Files::isRegularFile).toList()) {
+        zip.putNextEntry(new ZipEntry(dir.relativize(file).toString().replace('\\', '/')));
+        zip.write(Files.readAllBytes(file));
+        zip.closeEntry();
+      }
+    }
+    return bytes.toByteArray();
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/backup/BackupCoordinator.java
+++ b/server/src/main/java/com/arcadedb/server/backup/BackupCoordinator.java
@@ -64,6 +64,14 @@ import java.util.regex.Pattern;
  * because an import is ordinary transactions against a live database and backing a live database up is what the
  * auto-backup schedule does all day. Everything else is refused - see {@link Operation#conflictsWith}.
  * <p>
+ * An HA snapshot install takes {@link Operation#RESTORE} too, and for the same reason: it closes this node's copy of
+ * the database, swaps its directory for the leader's snapshot and reopens it, which is a restore of this node's copy
+ * whoever asked for it. That is what closes the one pair the per-server scoping above cannot see - a restore on the
+ * leader replicates as an install entry, and a follower running its own scheduled backup of that database answers
+ * the entry by replacing the directory the backup is reading (issue #7444). Unlike every other holder the install
+ * cannot simply be refused, because it applies a committed Raft entry: it uses
+ * {@link #begin(String, Operation, long)}, which waits out a conflicting operation for a bounded time first.
+ * <p>
  * The class name predates restores and is kept so that the callers and tests written against
  * {@code getBackupCoordinator()} keep compiling; what it coordinates is now every whole-database maintenance
  * operation this server runs, not only backups.
@@ -139,6 +147,16 @@ public class BackupCoordinator {
   private final Map<String, EnumSet<Operation>> inProgress = new ConcurrentHashMap<>();
 
   /**
+   * The monitor a bounded wait parks on, notified by every {@link #end(String, Operation)}.
+   * <p>
+   * One monitor for the whole coordinator rather than one per database: a server runs a handful of these
+   * operations a day, so the spurious wakeups a release on an unrelated database causes cost a re-check of a
+   * {@link ConcurrentHashMap} entry and nothing else, and a per-database monitor would need its own lifecycle to
+   * avoid leaking an entry per database name ever waited on.
+   */
+  private final Object slotReleased = new Object();
+
+  /**
    * Reserves this database for a backup. Returns {@code false} when a backup, restore or import of it is already
    * running, in which case the caller must not start a backup and must not call {@link #end(String)}.
    * <p>
@@ -181,6 +199,54 @@ public class BackupCoordinator {
   }
 
   /**
+   * Reserves this database for {@code operation}, waiting up to {@code timeoutMs} for a conflicting operation to
+   * finish rather than refusing straight away.
+   * <p>
+   * Every other caller may simply be refused: a scheduled backup is covered again on the next tick, and a restore or
+   * an import is an operator command that can be retried. An HA snapshot install cannot - it applies a committed
+   * Raft entry, and a follower that declines to apply one diverges from the cluster (issue #7444). So it needs a
+   * third answer between taking the slot and giving up: wait for whatever is in the way, and take the slot the
+   * moment it lets go.
+   * <p>
+   * The wait is bounded because the caller's own operation is: a timeout expiring means the caller proceeds without
+   * the slot, loudly, which is the same outcome it had before this existed. Bounding it is also what keeps a caller
+   * that already holds a conflicting reservation on this database from waiting on itself - these reservations are
+   * not reentrant.
+   *
+   * @param timeoutMs how long to wait; zero or negative does not wait at all and is exactly
+   *                  {@link #begin(String, Operation)}
+   *
+   * @return {@code null} when the reservation was taken - the caller must then release it with
+   * {@link #end(String, Operation)} from a {@code finally} - or the operation that was still refusing this one when
+   * the wait ran out. A non-null answer means nothing was reserved and {@link #end} must NOT be called.
+   */
+  public Operation begin(final String databaseName, final Operation operation, final long timeoutMs) {
+    Operation conflict = begin(databaseName, operation);
+    if (conflict == null || timeoutMs <= 0)
+      return conflict;
+
+    final long deadline = System.currentTimeMillis() + timeoutMs;
+    synchronized (slotReleased) {
+      // Re-checked inside the monitor before every wait, and end() takes the same monitor to notify AFTER it has
+      // updated the map: a release that lands between the check and the wait therefore cannot be missed.
+      while ((conflict = begin(databaseName, operation)) != null) {
+        final long remaining = deadline - System.currentTimeMillis();
+        if (remaining <= 0)
+          return conflict;
+
+        try {
+          slotReleased.wait(remaining);
+        } catch (final InterruptedException e) {
+          // Restore the flag and report the conflict: an interrupted caller took nothing and must not release.
+          Thread.currentThread().interrupt();
+          return conflict;
+        }
+      }
+      return null;
+    }
+  }
+
+  /**
    * Releases the backup reservation taken by a successful {@link #begin(String)}. Always call it from a
    * {@code finally}: a reservation leaked by a failed backup would block every later backup of that database until
    * the server restarts.
@@ -202,6 +268,11 @@ public class BackupCoordinator {
       updated.remove(operation);
       return updated.isEmpty() ? null : updated;
     });
+    // AFTER the map update, so a waiter that re-checks on waking sees the release that woke it. Unconditional: a
+    // release that changed nothing costs one uncontended monitor and a notify nobody is parked on.
+    synchronized (slotReleased) {
+      slotReleased.notifyAll();
+    }
   }
 
   /** Whether any backup, restore or import of this database is currently running. */

--- a/server/src/test/java/com/arcadedb/server/backup/Issue7444MaintenanceSlotWaitTest.java
+++ b/server/src/test/java/com/arcadedb/server/backup/Issue7444MaintenanceSlotWaitTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.backup;
+
+import com.arcadedb.server.backup.BackupCoordinator.Operation;
+import com.arcadedb.utility.StallAwareStopwatch;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The bounded-wait reservation an HA snapshot install needs (issue #7444).
+ * <p>
+ * Every other caller of the slot may simply be refused: a scheduled backup is covered again on the next tick, and a
+ * restore or an import is an operator command that can be retried. A snapshot install cannot - it applies a committed
+ * Raft entry, and a follower that declines to apply one diverges. So it needs a third answer between "take the slot"
+ * and "give up": wait for the operation in the way, for a bounded time, and take the slot the moment it lets go.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue7444MaintenanceSlotWaitTest {
+
+  @Test
+  void aFreeSlotIsTakenWithoutWaiting() {
+    final BackupCoordinator coordinator = new BackupCoordinator();
+
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+    assertThat(coordinator.begin("db", Operation.RESTORE, 60_000)).isNull();
+    stopwatch.assertGaveUpWithin(10_000, "taking a free slot from waiting for one");
+
+    assertThat(coordinator.isInProgress("db", Operation.RESTORE)).isTrue();
+  }
+
+  @Test
+  @Timeout(30)
+  void theSlotIsTakenAsSoonAsTheOperationInTheWayReleasesIt() throws Exception {
+    final BackupCoordinator coordinator = new BackupCoordinator();
+    assertThat(coordinator.begin("db", Operation.BACKUP)).isNull();
+
+    final CountDownLatch waiterStarted = new CountDownLatch(1);
+    final AtomicReference<Operation> outcome = new AtomicReference<>(Operation.BACKUP);
+    final Thread waiter = new Thread(() -> {
+      waiterStarted.countDown();
+      outcome.set(coordinator.begin("db", Operation.RESTORE, 20_000));
+    }, "slot-waiter");
+    waiter.start();
+
+    assertThat(waiterStarted.await(10, TimeUnit.SECONDS)).isTrue();
+    // The waiter must NOT have taken the slot while the backup still holds it.
+    waiter.join(300);
+    assertThat(waiter.isAlive()).as("the install waits instead of replacing the files under a running backup").isTrue();
+    assertThat(coordinator.isInProgress("db", Operation.RESTORE)).isFalse();
+
+    coordinator.end("db", Operation.BACKUP);
+
+    waiter.join(20_000);
+    assertThat(waiter.isAlive()).as("the waiter woke as soon as the backup released the slot").isFalse();
+    assertThat(outcome.get()).as("the slot was taken, not refused").isNull();
+    assertThat(coordinator.isInProgress("db", Operation.RESTORE)).isTrue();
+  }
+
+  @Test
+  @Timeout(60)
+  void theWaitIsBoundedAndNamesTheOperationStillHoldingTheSlot() {
+    final BackupCoordinator coordinator = new BackupCoordinator();
+    assertThat(coordinator.begin("db", Operation.BACKUP)).isNull();
+
+    // A committed install entry has to be applied, so the wait can never be unbounded: it expires and the caller is
+    // told which operation is still in the way so it can say so in its warning.
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+    assertThat(coordinator.begin("db", Operation.RESTORE, 250)).isEqualTo(Operation.BACKUP);
+    stopwatch.assertGaveUpWithin(30_000, "a bounded wait from an unbounded one");
+
+    // The expired wait took nothing: the backup is still the only holder, and releasing the backup leaves the
+    // database free rather than leaking a reservation the timed-out caller never made.
+    assertThat(coordinator.isInProgress("db", Operation.RESTORE)).isFalse();
+    coordinator.end("db", Operation.BACKUP);
+    assertThat(coordinator.isInProgress("db")).isFalse();
+  }
+
+  @Test
+  @Timeout(30)
+  void aZeroWaitIsTheSameAnswerTheNonWaitingReservationGives() {
+    final BackupCoordinator coordinator = new BackupCoordinator();
+    assertThat(coordinator.begin("db", Operation.BACKUP)).isNull();
+
+    assertThat(coordinator.begin("db", Operation.RESTORE, 0)).isEqualTo(Operation.BACKUP);
+    assertThat(coordinator.begin("db", Operation.RESTORE, -1)).isEqualTo(Operation.BACKUP);
+    assertThat(coordinator.begin("db", Operation.RESTORE)).isEqualTo(Operation.BACKUP);
+  }
+
+  @Test
+  @Timeout(30)
+  void aWaitOnOneDatabaseIsNotWokenByAnUnrelatedOne() throws Exception {
+    final BackupCoordinator coordinator = new BackupCoordinator();
+    assertThat(coordinator.begin("held", Operation.BACKUP)).isNull();
+    assertThat(coordinator.begin("other", Operation.BACKUP)).isNull();
+
+    final AtomicReference<Operation> outcome = new AtomicReference<>(Operation.BACKUP);
+    final Thread waiter = new Thread(() -> outcome.set(coordinator.begin("held", Operation.RESTORE, 20_000)), "slot-waiter");
+    waiter.start();
+
+    // Releasing a DIFFERENT database wakes the waiter, which must go straight back to waiting rather than take a
+    // slot it was never offered.
+    coordinator.end("other", Operation.BACKUP);
+    waiter.join(300);
+    assertThat(waiter.isAlive()).isTrue();
+    assertThat(coordinator.isInProgress("held", Operation.RESTORE)).isFalse();
+
+    coordinator.end("held", Operation.BACKUP);
+    waiter.join(20_000);
+    assertThat(outcome.get()).isNull();
+  }
+
+  @Test
+  @Timeout(30)
+  void aBackupAndAnImportStillCoexistThroughTheWaitingForm() {
+    final BackupCoordinator coordinator = new BackupCoordinator();
+    assertThat(coordinator.begin("db", Operation.BACKUP)).isNull();
+
+    // The waiting form is the same admission policy, not a stricter one: the one pair that coexists still does, and
+    // without spending the timeout to find out.
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+    assertThat(coordinator.begin("db", Operation.IMPORT, 60_000)).isNull();
+    stopwatch.assertGaveUpWithin(10_000, "an admitted operation from one that waited out its timeout");
+
+    assertThat(coordinator.isInProgress("db", Operation.IMPORT)).isTrue();
+  }
+}


### PR DESCRIPTION
Closes #7444

A restore is leader-only on both transports, so restore-versus-restore of one database is already serialised cluster-wide. A backup is not: `runOnServer` in `backup.json` defaults to `"*"`, so every node runs its own scheduled backup. After a successful restore the leader submits an install-database entry with `forceSnapshot=true`, and every follower answers it by **replacing its own copy of the database directory** from the leader's snapshot - while that follower's scheduled backup may be reading it. The per-database admission slot #7384 added is per server instance by design, so it could not see that pair: the restore happened on the leader's JVM, but the reinstall happens on the follower's. `SnapshotInstaller.install` - which closes the live database, swaps its directory and reopens it - was the one directory-replacing operation that took no slot. It now takes `Operation.RESTORE` for its whole duration, because an install *is* a restore of this node's copy; it is taken inside `install` rather than at any call site, since that method is the choke point every driver shares (the `forceSnapshot` arm of `applyInstallDatabaseEntry`, the bootstrap installs, the reconciler's resync, and `acquireNewDatabase`'s two delegating arms). An install cannot simply be refused the way every other holder of the slot can - it applies a committed Raft entry, and a follower that declines to apply one diverges - so `BackupCoordinator` grows a bounded waiting form of `begin()`, sized by the new `arcadedb.ha.snapshotInstallBackupWaitMs` (`SCOPE.SERVER`, default 60 000): the install waits out an in-flight backup or import and, if the wait expires, proceeds and says so at WARNING, naming the setting to raise. Sixty seconds is proportionate rather than cautious, since the download already runs on the same Ratis apply thread and takes minutes for a large database; bounding it also keeps a leadership change between a restore's submit and its apply from turning the leader's own held slot into a deadlock.

This is the smaller of the two options the issue offers ("the install-database apply path on a follower takes the local slot ... The second is much the smaller change and may be enough on its own"), and it is enough: the hazard is a follower replacing its own files, and a follower replaces them only from inside `install`.

## Test plan

- [ ] `mvn -o -pl server -am test -Dtest='com.arcadedb.server.backup.*Test'` - 169 tests, green. Includes the new `Issue7444MaintenanceSlotWaitTest` (6 cases on the bounded wait) and #7384's and #6753's existing admission tests unchanged.
- [ ] `mvn -o install -DskipTests -pl engine,server -am` then `mvn -o -pl ha-raft test -Dtest='Snapshot*Test,Issue7*Test,Issue6*Test,Issue4*Test,ArcadeStateMachine*Test,HAConfigDefaultsTest'` - 668 tests, green. Includes the new `Issue7444SnapshotInstallExcludesBackupTest`.
- [ ] `mvn -o -pl engine test -Dtest='GlobalConfigurationTest,Issue7124BooleanSettingStrictCoercionTest,Issue7163DatabaseScopeCallbackTest'` - 29 tests, green (the new enum constant does not disturb the settings-enumeration tests).
- [ ] Both new test classes were shown to fail without the fix. With the reservation in `install` replaced by a constant and the waiting `begin` short-circuited to the non-waiting one: `Issue7444MaintenanceSlotWaitTest` 2 failures (`theSlotIsTakenAsSoonAsTheOperationInTheWayReleasesIt`, `aWaitOnOneDatabaseIsNotWokenByAnUnrelatedOne`) and `Issue7444SnapshotInstallExcludesBackupTest` 2 failures (`aBackupIsRefusedWhileThisNodeIsReinstallingTheDatabase`, `anInstallWaitsForABackupThatIsAlreadyRunning`). The third case in each class pins a safety property rather than the bug - the wait must stay bounded, and a zero timeout must behave like the non-waiting form - so it passes either way by design.
- [ ] Manual, on a 3-node cluster: start a scheduled backup on a follower with `runOnServer: "*"`, issue `restore database` on the leader, and confirm the follower logs `Skipping backup for database 'x' - a restore of it is already in progress` instead of writing an archive of a directory being replaced.

## Coverage

The invariant: *on any one server, a snapshot install of a database and a backup of that same database can never be in flight at the same time.*

| Entry point | Covered |
|---|---|
| `ArcadeStateMachine.applyInstallDatabaseEntry` (forceSnapshot) -> `install` - the reported path | fixed, tested |
| `ArcadeStateMachine:3269` / `:3327` / `:4238` / `:4463` -> `install` | fixed - the slot is inside `install`, the choke point all of them share; tested by driving `install` itself |
| `DatabaseReconciler:280` / `:423` -> `install` | fixed, same choke point |
| `BackupTask.run` scheduled tick - the loser side the issue describes | fixed, tested (already took `BACKUP`; `RESTORE` now excludes it) |
| HTTP/gRPC "trigger backup" -> `ServerControlPlane.triggerBackup` | fixed, tested - same slot, same `Operation.BACKUP` |
| `DatabaseReconciler:274` -> `acquireNewDatabase` (database never seen locally) | argued: it publishes under the final name only while `!existsDatabase`, and both arms where the database *is* registered delegate to `install`. `BackupTask.run` returns at its first line for an unregistered database, and `performBackup` resolves it with `allowLoad=false` (#6752), so it can never be the thing that opens one |

### Known gaps

- **#7449** (filed by this PR) - `SnapshotInstaller.recoverPendingSnapshotSwaps`, the startup crash-recovery pass, finishes or rolls back an interrupted swap without taking the slot. It has no `ArcadeDBServer` parameter to reach a coordinator through, and `AutoBackupSchedulerPlugin` starts before the HA plugin, so a first tick can fire while it runs.
- **#7443** (pre-existing, unchanged) - SQL `BACKUP DATABASE` and `IMPORT DATABASE` take no slot at all, so they are outside every exclusion in this area.
- **Cluster-wide serialisation** - the larger of the two options the issue offers, deliberately not taken. See the summary above for why the follower-local one closes the reported hazard.

Further notes, including the adversarial pass and the reasoning for reusing `Operation.RESTORE` rather than adding a fourth constant, are in `docs/7444-follower-backup-vs-snapshot-install.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1vgWQXZoDXYq7TqAwLYXY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Snapshot installation now coordinates with active backups and imports for the same database, reducing the risk of concurrent file replacement.
  - Added a configurable wait period for snapshot installation when maintenance activity is already in progress.

- **Bug Fixes**
  - Snapshot installation waits for conflicting maintenance operations to finish when possible.
  - Installation proceeds after the configured wait expires, preventing indefinite blocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->