### PR TITLE
fix(#7342): hoist the context.parsed reset into Importer.loadFromSource() so a format cannot forget it

### DIFF
--- a/integration/src/main/java/com/arcadedb/integration/importer/Importer.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Importer.java
@@ -136,6 +136,13 @@ public class Importer extends AbstractImporter {
 
     format = sourceSchema.getContentImporter();
 
+    // One ImporterContext serves every phase of an import, so context.parsed arrives carrying whatever the previous
+    // phase left in it. Zeroed here rather than by each format in turn: this is the single place every phase of
+    // every import passes through, so a format cannot forget it and a format added later inherits it. The rows the
+    // previous phase parsed are rolled into context.totalParsed rather than discarded, so the run can still report
+    // what it parsed as a whole (issue #7342).
+    context.beginParsingPhase();
+
     format.load(sourceSchema, entityType, parser, database, context, settings);
   }
 

--- a/integration/src/main/java/com/arcadedb/integration/importer/ImporterContext.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/ImporterContext.java
@@ -125,9 +125,9 @@ public class ImporterContext {
    * accumulating them.
    */
   public void beginParsingPhase() {
-    // getAndSet rather than a read followed by set(0): every one of the eleven sites that increments this counter
-    // today runs on the thread inside FormatImporter.load(), so nothing races this call as the code stands - but
-    // the atomic form costs the same and cannot lose a row to a future writer that does not.
+    // getAndSet rather than a read followed by set(0): the fold is then correct whichever thread is incrementing
+    // `parsed` at the time, rather than only because all eleven increment sites happen to run on the thread inside
+    // FormatImporter.load() today. Same cost, and a future off-thread writer cannot lose a row to it.
     totalParsed.addAndGet(parsed.getAndSet(0L));
     // lastLapOn is deliberately NOT reset with it. printProgress divides every delta on the line by the same
     // window, and the createdDocuments/Vertices/Edges counters it also prints are import-wide and never reset -
@@ -146,15 +146,17 @@ public class ImporterContext {
    * The report {@link Importer#load()} returns.
    * <p>
    * {@code parsedRecords} is the row count of the <b>last phase that ran</b>, which is what nine of the ten
-   * {@code FormatImporter} implementations already reported and what callers of this map read today. {@code totalParsedRecords} is the whole
-   * run. On a single-phase import - every {@code IMPORT DATABASE} without a {@code documents}/{@code vertices}/
-   * {@code edges} setting, and the whole HTTP/gRPC {@code import database} command - the two are equal.
+   * {@code FormatImporter} implementations already reported and what callers of this map read today.
+   * {@code totalParsedRecords} is the whole run. On a single-phase import - every {@code IMPORT DATABASE}
+   * without a {@code documents}/{@code vertices}/{@code edges} setting, and the whole HTTP/gRPC
+   * {@code import database} command - the two are equal.
    */
   public Map<String, Object> toMap() {
     final LinkedHashMap<String, Object> map = new LinkedHashMap<>();
 
-    // Read once each: an import that failed mid-phase can still have an async thread incrementing while the report
-    // is built, and a key must not be tested against one value and published with another.
+    // Read once each, and summed here rather than through totalParsedRecords(): the two keys must agree, so the
+    // run total has to be built from the same reading of `parsed` that the phase key was, and neither key may be
+    // tested against one value and published with another.
     final long phaseParsed = parsed.get();
     if (phaseParsed > 0)
       map.put("parsedRecords", phaseParsed);

--- a/integration/src/main/java/com/arcadedb/integration/importer/ImporterContext.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/ImporterContext.java
@@ -137,7 +137,14 @@ public class ImporterContext {
     lastParsed = 0L;
   }
 
-  /** Rows parsed by this import so far: every finished phase plus the one currently running. */
+  /**
+   * Rows parsed by this import so far: every finished phase plus the one currently running.
+   * <p>
+   * {@link #toMap()} deliberately does not call this - it needs both published keys built from one reading of
+   * {@link #parsed}, which a second call here would re-read. The caller this exists for is a progress reader that
+   * wants a figure which does not jump backwards at a phase boundary, which is what the server's once-a-second
+   * import counter needs and does not yet use (issue #7483).
+   */
   public long totalParsedRecords() {
     return totalParsed.get() + parsed.get();
   }

--- a/integration/src/main/java/com/arcadedb/integration/importer/ImporterContext.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/ImporterContext.java
@@ -25,7 +25,22 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class ImporterContext {
+  /**
+   * Rows parsed by the phase currently running, and only by it. One ImporterContext serves every phase of an
+   * import - {@link Importer#load()} calls {@code loadFromSource()} for the url, documents, vertices and edges
+   * sources against the same context - so this counter is zeroed at each phase boundary by
+   * {@link #beginParsingPhase()}. Several formats take a decision off it (a commit boundary, a parse limit), and
+   * an inherited offset moved those boundaries to somewhere inside the phase's first batch (issues #7288, #7313).
+   * Use {@link #totalParsed} for the whole run.
+   */
   public final AtomicLong parsed                     = new AtomicLong();
+  /**
+   * Rows parsed by every phase that has already finished. Monotonic for the life of the import, and the companion
+   * the per-phase {@link #parsed} counter needs so that "the rows this import parsed" remains answerable once the
+   * reset is hoisted (issue #7342). It excludes the phase currently running, which no boundary has folded in yet -
+   * {@link #totalParsedRecords()} is the sum a reader wants.
+   */
+  public final AtomicLong totalParsed                = new AtomicLong();
   public final AtomicLong parsedDocumentAndVertices  = new AtomicLong();
   public final AtomicLong createdDocuments           = new AtomicLong();
   public final AtomicLong createdVertices            = new AtomicLong();
@@ -57,6 +72,12 @@ public class ImporterContext {
   public       boolean       callerTransactionActiveOnEntry;
   public       long          startedOn;
   public       long          lastLapOn;
+  /**
+   * The value of {@link #parsed} at the previous progress line, subtracted from the current one by
+   * {@code FormatImporter#printProgress} to print a rate. Zeroed by {@link #beginParsingPhase()} together with the
+   * counter it is a high-water mark of: left behind, it made the first progress line after a phase boundary
+   * subtract the previous phase's total from the new phase's handful of rows and print a negative rate (#7342).
+   */
   public       long          lastParsed;
   public       long          lastDocuments;
   public       long          lastVertices;
@@ -87,11 +108,59 @@ public class ImporterContext {
     return !callerTransactionActiveOnEntry || !database.isTransactionActive();
   }
 
+  /**
+   * Opens a parsing phase: rolls the rows the phase that just finished parsed into {@link #totalParsed}, then
+   * zeroes {@link #parsed} and the {@link #lastParsed} high-water mark that is read against it.
+   * <p>
+   * Called from {@link Importer#loadFromSource} immediately before {@code FormatImporter.load()}, which is the one
+   * place every phase of every import passes through, so a format cannot forget it and a format added later
+   * inherits it (issue #7342). The nine formats that used to zero the counter themselves call this instead of
+   * assigning the field, so there is a single definition of what a phase reset is and the two cannot drift; they
+   * keep doing it because {@code FormatImporter.load()} is public API and is called directly, not only through
+   * {@code loadFromSource()}. Calling it twice for the same phase is harmless: the second call folds zero.
+   * <p>
+   * Not to be confused with {@code OrientDBImporter.parseRecords()}'s own {@code parsed.set(0)}, which is not a
+   * phase boundary: {@code run()} parses the same input up to three times (ANALYZE, CREATE_SCHEMA, CREATE_EDGES)
+   * and every pass re-counts the records, so that one deliberately discards the previous pass's rows instead of
+   * accumulating them.
+   */
+  public void beginParsingPhase() {
+    // getAndSet rather than a read followed by set(0): every one of the eleven sites that increments this counter
+    // today runs on the thread inside FormatImporter.load(), so nothing races this call as the code stands - but
+    // the atomic form costs the same and cannot lose a row to a future writer that does not.
+    totalParsed.addAndGet(parsed.getAndSet(0L));
+    // lastLapOn is deliberately NOT reset with it. printProgress divides every delta on the line by the same
+    // window, and the createdDocuments/Vertices/Edges counters it also prints are import-wide and never reset -
+    // restarting the clock here would leave their deltas measured over a window shorter than the rows they cover
+    // and overstate those rates. A window that opened slightly before this phase did understates the parse rate of
+    // the first line after a boundary by the same slight amount; that is the cheaper of the two errors.
+    lastParsed = 0L;
+  }
+
+  /** Rows parsed by this import so far: every finished phase plus the one currently running. */
+  public long totalParsedRecords() {
+    return totalParsed.get() + parsed.get();
+  }
+
+  /**
+   * The report {@link Importer#load()} returns.
+   * <p>
+   * {@code parsedRecords} is the row count of the <b>last phase that ran</b>, which is what nine of the ten
+   * {@code FormatImporter} implementations already reported and what callers of this map read today. {@code totalParsedRecords} is the whole
+   * run. On a single-phase import - every {@code IMPORT DATABASE} without a {@code documents}/{@code vertices}/
+   * {@code edges} setting, and the whole HTTP/gRPC {@code import database} command - the two are equal.
+   */
   public Map<String, Object> toMap() {
     final LinkedHashMap<String, Object> map = new LinkedHashMap<>();
 
-    if (parsed.get() > 0)
-      map.put("parsedRecords", parsed.get());
+    // Read once each: an import that failed mid-phase can still have an async thread incrementing while the report
+    // is built, and a key must not be tested against one value and published with another.
+    final long phaseParsed = parsed.get();
+    if (phaseParsed > 0)
+      map.put("parsedRecords", phaseParsed);
+    final long runParsed = totalParsed.get() + phaseParsed;
+    if (runParsed > 0)
+      map.put("totalParsedRecords", runParsed);
     if (errors.get() > 0)
       map.put("errors", errors.get());
     if (warnings.get() > 0)

--- a/integration/src/main/java/com/arcadedb/integration/importer/OrientDBImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/OrientDBImporter.java
@@ -407,6 +407,10 @@ public class OrientDBImporter {
 
     final AtomicLong processedItems = new AtomicLong();
     context.skippedEdges.set(0);
+    // NOT a phase boundary, so deliberately not ImporterContext#beginParsingPhase(): run() calls parseInputFile()
+    // up to three times (ANALYZE, CREATE_SCHEMA, CREATE_EDGES) and each pass reaches here and re-counts the same
+    // records. The previous pass's rows are discarded rather than accumulated, or one OrientDB import would report
+    // its records two or three times over (issue #7342).
     context.parsed.set(0);
 
     final List<Map<String, Object>> batch = new ArrayList<>(batchSize);

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
@@ -96,7 +96,10 @@ public class CSVImporterFormat extends AbstractImporterFormat {
       final ImporterContext context,
       final ImporterSettings settings) throws ImportException {
 
-    context.parsed.set(0);
+    // Redundant with Importer.loadFromSource(), which zeroes the phase counter for every format before dispatching
+    // here; kept because FormatImporter.load() is public API and is called directly too. Routed through
+    // ImporterContext so there is one definition of what a phase reset is (issue #7342).
+    context.beginParsingPhase();
 
     switch (entityType) {
     case DOCUMENT, DATABASE -> loadDocuments(sourceSchema, parser, database, context, settings);

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
@@ -96,9 +96,8 @@ public class CSVImporterFormat extends AbstractImporterFormat {
       final ImporterContext context,
       final ImporterSettings settings) throws ImportException {
 
-    // Redundant with Importer.loadFromSource(), which zeroes the phase counter for every format before dispatching
-    // here; kept because FormatImporter.load() is public API and is called directly too. Routed through
-    // ImporterContext so there is one definition of what a phase reset is (issue #7342).
+    // Kept for direct FormatImporter.load() callers; loadFromSource() has already done it. See
+    // ImporterContext#beginParsingPhase() (issue #7342).
     context.beginParsingPhase();
 
     switch (entityType) {

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/GloVeImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/GloVeImporterFormat.java
@@ -44,9 +44,8 @@ public class GloVeImporterFormat extends AbstractImporterFormat {
   public void load(final SourceSchema sourceSchema, final AnalyzedEntity.EntityType entityType, final Parser parser, final DatabaseInternal database,
       final ImporterContext context, final ImporterSettings settings) throws ImportException {
 
-    // Redundant with Importer.loadFromSource(), which zeroes the phase counter for every format before dispatching
-    // here; kept because FormatImporter.load() is public API and is called directly too. Routed through
-    // ImporterContext so there is one definition of what a phase reset is (issue #7342).
+    // Kept for direct FormatImporter.load() callers; loadFromSource() has already done it. See
+    // ImporterContext#beginParsingPhase() (issue #7342).
     context.beginParsingPhase();
 
     try {

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/GloVeImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/GloVeImporterFormat.java
@@ -44,7 +44,10 @@ public class GloVeImporterFormat extends AbstractImporterFormat {
   public void load(final SourceSchema sourceSchema, final AnalyzedEntity.EntityType entityType, final Parser parser, final DatabaseInternal database,
       final ImporterContext context, final ImporterSettings settings) throws ImportException {
 
-    context.parsed.set(0);
+    // Redundant with Importer.loadFromSource(), which zeroes the phase counter for every format before dispatching
+    // here; kept because FormatImporter.load() is public API and is called directly too. Routed through
+    // ImporterContext so there is one definition of what a phase reset is (issue #7342).
+    context.beginParsingPhase();
 
     try {
       importer = new TextEmbeddingsImporterLSM(database, parser.getSource().inputStream, settings).setContext(context);

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JSONImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JSONImporterFormat.java
@@ -73,6 +73,13 @@ public class JSONImporterFormat implements FormatImporter {
     }
   }
 
+  /**
+   * Deliberately carries no {@code context.beginParsingPhase()} of its own, unlike the nine formats that grew one
+   * each: {@link com.arcadedb.integration.importer.Importer#loadFromSource} zeroes the phase counter for every
+   * format before dispatching here, and this is the format that proves it does - it was the one that never reset
+   * the counter itself, so a run ending in a JSON phase reported the previous phase's rows along with its own
+   * (issue #7342). A tenth copy of the line here would make the hoist unobservable.
+   */
   @Override
   public void load(final SourceSchema sourceSchema, final AnalyzedEntity.EntityType entityType, final Parser parser,
       final DatabaseInternal database,

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
@@ -118,9 +118,10 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
 
     // One ImporterContext serves every phase of an import, so this counter arrives carrying whatever an earlier
     // phase left in it, and the periodic commit below is taken off it: an inherited offset moved the first commit
-    // to somewhere inside the first batch. Zeroed here the way RDFImporterFormat and the six other formats zero
-    // it, so the boundary counts this phase's own records (issue #7313).
-    context.parsed.set(0);
+    // to somewhere inside the first batch (issue #7313). Since #7342 loadFromSource() already zeroes it before
+    // dispatching here, so this is redundant on that path and kept for the direct FormatImporter.load() call,
+    // which is public API; routed through ImporterContext so the two cannot drift.
+    context.beginParsingPhase();
 
     // Governs the commit granularity below (see the loop): skip mode needs one record per transaction so a
     // failed record's rollback can never discard an earlier, already-successful one riding in the same batch.

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
@@ -118,9 +118,8 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
 
     // One ImporterContext serves every phase of an import, so this counter arrives carrying whatever an earlier
     // phase left in it, and the periodic commit below is taken off it: an inherited offset moved the first commit
-    // to somewhere inside the first batch (issue #7313). Since #7342 loadFromSource() already zeroes it before
-    // dispatching here, so this is redundant on that path and kept for the direct FormatImporter.load() call,
-    // which is public API; routed through ImporterContext so the two cannot drift.
+    // to somewhere inside the first batch (issue #7313). Kept for direct FormatImporter.load() callers;
+    // loadFromSource() has already done it. See ImporterContext#beginParsingPhase().
     context.beginParsingPhase();
 
     // Governs the commit granularity below (see the loop): skip mode needs one record per transaction so a

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/Neo4jImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/Neo4jImporterFormat.java
@@ -36,7 +36,10 @@ public class Neo4jImporterFormat extends AbstractImporterFormat {
   public void load(final SourceSchema sourceSchema, final AnalyzedEntity.EntityType entityType, final Parser parser, final DatabaseInternal database,
       final ImporterContext context, final ImporterSettings settings) throws ImportException {
 
-    context.parsed.set(0);
+    // Redundant with Importer.loadFromSource(), which zeroes the phase counter for every format before dispatching
+    // here; kept because FormatImporter.load() is public API and is called directly too. Routed through
+    // ImporterContext so there is one definition of what a phase reset is (issue #7342).
+    context.beginParsingPhase();
 
     try {
       new Neo4jImporter(database, context) {

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/Neo4jImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/Neo4jImporterFormat.java
@@ -36,9 +36,8 @@ public class Neo4jImporterFormat extends AbstractImporterFormat {
   public void load(final SourceSchema sourceSchema, final AnalyzedEntity.EntityType entityType, final Parser parser, final DatabaseInternal database,
       final ImporterContext context, final ImporterSettings settings) throws ImportException {
 
-    // Redundant with Importer.loadFromSource(), which zeroes the phase counter for every format before dispatching
-    // here; kept because FormatImporter.load() is public API and is called directly too. Routed through
-    // ImporterContext so there is one definition of what a phase reset is (issue #7342).
+    // Kept for direct FormatImporter.load() callers; loadFromSource() has already done it. See
+    // ImporterContext#beginParsingPhase() (issue #7342).
     context.beginParsingPhase();
 
     try {

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/OrientDBImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/OrientDBImporterFormat.java
@@ -36,9 +36,8 @@ public class OrientDBImporterFormat extends AbstractImporterFormat {
   public void load(final SourceSchema sourceSchema, final AnalyzedEntity.EntityType entityType, final Parser parser, final DatabaseInternal database,
       final ImporterContext context, final ImporterSettings settings) throws ImportException {
 
-    // Redundant with Importer.loadFromSource(), which zeroes the phase counter for every format before dispatching
-    // here; kept because FormatImporter.load() is public API and is called directly too. Routed through
-    // ImporterContext so there is one definition of what a phase reset is (issue #7342).
+    // Kept for direct FormatImporter.load() callers; loadFromSource() has already done it. See
+    // ImporterContext#beginParsingPhase() (issue #7342).
     context.beginParsingPhase();
 
     try {

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/OrientDBImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/OrientDBImporterFormat.java
@@ -36,7 +36,10 @@ public class OrientDBImporterFormat extends AbstractImporterFormat {
   public void load(final SourceSchema sourceSchema, final AnalyzedEntity.EntityType entityType, final Parser parser, final DatabaseInternal database,
       final ImporterContext context, final ImporterSettings settings) throws ImportException {
 
-    context.parsed.set(0);
+    // Redundant with Importer.loadFromSource(), which zeroes the phase counter for every format before dispatching
+    // here; kept because FormatImporter.load() is public API and is called directly too. Routed through
+    // ImporterContext so there is one definition of what a phase reset is (issue #7342).
+    context.beginParsingPhase();
 
     try {
       new OrientDBImporter(database, settings) {

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java
@@ -70,10 +70,8 @@ public class RDFImporterFormat extends CSVImporterFormat {
 
     // One ImporterContext serves every phase of an import - Importer.load() calls loadFromSource() for the url,
     // documents, vertices and edges sources against the same context - so this counter arrives carrying whatever an
-    // earlier phase left in it, and the commit boundary below is taken off it (issue #7288). Since #7342
-    // loadFromSource() already zeroes it before dispatching here, so this is redundant on that path and kept for
-    // the direct FormatImporter.load() call, which is public API; routed through ImporterContext so the two
-    // cannot drift.
+    // earlier phase left in it, and the commit boundary below is taken off it (issue #7288). Kept for direct
+    // FormatImporter.load() callers; loadFromSource() has already done it. See ImporterContext#beginParsingPhase().
     context.beginParsingPhase();
 
     long skipEntries = settings.edgesSkipEntries != null ? settings.edgesSkipEntries : 0;

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java
@@ -70,9 +70,10 @@ public class RDFImporterFormat extends CSVImporterFormat {
 
     // One ImporterContext serves every phase of an import - Importer.load() calls loadFromSource() for the url,
     // documents, vertices and edges sources against the same context - so this counter arrives carrying whatever an
-    // earlier phase left in it, and the commit boundary below is taken off it. Since #7342 loadFromSource() already
-    // zeroes it before dispatching here, so this is redundant on that path and kept for the direct FormatImporter
-    // .load() call, which is public API; routed through ImporterContext so the two cannot drift (issue #7288).
+    // earlier phase left in it, and the commit boundary below is taken off it (issue #7288). Since #7342
+    // loadFromSource() already zeroes it before dispatching here, so this is redundant on that path and kept for
+    // the direct FormatImporter.load() call, which is public API; routed through ImporterContext so the two
+    // cannot drift.
     context.beginParsingPhase();
 
     long skipEntries = settings.edgesSkipEntries != null ? settings.edgesSkipEntries : 0;

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java
@@ -70,10 +70,10 @@ public class RDFImporterFormat extends CSVImporterFormat {
 
     // One ImporterContext serves every phase of an import - Importer.load() calls loadFromSource() for the url,
     // documents, vertices and edges sources against the same context - so this counter arrives carrying whatever an
-    // earlier phase left in it. Zeroed here the way CSVImporterFormat, Neo4jImporterFormat, OrientDBImporterFormat,
-    // GloVeImporterFormat, Word2VecImporterFormat and Word2VecImporterFormatLSM all zero it, so the number this
-    // phase reports is its own row count (issue #7288).
-    context.parsed.set(0);
+    // earlier phase left in it, and the commit boundary below is taken off it. Since #7342 loadFromSource() already
+    // zeroes it before dispatching here, so this is redundant on that path and kept for the direct FormatImporter
+    // .load() call, which is public API; routed through ImporterContext so the two cannot drift (issue #7288).
+    context.beginParsingPhase();
 
     long skipEntries = settings.edgesSkipEntries != null ? settings.edgesSkipEntries : 0;
     if (settings.edgesSkipEntries == null)

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/Word2VecImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/Word2VecImporterFormat.java
@@ -44,9 +44,8 @@ public class Word2VecImporterFormat extends AbstractImporterFormat {
   public void load(final SourceSchema sourceSchema, final AnalyzedEntity.EntityType entityType, final Parser parser, final DatabaseInternal database,
       final ImporterContext context, final ImporterSettings settings) throws ImportException {
 
-    // Redundant with Importer.loadFromSource(), which zeroes the phase counter for every format before dispatching
-    // here; kept because FormatImporter.load() is public API and is called directly too. Routed through
-    // ImporterContext so there is one definition of what a phase reset is (issue #7342).
+    // Kept for direct FormatImporter.load() callers; loadFromSource() has already done it. See
+    // ImporterContext#beginParsingPhase() (issue #7342).
     context.beginParsingPhase();
 
     try {

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/Word2VecImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/Word2VecImporterFormat.java
@@ -44,7 +44,10 @@ public class Word2VecImporterFormat extends AbstractImporterFormat {
   public void load(final SourceSchema sourceSchema, final AnalyzedEntity.EntityType entityType, final Parser parser, final DatabaseInternal database,
       final ImporterContext context, final ImporterSettings settings) throws ImportException {
 
-    context.parsed.set(0);
+    // Redundant with Importer.loadFromSource(), which zeroes the phase counter for every format before dispatching
+    // here; kept because FormatImporter.load() is public API and is called directly too. Routed through
+    // ImporterContext so there is one definition of what a phase reset is (issue #7342).
+    context.beginParsingPhase();
 
     try {
       settings.documentsSkipEntries = 1L; // SKIP 1ST LINE

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/Word2VecImporterFormatLSM.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/Word2VecImporterFormatLSM.java
@@ -44,9 +44,8 @@ public class Word2VecImporterFormatLSM extends AbstractImporterFormat {
   public void load(final SourceSchema sourceSchema, final AnalyzedEntity.EntityType entityType, final Parser parser, final DatabaseInternal database,
       final ImporterContext context, final ImporterSettings settings) throws ImportException {
 
-    // Redundant with Importer.loadFromSource(), which zeroes the phase counter for every format before dispatching
-    // here; kept because FormatImporter.load() is public API and is called directly too. Routed through
-    // ImporterContext so there is one definition of what a phase reset is (issue #7342).
+    // Kept for direct FormatImporter.load() callers; loadFromSource() has already done it. See
+    // ImporterContext#beginParsingPhase() (issue #7342).
     context.beginParsingPhase();
 
     try {

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/Word2VecImporterFormatLSM.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/Word2VecImporterFormatLSM.java
@@ -44,7 +44,10 @@ public class Word2VecImporterFormatLSM extends AbstractImporterFormat {
   public void load(final SourceSchema sourceSchema, final AnalyzedEntity.EntityType entityType, final Parser parser, final DatabaseInternal database,
       final ImporterContext context, final ImporterSettings settings) throws ImportException {
 
-    context.parsed.set(0);
+    // Redundant with Importer.loadFromSource(), which zeroes the phase counter for every format before dispatching
+    // here; kept because FormatImporter.load() is public API and is called directly too. Routed through
+    // ImporterContext so there is one definition of what a phase reset is (issue #7342).
+    context.beginParsingPhase();
 
     try {
       settings.documentsSkipEntries = 1L; // SKIP 1ST LINE

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/XMLImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/XMLImporterFormat.java
@@ -51,9 +51,10 @@ public class XMLImporterFormat implements FormatImporter {
 
       // One ImporterContext serves every phase of an import, so this counter arrives carrying whatever an earlier
       // phase left in it, and -parsingLimitEntries is checked against it below: a phase entered already past the
-      // limit imported nothing at all while still reporting success. Zeroed here the way RDFImporterFormat and the
-      // six other formats zero it, so the limit counts this phase's own objects (issue #7313).
-      context.parsed.set(0);
+      // limit imported nothing at all while still reporting success (issue #7313). Since #7342 loadFromSource()
+      // already zeroes it before dispatching here, so this is redundant on that path and kept for the direct
+      // FormatImporter.load() call, which is public API; routed through ImporterContext so the two cannot drift.
+      context.beginParsingPhase();
 
       final XMLInputFactory xmlFactory = XMLInputFactory.newInstance();
       xmlFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/XMLImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/XMLImporterFormat.java
@@ -51,9 +51,9 @@ public class XMLImporterFormat implements FormatImporter {
 
       // One ImporterContext serves every phase of an import, so this counter arrives carrying whatever an earlier
       // phase left in it, and -parsingLimitEntries is checked against it below: a phase entered already past the
-      // limit imported nothing at all while still reporting success (issue #7313). Since #7342 loadFromSource()
-      // already zeroes it before dispatching here, so this is redundant on that path and kept for the direct
-      // FormatImporter.load() call, which is public API; routed through ImporterContext so the two cannot drift.
+      // limit imported nothing at all while still reporting success (issue #7313). Kept for direct
+      // FormatImporter.load() callers; loadFromSource() has already done it. See
+      // ImporterContext#beginParsingPhase().
       context.beginParsingPhase();
 
       final XMLInputFactory xmlFactory = XMLInputFactory.newInstance();

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue7342ParsedCounterPhaseScopeTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue7342ParsedCounterPhaseScopeTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.integration.TestHelper;
+import com.arcadedb.integration.importer.format.XMLImporterFormat;
+import com.arcadedb.utility.FileUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7342: one {@link ImporterContext} serves all four {@code loadFromSource()} phases of an
+ * {@link Importer#load()}, so {@code context.parsed} is a running total unless the phase zeroes it. Nine of the
+ * ten {@code FormatImporter} implementations zeroed it themselves, one at a time; {@code JSONImporterFormat}
+ * never did. A run ending in a
+ * JSON phase therefore reported a {@code parsedRecords} that mixed that phase's rows with the previous phase's,
+ * while a run ending in any other format reported only the last phase's - two adjacent invocations of the same
+ * CLI reporting the same quantity two different ways.
+ * <p>
+ * The reset now lives in {@link Importer#loadFromSource} - one place every phase passes through - so a format
+ * cannot forget it and a format added later inherits it. {@code JSONImporterFormat} is deliberately left with no
+ * reset of its own: it is the one format whose phase is zeroed by the hoist alone, which is what makes
+ * {@link #theHoistedResetScopesTheCounterToTheJsonPhase()} a test of the hoist rather than of a tenth copy of the
+ * same line.
+ *
+ * @see <a href="https://github.com/ArcadeData/arcadedb/issues/7342">issue #7342</a>
+ */
+class Issue7342ParsedCounterPhaseScopeTest {
+
+  /** Three records in the first phase, two in the second: five rows, told apart by which phase parsed them. */
+  private static final String FIRST_PHASE_JSON  = "{\"Rows\":[{\"id\":\"1\"},{\"id\":\"2\"},{\"id\":\"3\"}]}";
+  private static final String SECOND_PHASE_JSON = "{\"Rows\":[{\"id\":\"4\"},{\"id\":\"5\"}]}";
+  private static final String MAPPING           = "{\"Rows\":[{\"@cat\":\"d\",\"@type\":\"Row\",\"@id\":\"id\",\"@idType\":\"string\"}]}";
+
+  /**
+   * The reported case, on the live CLI path: two {@code loadFromSource()} phases of one {@code Importer.load()},
+   * both dispatching to {@code JSONImporterFormat} - the format that never zeroed the counter itself. Before the
+   * hoist the second phase inherited the first phase's three rows and the run reported five; the hoist is the only
+   * thing that zeroes a JSON phase, so this is the assertion that fails if it is removed.
+   */
+  @Test
+  void theHoistedResetScopesTheCounterToTheJsonPhase() throws Exception {
+    final Map<String, Object> report = runTwoPhaseJsonImport("7342-json-phase-scope");
+
+    assertThat(report.get("parsedRecords"))
+        .as("the JSON phase's counter starts from zero, so it reports its own two records rather than five")
+        .isEqualTo(2L);
+  }
+
+  /**
+   * Finding 4: neither of the two things {@code parsedRecords} used to mean was "the rows this import parsed".
+   * {@code parsedRecords} stays the last phase's count - it is a published key of a public report map, and the
+   * two-phase CLI assertions #7313 added read it - and the whole-run figure is published alongside it.
+   */
+  @Test
+  void theImportWideTotalCountsEveryPhase() throws Exception {
+    final Map<String, Object> report = runTwoPhaseJsonImport("7342-json-import-wide-total");
+
+    assertThat(report.get("createdDocuments"))
+        .as("the import must actually have run: three records from the first phase and two from the second")
+        .isEqualTo(5L);
+    assertThat(report.get("totalParsedRecords"))
+        .as("the import-wide accumulator carries every phase's rows, including the one still running when the "
+            + "report is built")
+        .isEqualTo(5L);
+  }
+
+  /**
+   * Finding 3: {@code FormatImporter#printProgress} prints {@code (parsed - lastParsed) / deltaInSecs}.
+   * {@code lastParsed} was not reset alongside {@code parsed}, so the first progress line after a phase boundary
+   * subtracted the previous phase's total from this phase's handful of rows and printed a negative rate. The
+   * counter and its high-water mark are now zeroed together, in one place, so they cannot come apart.
+   */
+  @Test
+  void aPhaseBoundaryNeverPrintsANegativeParseRate() {
+    final List<String> lines = new ArrayList<>();
+    final ConsoleLogger logger = new ConsoleLogger(2, lines::add);
+
+    final ImporterSettings settings = new ImporterSettings();
+    settings.verboseLevel = 2;
+
+    final ImporterContext context = new ImporterContext();
+    // Where a phase that parsed a hundred rows and printed a progress line for them leaves the context.
+    context.lastLapOn = System.currentTimeMillis() - 2_000;
+    context.parsed.set(100);
+    context.lastParsed = 100;
+
+    context.beginParsingPhase();
+
+    // Ten rows into the phase that follows, which is when the next progress line falls due.
+    context.parsed.set(10);
+
+    // source == null takes printProgress's first branch, the one that needs no Parser position.
+    new XMLImporterFormat().printProgress(settings, context, null, null, logger);
+
+    assertThat(lines).as("verboseLevel 2 prints one progress line").hasSize(1);
+    assertThat(lines.getFirst())
+        .as("the line reports this phase's own ten rows, not the previous phase's hundred")
+        .startsWith("- Parsed 10 (");
+    // Not an equality on the rate: deltaInSecs is raw wall clock, so a stall between seeding lastLapOn and printing
+    // would move an exact expectation. The defect was a rate below zero, and no stall can produce one - a longer
+    // window only divides the same ten rows by a bigger number.
+    assertThat(parseRateOf(lines.getFirst()))
+        .as("the rate is this phase's own rows over the elapsed window, not this phase's rows minus the "
+            + "previous phase's total: %s", lines.getFirst())
+        .isNotNegative();
+  }
+
+  /**
+   * The accumulator in isolation, so the arithmetic the two CLI assertions above rest on is pinned where a
+   * failure names it: each boundary rolls the phase that just finished into the total and zeroes the phase
+   * counter and its high-water mark together, and the total the report publishes includes the phase still
+   * running.
+   */
+  @Test
+  void beginParsingPhaseRollsTheFinishedPhaseIntoTheImportWideTotal() {
+    final ImporterContext context = new ImporterContext();
+
+    context.beginParsingPhase();
+    context.parsed.set(3);
+    context.lastParsed = 3;
+
+    context.beginParsingPhase();
+    assertThat(context.parsed.get()).as("the phase counter starts the new phase at zero").isZero();
+    assertThat(context.lastParsed).as("and so does the high-water mark printProgress subtracts").isZero();
+    assertThat(context.totalParsed.get()).as("the finished phase's three rows are now in the total").isEqualTo(3L);
+
+    context.parsed.set(2);
+    assertThat(context.totalParsedRecords())
+        .as("the published total includes the phase still running, which no boundary has folded in yet")
+        .isEqualTo(5L);
+    assertThat(context.toMap())
+        .containsEntry("parsedRecords", 2L)
+        .containsEntry("totalParsedRecords", 5L);
+  }
+
+  /**
+   * Drives the two-phase CLI route: {@code -url} is the first {@code loadFromSource()} phase and
+   * {@code -documents} the second, both JSON, one shared {@code -mapping}.
+   */
+  private static Map<String, Object> runTwoPhaseJsonImport(final String name) throws Exception {
+    final Path firstPhase = Path.of("target", name + "-phase1.json").toAbsolutePath();
+    final Path secondPhase = Path.of("target", name + "-phase2.json").toAbsolutePath();
+    Files.createDirectories(firstPhase.getParent());
+    Files.writeString(firstPhase, FIRST_PHASE_JSON, StandardCharsets.UTF_8);
+    Files.writeString(secondPhase, SECOND_PHASE_JSON, StandardCharsets.UTF_8);
+
+    final String databasePath = "target/databases/" + name;
+    FileUtils.deleteRecursively(new File(databasePath));
+
+    try {
+      return new Importer(new String[] { "-url", "file://" + firstPhase, "-documents", "file://" + secondPhase,
+          "-database", databasePath, "-forceDatabaseCreate", "true", "-mapping", MAPPING }).load();
+    } finally {
+      dropDatabase(databasePath);
+      Files.deleteIfExists(firstPhase);
+      Files.deleteIfExists(secondPhase);
+      TestHelper.checkActiveDatabases();
+    }
+  }
+
+  /** The first {@code (N/sec)} group of a progress line - the parse rate, which is the one under test. */
+  private static long parseRateOf(final String progressLine) {
+    final Matcher matcher = Pattern.compile("\\((-?[\\d,]+)/sec").matcher(progressLine);
+    assertThat(matcher.find()).as("the progress line carries a parse rate: %s", progressLine).isTrue();
+    return Long.parseLong(matcher.group(1).replace(",", ""));
+  }
+
+  private static void dropDatabase(final String databasePath) {
+    final DatabaseFactory factory = new DatabaseFactory(databasePath);
+    if (factory.exists()) {
+      final Database db = factory.open();
+      db.drop();
+    }
+    FileUtils.deleteRecursively(new File(databasePath));
+  }
+}


### PR DESCRIPTION
Closes #7342

One `ImporterContext` serves all four `loadFromSource()` phases of an `Importer.load()`
(`Importer.java:79-82`, dispatch at `:139`), so `context.parsed` is a running total unless the phase
zeroes it. Nine of the ten `FormatImporter` implementations zeroed it themselves, one at a time;
`JSONImporterFormat` never did, so a run ending in a JSON phase reported a `parsedRecords` that mixed
that phase's rows with the previous phase's while a run ending in any other format reported only the
last phase's - two adjacent invocations of the same CLI reporting the same quantity two different ways.
The reset now lives in `Importer.loadFromSource()`, immediately before `format.load()`, which is the one
place every phase of every import passes through, so a format cannot forget it and a format added later
inherits it; the rows the finished phase parsed are rolled into a new import-wide `totalParsed`
accumulator rather than discarded, so the run can still report what it parsed as a whole.

## What changed

| File | Change |
|---|---|
| `ImporterContext` | new `totalParsed` accumulator; `beginParsingPhase()` folds the finished phase in and zeroes `parsed` **and** `lastParsed`; `totalParsedRecords()`; `toMap()` publishes `totalParsedRecords` alongside `parsedRecords` and documents what each means |
| `Importer.loadFromSource()` | `context.beginParsingPhase()` immediately before `format.load(...)` - the hoist |
| 9 formats (`CSV`, `RDF`, `Jsonl`, `XML`, `Neo4j`, `OrientDB`, `GloVe`, `Word2Vec`, `Word2VecLSM`) | `context.parsed.set(0)` -> `context.beginParsingPhase()` |
| `JSONImporterFormat` | javadoc only: why it deliberately has *no* reset of its own |
| `OrientDBImporter` | comment only: why `:410`'s `parsed.set(0)` is not a phase boundary |

## The two things the issue asked to settle

**1. What `parsedRecords` means.** It stays *the last phase's row count*, now uniform across all ten
formats, and the whole-run figure is published alongside it as a **new** `totalParsedRecords` key
rather than by redefining the existing one:

- `parsedRecords` is a published key of a public report map - `Importer.load()`'s return value, the SQL
  result row (`ImportDatabaseStatement:116 setPropertiesFromMap`) and the HTTP/gRPC import report
  (`ServerControlPlane:1503`). Silently changing what an existing key counts breaks readers with no signal.
- `JsonlImporterFormatStaleParsedCounterTest.theTwoPhaseCliRouteScopesTheCounterToTheJsonlPhase` asserts
  `parsedRecords == 2L` for a two-phase run that parsed five rows. Redefining the key means editing that
  assertion, and the assertion is not wrong - it is the only observable proof #7313's reset happens on the
  live CLI path.
- Additive is strictly more informative: the report now answers both "how many rows did the last phase
  parse" and "how many rows did this import parse", and the second is the one the issue said did not exist.

**2. The negative progress rate.** `FormatImporter#printProgress` prints
`(context.parsed.get() - context.lastParsed) / deltaInSecs`, and `lastParsed` was never reset alongside
`parsed`, so the first progress line after a phase boundary subtracted the previous phase's total from
this phase's handful of rows. Reproduced literally by reverting the fix:

```
- Parsed 10 (-45/sec) 0 documents (0/sec) 0 vertices (0/sec) 0 edges ...
```

`beginParsingPhase()` zeroes both. `lastLapOn` is deliberately **not** reset with them, and the code says
why: `printProgress` divides every delta on the line by the same window, and the
`createdDocuments`/`Vertices`/`Edges` counters it also prints are import-wide and never reset - restarting
the clock would leave their deltas measured over a window shorter than the rows they cover and overstate
those rates. Understating the parse rate on the first line after a boundary by the same small amount is
the cheaper of the two errors.

## Deviation from the issue's suggested fix

The issue sketched "hoist the reset and drop the ten per-format resets". Dropping them is not safe:
three existing tests (`RDFImporterFormatCommitCadenceTest`, `JsonlImporterFormatStaleParsedCounterTest`,
`XMLImporterFormatStaleParsedCounterTest`) call `format.load()` **directly** with a pre-loaded counter and
assert the format itself zeroes it, so the reset is part of `FormatImporter.load()`'s tested contract for
direct callers, and `FormatImporter` is a public interface in a public package. The duplication the issue
objected to is removed a different way: all nine now call the same `ImporterContext#beginParsingPhase()`,
so there is exactly one definition of what a phase reset is and they cannot drift.

`JSONImporterFormat` is deliberately left with **no** reset of its own. It is the one format whose phase
is zeroed by the hoist alone, which is what makes `theHoistedResetScopesTheCounterToTheJsonPhase` a test
of the hoist rather than of a tenth copy of the same line - remove the `beginParsingPhase()` call from
`loadFromSource()` and that test goes red.

`OrientDBImporter.parseRecords():410`'s `parsed.set(0)` is untouched: `run()` calls `parseInputFile()` up
to three times (`:230` ANALYZE, `:248` CREATE_SCHEMA, `:255` CREATE_EDGES) and every pass reaches
`parseRecords()` at `:373` and re-counts the same records, so that one is a deliberate discard, not a
phase boundary. Folding it into the accumulator would report every OrientDB record two or three times.

## Coverage

| Entry point | Fixed | Tested |
|---|---|---|
| CLI/SQL multi-phase run, **JSON phase last** (the format that never reset) | yes - the hoist | `theHoistedResetScopesTheCounterToTheJsonPhase` |
| CLI multi-phase run, any of the nine formats that already reset | yes - reset routed through `beginParsingPhase()` | existing jsonl/XML/RDF two-phase CLI tests, green unchanged |
| `printProgress()` first line after a phase boundary | yes - `lastParsed` zeroed with `parsed` | `aPhaseBoundaryNeverPrintsANegativeParseRate` |
| `parsedRecords` / `totalParsedRecords` meaning | yes - documented + accumulator | `theImportWideTotalCountsEveryPhase`, `beginParsingPhaseRollsTheFinishedPhaseIntoTheImportWideTotal` |
| Direct `FormatImporter.load()` on the nine resetting formats | yes - each keeps its own reset | the three existing direct-call tests |
| `ServerControlPlane` / SQL `IMPORT DATABASE` single-`-url` runs | yes - one phase, unchanged | `Issue7346RdfShapeDetectionTest`, `SQLLocalImporterIT` |

Argued, not fixed, with evidence:

- **Direct `format.load()` on `JSONImporterFormat`** - deliberate, see above; a reset there would make the
  hoist unobservable.
- **`OrientDBImporter:410`** - not a phase boundary, see above.
- **`ServerControlPlane.runImport()` and `ImportDatabaseStatement`** build the importer through
  `Importer(Database, String)`, which sets `settings.url` only (`Importer.java:40`); the other three
  `loadFromSource()` calls return immediately on a null url (`Importer.java:113-115`), so exactly one phase
  runs unless the caller also passes `documents`/`vertices`/`edges` through `setSettings` - which only the
  SQL `WITH` clause and the CLI can do, and both are covered by the rows above.

### Known gaps

- **#7483** - `ServerControlPlane.scheduleImportCounters()` resolves `ImporterContext.parsed` once and
  samples it every second into the SSE `parsed` field, so a multi-phase
  `IMPORT DATABASE ... WITH documents=..., vertices=...` makes a client's progress bar run backwards at
  each phase boundary. `totalParsed` added here is the monotonic field that reader wants, but rewiring the
  server's reflective lookup is a server-module change with its own fallback story for older importer jars.
  `FormatImporter#printProgress`'s printed `Parsed %,d` total has the same shape off the same counter and is
  noted on that issue, so both surfaces get decided together rather than one being fixed in isolation.

## Test plan

- [x] `Issue7342ParsedCounterPhaseScopeTest` - 4 new tests, and they **fail without the fix**: with both
      halves reverted (`beginParsingPhase()` removed from `loadFromSource()`, `lastParsed = 0L` removed from
      `beginParsingPhase()`), 3 of 4 go red with `expected: 2L but was: 5L`, `expected: 5L but was: -45L` and
      `expected: 0L but was: 3L`.
- [x] `mvn -o -pl integration test -DexcludedGroups=benchmark,slow,vector` -> **370 tests, 0 failures**
- [x] `mvn -o -pl integration verify -DskipITs=false -DexcludedGroups=benchmark,slow,vector` -> **133 ITs,
      0 failures**, covering every affected format end to end: `CSVImporterIT`, `JSONImporterIT`,
      `JsonLImporterIT`, `XMLImporterIT`, `Neo4jImporterIT`, `OrientDBImporterIT`, `GloVeImporterIT`,
      `Word2VecImporterIT`, `Word2VecImporterLSMIT`, `SQLLocalImporterIT`, `SQLRemoteImporterIT`
- [x] The 14 tests #7288/#7313 added on the three direct-`format.load()` classes are green **unchanged**,
      including their two-phase CLI assertions on `parsedRecords` - the compatibility claim above
- [x] `mvn -o -DskipTests install` (full reactor) -> BUILD SUCCESS

To verify by hand:

```bash
# two JSON phases, five records total
echo '{"Rows":[{"id":"1"},{"id":"2"},{"id":"3"}]}' > /tmp/p1.json
echo '{"Rows":[{"id":"4"},{"id":"5"}]}'            > /tmp/p2.json
java -cp ... com.arcadedb.integration.importer.Importer \
  -url file:///tmp/p1.json -documents file:///tmp/p2.json \
  -database /tmp/db7342 -forceDatabaseCreate true \
  -mapping '{"Rows":[{"@cat":"d","@type":"Row","@id":"id","@idType":"string"}]}'
# before: parsedRecords=5   after: parsedRecords=2, totalParsedRecords=5
```

## Review log

Three review cycles ran. Cycles 1 and 2 were comment/javadoc only - no behaviour changed after the first
commit, and the full integration suite (370 unit + 133 IT) was re-run green on each.

| Cycle | Head | Applied | Skipped, with reason |
|---|---|---|---|
| 1 | `ef60853` | Rewrapped `toMap()`'s over-long javadoc line; said in the code why `toMap()` inlines the sum instead of calling `totalParsedRecords()`; reworded `beginParsingPhase()`'s `getAndSet` rationale, which argued from "nothing races this today" and so undersold a form that is correct whichever thread increments; fixed a comment that wrapped mid-identifier in `RDFImporterFormat` | CodeRabbit's **Docstring Coverage 45.83%** pre-merge check. The 24 functions it counted are mostly the ten `FormatImporter.load()` overrides, which inherit their contract from the interface; adding a javadoc block to each to clear a generic threshold is the boilerplate CLAUDE.md's comment guidance exists to avoid. CodeRabbit's own verdict on the same commit was *Merge Risk: Minimal, no actionable merge risk remains*, with zero inline threads |
| 2 | `173ff01` | Collapsed the rationale comment that had been pasted verbatim above `beginParsingPhase()` in six formats into a two-line pointer at that method's javadoc, and trimmed the duplicated tail from the three that carry issue-specific rationale of their own; documented `totalParsedRecords()`, which had no production caller and read as dead code next to a `toMap()` that inlines the same arithmetic - the javadoc now names both why `toMap()` does not call it and the reader it exists for (#7483) | - |
| 3 | `37d0694` | Nothing - clean | The one remaining nit ("if `toMap()` and `totalParsedRecords()` ever drift, nothing enforces they compute the same thing") was raised as *"Not asking for a change"*. It is in fact enforced: `beginParsingPhaseRollsTheFinishedPhaseIntoTheImportWideTotal` asserts `totalParsedRecords()` **and** `toMap()`'s `totalParsedRecords` entry against the same `5L` in the same test, so a drift between them fails it |

Adversarial pass: the `Task` tool was unavailable in this environment, so the independent-subagent pass
could not be spawned and the review was done against the diff directly - weaker, because the reviewer had
already been convinced. It still caught four things before the PR opened: `toMap()` read the run total
twice (tested against one value, published with another); two comments asserted things that turned out to
be false (an async incrementer that does not exist, and "parses its input twice" where `OrientDBImporter`
parses it up to three times); a format count of "eleven" that is ten; and an equality assertion on a rate
derived from raw wall clock, which is now `isNotNegative()` - the claim the test actually makes, and one no
stall can break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1vgWQXZoDXYq7TqAwLYXY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Import progress now reports records parsed in the current phase separately from the total across all phases.
  * Multi-phase imports now maintain accurate cumulative record counts.
  * Progress rates no longer display negative values when transitioning between import phases.

* **Tests**
  * Added coverage for multi-phase imports, cumulative totals, phase resets, and progress reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
