### PR TITLE
fix(#7461): IMPORT DATABASE reported result=OK for the one failure it means to report as FAIL

### DIFF
--- a/docs/7461-import-database-result-ok-on-fail.md
+++ b/docs/7461-import-database-result-ok-on-fail.md
@@ -210,3 +210,76 @@ client uses. No feature flag gates it.
 
 - [x] 1. `result=FAIL` overwritten by an unconditional `result=OK` - fixed, on both producers of the
       branch, with a `reason` property and 6 tests.
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/7493
+
+### Follow-up issues filed before the PR opened
+
+- **#7484** - startup `import:` default-database command discards the statement's result row, so a
+  failed import is silent. Named in the PR body under **Known gaps**.
+
+### Review cycles
+
+**Cycle 1 - `6ae500d9b6`**
+
+- `claude` (gating): substantive review, **nothing blocking**. It re-derived the claims against
+  `Importer.java`, `SourceDiscovery.java` and `ImporterSettings.java` rather than taking the PR body
+  at face value, and confirmed each: both producers of the `FAIL` branch, the bare-path
+  `FileNotFoundException` at `SourceDiscovery.java:216` that makes `failureReason()`'s choice of the
+  wrapper's message the right one, the unguarded `e.getCause()` as a genuine latent NPE, and the exact
+  class-name match as correctly pinned by `aNonNumericNumericSettingStillThrows`. Two non-blocking
+  nits, neither of which asks for a change to this PR:
+  - the `reason` key has no precedent in the tree ("Not a problem for this PR", raised as a
+    consistency note for whatever a future statement does);
+  - the file's comment blocks are long ("consistent with the rest of this file's existing style, so
+    not something to change here").
+
+  One follow-through, not a code change: confirm in CI the two server ITs that could not run locally
+  because port 2480 was occupied.
+- `CodeRabbit`: **rate-limited on this push** and posted no findings ("Review limit reached ... You've
+  used all free OSS reviews for now"). No threads to resolve.
+- `Codacy`: 0 new issues, complexity 4.
+
+No changes were applied in this cycle - the working tree stayed empty and no deferred-items notes file
+was produced - so the loop exited at the early-exit check.
+
+### Final state
+
+`clean-approval` after 1 cycle of a permitted 4.
+
+### CI on this branch, and what is inherited
+
+The branch's own test ran and passed in CI: the `unit-test-reports` artifact of run 34657385125 carries
+`TEST-com.arcadedb.integration.importer.Issue7461ImportDatabaseFailResultTest.xml` with
+`tests="6" errors="0" skipped="0" failures="0"`.
+
+Two lanes are red, and **neither failure is this branch's**. Both are now filed, because a red lane that
+belongs to nobody costs every later PR author the same investigation:
+
+**`unit-tests` - three failures, all pre-existing on the base branch (#7495)**
+
+| Test | Assertion |
+|---|---|
+| `MultiColumnAggregationResultTest.emptySumAndCountStayZeroNotNaN` | `expected: 0.0 but was: NaN` |
+| `Issue7089NaNTransparentSumAvgTest.oneNaNSampleNoLongerPoisonsTheBucketOnAnyPath` | `expected: 0 but was: 2` |
+| `ArcadeStateMachinePerDatabaseHaltTest` (both methods) | got `Corrupted WAL transaction entry`, expected `per-database snapshot resync in progress` / `Apply error on database 'db-B'` |
+
+Evidence, not inference: the unrelated PR #7489 (`fix/7345-...`, RDF importer only, run 34657353357)
+fails on **exactly the same three report files**. Locally, `MultiColumnAggregationResultTest` fails
+identically with `ImportDatabaseStatement.java` restored to its `HEAD` content. Neither branch touches
+time series or Raft. `main` itself never runs this workflow, which is why the breakage surfaces on
+other people's PRs instead of on the commit that caused it.
+
+**`integration-tests` - one failure, a fixed-port collision (#7496)**
+
+`Issue7304GrpcAdminLeaderRoutingIT` errored in `@BeforeEach` for both its methods, before any test code
+ran: `Failed to bind to address 0.0.0.0/0.0.0.0:51142 ... Address already in use`. That class hardcodes
+`BASE_GRPC_PORT = 51141`, so 51142 is its own node 1. The same lane fails on unrelated PRs with a
+different victim each run (PR #7491, run 34656829906: `Issue6070GraphBatchLoadLeaderGuardIT`,
+`TimeSeriesGrpcForwardedInsertTypeIT`, `ServerProfilingIT`) - the signature of a port collision, not of
+a defect in any one test.
+
+Neither was re-run to force green: the three unit-test failures are deterministic on the base, so a
+re-run only burns CI, and the gRPC one would only be a different roll of the same dice.

--- a/docs/7461-import-database-result-ok-on-fail.md
+++ b/docs/7461-import-database-result-ok-on-fail.md
@@ -1,0 +1,212 @@
+# #7461 - IMPORT DATABASE reports result=OK for the one failure it means to report as FAIL
+
+## The defect
+
+`ImportDatabaseStatement.executeSimple` wrote `result=FAIL` inside the `InvocationTargetException`
+handler and then, two lines below the enclosing `try`, assigned `result=OK` unconditionally. The
+`FAIL` branch was therefore unobservable by any caller: an `IMPORT DATABASE` whose importer raised an
+`IllegalArgumentException` answered `{"result":"OK"}` with no rows and no statistics.
+
+## Root cause and history
+
+The `FAIL` branch arrived with `probeOnly` (#1401, Dec 2023). `probeOnly` asks "can this source be
+parsed?" without importing anything, so `Importer.load()` deliberately converts a failed probe into an
+`IllegalArgumentException`:
+
+```java
+} catch (final Exception e) {
+  if (settings.probeOnly)
+    throw new IllegalArgumentException(e);
+  else
+    throw new ImportException("Error on parsing source '" + source + "'", e);
+}
+```
+
+so the statement could report it as a **row** rather than as an error. The same commit added
+`result.setProperty("result", "FAIL")` above an `result.setProperty("result", "OK")` that was already
+unconditional, and never moved the latter. It has been dead since the day it was written; the `#7443`
+maintenance-slot change (#7460) re-indented the block but did not touch the behaviour.
+
+## The invariant
+
+> `IMPORT DATABASE` never answers `result=OK` for an import that did not run.
+
+## Completeness
+
+### Sweep commands and output
+
+Producers of the in-band `FAIL` - the reflective invokes inside the guarded block:
+
+```
+$ grep -n 'invoke(importer' engine/src/main/java/com/arcadedb/query/sql/parser/ImportDatabaseStatement.java
+103:        clazz.getMethod("setAllowLocalUrls", boolean.class).invoke(importer, !blockLocalNetworks);
+113:        clazz.getMethod("setSettings", Map.class).invoke(importer, settingsToString);
+114:        final Map<String, Object> statistics = (Map<String, Object>) clazz.getMethod("load").invoke(importer);
+```
+
+`setAllowLocalUrls` is a field assignment and throws nothing. That leaves **two** producers, not the
+one the issue names - `setSettings` reaches `ImporterSettings.parseParameter`, which raises the same
+exact type:
+
+```
+$ grep -rn 'IllegalArgumentException' --include='*.java' integration/src/main/java/com/arcadedb/integration/importer/ | head
+.../Importer.java:98:        throw new IllegalArgumentException(e);                       <- probeOnly
+.../ImporterSettings.java:191:  throw new IllegalArgumentException("Invalid value '" + value + "' for -onRowError. ...")
+.../SourceDiscovery.java:723,734,793 ... (all inside Importer.load()'s try, so wrapped in ImportException)
+```
+
+```
+$ grep -n 'setSettings' integration/src/main/java/com/arcadedb/integration/importer/*.java
+AbstractImporter.java:61:  public void setSettings(final Map<String, String> parameters) {
+      -> settings.parseParameter(entry.getKey(), entry.getValue())   // outside load()'s try
+```
+
+Siblings - the same statement shape elsewhere:
+
+```
+$ grep -rn 'setProperty("result"' --include='*.java' . | grep -v /target/
+BackupDatabaseStatement.java:165:  result.setProperty("result", "OK");    // inside the success branch, before return
+ImportDatabaseStatement.java:128:  result.setProperty("result", "FAIL");  <- THE BUG
+ImportDatabaseStatement.java:136:  result.setProperty("result", "OK");    <- overwrites it
+ExportDatabaseStatement.java:113: result.setProperty("result", "OK");     // its catch always throws
+SleepStatement.java:49/53:        OK / "failure" in mutually exclusive branches
+AlterTypeStatement.java:334:      result.setProperty("result", "OK");     // no catch at all
+```
+
+```
+$ grep -rn '"FAIL"' --include='*.java' . | grep -v /target/
+engine/src/main/java/com/arcadedb/query/sql/parser/ImportDatabaseStatement.java:128
+```
+
+`ImportDatabaseStatement` is the only statement in the tree with an in-band `FAIL`, so there is no
+sibling carrying the same defect.
+
+Readers of the row:
+
+```
+$ grep -rn 'getProperty("result")' --include='*.java' engine/src server/src console/src integration/src | grep -v /target/ | grep -v src/test
+(no hits)
+```
+
+No production code gates on the value - the console, Studio and the HTTP/gRPC layers render the row as
+it comes - so making `FAIL` survive cannot break a programmatic caller.
+
+### Entry-point coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| `IMPORT DATABASE <url> WITH probeOnly = true`, unparseable source -> `Importer.load()` raises `IllegalArgumentException` | yes - `FAIL` survives, `reason` added | yes - `aFailedProbeReportsFailWithAReason` |
+| `IMPORT DATABASE <url> WITH probeOnly = true`, good source -> `load()` returns `null` | yes - still `OK` | yes - `aSuccessfulProbeStillReportsOk` |
+| `IMPORT DATABASE <url> WITH onRowError = 'bogus'` -> `setSettings` raises exact `IllegalArgumentException` before the import runs | yes - `FAIL` survives, `reason` added | yes - `anUnusableSettingValueReportsFailWithAReason` |
+| `IMPORT DATABASE <url>` (no `probeOnly`), unparseable source | argued - `load()` wraps it in `ImportException`, which never reached the `FAIL` branch and still throws `CommandExecutionException` | yes, as a regression guard - `aGenuineImportFailureStillThrows` |
+| `IMPORT DATABASE <url> WITH commitEvery = 'abc'` -> `setSettings` raises `NumberFormatException` | argued - the exact class-name match excludes `IllegalArgumentException` subclasses, so this always threw and still does. Widening to `instanceof` would turn these errors into rows, which is why the comparison was deliberately left as-is | yes, as a regression guard - `aNonNumericNumericSettingStillThrows` |
+| Importer raises `SecurityException` (SSRF/LFI guard) | argued - the rethrow loop above the branch is unchanged apart from hoisting `e.getTargetException()` into a local; it still short-circuits to HTTP 403 | covered by the existing `ImportDatabaseSecurityIT` (not run here, see Verification) |
+| Startup `import:` default-database command (`ArcadeDBServer.loadDefaultDatabases`) | **filed - #7484**. It executes this statement and discards the result set (`// drain not needed`), so a `FAIL` row is as silent after this fix as it was before it | no |
+| `BACKUP` / `EXPORT DATABASE` siblings | argued - neither has an in-band `FAIL`; `EXPORT`'s catch always throws and `BACKUP` sets `OK` inside its success branch (greps above) | n/a |
+| Server `import database <name> <url>` command (HTTP/gRPC) | argued - routes through `ServerControlPlane.importDatabase`, which drives `Importer` directly and never reaches this statement | n/a |
+
+## The decision
+
+The issue offers two designs. This PR takes the first - keep the in-band shape, make `FAIL` survive,
+add a `reason` - because the second would break what the branch exists for. `probeOnly`'s whole point
+is to answer "can this be parsed?" **without** raising; turning a failed probe into a
+`CommandExecutionException` would leave no way to ask the question.
+
+Three parts:
+
+1. `result=OK` moves into the success path, immediately after the statistics are folded in, which is
+   the shape `BackupDatabaseStatement` already has. There is no flag and no second assignment.
+2. `reason` carries the failure message alongside `FAIL`. `FAIL` on its own tells a caller nothing it
+   can act on, and the server log was the only place the message existed. `failureReason()` reports the
+   failure's **own** message and deliberately not the cause's: `Importer.load()` builds its probe
+   failure as `new IllegalArgumentException(cause)`, so that message is already `cause.toString()` -
+   type included, which is the entire answer when the cause is a `FileNotFoundException` whose own
+   message is nothing but the path (`SourceDiscovery.openLocalStream` throws
+   `new FileNotFoundException(filePath)`). Probing a missing file therefore yields
+   `reason = "java.io.FileNotFoundException: /path/nodes.csv"`, and a refused setting yields its own
+   sentence, `"Invalid value 'bogus' for -onRowError. Supported values are 'abort' and 'skip'"`.
+3. `e.getTargetException()` is hoisted into `target` and null-guarded. `e.getCause()` was dereferenced
+   without a check, and the two accessors were being mixed for the same object.
+
+The exact class-name comparison is deliberately **kept**, not widened to `instanceof` - see the
+`commitEvery` row above.
+
+## Adversarial pass
+
+The orchestrator's Phase 1.5 spawns a subagent deliberately kept ignorant of the author's reasoning.
+**No `Task` tool was available in this session**, so the pass was run by the author against the diff
+instead - weaker by construction, and recorded as such. Four findings, all real, all fixed before the
+PR opened:
+
+1. **`failureReason()` discarded the informative half of the message.** The first version preferred the
+   cause's message over the failure's. For the probe that is exactly backwards: the cause is a
+   `FileNotFoundException` whose message is a bare path, while the `IllegalArgumentException` wrapper's
+   own message already carries `type: path`. The helper now reads `failure.getMessage()` and is three
+   lines shorter. Verified by running the test with a canary assertion and reading the actual string.
+2. **`aSuccessfulProbeStillReportsOk` passed for the wrong reason.** A build that ignored `probeOnly`
+   entirely and imported the file would also answer `OK`, so the test proved nothing about the probe.
+   It now asserts `db.getSchema().existsType("Document")` is false - an actual import of the fixture is
+   what creates that type, as the success test one method below relies on.
+3. **Three tests asserted only the exception TYPE, which several unrelated guards also produce.**
+   `aGenuineImportFailureStillThrows` now pins `hasRootCauseInstanceOf(FileNotFoundException)` on top of
+   the message, `aNonNumericNumericSettingStillThrows` pins `NumberFormatException` (the subclass the
+   exact class-name match must not absorb), and `aFailedProbeReportsFailWithAReason` pins both halves of
+   the reason string. Without those, each could pass against a statement that refused the command for a
+   completely different reason.
+4. **`anUnusableSettingValueReportsFailWithAReason` did not prove the import had not run.** It now
+   asserts the schema is untouched as well.
+
+Two further checks that found nothing:
+
+- `ImporterContext.toMap()` emits `parsedRecords`, `errors`, `warnings`, `createdDocuments`,
+  `createdVertices`, `createdEdges`, `createdTimeSeriesSamples` - neither `result` nor `reason`, so
+  moving the `OK` assignment below `setPropertiesFromMap(statistics)` collides with nothing and the new
+  `reason` key cannot shadow a statistic.
+- Studio's import button sends the server command `import database <name> <url>`
+  (`studio-database.js:672`), not this statement, so no UI special-cases the row. Console and Studio
+  render a result row generically.
+
+## Verification
+
+```
+$ mvn -o -pl integration -am test -Dtest=Issue7461ImportDatabaseFailResultTest ...   # BEFORE the fix
+Tests run: 6, Failures: 2   <- the two FAIL rows; the four guard tests were already green,
+                               which is the evidence for the three "argued" rows
+$ ... same command AFTER the fix
+Tests run: 6, Failures: 0
+```
+
+- `integration` module, full suite minus the `benchmark`/`slow`/`vector` lanes: **372 tests, 0
+  failures, 9 skipped** (re-run after the adversarial-pass changes).
+- `engine` module, full suite minus those lanes: 14870 tests, **1 failure** -
+  `MultiColumnAggregationResultTest.emptySumAndCountStayZeroNotNaN` (`expected: 0.0 but was: NaN`).
+  **Pre-existing and unrelated**: re-run with `ImportDatabaseStatement.java` restored to its `HEAD`
+  content, it fails identically. Time-series aggregation, nothing to do with this change.
+- Server ITs that exercise the import path (`ImportDatabaseSecurityIT`, `Issue7443SqlMaintenanceSlotIT`)
+  were **not** run: port 2480 was already held by another process on this machine
+  (`lsof -nP -iTCP:2480 -sTCP:LISTEN` -> a live `java` listener), and a server IT run against an
+  occupied port produces authentication errors rather than meaningful results. The `SecurityException`
+  rethrow they cover is unchanged in semantics - the loop reads the same object through a local.
+
+## Reachability
+
+`ImportDatabaseStatement` is instantiated by the SQL parser for every `IMPORT DATABASE` statement; the
+new tests reach the changed lines through `database.command("sql", ...)`, i.e. the same live path a
+client uses. No feature flag gates it.
+
+## Residual risk
+
+- A startup `import:` command still swallows the row - **#7484**. The fix gives that path an answer
+  worth reading; reading it is a server-module change and is out of scope here.
+- `IMPORT DATABASE ... WITH commitEvery = 'abc'` throws while
+  `IMPORT DATABASE ... WITH onRowError = 'bogus'` returns a `FAIL` row. That asymmetry is inherited,
+  documented in the code comment, and pinned by two tests. Unifying it means deciding whether a
+  refused setting is an error or a row for *every* setting, which is a contract change this PR
+  deliberately does not make.
+- `reason` is a new property on the row. It is absent on `OK`, so nothing that reads the existing
+  shape changes.
+
+## Finding ledger
+
+- [x] 1. `result=FAIL` overwritten by an unconditional `result=OK` - fixed, on both producers of the
+      branch, with a `reason` property and 6 tests.

--- a/docs/7461-import-database-result-ok-on-fail.md
+++ b/docs/7461-import-database-result-ok-on-fail.md
@@ -243,11 +243,30 @@ https://github.com/ArcadeData/arcadedb/pull/7493
 - `Codacy`: 0 new issues, complexity 4.
 
 No changes were applied in this cycle - the working tree stayed empty and no deferred-items notes file
-was produced - so the loop exited at the early-exit check.
+was produced - so the loop reached its early-exit check with nothing to do.
+
+**Cycle 2 - `bfd2f18195`**
+
+Triggered by the tracking-doc commit itself, which carries no source change. `claude` reviewed the
+branch again and closed with **"Nothing blocking"**, independently re-deriving the same three facts the
+sweep rests on: `ImporterContext.toMap()` emits neither `result` nor `reason`, so folding the statistics
+in before setting the outcome collides with nothing; `grep -rn 'getProperty("result")'` finds no
+production caller branching on the property, so making `FAIL` observable cannot change an existing
+caller's behaviour; and the exact class-name comparison has to stay exact, because
+`ImporterSettings.parseParameter` sends `NumberFormatException` into the same catch block. It repeated
+the two non-blocking notes from cycle 1 (the `reason` key has no precedent; the
+`onRowError`/`commitEvery` asymmetry is inherited and pinned by a test on each side) and added that the
+`SecurityException` rethrow is unchanged in semantics.
+
+Again no changes applied, and this is the last cycle recorded: a further doc commit would only
+re-trigger a review of itself.
 
 ### Final state
 
-`clean-approval` after 1 cycle of a permitted 4.
+`clean-approval` after 2 cycles of a permitted 4. Neither cycle produced an actionable item, the working
+tree was empty at both early-exit checks, and no `review-deferred-*.md` notes file was ever created.
+
+**The merge is the developer's.** This workflow does not merge or close PRs.
 
 ### CI on this branch, and what is inherited
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ImportDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ImportDatabaseStatement.java
@@ -116,28 +116,60 @@ public class ImportDatabaseStatement extends SimpleExecStatement {
         if (statistics != null)
           result.setPropertiesFromMap(statistics);
 
+        // THE OUTCOME IS SET ON THE SUCCESS PATH ONLY. IT USED TO BE ASSIGNED UNCONDITIONALLY BELOW THE try, WHERE IT
+        // OVERWROTE THE 'FAIL' THE HANDLER BENEATH HAD JUST WRITTEN - SO THE ONE FAILURE THIS STATEMENT REPORTS
+        // IN-BAND INSTEAD OF BY THROWING COULD NOT BE OBSERVED BY ANY CALLER, AND AN IMPORT THAT NEVER RAN ANSWERED
+        // {"result":"OK"} WITH NO ROWS AND NO STATISTICS (#7461)
+        result.setProperty("result", "OK");
+
       } catch (final ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InstantiationException e) {
         throw new CommandExecutionException("Error on importing database, importer libs not found in classpath", e);
       } catch (final InvocationTargetException e) {
+        final Throwable target = e.getTargetException();
+
         // SURFACE A SECURITY VIOLATION (SSRF/LFI GUARD IN THE IMPORTER) DIRECTLY SO IT MAPS TO HTTP 403 INSTEAD OF 500
-        for (Throwable cause = e.getTargetException(); cause != null; cause = cause.getCause())
+        for (Throwable cause = target; cause != null; cause = cause.getCause())
           if (cause instanceof SecurityException se)
             throw se;
 
-        if ("IllegalArgumentException".equals(e.getCause().getClass().getSimpleName()))
+        // THE IN-BAND FAILURE. 'WITH probeOnly = true' asks whether a source can be parsed, and Importer.load()
+        // answers a failed probe with an IllegalArgumentException precisely so this statement can report it as a row
+        // rather than as an error (#1401); ImporterSettings.parseParameter raises the same exact type for a
+        // 'WITH ...' value it refuses, before the import runs at all. Both are imports that did not happen, and both
+        // now say so. The reason travels with it because 'FAIL' on its own tells the caller nothing it can act on.
+        //
+        // The match stays an exact class-name comparison rather than an instanceof: the IllegalArgumentException
+        // SUBCLASSES that reach here - NumberFormatException, from parseParameter's Integer/Long.parse on a numeric
+        // setting - have always been thrown, and widening the branch would silently turn those errors into rows.
+        if (target != null && "IllegalArgumentException".equals(target.getClass().getSimpleName())) {
           result.setProperty("result", "FAIL");
-        else
-          throw new CommandExecutionException("Error on importing database", e.getTargetException());
+          result.setProperty("reason", failureReason(target));
+        } else
+          throw new CommandExecutionException("Error on importing database", target);
       } finally {
         OperationProgressRegistry.instance().unregister(progress);
       }
     }
 
-    result.setProperty("result", "OK");
-
     final InternalResultSet rs = new InternalResultSet();
     rs.add(result);
     return rs;
+  }
+
+  /**
+   * The human-readable reason behind an importer failure reported in-band, for the {@code reason} property that
+   * travels with {@code result=FAIL}.
+   * <p>
+   * The failure's own message is the right one to report for both producers of that branch, and deliberately not
+   * the cause's: {@code Importer.load()} builds a failed probe as {@code new IllegalArgumentException(cause)}, and
+   * that constructor makes the message the cause's {@code toString()} - type included, which is the whole of the
+   * answer when the cause is a {@code FileNotFoundException} whose own message is nothing but the path it could not
+   * open. A settings failure carries its own sentence and no cause. The {@code toString()} fallback is for the
+   * message-less exception neither shape produces today.
+   */
+  private static String failureReason(final Throwable failure) {
+    final String message = failure.getMessage();
+    return message != null && !message.isBlank() ? message : failure.toString();
   }
 
   @Override

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue7461ImportDatabaseFailResultTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue7461ImportDatabaseFailResultTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.integration.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+/**
+ * Issue #7461: {@code ImportDatabaseStatement.executeSimple} wrote {@code result=FAIL} for the one failure it
+ * deliberately reports in-band and then overwrote it with {@code result=OK} two lines later, so no caller could
+ * ever observe the FAIL branch. The statement answered {@code {"result":"OK"}} - with no rows and no statistics -
+ * for an import that never ran.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue7461ImportDatabaseFailResultTest {
+
+  private static final String GOOD_CSV = """
+      id,name
+      1,Alice
+      2,Bob
+      """;
+
+  /**
+   * {@code probeOnly} asks "can this source be parsed?", and {@code Importer.load()} answers a failed probe with an
+   * {@code IllegalArgumentException} precisely so the statement can report it as a row (#1401). The row has to say
+   * FAIL.
+   */
+  @Test
+  void aFailedProbeReportsFailWithAReason() throws Exception {
+    withDatabase("test-import-7461-probe-fail", db -> {
+      final String missing = new File("target/databases/7461-does-not-exist.csv").getAbsolutePath();
+
+      final Result row = single(db.command("sql", "IMPORT DATABASE file://" + missing + " WITH probeOnly = true"));
+
+      assertThat(row.<String>getProperty("result")).isEqualTo("FAIL");
+      // The reason has to say what went wrong AND name the source, not merely exist: 'FAIL' with an empty reason is
+      // barely better than the 'OK' it replaces. Asserting on both halves also proves the row came from the probe's
+      // IllegalArgumentException and not from some earlier guard that happens to answer FAIL too.
+      assertThat(row.<String>getProperty("reason"))
+          .contains("FileNotFoundException")
+          .contains("7461-does-not-exist.csv");
+    });
+  }
+
+  /** A probe that succeeds must keep reporting OK - the fix must not turn every probe into a FAIL. */
+  @Test
+  void aSuccessfulProbeStillReportsOk() throws Exception {
+    withDatabase("test-import-7461-probe-ok", db -> {
+      final File csv = writeCsv("importer-7461-probe-ok.csv", GOOD_CSV);
+      try {
+        final Result row = single(
+            db.command("sql", "IMPORT DATABASE file://" + csv.getAbsolutePath() + " WITH probeOnly = true"));
+
+        assertThat(row.<String>getProperty("result")).isEqualTo("OK");
+        // Proves the probe ACTUALLY probed. Without this the test passes just as well against a build that ignores
+        // 'probeOnly' entirely and imports the file, because a plain successful import also answers OK - and an
+        // import of this CSV is exactly what creates the 'Document' type the success test below counts.
+        assertThat(db.getSchema().existsType("Document")).isFalse();
+      } finally {
+        csv.delete();
+      }
+    });
+  }
+
+  /**
+   * The second producer of the in-band FAIL: {@code ImporterSettings.parseParameter} refuses an unusable
+   * {@code WITH ...} value with the same exact {@code IllegalArgumentException} type, before the import runs at all.
+   * That import did not happen either, so it must not be reported as OK.
+   */
+  @Test
+  void anUnusableSettingValueReportsFailWithAReason() throws Exception {
+    withDatabase("test-import-7461-bad-setting", db -> {
+      final File csv = writeCsv("importer-7461-bad-setting.csv", GOOD_CSV);
+      try {
+        final Result row = single(
+            db.command("sql", "IMPORT DATABASE file://" + csv.getAbsolutePath() + " WITH onRowError = 'bogus'"));
+
+        assertThat(row.<String>getProperty("result")).isEqualTo("FAIL");
+        assertThat(row.<String>getProperty("reason")).contains("onRowError").contains("bogus");
+        // The settings are refused before the import runs, so nothing was loaded and no schema was created.
+        assertThat(db.getSchema().existsType("Document")).isFalse();
+      } finally {
+        csv.delete();
+      }
+    });
+  }
+
+  /** A plain, successful import is unchanged: OK plus the importer's statistics. */
+  @Test
+  void aSuccessfulImportStillReportsOk() throws Exception {
+    withDatabase("test-import-7461-import-ok", db -> {
+      final File csv = writeCsv("importer-7461-import-ok.csv", GOOD_CSV);
+      try {
+        final Result row = single(db.command("sql", "IMPORT DATABASE file://" + csv.getAbsolutePath()));
+
+        assertThat(row.<String>getProperty("result")).isEqualTo("OK");
+        assertThat(row.<String>getProperty("reason")).isNull();
+        assertThat(db.countType("Document", true)).isEqualTo(2);
+      } finally {
+        csv.delete();
+      }
+    });
+  }
+
+  /**
+   * Every importer failure that is NOT the in-band one keeps throwing: without {@code probeOnly},
+   * {@code Importer.load()} wraps the failure in an {@code ImportException} and the statement turns it into a
+   * {@code CommandExecutionException}.
+   */
+  @Test
+  void aGenuineImportFailureStillThrows() throws Exception {
+    withDatabase("test-import-7461-import-throws", db -> {
+      final String missing = new File("target/databases/7461-does-not-exist.csv").getAbsolutePath();
+
+      // The message pins WHICH failure this is: ImportException's 'Error on parsing source' is the non-probe arm of
+      // Importer.load()'s catch, so the test cannot pass by way of an earlier guard refusing the statement.
+      assertThatThrownBy(() -> db.command("sql", "IMPORT DATABASE file://" + missing))
+          .isInstanceOf(CommandExecutionException.class)
+          .hasMessageContaining("Error on importing database")
+          .hasRootCauseInstanceOf(FileNotFoundException.class);
+    });
+  }
+
+  /**
+   * An {@code IllegalArgumentException} SUBCLASS out of the settings parser has always been thrown rather than
+   * reported in-band, and stays thrown: widening the FAIL branch to an {@code instanceof} would silently turn these
+   * errors into rows.
+   */
+  @Test
+  void aNonNumericNumericSettingStillThrows() throws Exception {
+    withDatabase("test-import-7461-nfe", db -> {
+      final File csv = writeCsv("importer-7461-nfe.csv", GOOD_CSV);
+      try {
+        final Throwable thrown = catchThrowable(
+            () -> db.command("sql", "IMPORT DATABASE file://" + csv.getAbsolutePath() + " WITH commitEvery = 'abc'"));
+
+        // The root cause pins the branch: a NumberFormatException out of parseParameter's Integer.parseInt is the
+        // IllegalArgumentException SUBCLASS the exact class-name match deliberately does not absorb.
+        assertThat(thrown).isInstanceOf(CommandExecutionException.class)
+            .hasRootCauseInstanceOf(NumberFormatException.class);
+      } finally {
+        csv.delete();
+      }
+    });
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @FunctionalInterface
+  private interface DatabaseTest {
+    void accept(Database db) throws Exception;
+  }
+
+  private static void withDatabase(final String name, final DatabaseTest test) throws Exception {
+    final DatabaseFactory databaseFactory = new DatabaseFactory("target/databases/" + name);
+    if (databaseFactory.exists())
+      databaseFactory.open().drop();
+
+    final Database db = databaseFactory.create();
+    try {
+      test.accept(db);
+    } finally {
+      db.drop();
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  private static Result single(final ResultSet rs) {
+    try (rs) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      assertThat(rs.hasNext()).isFalse();
+      return row;
+    }
+  }
+
+  private static File writeCsv(final String fileName, final String content) throws Exception {
+    final File file = new File("target/databases/" + fileName);
+    file.getParentFile().mkdirs();
+    Files.writeString(file.toPath(), content, StandardCharsets.UTF_8);
+    return file;
+  }
+}


### PR DESCRIPTION
Closes #7461

`ImportDatabaseStatement.executeSimple` wrote `result=FAIL` in the `InvocationTargetException` handler and then assigned `result=OK` unconditionally two lines below the enclosing `try`, so the `FAIL` branch could not be observed by any caller: an `IMPORT DATABASE` that never ran answered `{"result":"OK"}` with no rows and no statistics. The branch arrived with `probeOnly` (#1401) and has been dead since the day it was written - `Importer.load()` converts a failed probe into an `IllegalArgumentException` precisely so this statement can report it as a row rather than by throwing, which is why this PR takes the issue's first option (keep the in-band shape, make `FAIL` survive, add a `reason`) rather than the second: throwing a `CommandExecutionException` would leave no way to ask "can this source be parsed?" at all. Three changes - `result=OK` moves into the success path immediately after the statistics are folded in (the shape `BackupDatabaseStatement` already has, so there is no flag and no second assignment); a `reason` property travels with `FAIL`, because `FAIL` on its own tells a caller nothing it can act on and the server log was the only place the message existed; and `e.getTargetException()` is hoisted into a null-guarded local, since `e.getCause()` was being dereferenced unchecked and the two accessors were mixed for the same object. The exact class-name comparison is deliberately **kept** rather than widened to an `instanceof`: the `IllegalArgumentException` subclasses that reach here (`NumberFormatException`, from `ImporterSettings.parseParameter`'s `Integer.parseInt` on a numeric setting) have always been thrown, and widening the branch would silently turn those errors into rows.

The completeness sweep found a **second producer** of the branch that the issue does not name: `setSettings` reaches `ImporterSettings.parseParameter`, which raises the same exact type for a `WITH ...` value it refuses - before the import runs at all - so `IMPORT DATABASE ... WITH onRowError = 'bogus'` also answered `OK` for an import that never happened. Both producers are covered and both now carry a reason.

## Test plan

New `integration/src/test/java/com/arcadedb/integration/importer/Issue7461ImportDatabaseFailResultTest.java`, six tests, each driving the statement through `database.command("sql", ...)` - the same live path a client uses:

- [x] `aFailedProbeReportsFailWithAReason` - `WITH probeOnly = true` on a missing source returns `FAIL`, with a `reason` naming both the failure type and the file.
- [x] `aSuccessfulProbeStillReportsOk` - a good source still returns `OK`, **and** the schema is untouched, which is what proves the probe actually probed rather than imported.
- [x] `anUnusableSettingValueReportsFailWithAReason` - `WITH onRowError = 'bogus'` returns `FAIL` with the parser's own sentence, and nothing was loaded.
- [x] `aSuccessfulImportStillReportsOk` - a plain import is unchanged: `OK`, statistics, 2 records, no `reason`.
- [x] `aGenuineImportFailureStillThrows` - a non-probe import of a missing source still throws `CommandExecutionException`, pinned by root cause so it cannot pass via an earlier guard.
- [x] `aNonNumericNumericSettingStillThrows` - `WITH commitEvery = 'abc'` still throws, root cause `NumberFormatException`; this is the test that fails if someone widens the match to an `instanceof`.

Before the fix: `Tests run: 6, Failures: 2` - exactly the two `FAIL` rows, with the four guard tests already green. After: `Tests run: 6, Failures: 0`.

- [x] `integration` module, full suite minus the `benchmark`/`slow`/`vector` lanes: **372 tests, 0 failures, 9 skipped**.
- [x] `engine` module, same lanes: 14870 tests, 1 failure - `MultiColumnAggregationResultTest.emptySumAndCountStayZeroNotNaN` (`expected: 0.0 but was: NaN`). **Pre-existing on `main` and unrelated**: re-run with `ImportDatabaseStatement.java` restored to its `HEAD` content it fails identically. Time-series aggregation, nothing to do with this change - flagging it because it is red on the base commit.
- [ ] Server ITs that exercise the import path (`ImportDatabaseSecurityIT`, `Issue7443SqlMaintenanceSlotIT`) were **not** run locally: port 2480 was already held by another process on this machine, and a server IT against an occupied port reports authentication errors rather than anything meaningful. CI covers them. The `SecurityException` rethrow they exercise is unchanged in semantics - the loop reads the same object through a local.

## Coverage

| Entry point | Covered by fix? | Covered by a test? |
|---|---|---|
| `WITH probeOnly = true`, unparseable source -> `Importer.load()` raises `IllegalArgumentException` | yes | yes |
| `WITH probeOnly = true`, good source -> `load()` returns `null` | yes (still `OK`) | yes |
| `WITH onRowError = 'bogus'` -> `setSettings` raises the exact `IllegalArgumentException` | yes | yes |
| Non-probe import of an unparseable source | argued - `load()` wraps it in `ImportException`, which never reached the `FAIL` branch and still throws | yes, as a regression guard |
| `WITH commitEvery = 'abc'` -> `NumberFormatException` | argued - the exact class-name match excludes subclasses, so this always threw and still does | yes, as a regression guard |
| Importer raises `SecurityException` (SSRF/LFI guard) | argued - the rethrow loop is unchanged apart from hoisting `getTargetException()` into a local | existing `ImportDatabaseSecurityIT` |
| `BACKUP` / `EXPORT DATABASE` siblings | argued - neither has an in-band `FAIL`; `EXPORT`'s catch always throws, `BACKUP` sets `OK` inside its success branch. `grep '"FAIL"'` over the tree returns this one site | n/a |
| Server `import database <name> <url>` (HTTP/gRPC/Studio button) | argued - routes through `ServerControlPlane.importDatabase`, which drives `Importer` directly and never reaches this statement | n/a |

**Known gaps**

- **#7484** - `ArcadeDBServer.loadDefaultDatabases` runs the `import:` startup command through this statement and discards the result set (`// drain not needed`), so a `FAIL` row is as silent after this fix as it was before it. This PR gives that path an answer worth reading; reading it is a server-module change. Filed before this PR opened.
- The asymmetry between `WITH commitEvery = 'abc'` (throws) and `WITH onRowError = 'bogus'` (returns a `FAIL` row) is inherited, documented in the code comment, and pinned by two tests. Unifying it means deciding whether a refused setting is an error or a row for *every* setting - a contract change this PR deliberately does not make.

Tracking doc: `docs/7461-import-database-result-ok-on-fail.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1vgWQXZoDXYq7TqAwLYXY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `IMPORT DATABASE` now correctly reports `FAIL` instead of incorrectly marking failed operations as successful.
  * Failure results include a clear reason for invalid settings and probe failures.
  * Successful imports and probes continue to report `OK`.
  * Genuine import and parsing errors continue to be surfaced as exceptions.
* **Documentation**
  * Added documentation covering the issue, behavior, verification, and known limitations.
* **Tests**
  * Added coverage for successful operations, failure results, failure reasons, and preserved exception behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->