### PR TITLE
fix(#7341): -parsingLimitEntries is a cap, not a threshold

### DIFF
--- a/docs/7341-xml-importer-parsing-limit-off-by-one.md
+++ b/docs/7341-xml-importer-parsing-limit-off-by-one.md
@@ -194,3 +194,32 @@ Checked and **not** real:
   `aLimitAtOrAboveTheObjectCountImportsEverything`, which also covers a limit the source never reaches.
 - *"Breaking one event earlier skips `waitCompletion()` / `endParsing()`."* No: both sit after the loop,
   not inside it (`load():203`, `analyze():355`), and the 372-test module run is green.
+
+## Review cycles
+
+### Cycle 1 - `f09ccbd`
+
+`claude` reviewed the commit and closed with "correct, minimal, well-tested fix [...] Nothing blocking." It
+confirmed the root cause from the source (the increment and `createRecord(...)` are in the same
+`if (nestLevel == objectNestLevel)` block, both ahead of the bottom-of-loop check), confirmed the disabled
+(`0`) case and the limit-at-or-above-count case are unaffected, and endorsed filing #7482 and #7485 rather
+than folding them in. It also noted it could not run `mvn` in its sandbox, so its pass was a code read.
+
+One nit, **applied**: the two CLI tests built their argument array with
+`("-documents file://" + path + " ...").split(" ")` against an absolute path, which would mis-tokenise on a
+checkout directory containing a space. Both now pass a literal `new String[] { ... }` to `Importer`, which
+removes the hazard entirely. Not manufactured into a space-containing path in the test itself: that would
+be exercising URL handling rather than the limit, and a pre-existing limitation there would turn this PR
+red for an unrelated reason.
+
+Two remarks recorded and **not** acted on, with reasons:
+
+- *"the tracking doc is 196 lines, the bulk of the diff, for a two-character fix."* Observation, not a
+  request - the reviewer says it follows the repo's existing `docs/<issue>-<slug>.md` convention and
+  raises no objection. The line count is the completeness sweep the workflow requires; shrinking it would
+  delete the evidence for the "argued" rows.
+- *"could not run mvn."* Nothing to act on in the branch. The numbers in this doc come from runs in this
+  worktree, not from the reviewer's sandbox.
+
+No inline review comments and no `pulls/7486/reviews` entries were posted on this commit; CodeRabbit's only
+comment was its in-progress status notice.

--- a/docs/7341-xml-importer-parsing-limit-off-by-one.md
+++ b/docs/7341-xml-importer-parsing-limit-off-by-one.md
@@ -1,0 +1,196 @@
+# #7341 - XMLImporterFormat imports `parsingLimitEntries + 1` objects
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/7341
+
+## Finding ledger
+
+- [x] 1. **Fixed.** `XMLImporterFormat.load():195` - `context.parsed.get() > settings.parsingLimitEntries`, evaluated
+      after the object has already been handed to `database.async().createRecord(...)`, so
+      `-parsingLimitEntries N` imports `N + 1` objects.
+- [x] 2. **Fixed.** `XMLImporterFormat.analyze():339` - `parsedObjects > analyzingLimitEntries`, the same shape against a
+      different setting. The issue asks for both to be settled together.
+- [x] 3. **Updated.** `XMLImporterFormatStaleParsedCounterTest` pins the current `N + 1` behaviour (three assertions of
+      `isEqualTo(3)` for a limit of 2). The issue names it as the test to update.
+
+## Root cause
+
+Both loops increment the object counter when an object *completes*, then test the counter with a strict `>`
+at the bottom of the same iteration. For a limit of `N` the counter reaches `N` after the Nth object without
+tripping the test, the loop runs one more time, and the `N+1`th object is created (`load()`) or fed to the
+schema analyser (`analyze()`) before `N+1 > N` finally breaks.
+
+`load()` is worse than a cosmetic off-by-one because the break is below
+`database.async().createRecord(record, ...)`: the object that trips the limit has already been submitted.
+
+## Completeness
+
+### 1. Invariant
+
+> With `-parsingLimitEntries N` (resp. `-analyzingLimitEntries N`) an importer route that enforces the
+> setting processes **at most** N objects from the source, never N+1.
+
+### 2. Enumeration
+
+Every reader of the two settings, found by command:
+
+```
+$ grep -rn "parsingLimitEntries" --include="*.java" integration/src/main/java/
+integration/.../ImporterSettings.java:70:  public long    parsingLimitEntries;
+integration/.../ImporterSettings.java:186:    case "parsingLimitEntries" -> parsingLimitEntries = Long.parseLong(value);
+integration/.../SourceDiscovery.java:96:   (log line only)
+integration/.../format/XMLImporterFormat.java:53:  (comment)
+integration/.../format/XMLImporterFormat.java:195: if (settings.parsingLimitEntries > 0 && context.parsed.get() > settings.parsingLimitEntries)
+integration/.../vector/TextEmbeddingsImporterLSM.java:251: if (settings.parsingLimitEntries > 0)
+integration/.../vector/TextEmbeddingsImporterLSM.java:252:   parser = parser.limit(settings.parsingLimitEntries);
+
+$ grep -rn "analyzingLimitEntries" --include="*.java" .
+integration/.../format/XMLImporterFormat.java:210: final int analyzingLimitEntries = settings.getIntValue("analyzingLimitEntries", 0);
+integration/.../format/XMLImporterFormat.java:339: if (analyzingLimitEntries > 0 && parsedObjects > analyzingLimitEntries)
+```
+
+Sibling grep - the *shape* (a strict `>` against a `*Limit*` value), 15 hits in the importer module:
+
+```
+$ grep -rnE "> *(settings\.)?[A-Za-z]*[Ll]imit[A-Za-z]*\b" --include="*.java" integration/src/main/java/ | wc -l
+15
+```
+
+The 15 break down as: 4 are `ImporterSettings` switch arms (assignment, not a comparison), 3 are unrelated
+`Delimiter`/`delimiters` identifiers, 3 are `Parser.java:108/118/128` (`position.get() > limit`, a **byte**
+offset, where one byte of overshoot is not an entry count), 2 are the two sites this PR fixes, 1 is
+`CSVImporterFormat:876` (`analysisLimitBytes`, bytes again), 1 is `CSVImporterFormat:879`
+(`analysisLimitEntries`, argued below) and 1 is the `analysisLimitEntries` switch arm.
+
+Formats that never read `parsingLimitEntries` at all (`CSVImporterFormat`, `JSONImporterFormat`,
+`JsonlImporterFormat`, `RDFImporterFormat`, `Neo4jImporterFormat`, `OrientDBImporterFormat`,
+`GloVeImporterFormat`, `Word2VecImporterFormat`, `Word2VecImporterFormatLSM`) cannot violate an off-by-one
+they do not implement - they violate a *different* property (the flag is silently ignored), filed separately.
+
+### 3. Coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| `XMLImporterFormat.load()` direct call, `-parsingLimitEntries N` | yes | yes |
+| `Importer` CLI route (`-documents ... -parsingLimitEntries N`) → `load()` | yes | yes |
+| `XMLImporterFormat.analyze()` direct call, `-analyzingLimitEntries N` | yes | yes |
+| `Importer` CLI → `SourceDiscovery.getSchema()` → `analyze()`, `-analyzingLimitEntries N` | yes | yes (added by the adversarial pass) |
+| `TextEmbeddingsImporterLSM.loadFromFile()` → `Stream.limit(N)` | n/a - **argued** | n/a |
+| `CSVImporterFormat.analyze()` → `line > settings.analysisLimitEntries` | n/a - **argued** | n/a |
+| `Parser` byte limit (`position.get() > limit`) | n/a - **argued** | n/a |
+| 9 formats that ignore `parsingLimitEntries` entirely | no - **filed** #7482 | no |
+| `parsingLimitBytes` parsed, logged, never enforced | no - **filed** #7482 | no |
+| `analysisLimitEntries` (the documented flag) never reaches XML; XML analysis unbounded by default | no - **filed** #7485 | no |
+
+**Argued rows, with evidence:**
+
+- `TextEmbeddingsImporterLSM:252` uses `Stream.limit(n)`, whose contract is "at most `n` elements". It is
+  already the cap this fix makes XML agree with - it is the *reference* behaviour the issue cites, not a
+  violator.
+- `CSVImporterFormat:879` compares a **0-based** `line` counter (`for (long line = 0; ...; ++line)`,
+  `:871`) in a check placed **before** the row is consumed, and index 0 is spent on the header (either
+  read from the file at `:882` when `header == null`, or skipped by `skipEntries` defaulting to 1 at
+  `:834/:841/:850` when a header was supplied). Lines `1..L` are therefore the data rows analysed, i.e.
+  exactly `L` of them. Pre-check plus 0-based plus a consumed index 0 cancels the `>`; there is no
+  off-by-one here.
+- `Parser:108/118/128` bound a **byte** position, not an entry count. `-parsingLimitBytes` is documented as
+  a coarse cut-off and overshooting it by the tail of one record is its intended behaviour.
+
+### 5. Reachability
+
+- `XMLImporterFormat.load()` is reached from `Importer.loadFromSource()` via
+  `SourceSchema.getContentImporter().load(...)`; the new CLI test drives that path end to end, so the
+  changed line runs outside the unit test too.
+- `XMLImporterFormat.analyze()` is reached from `SourceDiscovery.getSchema():94`
+  (`formatImporter.analyze(entityType, parser, settings, analyzedSchema)`), which `Importer.load()` calls
+  for every source. `analyzingLimitEntries` has no named arm in `ImporterSettings.parseParameter`, but the
+  method ends with `options.put(name, value)` for *every* argument (`:227`), so `-analyzingLimitEntries 2`
+  on the command line does reach `settings.getIntValue("analyzingLimitEntries", 0)`. The setting is
+  undocumented, not dead.
+- No feature flag gates either site; both are plain `if`s in the parse loop.
+
+### 7. Residual risk
+
+The fix makes the two XML limits caps. It does **not** make `-parsingLimitEntries` work on the nine
+importer formats that never read it, and it does not make `-parsingLimitBytes` do anything anywhere; both
+are tracked by #7482. Within XML, a source whose objects are nested deeper than `objectNestLevel` still
+counts only objects at that level - unchanged by this PR and not part of the reported defect.
+
+## Changes
+
+| File | Change |
+|---|---|
+| `integration/src/main/java/com/arcadedb/integration/importer/format/XMLImporterFormat.java` | `load()`: `context.parsed.get() > settings.parsingLimitEntries` -> `>=`; `analyze()`: `parsedObjects > analyzingLimitEntries` -> `>=`. Both carry a comment saying why the comparison has to be non-strict. |
+| `integration/src/test/java/com/arcadedb/integration/importer/format/XMLImporterFormatParsingLimitTest.java` | New. Six tests: the cap on `load()`, a limit of one, a limit at and above the object count, a zero (disabled) limit, the cap on `analyze()`, and the CLI route end to end. |
+| `integration/src/test/java/com/arcadedb/integration/importer/format/XMLImporterFormatStaleParsedCounterTest.java` | The three assertions #7313 deliberately pinned at the old `N+1` boundary (`isEqualTo(3)` for a limit of 2) move to `isEqualTo(2)`, and the javadoc that pointed at #7341 as the reason for the three now records the cap. Nothing is deleted; #7313's own scenarios still assert what they asserted. |
+
+### Note on the modified existing test
+
+`constraints.md` forbids modifying existing tests. This is the one designated exception: #7341's own text
+names `XMLImporterFormatStaleParsedCounterTest` as "the test to update when this is fixed", and its javadoc
+at the time said the same. The assertions there pinned the defect on purpose so that #7313's counter reset
+could not silently move the boundary; the boundary is exactly what this PR moves, so leaving them would
+have made the branch red with no way to be both fixed and green. The scenarios, their names and their
+coverage are untouched; only the three pinned numbers and the comment explaining them changed.
+
+## Test results
+
+```
+$ mvn -o -pl integration test -Dtest='XMLImporterFormatParsingLimitTest,XMLImporterFormatStaleParsedCounterTest'
+  (before the fix) Tests run: 6, Failures: 4   - all four bug-reproducing tests red, both regression guards green
+  (after the fix)  Tests run: 9, Failures: 0
+
+$ mvn -o -pl integration test -DexcludedGroups=benchmark,vector,slow
+  Tests run: 373, Failures: 0, Errors: 0, Skipped: 9 - BUILD SUCCESS (re-run after the adversarial pass added a test)
+```
+
+No test outside `integration` touches the XML importer or either limit:
+
+```
+$ grep -rln "XMLImporter\|parsingLimitEntries" --include="*.java" --exclude-dir=integration . | grep -i test
+(no output)
+```
+
+## Impact
+
+`-parsingLimitEntries N` on an XML source now imports N objects instead of N+1, and
+`-analyzingLimitEntries N` samples N objects instead of N+1. This is a behaviour change for anyone who was
+relying on the old count, but the old count was never the documented one and never agreed with the vector
+route that applies the same flag. A limit of 0 (the default, "no limit") and a limit the source never
+reaches are both unaffected, each pinned by its own test.
+
+## Adversarial pass
+
+The skill asks for a `general-purpose` subagent that has not seen the reasoning. **The `Task` tool is not
+available in this environment**, so the pass was run directly against the staged diff and the issue text
+instead of the tracking doc. That is a weaker pass than the skill intends - it is the author re-reading his
+own patch - and it is recorded as such. Three findings, all verified by reading the tree:
+
+1. **The coverage table claimed a test it did not have.** The row
+   `SourceDiscovery.getSchema()` -> `analyze()` was marked "covered by a test", but the only CLI test
+   (`theCliRouteAppliesTheLimitAsACap`) passes `-parsingLimitEntries` and never sets an analyse limit, so
+   nothing drove the *analyse* boundary through its live caller - exactly the hole section 4 of the
+   checklist exists to catch. **Fixed here:** `theCliRouteAppliesTheAnalyzingLimitAsACap` runs
+   `Importer.load()` with `-analyzingLimitEntries 2` and asserts on the schema
+   `AbstractImporter.updateDatabaseSchema()` builds from the analysed properties. Reverting the `analyze()`
+   half of the fix turns it red ("Expecting value to be false but was true"), so it tests the boundary and
+   not the plumbing.
+2. **The analyse phase reads a setting that is not the documented one.** `XMLImporterFormat.analyze()`
+   reads `analyzingLimitEntries` out of the options map with a default of `0`, while `ImporterSettings` has
+   `analysisLimitEntries` (default `10000`, real CLI arm) that only `CSVImporterFormat` honours. So
+   `-analysisLimitEntries` does nothing to an XML import, and XML schema analysis reads the whole file by
+   default where CSV stops at 10000 rows. Real, and a behaviour change too big to fold into an off-by-one.
+   **Filed as #7485.**
+3. **`parsedStructure` in `analyze()` is dead.** Declared at `:236`, assigned at `:303-304`, never read.
+   Verified by grep (three hits, no reader). Pre-existing, invisible to users, untouched by this patch, and
+   too small to be worth a tracker entry - recorded here rather than filed, so the next reader does not
+   spend the same five minutes on it.
+
+Checked and **not** real:
+
+- *"`>=` breaks the disabled case."* No: both guards keep their `limit > 0` prefix, and
+  `aZeroLimitMeansNoLimit` imports all four objects.
+- *"`>=` now drops the last object when the limit equals the object count."* No: the break happens after
+  the Nth object has been created, so a limit of 4 on 4 objects still imports 4. Pinned by
+  `aLimitAtOrAboveTheObjectCountImportsEverything`, which also covers a limit the source never reaches.
+- *"Breaking one event earlier skips `waitCompletion()` / `endParsing()`."* No: both sit after the loop,
+  not inside it (`load():203`, `analyze():355`), and the 372-test module run is green.

--- a/docs/7341-xml-importer-parsing-limit-off-by-one.md
+++ b/docs/7341-xml-importer-parsing-limit-off-by-one.md
@@ -1,6 +1,7 @@
 # #7341 - XMLImporterFormat imports `parsingLimitEntries + 1` objects
 
 Issue: https://github.com/ArcadeData/arcadedb/issues/7341
+PR: https://github.com/ArcadeData/arcadedb/pull/7486
 
 ## Finding ledger
 
@@ -223,3 +224,36 @@ Two remarks recorded and **not** acted on, with reasons:
 
 No inline review comments and no `pulls/7486/reviews` entries were posted on this commit; CodeRabbit's only
 comment was its in-progress status notice.
+
+### Cycle 2 - `5616fff`
+
+`claude` re-reviewed the commit that applied the cycle-1 nit and closed with "Nothing blocking. Nice,
+minimal fix with thorough boundary-case coverage." No actionable items, no inline comments, no formal
+review entries. It independently re-derived the root cause and, usefully, **spot-checked the three "argued,
+not a violator" rows of the coverage table above and confirmed each**:
+
+- `TextEmbeddingsImporterLSM:251-252` really is `Stream.limit(N)`, "at most N" by contract.
+- `CSVImporterFormat.analyze():871-879` really does analyse exactly `L` data rows, because index 0 is always
+  spent on the header - so the `>` there is not the same defect.
+- `analyzingLimitEntries` really does reach `getIntValue` through `parseParameter`'s unconditional
+  `options.put(name, value)` - undocumented, not dead - which is the reachability claim #7485 rests on.
+
+It also confirmed the increment and the limit check are both on the parsing thread, so the `>=` introduces
+no race with the async `createRecord` callback (which only touches `createdVertices`/`createdDocuments`),
+and that the XXE hardening in the same method is untouched. Like cycle 1 it could not run `mvn` in its
+sandbox.
+
+No changes were made in this cycle; the working tree was empty at the early-exit check.
+
+## Deferred items
+
+None. No `review-deferred-*.md` notes file was produced by either cycle. (Two such files exist in `docs/`
+from PR #7442 and are unrelated to this branch.)
+
+## Final state
+
+`clean-approval` after 2 review cycles.
+
+- PR: https://github.com/ArcadeData/arcadedb/pull/7486
+- Follow-ups filed and named in the PR body: #7482, #7485
+- Merge is the developer's.

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/XMLImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/XMLImporterFormat.java
@@ -192,7 +192,11 @@ public class XMLImporterFormat implements FormatImporter {
           // IGNORE IT
         }
 
-        if (settings.parsingLimitEntries > 0 && context.parsed.get() > settings.parsingLimitEntries)
+        // >= AND NOT >: context.parsed IS INCREMENTED ABOVE, IN THIS SAME ITERATION, BEFORE THE RECORD IS HANDED TO
+        // database.async().createRecord(), SO A STRICT > LET THE OBJECT THAT REACHES THE LIMIT THROUGH AND BROKE ONLY
+        // ON THE NEXT ONE - IMPORTING parsingLimitEntries + 1 OBJECTS. -parsingLimitEntries IS A CAP, THE WAY THE SAME
+        // SETTING CAPS THE VECTOR ROUTE AT TextEmbeddingsImporterLSM:252 (Stream.limit) (ISSUE #7341)
+        if (settings.parsingLimitEntries > 0 && context.parsed.get() >= settings.parsingLimitEntries)
           break;
       }
 
@@ -336,7 +340,10 @@ public class XMLImporterFormat implements FormatImporter {
           // IGNORE IT
         }
 
-        if (analyzingLimitEntries > 0 && parsedObjects > analyzingLimitEntries)
+        // >= AND NOT >, FOR THE SAME REASON AS load() ABOVE: parsedObjects IS INCREMENTED WHEN AN OBJECT COMPLETES, SO
+        // A STRICT > FED THE (analyzingLimitEntries + 1)th OBJECT'S PROPERTIES TO THE SCHEMA ANALYSER BEFORE BREAKING
+        // (ISSUE #7341)
+        if (analyzingLimitEntries > 0 && parsedObjects >= analyzingLimitEntries)
           break;
       }
 

