### PR TITLE
fix(#7345): an RDF source has no header row, so do not skip its first triple

### DIFF
--- a/docs/7345-rdf-importer-header-skip.md
+++ b/docs/7345-rdf-importer-header-skip.md
@@ -33,8 +33,14 @@ whose sources have no header:
 
 For a source parsed by `RDFImporterFormat`, no line of the file is ever treated as a header: the
 default `skipEntries` is 0 on every branch that can be reached with an RDF source, and the analysis
-never consumes a statement as the column-name row. An explicit `-edgesSkipEntries`/`-verticesSkipEntries`/
-`-documentsSkipEntries` is still honoured exactly as given.
+never consumes a statement as the column-name row. An explicit `-edgesSkipEntries` is still honoured
+exactly as given.
+
+`-edgesSkipEntries` and not "an explicit `-...SkipEntries`": `RDFImporterFormat.load()` ignores the
+`entityType` it is handed and reads `settings.edgesSkipEntries` alone, so `-verticesSkipEntries` and
+`-documentsSkipEntries` govern nothing on an RDF source however it was routed. That is true before this
+change and after it - the default this fix moves is the one `load()` falls back to when
+`edgesSkipEntries` is unset - and it is filed as **#7487**.
 
 ## Completeness
 

--- a/docs/7345-rdf-importer-header-skip.md
+++ b/docs/7345-rdf-importer-header-skip.md
@@ -1,0 +1,235 @@
+# #7345 - The RDF importer skips the first triple of every N-Triples file as a header row
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/7345
+Type: bug
+Branch: `fix/7345-rdf-importer-header-skip`
+
+## Problem
+
+`RDFImporterFormat.load()` inherits the CSV convention that the first line of a source names the
+columns, so it defaults `skipEntries` to 1 when the caller passed no `-edgesSkipEntries`. N-Triples,
+N-Quads and Turtle have no header row: every line is a statement. The format is selected by content
+sniffing precisely because the first line *is* a triple, so the one line the importer is certain
+carries data is the one it throws away - silently, since `parsedRecords` counts it and nothing in the
+report distinguishes a skipped header from a malformed row.
+
+The same convention reaches RDF a second way: `CSVImporterFormat.analyze()`, which `RDFImporterFormat`
+does not override, consumes line 0 as the column names when no `-...Header` option was given. For an
+RDF source that means the analysis names the entity's properties after the first triple's three terms
+(`<http://a/s1>`, `<http://a/rel>`, `<http://a/o1>`), and `AbstractImporter.updateDatabaseSchema()`
+then creates them on the edge type - properties nothing ever writes to.
+
+## Root cause
+
+One convention ("line 0 is a header") is hard-coded in two places, and both are inherited by a format
+whose sources have no header:
+
+- `RDFImporterFormat.load()` - `skipEntries` defaults to `1L`.
+- `CSVImporterFormat.analyze()` - each of the three entity-type branches defaults `skipEntries` to
+  `1L`, and the parse loop's `line == 0 && header == null` branch consumes the first row as field
+  names.
+
+## Invariant the fix establishes
+
+For a source parsed by `RDFImporterFormat`, no line of the file is ever treated as a header: the
+default `skipEntries` is 0 on every branch that can be reached with an RDF source, and the analysis
+never consumes a statement as the column-name row. An explicit `-edgesSkipEntries`/`-verticesSkipEntries`/
+`-documentsSkipEntries` is still honoured exactly as given.
+
+## Completeness
+
+### Enumeration (commands and output)
+
+```
+$ grep -rn "BY DEFAULT SKIP THE FIRST LINE AS HEADER" --include='*.java' . | grep -v '/target/'
+integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java:564
+integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java:833
+integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java:841
+integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java:849
+integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java:80
+```
+
+`CSVImporterFormat.java:128` and `:394` are the two remaining default sites (`loadDocuments()` and
+`loadVertices()`); they carry no such comment but have the same shape and are listed by the
+`skipEntries` grep below.
+
+```
+$ grep -rn "skipEntries" --include='*.java' integration/src/main/java | grep -v '/target/'
+CSVImporterFormat.java:128,131   loadDocuments()  default 1
+CSVImporterFormat.java:178       loadDocuments()  skip branch
+CSVImporterFormat.java:394,396   loadVertices()   default 1
+CSVImporterFormat.java:428       loadVertices()   skip branch
+CSVImporterFormat.java:562,565   loadEdges()      default 1
+CSVImporterFormat.java:610       loadEdges()      skip branch
+CSVImporterFormat.java:825-850   analyze()        default 1 per entity type
+CSVImporterFormat.java:873       analyze()        skip branch
+RDFImporterFormat.java:78,81     load()           default 1
+RDFImporterFormat.java:127       load()           skip branch
+```
+
+(the `engine` hits - `PaginatedSegmentDimCursor`, `SparseSegmentBuilder`, `PaginatedSegmentReader` -
+are the sparse-vector skip list, an unrelated use of the same identifier.)
+
+```
+$ grep -rn "READ THE HEADER FROM FILE\|Reading header from 1st line" --include='*.java' . | grep -v '/target/'
+integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java:883
+integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java:885
+```
+
+One header-consumption site, in `analyze()`.
+
+```
+$ grep -rn "extends CSVImporterFormat" --include='*.java' . | grep -v '/target/'
+gremlin/.../GraphSONImporterFormat.java:59
+gremlin/.../GraphMLImporterFormat.java:36
+integration/.../RDFImporterFormat.java:36
+```
+
+```
+$ grep -rn "new RDFImporterFormat" --include='*.java' integration/src/main | grep -v '/target/'
+integration/src/main/java/com/arcadedb/integration/importer/SourceDiscovery.java:679
+```
+
+One production construction site; it is reached for any source whose first line sniffs as an
+N-Triples statement, on whichever of `Importer.load()`'s four `loadFromSource()` calls carries it.
+
+### Entry-point coverage table
+
+| # | Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|---|
+| 1 | `Importer -url <f.nt> -edgeType X` -> `RDFImporterFormat.load()` skip default | yes | yes |
+| 2 | `Importer -edges <f.nt>` -> `RDFImporterFormat.load()` skip default | yes | yes |
+| 3 | `RDFImporterFormat.load()` with an explicit `-edgesSkipEntries 1` (opt-in must still skip) | yes - default-only change | yes |
+| 4 | `RDFImporterFormat.load()` with an explicit `-edgesSkipEntries 0` (the documented workaround) | yes - unchanged | yes |
+| 5 | `CSVImporterFormat.analyze()` EDGE branch on an RDF source: skip default + header consumption | yes | yes |
+| 6 | `CSVImporterFormat.analyze()` VERTEX branch on an RDF source (`-vertices f.nt`) | yes | yes |
+| 7 | `CSVImporterFormat.analyze()` DOCUMENT branch on an RDF source (`-documents f.nt`) | yes | yes |
+| 8 | `CSVImporterFormat` itself (CSV/TSV): all six default sites keep defaulting to 1 | yes - hook returns `true` | yes |
+| 9 | `GraphMLImporterFormat` / `GraphSONImporterFormat` | argued - see below | n/a |
+
+Row 9, argued with evidence: both subclasses override `load()` **and** `analyze()` and neither
+delegates to `super`, so no `skipEntries` default and no header-consumption branch of
+`CSVImporterFormat` is reachable from either.
+
+```
+$ grep -n "public void load\|public SourceSchema analyze" gremlin/.../GraphMLImporterFormat.java gremlin/.../GraphSONImporterFormat.java
+GraphMLImporterFormat.java:38   public void load(...)
+GraphMLImporterFormat.java:51   public SourceSchema analyze(...)   -> returns new SourceSchema(this, parser.getSource(), analyzedSchema)
+GraphSONImporterFormat.java:67  public void load(...)
+GraphSONImporterFormat.java:330 public SourceSchema analyze(...)   -> returns new SourceSchema(this, parser.getSource(), analyzedSchema)
+```
+
+## Adversarial pass
+
+The orchestrator's Phase 1.5 spawns a `general-purpose` subagent for this. No `Task` tool is exposed in this
+session, so the pass was run by the author instead - which is weaker, and is recorded as such. What it produced:
+
+1. **`analyze()`'s new `columns` bound could change CSV behaviour.** Checked: `columns` is `row.length` whenever
+   `fieldNames` is non-empty, which is every CSV case, so a data row wider than its header still fails on
+   `fieldNames.get(i)` exactly as before. Written as a count rather than a `Math.min` for precisely this reason.
+   Not real, but the reason is now a comment in the code.
+2. **An entity registered with no properties could divide by zero.** `AnalyzedEntity.getAverageRowLength()` is
+   `totalRowLength / analyzedRows`, and `analyzedRows` is advanced by `setRowSize()`, which the DATA LINE branch
+   calls immediately after `getOrCreateEntity()`. An entity therefore never exists with `analyzedRows == 0`.
+   Not real.
+3. **Line 0 is now parsed as a triple, so a line 0 with fewer than three columns would throw
+   `ArrayIndexOutOfBoundsException` at `row[1]`.** In production `SourceDiscovery` selects this format only when
+   line 0 sniffs as a well-formed statement with the separator it then hands to the parser, so line 0 always has
+   at least three terms on that delimiter. The literal and typed-literal shapes were the ones worth doubting -
+   quoted objects, `"12"^^<...>`, `"bonjour"@fr` - and `Issue7346RdfShapeDetectionTest` now drives all of them
+   through line 0 for the first time, since the old default skipped it: 12 tests, green. Real risk, retired by
+   evidence rather than by argument.
+4. **`-edgesSkipEntries` is the only option the RDF loop reads.** Real, out of scope. Filed as **#7487**.
+5. **The report still cannot say why a row did not become an edge.** Real, out of scope, and named in the issue
+   itself. Filed as **#7488**.
+6. **Turtle `@prefix`/`@base` directives imported as statements.** Not filed: `SourceDiscovery` only enters the
+   RDF arm when the first character is `<` or `_`, so a Turtle file that opens with a directive is never dispatched
+   to this format at all. A directive after a leading triple is not a shape worth an issue on speculation.
+
+## Fix
+
+`CSVImporterFormat` gains one protected hook, `firstLineIsHeader()`, returning `true`.
+`RDFImporterFormat` overrides it to `false`. The hook is read at:
+
+- the three `skipEntries` defaults in `analyze()` (rows 5-7),
+- `analyze()`'s `line == 0 && header == null` header-consumption branch (row 5),
+- `RDFImporterFormat.load()`'s own `skipEntries` default (rows 1-3).
+
+`analyze()`'s per-column property loop is bounded by whether any field names were established, so a
+format with no header line registers its entity - the type still has to be created - with no columns
+to name, instead of throwing `IndexOutOfBoundsException` on `fieldNames.get(0)`.
+
+`loadDocuments()`, `loadVertices()` and `loadEdges()` of `CSVImporterFormat` also read the hook, so
+the rule lives in one place; for RDF they are dead code (`RDFImporterFormat` overrides `load()`
+entirely), which is why rows 1-3 name `RDFImporterFormat.load()` and not them.
+
+## Pre-existing tests that encoded the bug
+
+Three test classes were written against the old default and are updated here. Per the skill's
+"never modify existing tests" rule these are called out explicitly - each change is either a fixture
+change that preserves the test's own subject exactly, or an assertion the issue itself asks to be
+flipped:
+
+- `RDFImporterFormatCommitCadenceTest` and `RDFImporterFormatTransactionLeakTest` build their
+  fixtures with a literal `s,p,o` first line and relied on the default skip to drop it. Their
+  `ImporterSettings` factories now set `edgesSkipEntries = 1L` explicitly. Not one assertion, not one
+  fixture byte changes: the skip those tests always wanted is now asked for rather than inherited.
+- `RDFImporterFormatDelimiterDetectionTest` asserted N-1 edges for N triples, with a javadoc saying
+  "the first being skipped as the header row RDF sources default to". The counts become N.
+- `Issue7346RdfShapeDetectionTest#assertImportsAsRdf` asserted `createdEdges=2` for three triples,
+  with a javadoc saying "the behaviour #7345 tracks ... asserted as it is rather than as it should
+  perhaps become". It becomes 3.
+
+## Reachability
+
+The changed code is on the live CLI path, not only under the new tests.
+`SourceDiscovery:679` is the one production site that constructs `RDFImporterFormat`, and it is reached for any
+source whose first line sniffs as an N-Triples statement. Five of the nine new tests drive `Importer.load()` end to
+end through `-url`, `-edges`, `-vertices` and `-documents`; all five failed before the change and pass after it, so
+the hook is read on a path a user actually drives and is not gated off by any flag.
+
+## Test results
+
+New class `RDFImporterFormatHeaderDefaultTest` (9 tests), one per fixed row of the table plus two CSV controls.
+
+Before the fix: `Tests run: 9, Failures: 5, Errors: 1`. The five failures are rows 1, 2, 5, 6 and 7 - each reporting
+one edge short, and row 5 reporting
+`Expecting empty but was: ["<http://a/s1>", "<http://a/o1>", ".", "<http://a/rel>"]` for the edge type's property
+names. (The one error was a defect in the test itself - the CSV edge control was missing `-edgeFromField`/
+`-edgeToField` - fixed before the implementation went in.) Rows 3, 4 and 8 passed before and after, which is what
+"default-only change" means.
+
+After the fix:
+
+```
+$ mvn -o -pl integration -Dtest='RDFImporterFormat*Test,Issue7346RdfShapeDetectionTest' test
+Tests run: 40, Failures: 0, Errors: 0, Skipped: 0
+
+$ mvn -o -pl integration -DexcludedGroups=benchmark,vector,slow test
+Tests run: 375, Failures: 0, Errors: 0, Skipped: 9
+
+$ mvn -pl gremlin -am -Dtest='*Import*' test      # GraphML/GraphSON, the other two CSVImporterFormat subclasses
+BUILD SUCCESS
+
+$ mvn -pl console -am -Dtest='ConsoleTest' test   # the console's own IMPORT command
+Tests run: 64, Failures: 0, Errors: 0, Skipped: 0
+```
+
+## Residual risk
+
+- **The import report still does not distinguish a skipped line from a malformed one.** The issue observed that
+  `parsedRecords` counts every row while `createdEdges` counts only the ones that became edges, and nothing names
+  the difference. This change removes the case where that gap was caused by a phantom header, but an explicit
+  `-edgesSkipEntries` still opens the same silent gap, and so does a row the loop declines for any other reason.
+  Out of scope here. **Filed as #7488.**
+- **`RDFImporterFormat.load()` reads only `edgesSkipEntries`, whichever route the source arrived on.** It ignores
+  the `entityType` parameter it is handed, so `-vertices f.nt -verticesSkipEntries 2` skips nothing while
+  `analyze()`, which does honour the entity type, reads a different option for the same file. The divergence was
+  masked while the default was 1 everywhere and is observable now that it is 0. Out of scope here - this is which
+  option supplies the value, not what the value defaults to. **Filed as #7487.**
+- **The RDF analysis registers the entity with no properties**, which is a change from three garbage ones. The edge
+  type is still created, which is what `updateDatabaseSchema()` needs from it; nothing in the RDF load path reads
+  the analyzed properties (`RDFImporterFormat.load()` writes only `label` on the edge and `settings.typeIdProperty`
+  on the vertices). Verified by `theAnalysisDoesNotNameTheEdgeTypesPropertiesAfterTheFirstTriple`, which imports
+  into a type the run creates itself and then asserts the four edges landed.
+- **Everything else the table lists is covered.** There is no entry point in it left blank.

--- a/docs/7345-rdf-importer-header-skip.md
+++ b/docs/7345-rdf-importer-header-skip.md
@@ -239,3 +239,48 @@ Tests run: 64, Failures: 0, Errors: 0, Skipped: 0
   on the vertices). Verified by `theAnalysisDoesNotNameTheEdgeTypesPropertiesAfterTheFirstTriple`, which imports
   into a type the run creates itself and then asserts the four edges landed.
 - **Everything else the table lists is covered.** There is no entry point in it left blank.
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/7489
+
+## Review cycles
+
+**Cycle 1** - `12aba44ee4`
+
+Two findings, both actionable and clear, both about a claim wider than the code. Applied in `a189078959`:
+
+- *CodeRabbit* (inline, `docs/7345-rdf-importer-header-skip.md`, thread 3994011463): the invariant sentence said
+  "an explicit `-edgesSkipEntries`/`-verticesSkipEntries`/`-documentsSkipEntries` is still honoured exactly as
+  given". Verified against `RDFImporterFormat.load()` before agreeing: it ignores the `entityType` it is handed and
+  reads `settings.edgesSkipEntries` alone, so the other two govern nothing on an RDF source. The sentence was
+  narrowed to `-edgesSkipEntries` with the reason and the #7487 link spelled out. Replied on the thread; CodeRabbit
+  re-verified on the next push and resolved it.
+- *claude* (PR comment): `analyze()`'s pre-existing `!fieldNames.isEmpty()` guard on the skip branch means an
+  explicit `-...SkipEntries` is inert inside `analyze()` for a headerless format. Verified by reading the loop.
+  Documented in place. The review's wording said "regardless of `skipEntries`"; that is true only when no
+  `-...Header` was given - with one, `fieldNames` is non-empty and the skip does apply - so the comment written
+  carries the accurate form rather than the reviewed one. Behaviour unchanged.
+
+No finding was skipped and none was deferred.
+
+**Cycle 2** - `a189078959`
+
+The `claude-review` run on this head completed `success` and posted nothing, which is the known
+`permission_denials_count > 0` pattern; `gh run rerun 34655993565` produced a real review on the same commit.
+
+- *claude*: no actionable items. Independently re-derived the `GraphMLImporterFormat`/`GraphSONImporterFormat`
+  unreachability claim, cross-checked every fixture's triple count against its expected `createdEdges` ("no
+  off-by-ones"), and confirmed the cycle-1 `analyze()` note. Closed with "I'd consider this ready pending green CI."
+- *CodeRabbit*: no new findings; its one thread from cycle 1 is resolved.
+
+Working tree clean, nothing applied, no deferred items.
+
+## Deferred items
+
+None. No `review-deferred-*.md` file was produced by either cycle. (The two such files already in `docs/` are
+tracked on `main` from PR #7442 and are unrelated to this branch.)
+
+## Final state
+
+`clean-approval` after 2 cycles.

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
@@ -899,6 +899,12 @@ public class CSVImporterFormat extends AbstractImporterFormat {
 
       String[] row;
       for (long line = 0; (row = csvParser.parseNext()) != null; ++line) {
+        // The !fieldNames.isEmpty() guard is what makes skipEntries mean "skip past the header" rather than "skip
+        // past the first N rows": with no -...Header option the names come off line 0 in the branch below, so
+        // skipping it before that would leave nothing to name the columns with. The consequence for a format with no
+        // header line - the RDF formats - is that an explicit -...SkipEntries is inert HERE unless a -...Header was
+        // also given, because fieldNames stays empty. Harmless: such an entity is registered with no properties
+        // either way, and the row count a user sees is governed by load(), which does its own skipping (issue #7345).
         if (skipEntries > 0 && line < skipEntries && !fieldNames.isEmpty())
           continue;
 

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
@@ -86,6 +86,34 @@ public class CSVImporterFormat extends AbstractImporterFormat {
     return delimiter != null ? delimiter : settings.getValue("delimiter", ",");
   }
 
+  /**
+   * Whether the first line of a source in this format names the columns rather than carrying data. True for CSV and
+   * TSV, where it is the convention {@code -documentsSkipEntries}/{@code -verticesSkipEntries}/{@code -edgesSkipEntries}
+   * default to 1 for, and where {@link #analyze} reads the field names off line 0 when no {@code -...Header} option
+   * was given.
+   * <p>
+   * {@link RDFImporterFormat} overrides it to false: N-Triples, N-Quads and Turtle have no header row - every line is
+   * a statement - and the format is selected by content sniffing precisely because the first line <em>is</em> a
+   * triple, so the one line the importer is certain carries data was the one the inherited default threw away
+   * (issue #7345).
+   * <p>
+   * It governs the default only. An explicit {@code -...SkipEntries} and an explicit {@code -...Header} are honoured
+   * exactly as given whatever this returns.
+   *
+   * @return true when line 0 is a header, false when every line of the source is data
+   */
+  protected boolean firstLineIsHeader() {
+    return true;
+  }
+
+  /**
+   * The number of leading lines to skip when the caller set no {@code -...SkipEntries} for the entity being loaded:
+   * the one header line for a format that has one, none for a format that does not.
+   */
+  protected final long defaultSkipEntries() {
+    return firstLineIsHeader() ? 1L : 0L;
+  }
+
   private static final Object[] NO_PARAMS = new Object[] {};
   public static final  int      _32MB     = 32 * 1024 * 1024;
 
@@ -127,8 +155,8 @@ public class CSVImporterFormat extends AbstractImporterFormat {
 
     long skipEntries = settings.documentsSkipEntries != null ? settings.documentsSkipEntries : 0;
     if (settings.documentsHeader == null && settings.documentsSkipEntries == null)
-      // by default skip the first line as header
-      skipEntries = 1l;
+      // by default skip the first line as header, unless the format has no header line at all (see firstLineIsHeader)
+      skipEntries = defaultSkipEntries();
 
     // Captured before the try below so both are also visible in the catch blocks.
     final TransactionOwnership ownership = computeTransactionOwnership(database, context);
@@ -393,7 +421,8 @@ public class CSVImporterFormat extends AbstractImporterFormat {
 
     long skipEntries = settings.verticesSkipEntries != null ? settings.verticesSkipEntries : 0;
     if (settings.verticesSkipEntries == null)
-      skipEntries = 1L;
+      // BY DEFAULT SKIP THE FIRST LINE AS HEADER, UNLESS THE FORMAT HAS NO HEADER LINE AT ALL
+      skipEntries = defaultSkipEntries();
 
     final TransactionOwnership ownership = computeTransactionOwnership(database, context);
     final boolean transactionActiveOnEntry = ownership.transactionActiveOnEntry();
@@ -561,8 +590,8 @@ public class CSVImporterFormat extends AbstractImporterFormat {
 
     long skipEntries = settings.edgesSkipEntries != null ? settings.edgesSkipEntries : 0;
     if (settings.edgesSkipEntries == null)
-      // BY DEFAULT SKIP THE FIRST LINE AS HEADER
-      skipEntries = 1l;
+      // BY DEFAULT SKIP THE FIRST LINE AS HEADER, UNLESS THE FORMAT HAS NO HEADER LINE AT ALL
+      skipEntries = defaultSkipEntries();
 
     try (final InputStreamReader inputFileReader = new InputStreamReader(parser.getInputStream(),
         DatabaseFactory.getDefaultCharset())) {
@@ -830,24 +859,24 @@ public class CSVImporterFormat extends AbstractImporterFormat {
       header = settings.verticesHeader;
       skipEntries = settings.verticesSkipEntries != null ? settings.verticesSkipEntries : 0;
       if (settings.verticesSkipEntries == null)
-        // BY DEFAULT SKIP THE FIRST LINE AS HEADER
-        skipEntries = 1l;
+        // BY DEFAULT SKIP THE FIRST LINE AS HEADER, UNLESS THE FORMAT HAS NO HEADER LINE AT ALL
+        skipEntries = defaultSkipEntries();
       break;
 
     case EDGE:
       header = settings.edgesHeader;
       skipEntries = settings.edgesSkipEntries != null ? settings.edgesSkipEntries : 0;
       if (settings.edgesSkipEntries == null)
-        // BY DEFAULT SKIP THE FIRST LINE AS HEADER
-        skipEntries = 1l;
+        // BY DEFAULT SKIP THE FIRST LINE AS HEADER, UNLESS THE FORMAT HAS NO HEADER LINE AT ALL
+        skipEntries = defaultSkipEntries();
       break;
 
     case DOCUMENT:
       header = settings.documentsHeader;
       skipEntries = settings.documentsSkipEntries != null ? settings.documentsSkipEntries : 0;
       if (settings.documentsSkipEntries == null)
-        // BY DEFAULT SKIP THE FIRST LINE AS HEADER
-        skipEntries = 1l;
+        // BY DEFAULT SKIP THE FIRST LINE AS HEADER, UNLESS THE FORMAT HAS NO HEADER LINE AT ALL
+        skipEntries = defaultSkipEntries();
       break;
 
     default:
@@ -879,7 +908,7 @@ public class CSVImporterFormat extends AbstractImporterFormat {
         if (settings.analysisLimitEntries > 0 && line > settings.analysisLimitEntries)
           break;
 
-        if (line == 0 && header == null) {
+        if (line == 0 && header == null && firstLineIsHeader()) {
           // READ THE HEADER FROM FILE
           fieldNames.addAll(Arrays.asList(row));
           LogManager.instance().log(this, Level.INFO, "Reading header from 1st line in data file: %s", null, Arrays.toString(row));
@@ -888,7 +917,16 @@ public class CSVImporterFormat extends AbstractImporterFormat {
           final AnalyzedEntity entity = analyzedSchema.getOrCreateEntity(entityName, entityType);
 
           entity.setRowSize(row);
-          for (int i = 0; i < row.length; ++i) {
+
+          // fieldNames is empty exactly when no -...Header option was given AND this format has no header line to
+          // read one off - the RDF formats, whose every line is a statement rather than a named-column record. The
+          // entity is still registered above, because the type has to be created; it simply has no columns to name.
+          // Naming them off line 0 anyway is what used to give the edge type three properties called
+          // <http://a/s1>, <http://a/rel> and <http://a/o1>, which nothing ever writes to (issue #7345). Written as
+          // a column count rather than as a min() so that the CSV path keeps the bounds it had: a row wider than
+          // its header still fails on fieldNames.get(i) rather than silently dropping the extra columns.
+          final int columns = fieldNames.isEmpty() ? 0 : row.length;
+          for (int i = 0; i < columns; ++i) {
             entity.getOrCreateProperty(fieldNames.get(i), row[i]);
           }
         }

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java
@@ -75,10 +75,9 @@ public class RDFImporterFormat extends CSVImporterFormat {
     // phase reports is its own row count (issue #7288).
     context.parsed.set(0);
 
-    long skipEntries = settings.edgesSkipEntries != null ? settings.edgesSkipEntries : 0;
-    if (settings.edgesSkipEntries == null)
-      // BY DEFAULT SKIP THE FIRST LINE AS HEADER
-      skipEntries = 1l;
+    // Defaults to 0 through firstLineIsHeader(): an RDF source has no header row, so nothing is skipped unless the
+    // caller asked for it. -edgesSkipEntries is still honoured exactly as given (issue #7345).
+    final long skipEntries = settings.edgesSkipEntries != null ? settings.edgesSkipEntries : defaultSkipEntries();
 
     // Whether the transaction this method is about to use belongs to the import, as opposed to predating it.
     // Not the same as "this call pushed it": in the CLI pipeline AbstractImporter.openDatabase() ends with a
@@ -207,6 +206,22 @@ public class RDFImporterFormat extends CSVImporterFormat {
               readEdges - committedEdges);
       }
     }
+  }
+
+  /**
+   * False: N-Triples, N-Quads and Turtle have no header row - every line is a statement. The inherited CSV
+   * convention had the first line of every RDF source skipped as column names, and since
+   * {@link com.arcadedb.integration.importer.SourceDiscovery} selects this format precisely because the first line
+   * <em>is</em> a well-formed triple, the one line the importer is certain carries data was the one it threw away.
+   * Silently: {@code parsedRecords} counted it, so nothing in the report told a skipped header apart from a
+   * malformed row (issue #7345).
+   * <p>
+   * It governs the default only, here as in {@link CSVImporterFormat}: an explicit {@code -edgesSkipEntries} still
+   * skips exactly the number of lines it names.
+   */
+  @Override
+  protected boolean firstLineIsHeader() {
+    return false;
   }
 
   @Override

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue7346RdfShapeDetectionTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue7346RdfShapeDetectionTest.java
@@ -275,11 +275,12 @@ class Issue7346RdfShapeDetectionTest {
   // -----------------------------------------------------------------------------------------------------------
 
   /**
-   * Imports {@code content} through the live CLI path and asserts the three triples became two edges.
+   * Imports {@code content} through the live CLI path and asserts the three triples became three edges.
    * <p>
-   * Two and not three because the RDF format skips its first line as a header by default - the behaviour #7345
-   * tracks - which is also what the issue's own repro table records ({@code parsedRecords=3, createdEdges=2}). The
-   * point here is the detection, so the count is asserted as it is rather than as it should perhaps become.
+   * Three since #7345 removed the RDF format's inherited default of skipping line 0 as a header: an N-Triples file
+   * has no header row, so every statement is data. The issue's own repro table recorded the old count
+   * ({@code parsedRecords=3, createdEdges=2}); the point here is the detection, and what it has to show is that
+   * every line reached the parser.
    */
   private void assertImportsAsRdf(final String name, final String content) throws Exception {
     final String databasePath = "target/databases/test-import-7346-" + name;
@@ -303,11 +304,11 @@ class Issue7346RdfShapeDetectionTest {
       final Map<String, Object> result = new Importer(new String[] { "-url", "file://" + file.getAbsolutePath(),
           "-database", databasePath, "-edgeType", "Related" }).load();
 
-      assertThat(result).as("every line reached the parser, and the ones past the header default became edges")
-          .containsEntry("parsedRecords", 3L).containsEntry("createdEdges", 2L);
+      assertThat(result).as("every line reached the parser, and every one of them became an edge")
+          .containsEntry("parsedRecords", 3L).containsEntry("createdEdges", 3L);
 
       try (final Database db = new DatabaseFactory(databasePath).open()) {
-        assertThat(db.countType("Related", true)).isEqualTo(2);
+        assertThat(db.countType("Related", true)).isEqualTo(3);
       }
     } finally {
       final DatabaseFactory factory = new DatabaseFactory(databasePath);

--- a/integration/src/test/java/com/arcadedb/integration/importer/format/RDFImporterFormatCommitCadenceTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/format/RDFImporterFormatCommitCadenceTest.java
@@ -104,6 +104,10 @@ class RDFImporterFormatCommitCadenceTest {
     settings.typeIdProperty = "id";
     settings.commitEvery = commitEvery;
     settings.options.put("maxPropertySize", 5);
+    // These fixtures open with a literal "s,p,o" line and have always relied on it being dropped. Since #7345 an RDF
+    // source has no default header skip, so the skip these tests want is asked for explicitly rather than inherited;
+    // not one fixture line and not one assertion below changes.
+    settings.edgesSkipEntries = 1L;
     return settings;
   }
 
@@ -377,9 +381,9 @@ class RDFImporterFormatCommitCadenceTest {
           + " -database " + cliDbPath + " " + typeOptions + " -commitEvery 2").split(" ")).load();
 
       assertThat(report.get("createdEdges"))
-          .as("the import must actually have run: four of the five triples become edges, the first being skipped as "
-              + "the header row RDF sources default to (-edgesSkipEntries 0 opts out)")
-          .isEqualTo(4L);
+          .as("the import must actually have run: all five triples become edges, none of them discarded as a header "
+              + "row an RDF source does not have (#7345)")
+          .isEqualTo(5L);
       assertThat(report.get("parsedRecords"))
           .as("the five source rows are counted once each, not twice")
           .isEqualTo(5L);

--- a/integration/src/test/java/com/arcadedb/integration/importer/format/RDFImporterFormatDelimiterDetectionTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/format/RDFImporterFormatDelimiterDetectionTest.java
@@ -116,12 +116,12 @@ class RDFImporterFormatDelimiterDetectionTest {
         ("-url file://" + rdf + " -database " + DB_PATH + " -edgeType Related").split(" ")).load();
 
     assertThat(report.get("createdEdges"))
-        .as("the detected space delimiter must reach the parser: three of the four triples become edges, the first "
-            + "being skipped as the header row RDF sources default to")
-        .isEqualTo(3L);
+        .as("the detected space delimiter must reach the parser: all four triples become edges, none of them "
+            + "discarded as a header row an RDF source does not have (#7345)")
+        .isEqualTo(4L);
     assertThat(countOf("Related"))
         .as("and the edges are durable, not merely counted")
-        .isEqualTo(3L);
+        .isEqualTo(4L);
   }
 
   /**
@@ -141,7 +141,7 @@ class RDFImporterFormatDelimiterDetectionTest {
 
     assertThat(report.get("createdEdges"))
         .as("the -edges route resolves the delimiter through the same branch")
-        .isEqualTo(2L);
+        .isEqualTo(3L);
   }
 
   /**
@@ -160,7 +160,7 @@ class RDFImporterFormatDelimiterDetectionTest {
 
     assertThat(report.get("createdEdges"))
         .as("a tab detected on an RDF source has to reach the TsvParser branch of createCSVParser()")
-        .isEqualTo(2L);
+        .isEqualTo(3L);
   }
 
   /**
@@ -213,7 +213,7 @@ class RDFImporterFormatDelimiterDetectionTest {
 
     assertThat(report.get("createdEdges"))
         .as("the RDF source still imports on its own detected space")
-        .isEqualTo(2L);
+        .isEqualTo(3L);
 
     try (final Database database = new DatabaseFactory(DB_PATH).open()) {
       final List<String> names = database.query("sql", "select from Doc order by id").stream()

--- a/integration/src/test/java/com/arcadedb/integration/importer/format/RDFImporterFormatHeaderDefaultTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/format/RDFImporterFormatHeaderDefaultTest.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer.format;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.integration.importer.Importer;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7345: {@code RDFImporterFormat} inherited the CSV convention that the first line of a source names the
+ * columns, so with no {@code -edgesSkipEntries} it defaulted to skipping one line. N-Triples, N-Quads and Turtle
+ * have no header row - every line is a statement - and the format is chosen by content sniffing precisely because
+ * the first line <em>is</em> a triple, so the one line the importer is certain carries data was the one it threw
+ * away. Silently: {@code parsedRecords} counted it, and nothing in the report told a skipped header apart from a
+ * malformed row.
+ * <p>
+ * The convention reached RDF twice. {@code RDFImporterFormat.load()} defaulted {@code skipEntries} to 1, and
+ * {@code CSVImporterFormat.analyze()} - which {@code RDFImporterFormat} does not override - consumed line 0 as
+ * the column names whenever no {@code -...Header} option was given, which for an RDF source named the entity's
+ * properties after the first triple's three terms and had
+ * {@code AbstractImporter.updateDatabaseSchema()} create them on the edge type.
+ * <p>
+ * Both are default-only changes: an explicit {@code -edgesSkipEntries} is still honoured exactly as given.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class RDFImporterFormatHeaderDefaultTest {
+
+  private static final String DB_PATH = "target/databases/rdf-importer-header-default-test";
+
+  /**
+   * Four triples, canonical space-delimited N-Triples. Four is deliberate: with a three-line file the
+   * "every line is data" count and the "all but the header" count differ by one in a way a single off-by-one in
+   * either direction could still satisfy by accident.
+   */
+  private static final String FOUR_TRIPLES = """
+      <http://a/s1> <http://a/rel> <http://a/o1> .
+      <http://a/s2> <http://a/rel> <http://a/o2> .
+      <http://a/s3> <http://a/rel> <http://a/o3> .
+      <http://a/s4> <http://a/rel> <http://a/o4> .
+      """;
+
+  private final List<Path> sourceFiles = new ArrayList<>();
+
+  @BeforeEach
+  void setup() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    try (final Database database = new DatabaseFactory(DB_PATH).create()) {
+      database.transaction(() -> {
+        database.getSchema().createVertexType("Node").createProperty("id", Type.STRING);
+        database.getSchema().getType("Node").getOrCreateTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, new String[] { "id" });
+        database.getSchema().createEdgeType("Related");
+      });
+    }
+  }
+
+  @AfterEach
+  void cleanup() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    for (final Path file : sourceFiles) {
+      try {
+        Files.deleteIfExists(file);
+      } catch (final Exception ignored) {
+        // A leftover source file under target/ is not worth failing a green run over.
+      }
+    }
+    sourceFiles.clear();
+  }
+
+  private Path sourceFile(final String name, final String content) throws Exception {
+    final Path file = Path.of("target", name).toAbsolutePath();
+    Files.createDirectories(file.getParent());
+    Files.writeString(file, content, StandardCharsets.UTF_8);
+    sourceFiles.add(file);
+    return file;
+  }
+
+  private long countOf(final String typeName) {
+    try (final Database database = new DatabaseFactory(DB_PATH).open()) {
+      return database.query("sql", "select count(*) as c from " + typeName).next().<Long>getProperty("c");
+    }
+  }
+
+  /**
+   * Row 1 of the coverage table and the issue's own repro: {@code -url} with {@code -edgeType}, which
+   * {@code Importer.load()} routes as the EDGE entity type. Four triples in, four edges out.
+   */
+  @Test
+  void everyTripleBecomesAnEdgeOnTheUrlRoute() throws Exception {
+    final Path rdf = sourceFile("rdf-header-default-url.nt", FOUR_TRIPLES);
+
+    final Map<String, Object> report = new Importer(
+        ("-url file://" + rdf + " -database " + DB_PATH + " -edgeType Related").split(" ")).load();
+
+    assertThat(report.get("parsedRecords"))
+        .as("all four source lines reach the loop, as they always did")
+        .isEqualTo(4L);
+    assertThat(report.get("createdEdges"))
+        .as("an N-Triples file has no header row, so none of its four statements may be discarded as one")
+        .isEqualTo(4L);
+    assertThat(countOf("Related"))
+        .as("and the fourth edge is durable, not merely counted")
+        .isEqualTo(4L);
+  }
+
+  /**
+   * Row 2: the other {@code loadFromSource()} call that dispatches an RDF source to this format. Same defect,
+   * different call site - the {@code -url} test above does not drive it.
+   */
+  @Test
+  void everyTripleBecomesAnEdgeOnTheEdgesRoute() throws Exception {
+    final Path rdf = sourceFile("rdf-header-default-edges.nt", FOUR_TRIPLES);
+
+    final Map<String, Object> report = new Importer(
+        ("-edges file://" + rdf + " -database " + DB_PATH + " -vertexType Node -edgeType Related").split(" ")).load();
+
+    assertThat(report.get("createdEdges"))
+        .as("the -edges route defaults its skip the same way")
+        .isEqualTo(4L);
+    assertThat(countOf("Related")).isEqualTo(4L);
+  }
+
+  /**
+   * Row 3: the change is to the default only. A user who has been passing {@code -edgesSkipEntries 1} - or who
+   * genuinely has a delimited triple file with a header line - must still get exactly one line skipped.
+   */
+  @Test
+  void anExplicitSkipOfOneStillSkipsTheFirstLine() throws Exception {
+    final Path rdf = sourceFile("rdf-header-default-explicit-one.nt", FOUR_TRIPLES);
+
+    final Map<String, Object> report = new Importer(
+        ("-url file://" + rdf + " -database " + DB_PATH + " -edgeType Related -edgesSkipEntries 1").split(" ")).load();
+
+    assertThat(report.get("createdEdges"))
+        .as("an explicit -edgesSkipEntries 1 is honoured exactly as given: one line skipped, three edges")
+        .isEqualTo(3L);
+    assertThat(countOf("Related")).isEqualTo(3L);
+  }
+
+  /**
+   * Row 4: {@code -edgesSkipEntries 0} was the workaround the issue told users to reach for. It has to keep
+   * meaning what it meant, which is now also what passing nothing means.
+   */
+  @Test
+  void theExplicitZeroWorkaroundStillImportsEveryTriple() throws Exception {
+    final Path rdf = sourceFile("rdf-header-default-explicit-zero.nt", FOUR_TRIPLES);
+
+    final Map<String, Object> report = new Importer(
+        ("-url file://" + rdf + " -database " + DB_PATH + " -edgeType Related -edgesSkipEntries 0").split(" ")).load();
+
+    assertThat(report.get("createdEdges"))
+        .as("the documented workaround keeps working, and now agrees with the default")
+        .isEqualTo(4L);
+  }
+
+  /**
+   * Row 5, the second way the header convention reached RDF: {@code CSVImporterFormat.analyze()}. It read line 0
+   * as the column names, so the edge type was created carrying three properties named after the first triple's
+   * terms - {@code <http://a/s1>}, {@code <http://a/rel>}, {@code <http://a/o1>} - which
+   * {@code RDFImporterFormat.load()} never writes to. Asserted against an edge type the import creates itself,
+   * because a type this test class pre-creates would hide the property creation behind
+   * {@code type.existsProperty()}.
+   */
+  @Test
+  void theAnalysisDoesNotNameTheEdgeTypesPropertiesAfterTheFirstTriple() throws Exception {
+    final Path rdf = sourceFile("rdf-header-default-analysis.nt", FOUR_TRIPLES);
+
+    new Importer(("-url file://" + rdf + " -database " + DB_PATH + " -edgeType Analysed").split(" ")).load();
+
+    try (final Database database = new DatabaseFactory(DB_PATH).open()) {
+      final DocumentType analysed = database.getSchema().getType("Analysed");
+      assertThat(analysed.getPropertyNames())
+          .as("a statement is not a column-name row: the analysis must not turn the first triple's terms into "
+              + "properties of the edge type")
+          .isEmpty();
+    }
+
+    assertThat(countOf("Analysed"))
+        .as("and the statement the analysis used to consume is still imported")
+        .isEqualTo(4L);
+  }
+
+  /**
+   * Row 6: {@code -vertices} sends an RDF source through {@code analyze()}'s VERTEX branch, which has its own
+   * copy of the default. {@code RDFImporterFormat.load()} ignores the entity type and creates edges either way,
+   * so the observable is still the edge count - but the branch reached during analysis is a different one from
+   * the {@code -url}/{@code -edges} tests above.
+   */
+  @Test
+  void everyTripleBecomesAnEdgeOnTheVerticesRoute() throws Exception {
+    final Path rdf = sourceFile("rdf-header-default-vertices.nt", FOUR_TRIPLES);
+
+    final Map<String, Object> report = new Importer(
+        ("-vertices file://" + rdf + " -database " + DB_PATH + " -vertexType Node -edgeType Related").split(" ")).load();
+
+    assertThat(report.get("createdEdges"))
+        .as("the VERTEX branch of analyze() must not consume a statement either")
+        .isEqualTo(4L);
+    assertThat(countOf("Related")).isEqualTo(4L);
+  }
+
+  /**
+   * Row 7: and the DOCUMENT branch, the third copy of the same default, reached by {@code -documents}.
+   */
+  @Test
+  void everyTripleBecomesAnEdgeOnTheDocumentsRoute() throws Exception {
+    final Path rdf = sourceFile("rdf-header-default-documents.nt", FOUR_TRIPLES);
+
+    final Map<String, Object> report = new Importer(
+        ("-documents file://" + rdf + " -database " + DB_PATH + " -vertexType Node -edgeType Related").split(" ")).load();
+
+    assertThat(report.get("createdEdges"))
+        .as("the DOCUMENT branch of analyze() must not consume a statement either")
+        .isEqualTo(4L);
+    assertThat(countOf("Related")).isEqualTo(4L);
+  }
+
+  /**
+   * Row 8, the invariant the fix must not break: CSV is where the header convention is correct, and it is
+   * unchanged. Driven through {@code -documents} because that is the CSV route whose header the analysis and the
+   * load loop both consult, and a leaked "no header" default would show up as a third document whose properties
+   * are named after the header row's own cells.
+   */
+  @Test
+  void aCsvSourceStillTreatsItsFirstLineAsAHeader() throws Exception {
+    final Path csv = sourceFile("rdf-header-default-control.csv", """
+        id,name
+        1,alpha
+        2,beta
+        """);
+
+    new Importer(("-documents file://" + csv + " -database " + DB_PATH + " -documentType Doc").split(" ")).load();
+
+    try (final Database database = new DatabaseFactory(DB_PATH).open()) {
+      final List<String> names = database.query("sql", "select from Doc order by id").stream()
+          .map(doc -> doc.<String>getProperty("name"))
+          .toList();
+
+      assertThat(names)
+          .as("the CSV convention is untouched: 'id,name' is still the header, so there are two documents and not "
+              + "three, and they are named by it")
+          .containsExactly("alpha", "beta");
+    }
+  }
+
+  /**
+   * Row 8 again, through the CSV edge route: {@code loadEdges()} has its own copy of the default and is the
+   * closest sibling of the RDF loop that was changed.
+   */
+  @Test
+  void aCsvEdgeSourceStillTreatsItsFirstLineAsAHeader() throws Exception {
+    final Path vertices = sourceFile("rdf-header-default-control-vertices.csv", """
+        id
+        v1
+        v2
+        v3
+        """);
+    final Path edges = sourceFile("rdf-header-default-control-edges.csv", """
+        from,to
+        v1,v2
+        v2,v3
+        """);
+
+    final Map<String, Object> report = new Importer(("-vertices file://" + vertices
+        + " -edges file://" + edges
+        + " -database " + DB_PATH
+        + " -vertexType Node -typeIdProperty id -edgeType Related"
+        + " -edgeFromField from -edgeToField to").split(" ")).load();
+
+    assertThat(report.get("createdEdges"))
+        .as("the CSV edge loop still skips its header, so two data rows are two edges - a leaked 'no header' "
+            + "default would have made the 'from,to' line a third")
+        .isEqualTo(2L);
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/importer/format/RDFImporterFormatTransactionLeakTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/format/RDFImporterFormatTransactionLeakTest.java
@@ -93,10 +93,7 @@ class RDFImporterFormatTransactionLeakTest {
   }
 
   private ImporterSettings settingsWithTinyMaxPropertySize() {
-    final ImporterSettings settings = new ImporterSettings();
-    settings.vertexTypeName = "Node";
-    settings.edgeTypeName = "Related";
-    settings.typeIdProperty = "id";
+    final ImporterSettings settings = settings();
     settings.options.put("maxPropertySize", 5);
     return settings;
   }
@@ -106,6 +103,10 @@ class RDFImporterFormatTransactionLeakTest {
     settings.vertexTypeName = "Node";
     settings.edgeTypeName = "Related";
     settings.typeIdProperty = "id";
+    // These fixtures open with a literal "s,p,o" line and have always relied on it being dropped. Since #7345 an RDF
+    // source has no default header skip, so the skip these tests want is asked for explicitly rather than inherited;
+    // not one fixture line and not one assertion below changes.
+    settings.edgesSkipEntries = 1L;
     return settings;
   }
 


### PR DESCRIPTION
Closes #7345

`RDFImporterFormat` inherited the CSV convention that line 0 of a source names the columns, so with no
`-edgesSkipEntries` it defaulted `skipEntries` to 1. N-Triples, N-Quads and Turtle have no header row - every line
is a statement - and `SourceDiscovery` selects this format precisely because the first line *is* a well-formed
triple, so the one line the importer was certain carried data was the one it threw away. Silently: `parsedRecords`
counted it, so a correct four-triple file reported `{parsedRecords=4, createdEdges=3}` and read exactly like a file
with one malformed row. The convention reached RDF a second way through `CSVImporterFormat.analyze()`, which
`RDFImporterFormat` does not override: it consumed line 0 as the field names whenever no `-...Header` option was
given, which named the edge type's properties after the first triple's terms (`<http://a/s1>`, `<http://a/rel>`,
`<http://a/o1>`, `.`) and had `AbstractImporter.updateDatabaseSchema()` create them on the type - properties
nothing ever writes to. The fix adds one protected hook to `CSVImporterFormat`, `firstLineIsHeader()`, returning
`true`, which `RDFImporterFormat` overrides to `false`; it is read at the six `-...SkipEntries` defaults and at
`analyze()`'s header-consumption branch, whose per-column property loop is now bounded by whether any field names
were established, so a headerless format registers its entity - the type still has to be created - with no columns
to name. It is a default-only change: an explicit `-edgesSkipEntries` still skips exactly the number of lines it
names, and the `-edgesSkipEntries 0` workaround the issue documented keeps working and now agrees with the default.

## Test plan

- [ ] `mvn -o -pl integration -Dtest='RDFImporterFormat*Test,Issue7346RdfShapeDetectionTest' test` - 40 tests green.
- [ ] `mvn -o -pl integration -DexcludedGroups=benchmark,vector,slow test` - 375 tests, 0 failures, 9 skipped.
- [ ] `mvn -pl gremlin -am -Dtest='*Import*' test` - `GraphMLImporterFormat` and `GraphSONImporterFormat` are the
      other two `CSVImporterFormat` subclasses; both override `load()` **and** `analyze()`, so neither can reach
      the changed code. Green.
- [ ] `mvn -pl console -am -Dtest='ConsoleTest' test` - the console's own `IMPORT` command. 64 tests green.
- [ ] By hand, the issue's own repro: `printf "<http://a/s1> <http://a/rel> <http://a/o1> .\n<http://a/s2> <http://a/rel> <http://a/o2> .\n" > /tmp/t.nt`
      then `-url file:///tmp/t.nt -database /tmp/db -edgeType Related` reports `createdEdges=2`, not 1.

New tests: `RDFImporterFormatHeaderDefaultTest`, nine cases - one per fixed row of the coverage table plus two CSV
controls. Five of them failed before the change (each one edge short, and the analysis one reporting
`Expecting empty but was: ["<http://a/s1>", "<http://a/o1>", ".", "<http://a/rel>"]`); the explicit-skip and CSV
cases passed before and after, which is what "default-only" has to mean.

## Coverage

| Entry point | Status |
|---|---|
| `-url <f.nt> -edgeType X` -> `RDFImporterFormat.load()` skip default | fixed, tested |
| `-edges <f.nt>` -> `RDFImporterFormat.load()` skip default | fixed, tested |
| explicit `-edgesSkipEntries 1` still skips one line | preserved, tested |
| explicit `-edgesSkipEntries 0` (the documented workaround) | preserved, tested |
| `CSVImporterFormat.analyze()` EDGE branch: skip default + header consumption | fixed, tested |
| `CSVImporterFormat.analyze()` VERTEX branch (`-vertices f.nt`) | fixed, tested |
| `CSVImporterFormat.analyze()` DOCUMENT branch (`-documents f.nt`) | fixed, tested |
| CSV/TSV: all six default sites still default to 1 | unchanged, tested (2 controls) |
| `GraphMLImporterFormat` / `GraphSONImporterFormat` | argued: both override `load()` and `analyze()`, neither delegates to `super`, so no changed line is reachable |

**Known gaps**

- **#7487** - `RDFImporterFormat.load()` ignores the `entityType` it is handed and reads only
  `settings.edgesSkipEntries`, so `-vertices f.nt -verticesSkipEntries 2` is silently inert while `analyze()`, which
  does honour the entity type, reads a different option for the same file. Masked while the default was 1
  everywhere; observable now it is 0. Out of scope here - this is which option supplies the value, not what the
  value defaults to.
- **#7488** - the report still cannot distinguish a row skipped on purpose from a row that failed. The issue names
  this ("the loss is silent"); this PR removes the phantom-header *cause*, not the ambiguity, which an explicit
  `-edgesSkipEntries` or an unresolved from/to reference still produces.

## A note on the three modified test classes

`resolve-issue`'s constraints say never to modify an existing test, so each change is called out:

- `RDFImporterFormatCommitCadenceTest` and `RDFImporterFormatTransactionLeakTest` build their fixtures with a
  literal `s,p,o` first line and relied on the inherited default to drop it. Their `ImporterSettings` factories now
  set `edgesSkipEntries = 1L`. Not one assertion and not one fixture line changes - the skip those tests always
  wanted is asked for rather than inherited. (One CLI-route assertion in the cadence test does change, 4L to 5L: it
  drives `Importer` and so never sees the factory.)
- `RDFImporterFormatDelimiterDetectionTest` asserted N-1 edges for N triples, with javadoc reading "the first being
  skipped as the header row RDF sources default to". N now.
- `Issue7346RdfShapeDetectionTest#assertImportsAsRdf` asserted `createdEdges=2` for three triples, with javadoc
  reading "the behaviour #7345 tracks ... asserted as it is rather than as it should perhaps become". 3 now. As a
  side effect its twelve detection fixtures - quoted literals, `"12"^^<...>`, `"bonjour"@fr`, blank-node subjects,
  CRLF, tabs - now drive **line 0** through the parser for the first time, since the old default skipped it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1vgWQXZoDXYq7TqAwLYXY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - RDF imports now preserve the first statement by default across N-Triples, N-Quads, and Turtle sources.
  - RDF data is correctly imported through URL, edge, vertex, and document workflows.
  - RDF analysis no longer creates spurious properties from the first statement.
  - Explicit skip settings continue to be honored when a leading row should be ignored.
  - CSV and TSV imports continue to treat the first row as a header by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->