### PR TITLE
fix(build): import MaintenanceCoordinator.Operation by its canonical name in two server tests

### DIFF
--- a/server/src/test/java/com/arcadedb/server/backup/Issue7441RestoreNameReservationIT.java
+++ b/server/src/test/java/com/arcadedb/server/backup/Issue7441RestoreNameReservationIT.java
@@ -26,7 +26,7 @@ import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.BaseGraphServerTest;
 import com.arcadedb.server.ServerControlPlane;
-import com.arcadedb.server.backup.BackupCoordinator.Operation;
+import com.arcadedb.engine.MaintenanceCoordinator.Operation;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;

--- a/server/src/test/java/com/arcadedb/server/backup/Issue7444MaintenanceSlotWaitTest.java
+++ b/server/src/test/java/com/arcadedb/server/backup/Issue7444MaintenanceSlotWaitTest.java
@@ -18,7 +18,7 @@
  */
 package com.arcadedb.server.backup;
 
-import com.arcadedb.server.backup.BackupCoordinator.Operation;
+import com.arcadedb.engine.MaintenanceCoordinator.Operation;
 import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;


### PR DESCRIPTION
main is red since the three backup PRs merged this morning: #7460 moved the `Operation` enum from `BackupCoordinator` to the engine's `MaintenanceCoordinator` interface, while #7452 and #7453, merged alongside it, still import it through `BackupCoordinator`. javac refuses an inherited member type imported by a non-canonical name, so `server` test compilation fails on main and on every PR built against it:

```
Issue7441RestoreNameReservationIT.java:[29,52] import requires canonical name for com.arcadedb.engine.MaintenanceCoordinator.Operation
Issue7444MaintenanceSlotWaitTest.java:[21,52] import requires canonical name for com.arcadedb.engine.MaintenanceCoordinator.Operation
```

Two import lines. `server` test-compiles and `Issue7444MaintenanceSlotWaitTest` passes locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated maintenance and backup test references to use the correct operation definition.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->