--- a/integration/src/test/java/com/arcadedb/integration/importer/format/XMLImporterFormatParsingLimitTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/format/XMLImporterFormatParsingLimitTest.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer.format;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.integration.importer.AnalyzedEntity;
+import com.arcadedb.integration.importer.AnalyzedSchema;
+import com.arcadedb.integration.importer.Importer;
+import com.arcadedb.integration.importer.ImporterContext;
+import com.arcadedb.integration.importer.ImporterSettings;
+import com.arcadedb.integration.importer.Parser;
+import com.arcadedb.integration.importer.Source;
+import com.arcadedb.integration.importer.SourceSchema;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.utility.FileUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7341: both object limits in {@link XMLImporterFormat} were a strict {@code >} evaluated at the bottom of the
+ * parse loop, against a counter the same iteration had already incremented. For a limit of N the counter reached N
+ * after the Nth object without tripping the test, so the loop ran once more and the (N+1)th object was created - in
+ * {@code load()} below {@code database.async().createRecord(...)}, so it was imported - before {@code N+1 > N} finally
+ * broke out.
+ * <p>
+ * {@code -parsingLimitEntries N} reads as "import at most N entries", and the vector route applies the very same
+ * setting through {@code Stream.limit(N)} ({@code TextEmbeddingsImporterLSM:252}), which stops <i>at</i> N. These tests
+ * pin both XML limits to the same cap semantics.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class XMLImporterFormatParsingLimitTest {
+
+  private static final String DB_PATH = "target/databases/xml-importer-parsing-limit-test";
+
+  /**
+   * Four objects, so a limit of two leaves two objects unread: enough to tell "stopped at 2" from "stopped at 3" from
+   * "never stopped".
+   */
+  private static final String FOUR_ITEMS = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <root>
+        <item id="1"/>
+        <item id="2"/>
+        <item id="3"/>
+        <item id="4"/>
+      </root>""";
+
+  /**
+   * The third object carries a property the first two do not. Whether the analysed schema ends up with that property is
+   * a direct, observable answer to "did the analyser look at the third object?" - which is what
+   * {@code -analyzingLimitEntries 2} is supposed to forbid.
+   */
+  private static final String THIRD_ITEM_HAS_AN_EXTRA_PROPERTY = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <root>
+        <item id="1"/>
+        <item id="2"/>
+        <item id="3" onlyInTheThirdObject="x"/>
+        <item id="4"/>
+      </root>""";
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    database = new DatabaseFactory(DB_PATH).create();
+  }
+
+  @AfterEach
+  void cleanup() {
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollbackAllNested();
+      if (database.isOpen())
+        database.drop();
+      database = null;
+    }
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  private static Parser xmlParser(final String content) throws Exception {
+    final byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+    final Source source = new Source("test.xml", new ByteArrayInputStream(bytes), bytes.length, false, null, null);
+    return new Parser(source, 0);
+  }
+
+  private static long countOf(final Database db, final String typeName) {
+    return db.getSchema().existsType(typeName) ? db.countType(typeName, true) : 0;
+  }
+
+  /**
+   * The reported case: {@code -parsingLimitEntries 2} on a four-object source must import two objects, not three.
+   */
+  @Test
+  void theParsingLimitIsACapNotAThreshold() throws Exception {
+    final ImporterSettings settings = new ImporterSettings();
+    settings.parsingLimitEntries = 2;
+
+    final ImporterContext context = new ImporterContext();
+
+    new XMLImporterFormat().load(null, AnalyzedEntity.EntityType.DOCUMENT, xmlParser(FOUR_ITEMS), (DatabaseInternal) database,
+        context, settings);
+
+    assertThat(countOf(database, "item"))
+        .as("-parsingLimitEntries 2 imports at most 2 objects: the object that reaches the limit is the last one kept, "
+            + "not the first one past it")
+        .isEqualTo(2);
+    assertThat(context.parsed.get())
+        .as("the reported parsed count stops at the limit too")
+        .isEqualTo(2);
+  }
+
+  /**
+   * A limit of one is the tightest non-zero cap and the one where an off-by-one doubles the import.
+   */
+  @Test
+  void aLimitOfOneImportsExactlyOneObject() throws Exception {
+    final ImporterSettings settings = new ImporterSettings();
+    settings.parsingLimitEntries = 1;
+
+    new XMLImporterFormat().load(null, AnalyzedEntity.EntityType.DOCUMENT, xmlParser(FOUR_ITEMS), (DatabaseInternal) database,
+        new ImporterContext(), settings);
+
+    assertThat(countOf(database, "item")).isEqualTo(1);
+  }
+
+  /**
+   * The other direction, so the fix cannot be "stop one object early everywhere": a limit that the source never reaches
+   * must not truncate anything, and a limit equal to the object count must keep every object.
+   */
+  @Test
+  void aLimitAtOrAboveTheObjectCountImportsEverything() throws Exception {
+    final ImporterSettings exactly = new ImporterSettings();
+    exactly.parsingLimitEntries = 4;
+
+    new XMLImporterFormat().load(null, AnalyzedEntity.EntityType.DOCUMENT, xmlParser(FOUR_ITEMS), (DatabaseInternal) database,
+        new ImporterContext(), exactly);
+
+    assertThat(countOf(database, "item"))
+        .as("a limit equal to the object count is not a reason to drop the last object")
+        .isEqualTo(4);
+
+    database.getSchema().dropType("item");
+
+    final ImporterSettings unreached = new ImporterSettings();
+    unreached.parsingLimitEntries = 10;
+
+    new XMLImporterFormat().load(null, AnalyzedEntity.EntityType.DOCUMENT, xmlParser(FOUR_ITEMS), (DatabaseInternal) database,
+        new ImporterContext(), unreached);
+
+    assertThat(countOf(database, "item"))
+        .as("a limit the source never reaches imports the whole source")
+        .isEqualTo(4);
+  }
+
+  /**
+   * {@code -parsingLimitEntries 0} means "no limit": the guard is {@code parsingLimitEntries > 0}, and tightening the
+   * comparison must not turn the disabled case into "stop immediately".
+   */
+  @Test
+  void aZeroLimitMeansNoLimit() throws Exception {
+    final ImporterSettings settings = new ImporterSettings();
+    settings.parsingLimitEntries = 0;
+
+    new XMLImporterFormat().load(null, AnalyzedEntity.EntityType.DOCUMENT, xmlParser(FOUR_ITEMS), (DatabaseInternal) database,
+        new ImporterContext(), settings);
+
+    assertThat(countOf(database, "item")).isEqualTo(4);
+  }
+
+  /**
+   * The analyse half of the pair ({@code XMLImporterFormat.analyze()}), reached in production from
+   * {@code SourceDiscovery.getSchema()}. The third object is the first one carrying {@code onlyInTheThirdObject}, so
+   * that property appearing in the analysed schema is proof the analyser read a third object under a limit of two.
+   */
+  @Test
+  void theAnalyzingLimitIsACapNotAThreshold() throws Exception {
+    final ImporterSettings settings = new ImporterSettings();
+    settings.parseParameter("analyzingLimitEntries", "2");
+
+    final AnalyzedSchema analyzedSchema = new AnalyzedSchema(100);
+
+    final SourceSchema sourceSchema = new XMLImporterFormat().analyze(AnalyzedEntity.EntityType.DOCUMENT,
+        xmlParser(THIRD_ITEM_HAS_AN_EXTRA_PROPERTY), settings, analyzedSchema);
+
+    assertThat(sourceSchema).isNotNull();
+
+    final AnalyzedEntity entity = analyzedSchema.getEntity("item");
+    assertThat(entity).as("the first two objects are analysed").isNotNull();
+    assertThat(entity.getProperty("id")).as("the first two objects are analysed").isNotNull();
+    assertThat(entity.getProperty("onlyInTheThirdObject"))
+        .as("-analyzingLimitEntries 2 stops after the second object, so the third object's properties never reach the "
+            + "analysed schema")
+        .isNull();
+  }
+
+  /**
+   * The live CLI route, end to end: {@code Importer} builds the settings, {@code SourceDiscovery} runs
+   * {@code analyze()} and {@code Importer.loadFromSource()} runs {@code load()}. Nothing here reaches into
+   * {@code XMLImporterFormat} directly, so it is the proof that the changed lines run outside the unit tests.
+   */
+  @Test
+  void theCliRouteAppliesTheLimitAsACap() throws Exception {
+    final Path source = Path.of("target", "xml-parsing-limit-cli.xml").toAbsolutePath();
+    Files.createDirectories(source.getParent());
+    Files.writeString(source, FOUR_ITEMS, StandardCharsets.UTF_8);
+
+    final String cliDbPath = "target/databases/xml-parsing-limit-cli";
+    FileUtils.deleteRecursively(new File(cliDbPath));
+
+    try {
+      new Importer(("-documents file://" + source + " -database " + cliDbPath + " -parsingLimitEntries 2").split(" ")).load();
+
+      try (final Database cliDatabase = new DatabaseFactory(cliDbPath).open()) {
+        assertThat(countOf(cliDatabase, "item"))
+            .as("-parsingLimitEntries 2 on the command line imports 2 objects")
+            .isEqualTo(2);
+      }
+    } finally {
+      FileUtils.deleteRecursively(new File(cliDbPath));
+      Files.deleteIfExists(source);
+    }
+  }
+
+  /**
+   * The analyse limit through its live caller rather than through a direct {@code analyze()} call:
+   * {@code Importer.load()} runs {@code SourceDiscovery.getSchema()} -> {@code analyze()} and then feeds the analysed
+   * schema to {@code AbstractImporter.updateDatabaseSchema()}, which declares one property per analysed property
+   * ({@code type.createProperty(...)}). A declared {@code onlyInTheThirdObject} on the created type is therefore proof
+   * that the analyser reached a third object under {@code -analyzingLimitEntries 2} - the schema is the only place
+   * that shows it, since the record the property came from carries it whether or not the type declares it.
+   */
+  @Test
+  void theCliRouteAppliesTheAnalyzingLimitAsACap() throws Exception {
+    final Path source = Path.of("target", "xml-analyzing-limit-cli.xml").toAbsolutePath();
+    Files.createDirectories(source.getParent());
+    Files.writeString(source, THIRD_ITEM_HAS_AN_EXTRA_PROPERTY, StandardCharsets.UTF_8);
+
+    final String cliDbPath = "target/databases/xml-analyzing-limit-cli";
+    FileUtils.deleteRecursively(new File(cliDbPath));
+
+    try {
+      new Importer(("-documents file://" + source + " -database " + cliDbPath + " -analyzingLimitEntries 2").split(" ")).load();
+
+      try (final Database cliDatabase = new DatabaseFactory(cliDbPath).open()) {
+        assertThat(cliDatabase.getSchema().existsType("item")).isTrue();
+
+        final DocumentType type = cliDatabase.getSchema().getType("item");
+        assertThat(type.existsProperty("id"))
+            .as("the objects within the limit are analysed, so their properties are declared")
+            .isTrue();
+        assertThat(type.existsProperty("onlyInTheThirdObject"))
+            .as("-analyzingLimitEntries 2 on the command line stops the analyser after the second object, so the third "
+                + "object's property never becomes part of the schema")
+            .isFalse();
+      }
+    } finally {
+      FileUtils.deleteRecursively(new File(cliDbPath));
+      Files.deleteIfExists(source);
+    }
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/importer/format/XMLImporterFormatParsingLimitTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/format/XMLImporterFormatParsingLimitTest.java
@@ -239,7 +239,10 @@ class XMLImporterFormatParsingLimitTest {
     FileUtils.deleteRecursively(new File(cliDbPath));
 
     try {
-      new Importer(("-documents file://" + source + " -database " + cliDbPath + " -parsingLimitEntries 2").split(" ")).load();
+      // THE ARGUMENT ARRAY IS BUILT RATHER THAN SPLIT ON " ": source IS AN ABSOLUTE PATH UNDER THE MODULE'S target/,
+      // AND A CHECKOUT DIRECTORY CONTAINING A SPACE WOULD MAKE split(" ") MIS-TOKENISE THE -documents ARGUMENT
+      new Importer(new String[] { "-documents", "file://" + source, "-database", cliDbPath, "-parsingLimitEntries", "2" })
+          .load();
 
       try (final Database cliDatabase = new DatabaseFactory(cliDbPath).open()) {
         assertThat(countOf(cliDatabase, "item"))
@@ -270,7 +273,9 @@ class XMLImporterFormatParsingLimitTest {
     FileUtils.deleteRecursively(new File(cliDbPath));
 
     try {
-      new Importer(("-documents file://" + source + " -database " + cliDbPath + " -analyzingLimitEntries 2").split(" ")).load();
+      // SEE THE COMMENT IN theCliRouteAppliesTheLimitAsACap(): NOT split(" "), SO A PATH WITH A SPACE STILL WORKS
+      new Importer(new String[] { "-documents", "file://" + source, "-database", cliDbPath, "-analyzingLimitEntries", "2" })
+          .load();
 
       try (final Database cliDatabase = new DatabaseFactory(cliDbPath).open()) {
         assertThat(cliDatabase.getSchema().existsType("item")).isTrue();

--- a/integration/src/test/java/com/arcadedb/integration/importer/format/XMLImporterFormatStaleParsedCounterTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/format/XMLImporterFormatStaleParsedCounterTest.java
@@ -125,21 +125,19 @@ class XMLImporterFormatStaleParsedCounterTest {
 
     assertThat(countOf(database, "item"))
         .as("-parsingLimitEntries is measured from this phase's own first object, not from an inherited offset")
-        .isEqualTo(3);
+        .isEqualTo(2);
     assertThat(context.parsed.get())
         .as("the counter this phase reports is its own object count, not the previous phase's plus its own")
-        .isEqualTo(3);
+        .isEqualTo(2);
   }
 
   /**
    * The other half, so the fix cannot be "ignore the limit": with no stale offset the limit must still stop the
    * parse where it stopped it before.
    * <p>
-   * Three, not two, for a limit of two: the check is a strict {@code parsed > limit} taken after the object has
-   * been created, so the object that trips the limit is imported as well. That off-by-one is not this issue's
-   * subject - #7313 changes what the counter counts, not where the boundary falls - and is tracked separately as
-   * #7341. This assertion pins the current behaviour so the reset cannot silently move it; it is the assertion
-   * to update when #7341 is fixed.
+   * Two for a limit of two since #7341 turned the check into {@code parsed >= limit}: the object that reaches the
+   * limit is the last one kept rather than the first one past it. This assertion pins where the boundary falls, so
+   * a later change to what the counter counts cannot silently move it.
    */
   @Test
   void theParseLimitStillStopsTheImport() throws Exception {
@@ -150,9 +148,8 @@ class XMLImporterFormatStaleParsedCounterTest {
         settingsWithParsingLimit(2));
 
     assertThat(countOf(database, "item"))
-        .as("the limit still stops the parse: the fourth object is never reached (see #7341 for why it is three "
-            + "objects rather than two)")
-        .isEqualTo(3);
+        .as("the limit stops the parse at the limit: the third object is never reached")
+        .isEqualTo(2);
   }
 
   /**
@@ -179,10 +176,10 @@ class XMLImporterFormatStaleParsedCounterTest {
       try (final Database cliDatabase = new DatabaseFactory(cliDbPath).open()) {
         assertThat(countOf(cliDatabase, "v_first"))
             .as("the first phase imports up to its own limit")
-            .isEqualTo(3);
+            .isEqualTo(2);
         assertThat(countOf(cliDatabase, "second"))
             .as("the second phase gets its own budget of objects rather than inheriting an already-spent one")
-            .isEqualTo(3);
+            .isEqualTo(2);
       }
     } finally {
       FileUtils.deleteRecursively(new File(cliDbPath));


### PR DESCRIPTION
Closes #7341

## Summary

Both object limits in `XMLImporterFormat` tested a counter that the same loop iteration had already
incremented, with a strict `>`. For a limit of N the counter reached N after the Nth object without
tripping the test, the loop ran once more, and the (N+1)th object was processed before `N+1 > N` finally
broke out. In `load()` the break sits *below* `database.async().createRecord(...)`, so the object that trips
the limit is imported as well: `-parsingLimitEntries 2` on a four-object source imported three. `analyze()`
has the identical shape against `-analyzingLimitEntries`, handing the (N+1)th object's properties to the
schema analyser. Both comparisons become `>=`, so N means N on either route, matching the way the very same
setting already caps the vector route through `Stream.limit` (`TextEmbeddingsImporterLSM:252`). The change
is two characters plus the comments that say why the comparison has to be non-strict; everything else in
the diff is tests.

## Test plan

- [ ] `mvn -o -pl integration -am install -DskipTests` then
      `mvn -o -pl integration test -Dtest='XMLImporterFormatParsingLimitTest,XMLImporterFormatStaleParsedCounterTest'`
      - 10 tests, green. The four bug-reproducing tests in the new class are red on `main` (verified:
      `Tests run: 6, Failures: 4` before the fix), and the CLI analyse test was re-checked individually by
      reverting only the `analyze()` half, which turns it red.
- [ ] `mvn -o -pl integration test -DexcludedGroups=benchmark,vector,slow` - `Tests run: 373, Failures: 0,
      Errors: 0, Skipped: 9`.
- [ ] Manual: `-parsingLimitEntries 2` on an XML file with four objects now yields 2 rows, not 3.
- [ ] Check the three changed assertions in `XMLImporterFormatStaleParsedCounterTest` read as intended -
      they pinned the defect deliberately (see below).

## Coverage

Entry points the fix covers, each with a test that drives it through *that* path:

| Entry point | Test |
|---|---|
| `XMLImporterFormat.load()` direct call, `-parsingLimitEntries N` | `theParsingLimitIsACapNotAThreshold`, `aLimitOfOneImportsExactlyOneObject` |
| Boundary cases: limit == object count, limit > object count, limit == 0 (disabled) | `aLimitAtOrAboveTheObjectCountImportsEverything`, `aZeroLimitMeansNoLimit` |
| `Importer` CLI -> `loadFromSource()` -> `load()` | `theCliRouteAppliesTheLimitAsACap` |
| `XMLImporterFormat.analyze()` direct call, `-analyzingLimitEntries N` | `theAnalyzingLimitIsACapNotAThreshold` |
| `Importer` CLI -> `SourceDiscovery.getSchema()` -> `analyze()` | `theCliRouteAppliesTheAnalyzingLimitAsACap` |

Paths that cannot violate the invariant, argued rather than tested:

- `TextEmbeddingsImporterLSM:252` applies the same setting through `Stream.limit(n)`, whose contract is
  already "at most n". It is the reference this PR makes XML agree with, not a violator.
- `CSVImporterFormat:879` compares a **0-based** `line` in a check placed **before** the row is consumed,
  and index 0 is spent on the header (read from the file at `:882`, or skipped by the `skipEntries` default
  of 1). Lines 1..L are the data rows analysed, i.e. exactly L. Pre-check plus 0-based plus a consumed
  index 0 cancels the `>`; no off-by-one there.
- `Parser:108/118/128` bound a **byte** position, not an entry count.

### Known gaps

- **#7482** - `-parsingLimitEntries` is silently ignored by the nine importer formats that never read it
  (CSV, JSON, JSONL, RDF, Neo4j, OrientDB, GloVe, Word2Vec x2); `-parsingLimitBytes` is parsed, logged by
  `SourceDiscovery:96`, and enforced nowhere. A format that never implements the limit violates a different
  property than an off-by-one and needs a different fix per format.
- **#7485** - `XMLImporterFormat.analyze()` reads `analyzingLimitEntries` from the generic options map with
  a default of `0`, while the documented `analysisLimitEntries` (default `10000`, real CLI arm) reaches
  only `CSVImporterFormat`. So `-analysisLimitEntries` does nothing to an XML import and XML schema
  analysis is unbounded by default. Found by the adversarial pass; changing which setting a format reads is
  a behaviour change that wants its own review.

## Note on the one modified existing test

`XMLImporterFormatStaleParsedCounterTest` pinned the old `N+1` boundary **on purpose** - #7313 changed what
the counter counts and wanted a guard against silently moving where the boundary falls - and both the issue
text and that test's javadoc name it as the thing to update when this is fixed. Its three pinned numbers go
from `3` to `2` and the comment explaining them is rewritten. No scenario, name or assertion is removed;
#7313's own cases still assert exactly what they asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1vgWQXZoDXYq7TqAwLYXY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * XML import and analysis limits now stop precisely at the configured number of objects, preventing one extra object from being processed.
  * Parsing limits are correctly reset and counted for each import phase.
  * A limit matching the total number of objects retains all objects, while a zero limit remains unlimited.

* **Tests**
  * Added coverage for parsing and analysis limits through direct and command-line import workflows.
  * Improved command-line argument handling for file paths containing spaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->