### PR TITLE
Fix importer limit/progress follow-ups from #7341/#7342/#7461 (#7485, #7484, #7483, #7482)

### DIFF
--- a/integration/src/main/java/com/arcadedb/integration/importer/ImporterContext.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/ImporterContext.java
@@ -135,14 +135,16 @@ public class ImporterContext {
    * each format on entry to its own {@code load()}: a format could forget, two of them had, and a format added
    * later inherits the reset instead of having to know about it (issue #7342).
    * <p>
-   * {@code lastParsed} - the value {@code FormatImporter#printProgress} subtracts to turn the counter into a rate -
-   * goes with it. Left behind, it made the first progress line of every phase after the first report a NEGATIVE
-   * rate, which is the visible artefact of the per-phase reset and was already true for the nine formats that used
-   * to reset the counter themselves.
+   * {@code lastParsed} - the value {@code FormatImporter#printProgress} subtracts from {@link #getParsedTotal()} to
+   * turn the counter into a rate - is rebased to {@link #parsedInPreviousPhases}, NOT zeroed, for the same reason:
+   * {@code printProgress} reads the CUMULATIVE total (issue #7483), so zeroing this baseline at a phase boundary
+   * made the very next progress line compute {@code (wholeImportSoFar - 0) / oneSecond} - a rate spike as visible
+   * as the negative-rate bug zeroing used to fix, just inflated instead of negative. Rebasing to the cumulative
+   * total AS OF this boundary keeps the subtraction measuring only what the new phase parses after it.
    */
   public void beginPhase() {
     parsedInPreviousPhases.addAndGet(parsed.getAndSet(0));
-    lastParsed = 0;
+    lastParsed = parsedInPreviousPhases.get();
     lastLapOn = System.currentTimeMillis();
   }
 

--- a/integration/src/main/java/com/arcadedb/integration/importer/ImporterContext.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/ImporterContext.java
@@ -141,8 +141,16 @@ public class ImporterContext {
    * made the very next progress line compute {@code (wholeImportSoFar - 0) / oneSecond} - a rate spike as visible
    * as the negative-rate bug zeroing used to fix, just inflated instead of negative. Rebasing to the cumulative
    * total AS OF this boundary keeps the subtraction measuring only what the new phase parses after it.
+   * <p>
+   * {@code synchronized}, with {@link #getParsedTotal()}: {@code parsed.getAndSet(0)} and
+   * {@code parsedInPreviousPhases.addAndGet(...)} are each individually atomic but not atomic AS A PAIR, so a
+   * concurrent reader - {@code ServerControlPlane}'s progress-polling {@code Timer} thread runs on a different
+   * thread than the import itself - could land between the two: {@code parsed} already zeroed,
+   * {@code parsedInPreviousPhases} not yet credited with what it held. That reads as a total LOWER than the one
+   * reported a moment before, the exact symptom this issue (#7483) exists to eliminate, just from a race instead
+   * of from the reset this method already fixed.
    */
-  public void beginPhase() {
+  public synchronized void beginPhase() {
     parsedInPreviousPhases.addAndGet(parsed.getAndSet(0));
     lastParsed = parsedInPreviousPhases.get();
     lastLapOn = System.currentTimeMillis();
@@ -150,9 +158,10 @@ public class ImporterContext {
 
   /**
    * The rows this IMPORT parsed: the phases already finished plus the one still running. This is what
-   * {@code parsedRecords} reports (issue #7342).
+   * {@code parsedRecords} reports (issue #7342). {@code synchronized} with {@link #beginPhase()} - see there for
+   * the race it closes.
    */
-  public long getParsedTotal() {
+  public synchronized long getParsedTotal() {
     return parsedInPreviousPhases.get() + parsed.get();
   }
 

--- a/integration/src/main/java/com/arcadedb/integration/importer/ImporterSettings.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/ImporterSettings.java
@@ -156,6 +156,17 @@ public class ImporterSettings {
     return defaultValue;
   }
 
+  public long getLongValue(final String name, final long defaultValue) {
+    final Object v = options.get(name);
+    if (v != null) {
+      if (v instanceof Number number)
+        return number.longValue();
+      else
+        return Long.parseLong(v.toString());
+    }
+    return defaultValue;
+  }
+
   protected void parseParameters(final String[] args) {
     if (args != null)
       for (int i = 0; i < args.length - 1; i += 2) {

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
@@ -171,6 +171,13 @@ public class CSVImporterFormat extends AbstractImporterFormat {
       for (long line = 0; (row = csvParser.parseNext()) != null; ++line) {
         context.parsed.incrementAndGet();
 
+        // CHECKED BEFORE THE SKIP-ROW 'continue' BELOW, NOT ONLY AFTER A ROW IS ACTUALLY PROCESSED: A SKIPPED
+        // ROW (e.g. A LARGE -documentsSkipEntries HEADER BLOCK) NEVER REACHES THE POST-PROCESSING CHECK AT THE
+        // BOTTOM OF THIS LOOP, SO parsingLimitBytes WOULD OTHERWISE GO ON READING PAST ITS BUDGET FOR AS LONG AS
+        // ROWS KEEP BEING SKIPPED. parsingLimitEntries STAYS A POST-PROCESSING CHECK ON PURPOSE (SEE BELOW).
+        if (settings.parsingLimitBytes > 0 && parser.getPosition() > settings.parsingLimitBytes)
+          break;
+
         if (skipEntries > 0 && line < skipEntries) {
           // SKIP IT
           ++skipped;
@@ -209,9 +216,9 @@ public class CSVImporterFormat extends AbstractImporterFormat {
 
         // SAME CAP AND SAME '>=' AS XMLImporterFormat.load() (ISSUE #7341): context.parsed IS INCREMENTED ONCE PER
         // ROW, SO STOPPING ONCE IT REACHES THE LIMIT IMPORTS EXACTLY -parsingLimitEntries ROWS, NOT ONE MORE (#7482).
-        // -parsingLimitBytes IS THE SAME IDEA MEASURED IN BYTES READ FROM THE SOURCE RATHER THAN ROWS PARSED.
-        if ((settings.parsingLimitEntries > 0 && context.parsed.get() >= settings.parsingLimitEntries)
-            || (settings.parsingLimitBytes > 0 && parser.getPosition() > settings.parsingLimitBytes))
+        // KEPT AS A POST-PROCESSING CHECK, UNLIKE parsingLimitBytes ABOVE: THE ROW THAT TRIPS THIS CAP IS MEANT TO
+        // STILL LAND, THE SAME WAY XML's DOES.
+        if (settings.parsingLimitEntries > 0 && context.parsed.get() >= settings.parsingLimitEntries)
           break;
       }
 
@@ -429,6 +436,11 @@ public class CSVImporterFormat extends AbstractImporterFormat {
       for (long line = 0; (row = csvParser.parseNext()) != null; ++line) {
         context.parsed.incrementAndGet();
 
+        // SAME REASONING AS loadDocuments() ABOVE: CHECKED BEFORE EITHER 'continue' BELOW, SO A LONG RUN OF SKIPPED
+        // OR ID-LESS ROWS CANNOT KEEP READING PAST THE BYTE BUDGET.
+        if (settings.parsingLimitBytes > 0 && parser.getPosition() > settings.parsingLimitBytes)
+          break;
+
         if (skipEntries > 0 && line < skipEntries) {
           ++skipped;
           continue;
@@ -473,9 +485,9 @@ public class CSVImporterFormat extends AbstractImporterFormat {
 
         // SAME CAP AND SAME '>=' AS XMLImporterFormat.load() (ISSUE #7341): context.parsed IS INCREMENTED ONCE PER
         // ROW, SO STOPPING ONCE IT REACHES THE LIMIT IMPORTS EXACTLY -parsingLimitEntries ROWS, NOT ONE MORE (#7482).
-        // -parsingLimitBytes IS THE SAME IDEA MEASURED IN BYTES READ FROM THE SOURCE RATHER THAN ROWS PARSED.
-        if ((settings.parsingLimitEntries > 0 && context.parsed.get() >= settings.parsingLimitEntries)
-            || (settings.parsingLimitBytes > 0 && parser.getPosition() > settings.parsingLimitBytes))
+        // KEPT AS A POST-PROCESSING CHECK, UNLIKE parsingLimitBytes ABOVE: THE ROW THAT TRIPS THIS CAP IS MEANT TO
+        // STILL LAND, THE SAME WAY XML's DOES.
+        if (settings.parsingLimitEntries > 0 && context.parsed.get() >= settings.parsingLimitEntries)
           break;
       }
 
@@ -618,6 +630,11 @@ public class CSVImporterFormat extends AbstractImporterFormat {
         for (long line = 0; (row = csvParser.parseNext()) != null; ++line) {
           context.parsed.incrementAndGet();
 
+          // SAME REASONING AS loadDocuments()/loadVertices() ABOVE: CHECKED BEFORE THE SKIP-ROW 'continue', SO A
+          // LONG RUN OF SKIPPED ROWS CANNOT KEEP READING PAST THE BYTE BUDGET.
+          if (settings.parsingLimitBytes > 0 && parser.getPosition() > settings.parsingLimitBytes)
+            break;
+
           if (skipEntries > 0 && line < skipEntries) {
             ++skipped;
             continue;
@@ -649,9 +666,9 @@ public class CSVImporterFormat extends AbstractImporterFormat {
 
           // SAME CAP AND SAME '>=' AS XMLImporterFormat.load() (ISSUE #7341): context.parsed IS INCREMENTED ONCE PER
           // ROW, SO STOPPING ONCE IT REACHES THE LIMIT IMPORTS EXACTLY -parsingLimitEntries ROWS, NOT ONE MORE (#7482).
-          // -parsingLimitBytes IS THE SAME IDEA MEASURED IN BYTES READ FROM THE SOURCE RATHER THAN ROWS PARSED.
-          if ((settings.parsingLimitEntries > 0 && context.parsed.get() >= settings.parsingLimitEntries)
-              || (settings.parsingLimitBytes > 0 && parser.getPosition() > settings.parsingLimitBytes))
+          // KEPT AS A POST-PROCESSING CHECK, UNLIKE parsingLimitBytes ABOVE: THE ROW THAT TRIPS THIS CAP IS MEANT TO
+          // STILL LAND, THE SAME WAY XML's DOES.
+          if (settings.parsingLimitEntries > 0 && context.parsed.get() >= settings.parsingLimitEntries)
             break;
         }
         txOpen = false;

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
@@ -206,6 +206,13 @@ public class CSVImporterFormat extends AbstractImporterFormat {
           context.errors.incrementAndGet();
           database.begin();
         }
+
+        // SAME CAP AND SAME '>=' AS XMLImporterFormat.load() (ISSUE #7341): context.parsed IS INCREMENTED ONCE PER
+        // ROW, SO STOPPING ONCE IT REACHES THE LIMIT IMPORTS EXACTLY -parsingLimitEntries ROWS, NOT ONE MORE (#7482).
+        // -parsingLimitBytes IS THE SAME IDEA MEASURED IN BYTES READ FROM THE SOURCE RATHER THAN ROWS PARSED.
+        if ((settings.parsingLimitEntries > 0 && context.parsed.get() >= settings.parsingLimitEntries)
+            || (settings.parsingLimitBytes > 0 && parser.getPosition() > settings.parsingLimitBytes))
+          break;
       }
 
       // Same ownsTransaction gate as the rollback paths below: don't commit the caller's unrelated pending work as
@@ -463,6 +470,13 @@ public class CSVImporterFormat extends AbstractImporterFormat {
           context.errors.incrementAndGet();
           database.begin();
         }
+
+        // SAME CAP AND SAME '>=' AS XMLImporterFormat.load() (ISSUE #7341): context.parsed IS INCREMENTED ONCE PER
+        // ROW, SO STOPPING ONCE IT REACHES THE LIMIT IMPORTS EXACTLY -parsingLimitEntries ROWS, NOT ONE MORE (#7482).
+        // -parsingLimitBytes IS THE SAME IDEA MEASURED IN BYTES READ FROM THE SOURCE RATHER THAN ROWS PARSED.
+        if ((settings.parsingLimitEntries > 0 && context.parsed.get() >= settings.parsingLimitEntries)
+            || (settings.parsingLimitBytes > 0 && parser.getPosition() > settings.parsingLimitBytes))
+          break;
       }
 
       if (skipOnError) {
@@ -632,6 +646,13 @@ public class CSVImporterFormat extends AbstractImporterFormat {
             txOpen = true;
             txCount = 0;
           }
+
+          // SAME CAP AND SAME '>=' AS XMLImporterFormat.load() (ISSUE #7341): context.parsed IS INCREMENTED ONCE PER
+          // ROW, SO STOPPING ONCE IT REACHES THE LIMIT IMPORTS EXACTLY -parsingLimitEntries ROWS, NOT ONE MORE (#7482).
+          // -parsingLimitBytes IS THE SAME IDEA MEASURED IN BYTES READ FROM THE SOURCE RATHER THAN ROWS PARSED.
+          if ((settings.parsingLimitEntries > 0 && context.parsed.get() >= settings.parsingLimitEntries)
+              || (settings.parsingLimitBytes > 0 && parser.getPosition() > settings.parsingLimitBytes))
+            break;
         }
         txOpen = false;
         database.commit();

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/FormatImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/FormatImporter.java
@@ -48,11 +48,18 @@ public interface FormatImporter {
       if (deltaInSecs == 0)
         deltaInSecs = 1;
 
+      // context.getParsedTotal(), NOT context.parsed.get(): the latter is per-phase and resets to 0 at every phase
+      // boundary (ImporterContext#beginPhase()), so on a multi-phase import (documents + vertices + edges) this log
+      // line's "Parsed" figure - and the rate computed against context.lastParsed below - would climb, drop back
+      // towards zero, then climb again, exactly the SSE progress stream's #7483 before it was fixed to read the
+      // same monotonic total.
+      final long parsedTotal = context.getParsedTotal();
+
       if (source == null || source.compressed || source.totalSize < 0) {
         logger.logLine(2,//
             "- Parsed %,d (%,d/sec) %,d documents (%,d/sec) %,d vertices (%,d/sec) %,d edges (%,d/sec %,d skipped) %,d linked edges (%,d/sec %,d%%) updated documents %,d (%,d%%)",
 //
-            context.parsed.get(), (context.parsed.get() - context.lastParsed) / deltaInSecs, context.createdDocuments.get(),
+            parsedTotal, (parsedTotal - context.lastParsed) / deltaInSecs, context.createdDocuments.get(),
             (context.createdDocuments.get() - context.lastDocuments) / deltaInSecs, context.createdVertices.get(),
             (context.createdVertices.get() - context.lastVertices) / deltaInSecs, context.createdEdges.get(),
             (context.createdEdges.get() - context.lastEdges) / deltaInSecs, context.skippedEdges.get(), context.linkedEdges.get(),
@@ -64,7 +71,7 @@ public interface FormatImporter {
         final int progressPerc = (int) (parser.getPosition() * 100 / source.totalSize);
         logger.logLine(2,//
             "Parsed %,d (%,d/sec %,d%%) %,d records (%,d/sec) %,d vertices (%,d/sec) %,d edges (%,d/sec %,d skipped) %,d linked edges (%,d/sec %,d%%) updated documents %,d (%,d%%)",
-            context.parsed.get(), (context.parsed.get() - context.lastParsed) / deltaInSecs, progressPerc, context.createdDocuments.get(),
+            parsedTotal, (parsedTotal - context.lastParsed) / deltaInSecs, progressPerc, context.createdDocuments.get(),
             (context.createdDocuments.get() - context.lastDocuments) / deltaInSecs, context.createdVertices.get(),
             (context.createdVertices.get() - context.lastVertices) / deltaInSecs, context.createdEdges.get(),
             (context.createdEdges.get() - context.lastEdges) / deltaInSecs, context.skippedEdges.get(), context.linkedEdges.get(),
@@ -75,7 +82,7 @@ public interface FormatImporter {
 
       }
       context.lastLapOn = System.currentTimeMillis();
-      context.lastParsed = context.parsed.get();
+      context.lastParsed = parsedTotal;
 
       context.lastDocuments = context.createdDocuments.get();
       context.lastVertices = context.createdVertices.get();

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JSONImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JSONImporterFormat.java
@@ -244,11 +244,15 @@ public class JSONImporterFormat implements FormatImporter {
 
       database.begin();
 
-      // SAME CAP AND SAME '>=' AS XMLImporterFormat.load() (ISSUE #7341): context.parsed IS INCREMENTED ONCE PER
-      // RECORD (INSIDE parseRecord()), SO STOPPING ONCE IT REACHES THE LIMIT IMPORTS EXACTLY -parsingLimitEntries
-      // RECORDS, NOT ONE MORE (#7482). reader.endArray() BELOW REQUIRES THE ARRAY TO BE FULLY CONSUMED FIRST, SO
-      // WHATEVER RECORDS THE LIMIT LEFT UNREAD ARE SKIPPED RATHER THAN PARSED.
-      if ((settings.parsingLimitEntries > 0 && context.parsed.get() >= settings.parsingLimitEntries)
+      // recordIndex, NOT context.parsed: parseRecord() increments context.parsed for every nested object it
+      // recurses into too (a BEGIN_OBJECT property, or a BEGIN_OBJECT array entry via parseArray()), so a record
+      // with even one nested object pushed context.parsed two past where this array's own entry count actually
+      // was, making the cap trip after fewer TOP-LEVEL records than requested. recordIndex is incremented exactly
+      // once per top-level array object above, which is what '-parsingLimitEntries N' means here - the same '>='
+      // as XMLImporterFormat.load()'s cap (ISSUE #7341): the record that trips it is still imported, so N of them
+      // land, not N-1. reader.endArray() below requires the array to be fully consumed first, so whatever records
+      // the limit left unread are skipped rather than parsed (#7482).
+      if ((settings.parsingLimitEntries > 0 && recordIndex >= settings.parsingLimitEntries)
           || (settings.parsingLimitBytes > 0 && parser.getPosition() > settings.parsingLimitBytes)) {
         while (reader.hasNext())
           reader.skipValue();

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JSONImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JSONImporterFormat.java
@@ -251,7 +251,9 @@ public class JSONImporterFormat implements FormatImporter {
       // once per top-level array object above, which is what '-parsingLimitEntries N' means here - the same '>='
       // as XMLImporterFormat.load()'s cap (ISSUE #7341): the record that trips it is still imported, so N of them
       // land, not N-1. reader.endArray() below requires the array to be fully consumed first, so whatever records
-      // the limit left unread are skipped rather than parsed (#7482).
+      // the limit left unread are skipped rather than parsed (#7482). parser.getPosition(), not the more precise
+      // per-token position XMLImporterFormat uses: Gson's JsonReader does its own internal buffering the same way
+      // the XML fix worked around, so this byte budget carries the same "coarse as one buffer full" caveat.
       if ((settings.parsingLimitEntries > 0 && recordIndex >= settings.parsingLimitEntries)
           || (settings.parsingLimitBytes > 0 && parser.getPosition() > settings.parsingLimitBytes)) {
         while (reader.hasNext())

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JSONImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JSONImporterFormat.java
@@ -110,7 +110,7 @@ public class JSONImporterFormat implements FormatImporter {
         case END_OBJECT:
           reader.endObject();
         case BEGIN_ARRAY:
-          parseRecords(reader, database, settings, context, (JSONArray) tagValue, waitFor != token);
+          parseRecords(reader, parser, database, settings, context, (JSONArray) tagValue, waitFor != token);
           break;
         case NAME:
           final String tag = reader.nextName();
@@ -137,7 +137,7 @@ public class JSONImporterFormat implements FormatImporter {
     return "JSON";
   }
 
-  private void parseRecords(final JsonReader reader, final Database database, final ImporterSettings settings,
+  private void parseRecords(final JsonReader reader, final Parser parser, final Database database, final ImporterSettings settings,
       final ImporterContext context,
       final JSONArray mapping, boolean ignore) throws IOException {
     // Each record below commits/rolls back its own nested transaction (database.begin() nests rather than reusing
@@ -151,7 +151,7 @@ public class JSONImporterFormat implements FormatImporter {
 
     database.begin();
     try {
-      parseRecordsArray(reader, database, settings, context, mapping, ignore);
+      parseRecordsArray(reader, parser, database, settings, context, mapping, ignore);
     } catch (final IOException e) {
       // A genuinely source-level failure never passes through parseRecordsArray()'s per-record catch below (which
       // only catches RuntimeException), so the active transaction here is always this method's own, untouched
@@ -170,7 +170,7 @@ public class JSONImporterFormat implements FormatImporter {
     }
   }
 
-  private void parseRecordsArray(final JsonReader reader, final Database database, final ImporterSettings settings,
+  private void parseRecordsArray(final JsonReader reader, final Parser parser, final Database database, final ImporterSettings settings,
       final ImporterContext context, final JSONArray mapping, boolean ignore) throws IOException {
     final Object mappingValue = mapping != null && !mapping.isEmpty() ? mapping.get(0) : null;
     JSONObject mappingObject;
@@ -243,6 +243,17 @@ public class JSONImporterFormat implements FormatImporter {
       }
 
       database.begin();
+
+      // SAME CAP AND SAME '>=' AS XMLImporterFormat.load() (ISSUE #7341): context.parsed IS INCREMENTED ONCE PER
+      // RECORD (INSIDE parseRecord()), SO STOPPING ONCE IT REACHES THE LIMIT IMPORTS EXACTLY -parsingLimitEntries
+      // RECORDS, NOT ONE MORE (#7482). reader.endArray() BELOW REQUIRES THE ARRAY TO BE FULLY CONSUMED FIRST, SO
+      // WHATEVER RECORDS THE LIMIT LEFT UNREAD ARE SKIPPED RATHER THAN PARSED.
+      if ((settings.parsingLimitEntries > 0 && context.parsed.get() >= settings.parsingLimitEntries)
+          || (settings.parsingLimitBytes > 0 && parser.getPosition() > settings.parsingLimitBytes)) {
+        while (reader.hasNext())
+          reader.skipValue();
+        break;
+      }
     }
 
     database.commit();

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
@@ -195,6 +195,14 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
           database.begin();
           timeSeriesSamplesSinceCommit = 0;
         }
+
+        // SAME CAP AND SAME '>=' AS XMLImporterFormat.load() (ISSUE #7341): context.parsed IS INCREMENTED ONCE PER
+        // RECORD, SO STOPPING ONCE IT REACHES THE LIMIT IMPORTS EXACTLY -parsingLimitEntries RECORDS, NOT ONE MORE
+        // (#7482). -parsingLimitBytes IS THE SAME IDEA MEASURED IN BYTES READ FROM THE SOURCE RATHER THAN RECORDS
+        // PARSED.
+        if ((settings.parsingLimitEntries > 0 && context.parsed.get() >= settings.parsingLimitEntries)
+            || (settings.parsingLimitBytes > 0 && parser.getPosition() > settings.parsingLimitBytes))
+          break;
       }
 
       // Issue #6460: resolve any LINK / LIST-of-LINK / MAP-of-LINK property values that were still forward

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
@@ -151,7 +151,10 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
 
         // CHECKED BEFORE ANYTHING ELSE IN THE LOOP BODY, NOT ONLY AT THE BOTTOM: THE -onRowError skip 'continue'
         // BELOW BYPASSES A CHECK PLACED AFTER IT, SO A RUN OF MALFORMED LINES BEING SKIPPED COULD KEEP READING
-        // PAST parsingLimitBytes'S BUDGET FOR AS LONG AS THE BAD LINES KEEP COMING.
+        // PAST parsingLimitBytes'S BUDGET FOR AS LONG AS THE BAD LINES KEEP COMING. parser.getPosition() (NOT
+        // xmlReader.getLocation().getCharacterOffset()-STYLE PRECISION, WHICH HAS NO EQUIVALENT HERE): THE
+        // UNDERLYING BufferedReader DOES ITS OWN READ-AHEAD, SO THE SAME "BUDGET AS COARSE AS ONE BUFFER FULL"
+        // CAVEAT XML's ANALYZE()/LOAD() COMMENTS DESCRIBE APPLIES TO THIS CHECK TOO.
         if (settings.parsingLimitBytes > 0 && parser.getPosition() > settings.parsingLimitBytes)
           break;
 

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
@@ -149,6 +149,12 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
       String line;
       while ((line = reader.readLine()) != null) {
 
+        // CHECKED BEFORE ANYTHING ELSE IN THE LOOP BODY, NOT ONLY AT THE BOTTOM: THE -onRowError skip 'continue'
+        // BELOW BYPASSES A CHECK PLACED AFTER IT, SO A RUN OF MALFORMED LINES BEING SKIPPED COULD KEEP READING
+        // PAST parsingLimitBytes'S BUDGET FOR AS LONG AS THE BAD LINES KEEP COMING.
+        if (settings.parsingLimitBytes > 0 && parser.getPosition() > settings.parsingLimitBytes)
+          break;
+
         var jsonLine = new JSONObject(line);
         final String recordType = jsonLine.getString("t");
 
@@ -198,10 +204,9 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
 
         // SAME CAP AND SAME '>=' AS XMLImporterFormat.load() (ISSUE #7341): context.parsed IS INCREMENTED ONCE PER
         // RECORD, SO STOPPING ONCE IT REACHES THE LIMIT IMPORTS EXACTLY -parsingLimitEntries RECORDS, NOT ONE MORE
-        // (#7482). -parsingLimitBytes IS THE SAME IDEA MEASURED IN BYTES READ FROM THE SOURCE RATHER THAN RECORDS
-        // PARSED.
-        if ((settings.parsingLimitEntries > 0 && context.parsed.get() >= settings.parsingLimitEntries)
-            || (settings.parsingLimitBytes > 0 && parser.getPosition() > settings.parsingLimitBytes))
+        // (#7482). KEPT AS A POST-PROCESSING CHECK, UNLIKE parsingLimitBytes ABOVE: THE RECORD THAT TRIPS THIS CAP
+        // IS MEANT TO STILL LAND, THE SAME WAY XML's DOES.
+        if (settings.parsingLimitEntries > 0 && context.parsed.get() >= settings.parsingLimitEntries)
           break;
       }
 

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java
@@ -138,6 +138,12 @@ public class RDFImporterFormat extends CSVImporterFormat {
       for (long line = 0; (row = csvParser.parseNext()) != null; ++line) {
         context.parsed.incrementAndGet();
 
+        // CHECKED BEFORE THE SKIP-ROW 'continue' BELOW, THE SAME WAY CSVImporterFormat's ROW LOOPS ARE: A SKIPPED
+        // ROW NEVER REACHES THE POST-PROCESSING CHECK AT THE BOTTOM OF THIS LOOP, SO parsingLimitBytes WOULD
+        // OTHERWISE GO ON READING PAST ITS BUDGET FOR AS LONG AS ROWS KEEP BEING SKIPPED.
+        if (settings.parsingLimitBytes > 0 && parser.getPosition() > settings.parsingLimitBytes)
+          break;
+
         if (skipEntries > 0 && line < skipEntries) {
           // SKIP IT
           ++skipped;
@@ -179,9 +185,9 @@ public class RDFImporterFormat extends CSVImporterFormat {
 
         // SAME CAP AND SAME '>=' AS XMLImporterFormat.load() (ISSUE #7341): context.parsed IS INCREMENTED ONCE PER
         // ROW, SO STOPPING ONCE IT REACHES THE LIMIT IMPORTS EXACTLY -parsingLimitEntries ROWS, NOT ONE MORE (#7482).
-        // -parsingLimitBytes IS THE SAME IDEA MEASURED IN BYTES READ FROM THE SOURCE RATHER THAN ROWS PARSED.
-        if ((settings.parsingLimitEntries > 0 && context.parsed.get() >= settings.parsingLimitEntries)
-            || (settings.parsingLimitBytes > 0 && parser.getPosition() > settings.parsingLimitBytes))
+        // KEPT AS A POST-PROCESSING CHECK, UNLIKE parsingLimitBytes ABOVE: THE ROW THAT TRIPS THIS CAP IS MEANT TO
+        // STILL LAND, THE SAME WAY XML's DOES.
+        if (settings.parsingLimitEntries > 0 && context.parsed.get() >= settings.parsingLimitEntries)
           break;
       }
 

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java
@@ -176,6 +176,13 @@ public class RDFImporterFormat extends CSVImporterFormat {
           txOpen = true;
           txCount = 0;
         }
+
+        // SAME CAP AND SAME '>=' AS XMLImporterFormat.load() (ISSUE #7341): context.parsed IS INCREMENTED ONCE PER
+        // ROW, SO STOPPING ONCE IT REACHES THE LIMIT IMPORTS EXACTLY -parsingLimitEntries ROWS, NOT ONE MORE (#7482).
+        // -parsingLimitBytes IS THE SAME IDEA MEASURED IN BYTES READ FROM THE SOURCE RATHER THAN ROWS PARSED.
+        if ((settings.parsingLimitEntries > 0 && context.parsed.get() >= settings.parsingLimitEntries)
+            || (settings.parsingLimitBytes > 0 && parser.getPosition() > settings.parsingLimitBytes))
+          break;
       }
 
       txOpen = false;

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/XMLImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/XMLImporterFormat.java
@@ -219,10 +219,10 @@ public class XMLImporterFormat implements FormatImporter {
     // `analyzingLimitEntries` WAS THIS FORMAT'S OWN MISSPELLED, DEFAULT-LESS COPY: KEPT HERE, IF EXPLICITLY PASSED,
     // AS A DEPRECATED ALIAS SO A SCRIPT THAT SET IT STILL WORKS (ISSUE #7485). getLongValue, NOT getIntValue: THE
     // FIELD IT FALLS BACK TO IS A long, AND THE DEPRECATED ALIAS SHOULD ACCEPT THE SAME RANGE.
-    final boolean deprecatedAliasSet = settings.getValue("analyzingLimitEntries", null) != null;
+    final boolean deprecatedAliasSet = settings.options.containsKey("analyzingLimitEntries");
     final long analyzingLimitEntries = deprecatedAliasSet ?
         settings.getLongValue("analyzingLimitEntries", 0) : settings.analysisLimitEntries;
-    if (deprecatedAliasSet && settings.getValue("analysisLimitEntries", null) != null)
+    if (deprecatedAliasSet && settings.options.containsKey("analysisLimitEntries"))
       LogManager.instance().log(this, Level.WARNING,
           "Both the deprecated -analyzingLimitEntries and the current -analysisLimitEntries were set; using the "
               + "deprecated -analyzingLimitEntries value (%d)", null, analyzingLimitEntries);

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/XMLImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/XMLImporterFormat.java
@@ -195,7 +195,10 @@ public class XMLImporterFormat implements FormatImporter {
         // parser.getPosition(): THE LATTER IS THE UNDERLYING InputStream'S READ POSITION, WHICH A BUFFERING
         // XMLStreamReader FILLS FAR AHEAD OF THE EVENT IT HAS ACTUALLY HANDED BACK, MAKING THE BYTE BUDGET AS COARSE
         // AS ONE BUFFER FULL. getCharacterOffset() IS THE PARSER'S OWN LOGICAL POSITION IN THE DOCUMENT, THE SAME
-        // GRANULARITY CSVImporterFormat.analyze() ALREADY GETS FROM ITS TOKENIZER'S currentChar().
+        // GRANULARITY CSVImporterFormat.analyze() ALREADY GETS FROM ITS TOKENIZER'S currentChar(). ASSUMES THE
+        // FACTORY'S Location TRACKS IT (THE JDK's BUILT-IN STAX IMPLEMENTATION DOES); PER THE XMLStreamReader
+        // CONTRACT AN IMPLEMENTATION THAT DOES NOT IS ALLOWED TO ANSWER -1, WHICH WOULD MAKE THIS GUARD A SILENT
+        // NO-OP (-1 > limit IS NEVER true) RATHER THAN FAIL LOUDLY.
         if ((settings.parsingLimitEntries > 0 && context.parsed.get() >= settings.parsingLimitEntries)
             || (settings.parsingLimitBytes > 0 && xmlReader.getLocation().getCharacterOffset() > settings.parsingLimitBytes))
           break;

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/XMLImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/XMLImporterFormat.java
@@ -189,8 +189,15 @@ public class XMLImporterFormat implements FormatImporter {
         // '>=' AND NOT '>': context.parsed IS INCREMENTED ONCE PER COMPLETED OBJECT, SO A STRICT COMPARISON ONLY
         // BREAKS ONCE THE COUNT HAS PASSED THE LIMIT - AND THE OBJECT THAT TRIPPED IT HAS ALREADY BEEN HANDED TO
         // database.async().createRecord(). '-parsingLimitEntries N' IMPORTED N+1 ENTRIES, WHILE THE SAME FLAG ON THE
-        // VECTOR ROUTE (TextEmbeddingsImporterLSM, THROUGH parser.limit()) STOPPED AT N (ISSUE #7341)
-        if (settings.parsingLimitEntries > 0 && context.parsed.get() >= settings.parsingLimitEntries)
+        // VECTOR ROUTE (TextEmbeddingsImporterLSM, THROUGH parser.limit()) STOPPED AT N (ISSUE #7341).
+        // -parsingLimitBytes IS THE SAME IDEA MEASURED IN BYTES READ FROM THE SOURCE RATHER THAN OBJECTS PARSED,
+        // AND WAS SILENTLY IGNORED HERE LIKE EVERY OTHER FORMAT (ISSUE #7482). xmlReader.getLocation() RATHER THAN
+        // parser.getPosition(): THE LATTER IS THE UNDERLYING InputStream'S READ POSITION, WHICH A BUFFERING
+        // XMLStreamReader FILLS FAR AHEAD OF THE EVENT IT HAS ACTUALLY HANDED BACK, MAKING THE BYTE BUDGET AS COARSE
+        // AS ONE BUFFER FULL. getCharacterOffset() IS THE PARSER'S OWN LOGICAL POSITION IN THE DOCUMENT, THE SAME
+        // GRANULARITY CSVImporterFormat.analyze() ALREADY GETS FROM ITS TOKENIZER'S currentChar().
+        if ((settings.parsingLimitEntries > 0 && context.parsed.get() >= settings.parsingLimitEntries)
+            || (settings.parsingLimitBytes > 0 && xmlReader.getLocation().getCharacterOffset() > settings.parsingLimitBytes))
           break;
       }
 
@@ -205,7 +212,11 @@ public class XMLImporterFormat implements FormatImporter {
   @Override
   public SourceSchema analyze(final AnalyzedEntity.EntityType entityType, final Parser parser, final ImporterSettings settings,
       final AnalyzedSchema analyzedSchema) {
-    final int analyzingLimitEntries = settings.getIntValue("analyzingLimitEntries", 0);
+    // `analysisLimitEntries` IS THE ONE REAL SETTING (WITH A DEFAULT OF 10000), SHARED WITH CSVImporterFormat.
+    // `analyzingLimitEntries` WAS THIS FORMAT'S OWN MISSPELLED, DEFAULT-LESS COPY: KEPT HERE, IF EXPLICITLY PASSED,
+    // AS A DEPRECATED ALIAS SO A SCRIPT THAT SET IT STILL WORKS (ISSUE #7485)
+    final long analyzingLimitEntries = settings.getValue("analyzingLimitEntries", null) != null ?
+        settings.getIntValue("analyzingLimitEntries", 0) : settings.analysisLimitEntries;
     final int objectNestLevel = settings.getIntValue("objectNestLevel", 1);
 
     long parsedObjects = 0;
@@ -337,6 +348,14 @@ public class XMLImporterFormat implements FormatImporter {
         // SAME OFF-BY-ONE AND SAME FIX AS load()'S -parsingLimitEntries ABOVE: parsedObjects IS INCREMENTED ONCE PER
         // COMPLETED OBJECT, SO A STRICT COMPARISON ANALYZED N+1 OF THEM (ISSUE #7341)
         if (analyzingLimitEntries > 0 && parsedObjects >= analyzingLimitEntries)
+          break;
+
+        // CSVImporterFormat.analyze() HAS HONOURED analysisLimitBytes SINCE ITS INTRODUCTION; XML HAD NO EQUIVALENT
+        // GUARD AT ALL, SO SCHEMA ANALYSIS ON A SOURCE WITH FEW BUT HUGE OBJECTS WAS UNBOUNDED (ISSUE #7485).
+        // xmlReader.getLocation().getCharacterOffset() RATHER THAN parser.getPosition(): SEE THE SAME CHOICE IN
+        // load()'S -parsingLimitBytes GUARD ABOVE (ISSUE #7482) - THE PARSER'S OWN LOGICAL POSITION, NOT THE
+        // UNDERLYING BUFFERED STREAM'S READ-AHEAD POSITION.
+        if (settings.analysisLimitBytes > 0 && xmlReader.getLocation().getCharacterOffset() > settings.analysisLimitBytes)
           break;
       }
 

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/XMLImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/XMLImporterFormat.java
@@ -214,9 +214,15 @@ public class XMLImporterFormat implements FormatImporter {
       final AnalyzedSchema analyzedSchema) {
     // `analysisLimitEntries` IS THE ONE REAL SETTING (WITH A DEFAULT OF 10000), SHARED WITH CSVImporterFormat.
     // `analyzingLimitEntries` WAS THIS FORMAT'S OWN MISSPELLED, DEFAULT-LESS COPY: KEPT HERE, IF EXPLICITLY PASSED,
-    // AS A DEPRECATED ALIAS SO A SCRIPT THAT SET IT STILL WORKS (ISSUE #7485)
-    final long analyzingLimitEntries = settings.getValue("analyzingLimitEntries", null) != null ?
-        settings.getIntValue("analyzingLimitEntries", 0) : settings.analysisLimitEntries;
+    // AS A DEPRECATED ALIAS SO A SCRIPT THAT SET IT STILL WORKS (ISSUE #7485). getLongValue, NOT getIntValue: THE
+    // FIELD IT FALLS BACK TO IS A long, AND THE DEPRECATED ALIAS SHOULD ACCEPT THE SAME RANGE.
+    final boolean deprecatedAliasSet = settings.getValue("analyzingLimitEntries", null) != null;
+    final long analyzingLimitEntries = deprecatedAliasSet ?
+        settings.getLongValue("analyzingLimitEntries", 0) : settings.analysisLimitEntries;
+    if (deprecatedAliasSet && settings.getValue("analysisLimitEntries", null) != null)
+      LogManager.instance().log(this, Level.WARNING,
+          "Both the deprecated -analyzingLimitEntries and the current -analysisLimitEntries were set; using the "
+              + "deprecated -analyzingLimitEntries value (%d)", null, analyzingLimitEntries);
     final int objectNestLevel = settings.getIntValue("objectNestLevel", 1);
 
     long parsedObjects = 0;

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue7342PhaseCounterTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue7342PhaseCounterTest.java
@@ -30,6 +30,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -83,6 +86,56 @@ class Issue7342PhaseCounterTest {
             + "cumulative 10")
         .isEqualTo(3);
     assertThat(context.toMap()).containsEntry("parsedRecords", 10L);
+  }
+
+  /**
+   * A code-review finding on #7483's own fix: {@code parsed.getAndSet(0)} and
+   * {@code parsedInPreviousPhases.addAndGet(...)} inside {@code beginPhase()} are each individually atomic but not
+   * atomic AS A PAIR, so a concurrent {@code getParsedTotal()} - exactly what {@code ServerControlPlane}'s
+   * progress-polling {@code Timer} thread does, on a thread other than the import's own - could land between the
+   * two: {@code parsed} already zeroed, {@code parsedInPreviousPhases} not yet credited. That reads as a total
+   * LOWER than the one reported a moment before - the same "progress went backwards" symptom this issue exists to
+   * eliminate, just from a race instead of from the reset the rest of this fix already covers. {@code beginPhase()}
+   * and {@code getParsedTotal()} are now both {@code synchronized} on the instance to close it.
+   * <p>
+   * Hammers both methods from separate threads long enough that, before the fix, the race reliably reproduces
+   * within the loop count below; the assertion is simply that {@code getParsedTotal()} never returns less than the
+   * highest value already observed.
+   */
+  @Test
+  void getParsedTotalNeverGoesBackwardsUnderConcurrentBeginPhase() throws Exception {
+    final ImporterContext context = new ImporterContext();
+    final int             phases  = 20_000;
+    final AtomicBoolean stop    = new AtomicBoolean(false);
+    final AtomicLong    maxSeen = new AtomicLong(0);
+    final AtomicReference<AssertionError> failure = new AtomicReference<>();
+
+    final Thread reader = new Thread(() -> {
+      while (!stop.get()) {
+        final long total = context.getParsedTotal();
+        final long previousMax = maxSeen.getAndUpdate(current -> Math.max(current, total));
+        if (total < previousMax)
+          failure.compareAndSet(null,
+              new AssertionError("getParsedTotal() returned " + total + " after already having reported " + previousMax));
+      }
+    });
+
+    reader.start();
+    try {
+      for (int i = 0; i < phases; i++) {
+        context.parsed.incrementAndGet();
+        context.beginPhase();
+      }
+    } finally {
+      stop.set(true);
+      reader.join();
+    }
+
+    if (failure.get() != null)
+      throw failure.get();
+
+    assertThat(context.getParsedTotal()).as("every one of the phases' single row must still be accounted for")
+        .isEqualTo(phases);
   }
 
   /**

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue7342PhaseCounterTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue7342PhaseCounterTest.java
@@ -51,11 +51,15 @@ class Issue7342PhaseCounterTest {
 
   /**
    * The unit the hoist rests on. {@code lastParsed} goes with the counter: it is what
-   * {@code FormatImporter#printProgress} subtracts to turn the counter into a rate, so left behind it made the
-   * first progress line of every phase after the first report a NEGATIVE rate.
+   * {@code FormatImporter#printProgress} subtracts from {@link ImporterContext#getParsedTotal()} to turn the
+   * counter into a rate (issue #7483 moved that subtraction from the per-phase counter to the cumulative total).
+   * {@code lastParsed} is therefore rebased to the cumulative total as of the boundary, not zeroed: zeroing it
+   * while the thing it is subtracted FROM stayed cumulative would make the very next progress line compute
+   * {@code (wholeImportSoFar - 0) / oneSecond} - a rate spike exactly as visible as the negative-rate bug this
+   * reset originally fixed, just inflated instead of negative.
    */
   @Test
-  void beginPhaseFoldsThePhaseIntoTheTotalAndZeroesTheRest() {
+  void beginPhaseFoldsThePhaseIntoTheTotalAndRebasesLastParsedToIt() {
     final ImporterContext context = new ImporterContext();
 
     context.parsed.set(7);
@@ -64,14 +68,20 @@ class Issue7342PhaseCounterTest {
     context.beginPhase();
 
     assertThat(context.parsed.get()).as("the next phase counts its own rows from zero").isZero();
-    assertThat(context.lastParsed).as("so the first progress line of the next phase cannot report a negative rate")
-        .isZero();
+    assertThat(context.lastParsed)
+        .as("rebased to the cumulative total as of this boundary, so the next call's (getParsedTotal() - lastParsed) "
+            + "measures only what the NEW phase parses, not the whole import re-divided by one tick's elapsed time")
+        .isEqualTo(7);
     assertThat(context.getParsedTotal()).as("and nothing is lost: the phase's rows join the import-wide total")
         .isEqualTo(7);
 
     context.parsed.set(3);
     assertThat(context.getParsedTotal()).as("the total is the finished phases plus the one still running")
         .isEqualTo(10);
+    assertThat(context.getParsedTotal() - context.lastParsed)
+        .as("the rate computation a progress reader does: only the 3 rows the new phase has parsed so far, not the "
+            + "cumulative 10")
+        .isEqualTo(3);
     assertThat(context.toMap()).containsEntry("parsedRecords", 10L);
   }
 

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue7482ParsingLimitAppliesToAllFormatsTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue7482ParsingLimitAppliesToAllFormatsTest.java
@@ -140,10 +140,53 @@ class Issue7482ParsingLimitAppliesToAllFormatsTest {
   }
 
   /**
+   * A record with a nested object used to cost the entries budget twice: {@code parseRecord()} increments
+   * {@code context.parsed} for every object it recurses into too - a nested object property, or a nested object
+   * that is itself an array entry via {@code parseArray()} - so a record with one nested object advanced
+   * {@code context.parsed} by 2, not 1, and the JSON array cap (originally checked against {@code context.parsed})
+   * tripped after fewer TOP-LEVEL records than requested. The cap now checks {@code recordIndex}, which
+   * {@code parseRecordsArray()} increments exactly once per top-level array object.
+   */
+  @Test
+  void jsonArrayParsingLimitCountsTopLevelRecordsNotNestedObjects() throws Exception {
+    final StringBuilder json = new StringBuilder("{\"Users\":[");
+    for (int i = 0; i < ROWS; i++) {
+      if (i > 0)
+        json.append(',');
+      json.append("{\"id\":\"").append(i).append("\",\"address\":{\"city\":\"city-").append(i).append("\"}}");
+    }
+    json.append("]}");
+    final File file = writeFile("importer-7482-json-nested.json", json.toString());
+    final String databasePath = "target/databases/test-import-7482-json-nested";
+    FileUtils.deleteRecursively(new File(databasePath));
+
+    try {
+      new Importer(("-url file://" + file.getAbsolutePath() + " -database " + databasePath
+          + " -forceDatabaseCreate true -mapping {'Users':[]} -parsingLimitEntries 2").split(" ")).load();
+
+      try (final Database db = new DatabaseFactory(databasePath).open()) {
+        assertThat(db.countType("Document", true))
+            .as("each of the 6 records carries one nested object, so counting nested objects toward the cap would "
+                + "trip it after 1 top-level record instead of 2")
+            .isEqualTo(2);
+      }
+    } finally {
+      dropDatabase(databasePath);
+      file.delete();
+      TestHelper.checkActiveDatabases();
+    }
+  }
+
+  /**
    * {@code -parsingLimitBytes} used to be pure decoration: parsed, logged, never enforced anywhere. Univocity's own
    * internal buffering means the exact row where the cap fires cannot be pinned without depending on its buffer
    * size, so this only pins that a small byte budget on a source many times its size stops the import well short
    * of the end - which no test before this issue could have failed, because nothing checked the flag at all.
+   * <p>
+   * Not asserted as "at least one row lands": the byte check now runs before the header-row skip too (see
+   * {@link #csvParsingLimitBytesStopsTheImportEvenWhileSkippingRows()}), and Univocity's own internal buffering can
+   * legitimately push {@code parser.getPosition()} past a budget this small before the very first row is even
+   * handed back, importing zero rows - which is the check doing its job, not a defect.
    */
   @Test
   void csvDocumentsHonourParsingLimitBytes() throws Exception {
@@ -157,9 +200,43 @@ class Issue7482ParsingLimitAppliesToAllFormatsTest {
           .split(" ")).load();
 
       try (final Database db = new DatabaseFactory(databasePath).open()) {
-        final long imported = db.countType("Document", true);
+        final long imported = db.getSchema().existsType("Document") ? db.countType("Document", true) : 0;
         assertThat(imported).as("a 200-byte budget on a source many times larger must stop the import short of the end")
-            .isPositive().isLessThan(rows);
+            .isLessThan(rows);
+      }
+    } finally {
+      dropDatabase(databasePath);
+      csv.delete();
+      TestHelper.checkActiveDatabases();
+    }
+  }
+
+  /**
+   * The byte-limit check has to run BEFORE the skip-row {@code continue} that {@code -documentsSkipEntries} takes,
+   * not only after a row is actually processed: checked only at the bottom of the loop, a long run of skipped rows
+   * would keep reading (and re-checking nothing) for as long as skipping continued, so a tiny byte budget entirely
+   * inside the skipped block would not stop the import until the skip block ended - importing every row after it
+   * regardless of the budget. With the fix, the loop breaks WHILE still skipping, before a single row is imported.
+   */
+  @Test
+  void csvParsingLimitBytesStopsTheImportEvenWhileSkippingRows() throws Exception {
+    final int rows = 100;
+    final int skipRows = 80;
+    final File csv = writeFile("importer-7482-csv-bytes-skip.csv", csvOf(rows));
+    final String databasePath = "target/databases/test-import-7482-csv-bytes-skip";
+    FileUtils.deleteRecursively(new File(databasePath));
+
+    try {
+      // -documentsSkipEntries 80: THE FIRST 80 (OUT OF 101, HEADER INCLUDED) ROWS ARE SKIPPED VIA THE LOOP'S
+      // 'continue'. A 50-BYTE BUDGET LANDS WELL INSIDE THAT SKIPPED PREFIX.
+      new Importer(("-url file://" + csv.getAbsolutePath() + " -database " + databasePath
+          + " -documentsSkipEntries " + skipRows + " -parsingLimitBytes 50").split(" ")).load();
+
+      try (final Database db = new DatabaseFactory(databasePath).open()) {
+        assertThat(db.getSchema().existsType("Document") ? db.countType("Document", true) : 0)
+            .as("a 50-byte budget entirely inside the 80-row skipped prefix must stop the import before any of the "
+                + "20 rows after the skip block are ever reached, not after the whole skipped prefix is read")
+            .isZero();
       }
     } finally {
       dropDatabase(databasePath);

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue7482ParsingLimitAppliesToAllFormatsTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue7482ParsingLimitAppliesToAllFormatsTest.java
@@ -21,6 +21,8 @@ package com.arcadedb.integration.importer;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.integration.TestHelper;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
 import com.arcadedb.utility.FileUtils;
 
 import org.junit.jupiter.api.Test;
@@ -241,6 +243,85 @@ class Issue7482ParsingLimitAppliesToAllFormatsTest {
     } finally {
       dropDatabase(databasePath);
       csv.delete();
+      TestHelper.checkActiveDatabases();
+    }
+  }
+
+  /**
+   * RDF got the identical {@code parsingLimitBytes} guard as CSV, but only CSV had an end-to-end test exercising
+   * it; this pins the same claim for RDF's own row loop.
+   */
+  @Test
+  void rdfHonoursParsingLimitBytes() throws Exception {
+    final int triples = 500;
+    final StringBuilder content = new StringBuilder(triples * 40);
+    for (int i = 1; i <= triples; ++i)
+      content.append("<http://a/s").append(i).append("> <http://a/rel> <http://a/o").append(i).append("> .\n");
+    final File file = writeFile("importer-7482-rdf-bytes.nt", content.toString());
+    final String databasePath = "target/databases/test-import-7482-rdf-bytes";
+    FileUtils.deleteRecursively(new File(databasePath));
+
+    // THE VERTEX TYPE RDFImporterFormat RESOLVES SUBJECTS/OBJECTS AGAINST: AN RDF SOURCE'S OWN ANALYSIS ONLY
+    // REGISTERS THE EDGE TYPE, THE SAME SETUP EVERY OTHER RDFImporterFormat CLI TEST USES.
+    try (final Database seed = new DatabaseFactory(databasePath).create()) {
+      seed.transaction(() -> {
+        seed.getSchema().createVertexType("Node").createProperty("id", Type.STRING);
+        seed.getSchema().getType("Node").getOrCreateTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, new String[] { "id" });
+        seed.getSchema().createEdgeType("Related");
+      });
+    }
+
+    try {
+      new Importer(("-url file://" + file.getAbsolutePath() + " -database " + databasePath + " -edgeType Related"
+          + " -parsingLimitBytes 200").split(" ")).load();
+
+      try (final Database db = new DatabaseFactory(databasePath).open()) {
+        assertThat(db.countType("Related", true))
+            .as("a 200-byte budget on a source many times larger must stop the import short of the end")
+            .isLessThan(triples);
+      }
+    } finally {
+      dropDatabase(databasePath);
+      file.delete();
+      TestHelper.checkActiveDatabases();
+    }
+  }
+
+  /**
+   * XMLImporterFormat.load() got its own {@code parsingLimitBytes} guard measured via
+   * {@code xmlReader.getLocation().getCharacterOffset()} (unlike every other format, to stay precise despite
+   * {@code XMLStreamReader}'s own internal buffering - see the comment at the guard). Only {@code analyze()}'s
+   * matching guard had an end-to-end test before this; this pins {@code load()}'s.
+   */
+  @Test
+  void xmlLoadHonoursParsingLimitBytes() throws Exception {
+    final StringBuilder xml = new StringBuilder("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<root>\n");
+    for (int i = 1; i <= ROWS; ++i)
+      xml.append("  <item id=\"").append(i).append("\"/>\n");
+    xml.append("</root>");
+    final File file = writeFile("importer-7482-xml-bytes.xml", xml.toString());
+    final String databasePath = "target/databases/test-import-7482-xml-bytes";
+    FileUtils.deleteRecursively(new File(databasePath));
+
+    // A BUDGET LANDING RIGHT AFTER THE SECOND <item>: xmlReader.getLocation().getCharacterOffset() IS THE PARSER'S
+    // OWN LOGICAL POSITION, NOT A BUFFER-SIZE-GRANULAR ONE, SO (UNLIKE THE CSV/RDF/Jsonl BYTE TESTS ABOVE) THE
+    // EXACT STOPPING POINT CAN BE PINNED HERE.
+    final int budget = xml.indexOf("<item id=\"3");
+
+    try {
+      new Importer(
+          ("-url file://" + file.getAbsolutePath() + " -database " + databasePath + " -parsingLimitBytes " + budget)
+              .split(" ")).load();
+
+      try (final Database db = new DatabaseFactory(databasePath).open()) {
+        assertThat(db.countType("v_item", true))
+            .as("the budget lands right after the 2nd item's closing tag, so exactly 2 objects should have been "
+                + "handed to createRecord() before the guard fired")
+            .isEqualTo(2);
+      }
+    } finally {
+      dropDatabase(databasePath);
+      file.delete();
       TestHelper.checkActiveDatabases();
     }
   }

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue7482ParsingLimitAppliesToAllFormatsTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue7482ParsingLimitAppliesToAllFormatsTest.java
@@ -106,6 +106,42 @@ class Issue7482ParsingLimitAppliesToAllFormatsTest {
   }
 
   /**
+   * Jsonl got the identical {@code parsingLimitBytes} guard as CSV/RDF, checked at the top of its {@code while}
+   * loop before the {@code -onRowError skip} {@code continue} - but only CSV's own row loop had an end-to-end test
+   * exercising the guard. This pins the same claim for Jsonl's.
+   */
+  @Test
+  void jsonlHonoursParsingLimitBytes() throws Exception {
+    final int rows = 500;
+    final StringBuilder jsonl = new StringBuilder();
+    for (int i = 0; i < rows; i++)
+      jsonl.append("{\"t\":\"d\",\"c\":{\"t\":\"Doc\",\"r\":\"#1:").append(i).append("\",\"p\":{\"n\":\"v").append(i)
+          .append("\"}}}\n");
+    final File file = writeFile("importer-7482-jsonl-bytes.jsonl", jsonl.toString());
+    final String databasePath = "target/databases/test-import-7482-jsonl-bytes";
+    FileUtils.deleteRecursively(new File(databasePath));
+
+    try (final Database setup = new DatabaseFactory(databasePath).create()) {
+      setup.transaction(() -> setup.getSchema().createDocumentType("Doc"));
+    }
+
+    try {
+      new Importer(("-url file://" + file.getAbsolutePath() + " -database " + databasePath + " -parsingLimitBytes 200")
+          .split(" ")).load();
+
+      try (final Database db = new DatabaseFactory(databasePath).open()) {
+        final long imported = db.query("sql", "select count(*) as c from Doc").next().<Long>getProperty("c");
+        assertThat(imported).as("a 200-byte budget on a source many times larger must stop the import short of the end")
+            .isLessThan(rows);
+      }
+    } finally {
+      dropDatabase(databasePath);
+      file.delete();
+      TestHelper.checkActiveDatabases();
+    }
+  }
+
+  /**
    * The array-based JSON format needed the byte limit threaded through two more call levels than the others, and
    * the array has to be fully drained (via {@code JsonReader#skipValue()}) once the limit trips, or
    * {@code reader.endArray()} throws: this pins that the limit stops importing AND that the reader is left in a

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue7482ParsingLimitAppliesToAllFormatsTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue7482ParsingLimitAppliesToAllFormatsTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.integration.TestHelper;
+import com.arcadedb.utility.FileUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7482: {@code -parsingLimitEntries} was read by {@code ImporterSettings.parseParameter} and echoed back in
+ * {@code SourceDiscovery}'s recognition log line, but only {@code XMLImporterFormat} (after issue #7341) and the
+ * vector route ({@code TextEmbeddingsImporterLSM}) actually enforced it. Every other {@code FormatImporter} -
+ * {@code CSVImporterFormat}, {@code JSONImporterFormat}, {@code JsonlImporterFormat}, {@code RDFImporterFormat} -
+ * imported the whole source while logging the limit as if it were in effect.
+ * <p>
+ * {@code -parsingLimitBytes} was worse: parsed, stored and logged, but enforced by NOTHING - {@code Parser}'s own
+ * byte-limit machinery exists but every construction site passed {@code 0}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7482ParsingLimitAppliesToAllFormatsTest {
+
+  private static final int ROWS = 6;
+
+  @Test
+  void csvDocumentsHonourParsingLimitEntries() throws Exception {
+    final File csv = writeFile("importer-7482-csv.csv", csvOf(ROWS));
+    final String databasePath = "target/databases/test-import-7482-csv";
+    FileUtils.deleteRecursively(new File(databasePath));
+
+    try {
+      // context.parsed COUNTS EVERY ROW read() HANDS BACK, THE HEADER INCLUDED (THE SAME COUNTER RDFImporterFormat's
+      // OWN COMMENT DESCRIBES): 1 HEADER ROW + 2 DATA ROWS = A LIMIT OF 3 TO GET EXACTLY 2 DOCUMENTS.
+      new Importer(("-url file://" + csv.getAbsolutePath() + " -database " + databasePath + " -parsingLimitEntries 3")
+          .split(" ")).load();
+
+      try (final Database db = new DatabaseFactory(databasePath).open()) {
+        assertThat(db.countType("Document", true))
+            .as("-parsingLimitEntries 3 must cap a CSV document import at 2 data rows (plus the 1 header row it also "
+                + "counts), not import the whole file")
+            .isEqualTo(2);
+      }
+    } finally {
+      dropDatabase(databasePath);
+      csv.delete();
+      TestHelper.checkActiveDatabases();
+    }
+  }
+
+  @Test
+  void jsonlHonoursParsingLimitEntries() throws Exception {
+    final StringBuilder jsonl = new StringBuilder();
+    for (int i = 0; i < ROWS; i++)
+      jsonl.append("{\"t\":\"d\",\"c\":{\"t\":\"Doc\",\"r\":\"#1:").append(i).append("\",\"p\":{\"n\":\"v").append(i)
+          .append("\"}}}\n");
+    final File file = writeFile("importer-7482-jsonl.jsonl", jsonl.toString());
+    final String databasePath = "target/databases/test-import-7482-jsonl";
+    FileUtils.deleteRecursively(new File(databasePath));
+
+    try (final Database setup = new DatabaseFactory(databasePath).create()) {
+      setup.transaction(() -> setup.getSchema().createDocumentType("Doc"));
+    }
+
+    try {
+      new Importer(
+          ("-url file://" + file.getAbsolutePath() + " -database " + databasePath + " -parsingLimitEntries 2").split(" "))
+          .load();
+
+      try (final Database db = new DatabaseFactory(databasePath).open()) {
+        assertThat(db.query("sql", "select count(*) as c from Doc").next().<Long>getProperty("c"))
+            .as("-parsingLimitEntries 2 must cap a jsonl import at 2 records")
+            .isEqualTo(2L);
+      }
+    } finally {
+      dropDatabase(databasePath);
+      file.delete();
+      TestHelper.checkActiveDatabases();
+    }
+  }
+
+  /**
+   * The array-based JSON format needed the byte limit threaded through two more call levels than the others, and
+   * the array has to be fully drained (via {@code JsonReader#skipValue()}) once the limit trips, or
+   * {@code reader.endArray()} throws: this pins that the limit stops importing AND that the reader is left in a
+   * state {@code endArray()} accepts.
+   */
+  @Test
+  void jsonArrayHonoursParsingLimitEntriesWithoutBreakingTheReader() throws Exception {
+    final StringBuilder json = new StringBuilder("{\"Users\":[");
+    for (int i = 0; i < ROWS; i++) {
+      if (i > 0)
+        json.append(',');
+      json.append("{\"id\":\"").append(i).append("\"}");
+    }
+    json.append("]}");
+    final File file = writeFile("importer-7482-json.json", json.toString());
+    final String databasePath = "target/databases/test-import-7482-json";
+    FileUtils.deleteRecursively(new File(databasePath));
+
+    try {
+      new Importer(("-url file://" + file.getAbsolutePath() + " -database " + databasePath
+          + " -forceDatabaseCreate true -mapping {'Users':[]} -parsingLimitEntries 2").split(" ")).load();
+
+      try (final Database db = new DatabaseFactory(databasePath).open()) {
+        assertThat(db.countType("Document", true))
+            .as("-parsingLimitEntries 2 must cap a JSON array import at 2 records, and the reader must still close "
+                + "cleanly (no unread array elements left for reader.endArray() to choke on)")
+            .isEqualTo(2);
+      }
+    } finally {
+      dropDatabase(databasePath);
+      file.delete();
+      TestHelper.checkActiveDatabases();
+    }
+  }
+
+  /**
+   * {@code -parsingLimitBytes} used to be pure decoration: parsed, logged, never enforced anywhere. Univocity's own
+   * internal buffering means the exact row where the cap fires cannot be pinned without depending on its buffer
+   * size, so this only pins that a small byte budget on a source many times its size stops the import well short
+   * of the end - which no test before this issue could have failed, because nothing checked the flag at all.
+   */
+  @Test
+  void csvDocumentsHonourParsingLimitBytes() throws Exception {
+    final int rows = 500;
+    final File csv = writeFile("importer-7482-csv-bytes.csv", csvOf(rows));
+    final String databasePath = "target/databases/test-import-7482-csv-bytes";
+    FileUtils.deleteRecursively(new File(databasePath));
+
+    try {
+      new Importer(("-url file://" + csv.getAbsolutePath() + " -database " + databasePath + " -parsingLimitBytes 200")
+          .split(" ")).load();
+
+      try (final Database db = new DatabaseFactory(databasePath).open()) {
+        final long imported = db.countType("Document", true);
+        assertThat(imported).as("a 200-byte budget on a source many times larger must stop the import short of the end")
+            .isPositive().isLessThan(rows);
+      }
+    } finally {
+      dropDatabase(databasePath);
+      csv.delete();
+      TestHelper.checkActiveDatabases();
+    }
+  }
+
+  // -----------------------------------------------------------------------------------------------------------
+
+  private static String csvOf(final int rows) {
+    final StringBuilder csv = new StringBuilder("id,name\n");
+    for (int i = 0; i < rows; i++)
+      csv.append(i).append(",name-").append(i).append('\n');
+    return csv.toString();
+  }
+
+  private static File writeFile(final String fileName, final String content) throws Exception {
+    final File file = new File("target/" + fileName);
+    file.getParentFile().mkdirs();
+    Files.writeString(file.toPath(), content, StandardCharsets.UTF_8);
+    return file;
+  }
+
+  private static void dropDatabase(final String databasePath) {
+    final DatabaseFactory factory = new DatabaseFactory(databasePath);
+    if (factory.exists())
+      factory.open().drop();
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue7483ConsoleProgressMonotonicTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue7483ConsoleProgressMonotonicTest.java
@@ -23,6 +23,9 @@ import com.arcadedb.integration.importer.format.FormatImporter;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -63,5 +66,40 @@ class Issue7483ConsoleProgressMonotonicTest {
         .as("the figure the log prints (and the next call's rate is measured against) is the import-wide total, "
             + "not the just-reset per-phase counter, so it must never go backwards across a phase boundary")
         .isEqualTo(105);
+  }
+
+  /**
+   * The rate half of the same fix. Reading {@code getParsedTotal()} as the numerator is not enough on its own:
+   * {@code ImporterContext#beginPhase()} has to rebase {@code lastParsed} to the cumulative total AS OF the
+   * boundary, not zero it, or the very next call's {@code (parsedTotal - lastParsed) / deltaInSecs} divides the
+   * WHOLE import's total-so-far by one tick's elapsed time - a rate spike as visible as the negative-rate bug this
+   * reset originally fixed, just inflated instead of negative. Pinned by parsing the printed rate straight out of
+   * the log line, not just the raw counter state after the call, since that state looks identical either way.
+   */
+  @Test
+  void printProgressDoesNotSpikeTheRateAcrossAPhaseBoundary() {
+    final ImporterSettings settings = new ImporterSettings();
+    settings.verboseLevel = 2;
+    final ImporterContext context = new ImporterContext();
+    final List<String> lines = new ArrayList<>();
+    final ConsoleLogger logger = new ConsoleLogger(settings.verboseLevel, lines::add);
+    final FormatImporter importer = new CSVImporterFormat();
+
+    context.parsed.set(100);
+    importer.printProgress(settings, context, null, null, logger);
+
+    context.beginPhase();
+    context.parsed.set(5);
+    importer.printProgress(settings, context, null, null, logger);
+
+    assertThat(lines).hasSize(2);
+    // deltaInSecs IS FORCED TO 1 WHEN THE CLOCK HASN'T ADVANCED (BOTH CALLS HAPPEN WITHIN THE SAME MILLISECOND
+    // HERE), SO THE PRINTED RATE IS DIRECTLY (parsedTotal - lastParsed): 5 FOR THE NEW PHASE'S OWN PROGRESS IF
+    // lastParsed WAS CORRECTLY REBASED TO 100, OR 105 (THE WHOLE IMPORT'S TOTAL) IF IT WAS WRONGLY ZEROED.
+    assertThat(lines.get(1))
+        .as("the second phase parsed only 5 rows of its own since the boundary, so the printed rate must read that, "
+            + "not the cumulative 105")
+        .contains("Parsed 105 (5/sec)")
+        .doesNotContain("(105/sec)");
   }
 }

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue7483ConsoleProgressMonotonicTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue7483ConsoleProgressMonotonicTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.integration.importer.format.CSVImporterFormat;
+import com.arcadedb.integration.importer.format.FormatImporter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7483's CLI-side half (raised in comment by robfrank): {@code FormatImporter#printProgress}, used by every
+ * format's {@code AbstractImporter.printProgress()}, printed {@code context.parsed.get()} as the running
+ * "Parsed %,d" figure. That counter is per-phase and is reset to zero by {@code ImporterContext#beginPhase()} at
+ * every phase boundary (issue #7342), so a multi-phase CLI run (documents + vertices + edges) printed a total that
+ * climbed, dropped back to near zero at the phase boundary, then climbed again - the console-log twin of the SSE
+ * stream's #7483, just on stdout instead of {@code GET /api/v1/progress}.
+ * <p>
+ * {@code context.getParsedTotal()} is the monotonic, import-wide figure both readers want (per the same comment),
+ * so {@code printProgress} now reads it, and {@code lastParsed} - what the NEXT call subtracts to turn the counter
+ * into a rate - is kept in the same unit so the rate itself cannot go negative either.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7483ConsoleProgressMonotonicTest {
+
+  @Test
+  void printProgressTracksTheImportWideTotalAcrossAPhaseBoundary() {
+    final ImporterSettings settings = new ImporterSettings();
+    settings.verboseLevel = 2;
+    final ImporterContext context = new ImporterContext();
+    final ConsoleLogger logger = new ConsoleLogger(settings.verboseLevel);
+    final FormatImporter importer = new CSVImporterFormat();
+
+    context.parsed.set(100);
+    importer.printProgress(settings, context, null, null, logger);
+    assertThat(context.lastParsed).as("the first phase's own count").isEqualTo(100);
+
+    // PHASE BOUNDARY: THE RAW PER-PHASE COUNTER RESETS TO 0 HERE. THIS IS THE EXACT MOMENT THE LOG USED TO PRINT A
+    // SMALLER "Parsed" FIGURE THAN THE LINE BEFORE IT.
+    context.beginPhase();
+    context.parsed.set(5);
+    importer.printProgress(settings, context, null, null, logger);
+
+    assertThat(context.lastParsed)
+        .as("the figure the log prints (and the next call's rate is measured against) is the import-wide total, "
+            + "not the just-reset per-phase counter, so it must never go backwards across a phase boundary")
+        .isEqualTo(105);
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue7485XmlAnalysisLimitTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue7485XmlAnalysisLimitTest.java
@@ -95,6 +95,26 @@ class Issue7485XmlAnalysisLimitTest {
     assertThat(analyzedSchema.getEntity("item").getProperties()).hasSize(limit);
   }
 
+  /**
+   * Both flags passed together: the deprecated one still wins (a caller who bothered to pass it almost certainly
+   * means it), and it is read with the same range as the field it overrides - {@code getLongValue}, not
+   * {@code getIntValue} - so a caller cannot silently lose precision by using the deprecated spelling.
+   */
+  @Test
+  void whenBothFlagsAreSetTheDeprecatedAliasWinsAtFullLongRange() throws Exception {
+    final ImporterSettings settings = new ImporterSettings();
+    settings.parseParameter("analysisLimitEntries", "5");
+    settings.options.put("analyzingLimitEntries", "2");
+
+    final AnalyzedSchema analyzedSchema = new AnalyzedSchema(100);
+    new XMLImporterFormat().analyze(AnalyzedEntity.EntityType.DOCUMENT, parserOf(distinctlyPropertiedXml()), settings,
+        analyzedSchema);
+
+    assertThat(analyzedSchema.getEntity("item").getProperties())
+        .as("the deprecated -analyzingLimitEntries (2) must win over -analysisLimitEntries (5) when both are set")
+        .hasSize(2);
+  }
+
   @Test
   void analysisLimitBytesCapsXmlSchemaAnalysisToo() throws Exception {
     final String xml = distinctlyPropertiedXml();

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue7485XmlAnalysisLimitTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue7485XmlAnalysisLimitTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.integration.importer.format.XMLImporterFormat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7485: {@code XMLImporterFormat.analyze()} read its entries cap from the generic options map under the
+ * misspelled, default-less key {@code analyzingLimitEntries} instead of the real {@code ImporterSettings} field
+ * {@code analysisLimitEntries} - the one with a default of 10000 that {@code CSVImporterFormat.analyze()} already
+ * honours - so:
+ * <ul>
+ *   <li>{@code -analysisLimitEntries 500}, the documented flag, did nothing on an XML source;</li>
+ *   <li>with neither flag passed, XML schema analysis was UNBOUNDED, walking the entire file before {@code load()}
+ *   walks it a second time;</li>
+ *   <li>there was no XML equivalent of {@code -analysisLimitBytes} at all.</li>
+ * </ul>
+ * The fix reads {@code settings.analysisLimitEntries} (falling back to the old {@code analyzingLimitEntries} key
+ * only when a caller still passes it explicitly) and adds the same {@code -analysisLimitBytes} guard
+ * {@code CSVImporterFormat.analyze()} already has.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7485XmlAnalysisLimitTest {
+
+  private static final int OBJECTS = 6;
+
+  @Test
+  void theDefaultAnalysisLimitEntriesCapsXmlSchemaAnalysis() throws Exception {
+    final ImporterSettings settings = new ImporterSettings();
+    settings.analysisLimitEntries = 3;
+
+    final AnalyzedSchema analyzedSchema = new AnalyzedSchema(100);
+    new XMLImporterFormat().analyze(AnalyzedEntity.EntityType.DOCUMENT, parserOf(distinctlyPropertiedXml()), settings,
+        analyzedSchema);
+
+    assertThat(analyzedSchema.getEntity("item").getProperties())
+        .as("-analysisLimitEntries - the real, defaulted setting, not the misspelled 'analyzingLimitEntries' - must "
+            + "cap XML schema analysis the same way it already caps CSV's")
+        .hasSize(3);
+  }
+
+  @Test
+  void withNoLimitSetAtAllAnalysisIsStillUnbounded() throws Exception {
+    final AnalyzedSchema analyzedSchema = new AnalyzedSchema(100);
+    final ImporterSettings settings = new ImporterSettings();
+    // ImporterSettings' OWN DEFAULT (10000) IS FAR ABOVE OBJECTS, SO THE WHOLE SOURCE IS STILL ANALYZED - THIS IS
+    // NOT "NO CAP", IT IS "A GENEROUS DEFAULT CAP", EXACTLY LIKE analysisLimitBytes/analysisLimitEntries FOR CSV.
+    new XMLImporterFormat().analyze(AnalyzedEntity.EntityType.DOCUMENT, parserOf(distinctlyPropertiedXml()), settings,
+        analyzedSchema);
+
+    assertThat(analyzedSchema.getEntity("item").getProperties()).hasSize(OBJECTS);
+  }
+
+  /**
+   * The deprecated alias some script out there may already pass: still honoured, and still takes priority when
+   * explicitly set (mirroring how a caller who set BOTH old and new flags almost certainly means the one they
+   * bothered to pass).
+   */
+  @ParameterizedTest
+  @ValueSource(ints = { 1, 2, 4 })
+  void theDeprecatedAnalyzingLimitEntriesAliasStillWorks(final int limit) throws Exception {
+    final ImporterSettings settings = new ImporterSettings();
+    settings.options.put("analyzingLimitEntries", String.valueOf(limit));
+
+    final AnalyzedSchema analyzedSchema = new AnalyzedSchema(100);
+    new XMLImporterFormat().analyze(AnalyzedEntity.EntityType.DOCUMENT, parserOf(distinctlyPropertiedXml()), settings,
+        analyzedSchema);
+
+    assertThat(analyzedSchema.getEntity("item").getProperties()).hasSize(limit);
+  }
+
+  @Test
+  void analysisLimitBytesCapsXmlSchemaAnalysisToo() throws Exception {
+    final String xml = distinctlyPropertiedXml();
+    // A byte budget that lands partway through the source: strictly less than the whole thing, but enough to reach
+    // past the opening <root> and at least the first object.
+    final int budget = xml.indexOf("<item p2") ;
+
+    final ImporterSettings settings = new ImporterSettings();
+    settings.analysisLimitBytes = budget;
+
+    final AnalyzedSchema analyzedSchema = new AnalyzedSchema(100);
+    new XMLImporterFormat().analyze(AnalyzedEntity.EntityType.DOCUMENT, parserOf(xml), settings, analyzedSchema);
+
+    assertThat(analyzedSchema.getEntity("item").getProperties().size())
+        .as("-analysisLimitBytes must stop analysis before the byte budget's worth of the source has all been read, "
+            + "which for a source with more than one object means fewer objects analyzed than the whole file has")
+        .isPositive().isLessThan(OBJECTS);
+  }
+
+  // -----------------------------------------------------------------------------------------------------------
+
+  private static String distinctlyPropertiedXml() {
+    final StringBuilder xml = new StringBuilder("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<root>\n");
+    for (int i = 1; i <= OBJECTS; ++i)
+      xml.append("  <item p").append(i).append("=\"v\"/>\n");
+    return xml.append("</root>").toString();
+  }
+
+  private static Parser parserOf(final String content) throws Exception {
+    final byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+    return new Parser(new Source("test.xml", new ByteArrayInputStream(bytes), bytes.length, false, null, null), 0);
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -1613,8 +1613,22 @@ public class ArcadeDBServer {
                 database = createDatabase(dbName, defaultDbMode);
               }
               try (final var rs = database.command("sql", "import database " + commandParams)) {
-                // drain not needed: the import command produces no rows we consume here.
-                // try-with-resources ensures the result set / execution plan is released.
+                // ImportDatabaseStatement REPORTS EXACTLY ONE CLASS OF FAILURE IN-BAND RATHER THAN BY THROWING: A
+                // FAILED probeOnly PROBE, AND (SINCE ISSUE #7461) A 'WITH ...' SETTING VALUE THE IMPORTER REFUSES,
+                // BOTH AS THE SINGLE ROW {"result":"FAIL","reason":...}. DISCARDING THAT ROW USED TO LEAVE dbName
+                // CREATED AND EMPTY WITH NOTHING IN THE LOG SAYING WHY (ISSUE #7484). TREATED THE SAME AS A FAILED
+                // 'restore:' ABOVE - LOUD AND FATAL TO STARTUP - RATHER THAN LOGGED AND IGNORED: A STARTUP
+                // MISCONFIGURATION THAT SILENTLY LEAVES A DEFAULT DATABASE EMPTY IS WORSE THAN ONE THAT REFUSES TO
+                // START, AND THE TWO STARTUP COMMANDS NOW ANSWER A BAD SOURCE THE SAME WAY.
+                if (rs.hasNext()) {
+                  final var row = rs.next();
+                  final String outcome = row.getProperty("result");
+                  if (!"OK".equals(outcome)) {
+                    final String reason = row.getProperty("reason");
+                    throw new CommandExecutionException(
+                        "Startup 'import:' command failed to import default database '" + dbName + "': " + reason);
+                  }
+                }
               }
               break;
 

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -441,7 +441,20 @@ public class ArcadeDBServer {
     // DATABASES SO A RECOVERED ONE IS REGISTERED RATHER THAN MISTAKEN FOR ABSENT AND RECREATED (ISSUE #7129).
     loadDatabases(true);
 
-    loadDefaultDatabases();
+    try {
+      loadDefaultDatabases();
+    } catch (final Exception e) {
+      // Security, the HTTP service and every BEFORE_HTTP_ON/AFTER_HTTP_ON plugin are already up at this point,
+      // and a failing 'restore:' or 'import:' default-database command (issue #7484) can leave one created and
+      // half-initialized. status is still STARTING here - it is only set to ONLINE below - so leaving the
+      // exception to propagate on its own, the way it used to, left every one of those resources running with
+      // no stop() ever called and no path back to OFFLINE: main() has already discarded this ArcadeDBServer
+      // instance by the time the exception reaches it. stop() before rethrowing is the same recovery
+      // lifecycleEvent(SERVER_UP)'s own failure handler below already uses, and it is reentrant with the lock
+      // start() is still holding (see the field comment on lifecycleLock).
+      stop();
+      throw e;
+    }
 
     pluginManager.startPlugins(ServerPlugin.PluginInstallationPriority.AFTER_DATABASES_OPEN);
 

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -1551,9 +1551,17 @@ public class ServerControlPlane {
     timer.schedule(new TimerTask() {
       @Override
       public void run() {
-        final long parsed = parsedCounter.getAsLong();
-        if (parsed > 0)
-          listener.onImportCounters(parsed, vertexCounter.get(), edgeCounter.get());
+        try {
+          final long parsed = parsedCounter.getAsLong();
+          if (parsed > 0)
+            listener.onImportCounters(parsed, vertexCounter.get(), edgeCounter.get());
+        } catch (final Exception ignored) {
+          // Same policy as the one-time lookup above: a tick that cannot report progress must not take the rest
+          // of them down with it. Without this, a failure here - parsedTotalSupplier()'s reflective invoke()
+          // wrapped as an unchecked exception, most plausibly - would propagate out of TimerTask.run() uncaught,
+          // which kills this Timer's background thread for good: every later tick for the rest of the import
+          // silently stops scheduling, with nothing in the log to say why.
+        }
       }
     }, 1000, 1000);
   }

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -49,6 +49,7 @@ import com.arcadedb.utility.IPAddressBlocklist;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.net.InetAddress;
 import java.net.URI;
@@ -70,6 +71,7 @@ import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
 import java.util.logging.Level;
 
 /**
@@ -1523,8 +1525,8 @@ public class ServerControlPlane {
   /**
    * Samples the importer's counters once a second for as long as the import runs.
    * <p>
-   * The three {@code AtomicLong}s are resolved <b>once</b>, here, rather than on every tick: neither
-   * the context nor its class changes for the life of the import, so a reflective lookup per field
+   * The parsed-rows supplier and the two {@code AtomicLong}s are resolved <b>once</b>, here, rather than on every
+   * tick: neither the context nor its class changes for the life of the import, so a reflective lookup per field
    * per second is work with no answer that could differ. A build whose {@code ImporterContext} does
    * not carry all three schedules nothing at all, rather than failing quietly every second.
    */
@@ -1532,12 +1534,12 @@ public class ServerControlPlane {
     if (context == null)
       return;
 
-    final AtomicLong parsedCounter;
+    final LongSupplier parsedCounter;
     final AtomicLong vertexCounter;
     final AtomicLong edgeCounter;
     try {
       final Class<?> ctxClass = context.getClass();
-      parsedCounter = (AtomicLong) ctxClass.getField("parsed").get(context);
+      parsedCounter = parsedTotalSupplier(ctxClass, context);
       vertexCounter = (AtomicLong) ctxClass.getField("createdVertices").get(context);
       edgeCounter = (AtomicLong) ctxClass.getField("createdEdges").get(context);
     } catch (final Exception ignored) {
@@ -1549,11 +1551,37 @@ public class ServerControlPlane {
     timer.schedule(new TimerTask() {
       @Override
       public void run() {
-        final long parsed = parsedCounter.get();
+        final long parsed = parsedCounter.getAsLong();
         if (parsed > 0)
           listener.onImportCounters(parsed, vertexCounter.get(), edgeCounter.get());
       }
     }, 1000, 1000);
+  }
+
+  /**
+   * {@code ImporterContext#getParsedTotal()} - the phases already finished plus the one still running, monotonic
+   * for the life of the import - when this build carries it; the raw per-phase {@code parsed} field otherwise, for
+   * a server running against an {@code arcadedb-integration} jar older than issue #7342.
+   * <p>
+   * {@code parsed} alone is reset to zero at the start of every phase ({@code ImporterContext#beginPhase()}), so on
+   * a multi-phase {@code IMPORT DATABASE} (documents + vertices + edges) sampling it directly made the reported
+   * {@code parsed} figure climb, drop back towards zero at each phase boundary, then climb again - a progress bar
+   * driven off it ran backwards (issue #7483).
+   */
+  private static LongSupplier parsedTotalSupplier(final Class<?> ctxClass, final Object context) throws ReflectiveOperationException {
+    try {
+      final Method getParsedTotal = ctxClass.getMethod("getParsedTotal");
+      return () -> {
+        try {
+          return (long) getParsedTotal.invoke(context);
+        } catch (final ReflectiveOperationException e) {
+          throw new IllegalStateException(e);
+        }
+      };
+    } catch (final NoSuchMethodException e) {
+      final AtomicLong parsed = (AtomicLong) ctxClass.getField("parsed").get(context);
+      return parsed::get;
+    }
   }
 
   /**

--- a/server/src/test/java/com/arcadedb/server/Issue7483ImportProgressCounterMonotonicTest.java
+++ b/server/src/test/java/com/arcadedb/server/Issue7483ImportProgressCounterMonotonicTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import com.arcadedb.integration.importer.ImporterContext;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7483: {@code ServerControlPlane.scheduleImportCounters()} used to resolve the {@code AtomicLong} behind
+ * {@code ImporterContext#parsed} once and sample it directly. That counter is per-phase - it is reset to zero by
+ * {@code ImporterContext#beginPhase()} at every phase boundary of a multi-phase import (documents, then vertices,
+ * then edges) - so a client watching the SSE/{@code GET /api/v1/progress} stream saw the reported {@code parsed}
+ * figure climb, drop back towards zero at each boundary, then climb again.
+ * <p>
+ * {@code ImporterContext#getParsedTotal()} is the monotonic import-wide equivalent (phases already finished plus
+ * the one still running), so {@code parsedTotalSupplier()} now prefers it, falling back to the raw {@code parsed}
+ * field only for a server running against an {@code arcadedb-integration} build that predates it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7483ImportProgressCounterMonotonicTest {
+
+  @Test
+  void parsedTotalSupplierReadsTheMonotonicImportWideTotal() throws Exception {
+    final ImporterContext context = new ImporterContext();
+    context.parsed.set(500);
+
+    final LongSupplier supplier = parsedTotalSupplier(context);
+    assertThat(supplier.getAsLong()).isEqualTo(500);
+
+    // End of the first phase: the raw per-phase counter resets to 0 here - this is exactly the moment the SSE
+    // stream used to report a value smaller than the one before it.
+    context.beginPhase();
+    final long afterFirstPhaseBoundary = supplier.getAsLong();
+    assertThat(afterFirstPhaseBoundary)
+        .as("a phase boundary must not lose progress already reported")
+        .isEqualTo(500);
+
+    context.parsed.addAndGet(10);
+    assertThat(supplier.getAsLong())
+        .as("the second phase's own progress is added on top of the first phase's total")
+        .isEqualTo(510);
+
+    // A second phase boundary: same check from the other side, now with two phases already folded in.
+    context.beginPhase();
+    assertThat(supplier.getAsLong())
+        .as("a phase boundary rolls 'parsed' into the accumulator; the reported total must never go backwards")
+        .isGreaterThanOrEqualTo(afterFirstPhaseBoundary);
+  }
+
+  /**
+   * A stand-in for an {@code ImporterContext} predating issues #7342/#7483: no {@code getParsedTotal()}, just the
+   * raw per-phase field. {@code parsedTotalSupplier()} must still report something rather than schedule nothing.
+   */
+  @Test
+  void fallsBackToTheRawPerPhaseCounterOnAnOlderIntegrationBuild() throws Exception {
+    final LegacyImporterContext legacy = new LegacyImporterContext();
+    legacy.parsed.set(42);
+
+    assertThat(parsedTotalSupplier(legacy).getAsLong()).isEqualTo(42);
+  }
+
+  public static final class LegacyImporterContext {
+    public final AtomicLong parsed = new AtomicLong();
+  }
+
+  private static LongSupplier parsedTotalSupplier(final Object context) throws Exception {
+    final Method method = ServerControlPlane.class.getDeclaredMethod("parsedTotalSupplier", Class.class, Object.class);
+    method.setAccessible(true);
+    return (LongSupplier) method.invoke(null, context.getClass(), context);
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/Issue7484StartupImportFailureTest.java
+++ b/server/src/test/java/com/arcadedb/server/Issue7484StartupImportFailureTest.java
@@ -26,6 +26,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -92,6 +96,40 @@ class Issue7484StartupImportFailureTest extends StaticBaseServerTest {
             + "started by this point stopped again - not merely fail to reach ONLINE while everything it already "
             + "brought up (and status == STARTING) is left running")
         .isEqualTo(ArcadeDBServer.STATUS.OFFLINE);
+  }
+
+  /**
+   * The other of the two failures {@code ImportDatabaseStatement} reports in band (issue #7461): a {@code WITH ...}
+   * setting value the importer refuses, as opposed to {@link #aFailingImportStartupCommandAbortsStartupWithTheReason}'s
+   * unreadable-source probe. Both answer {@code {"result":"FAIL","reason":...}} through the same code path, but
+   * pinning only one of the two leaves the other unverified against a fix that could, in principle, special-case
+   * the probe failure and miss this one.
+   * <p>
+   * A single {@code WITH} setting, deliberately: {@code loadDefaultDatabases()}'s own {@code commands.split(",")}
+   * tokenizes a {@code {...}} block's commands on every comma BEFORE the SQL statement ever sees the text, so a
+   * multi-setting {@code WITH a = 1, b = 2} - fine inside a plain {@code IMPORT DATABASE} SQL command - would be
+   * silently split into "a = 1" (this command) and a bogus second "command" ("b = 2", with no {@code type:} prefix,
+   * logged and ignored) here.
+   */
+  @Test
+  void aRefusedWithSettingAbortsStartupWithTheReason() throws Exception {
+    final Path csv = Path.of("target", "import-7484-badsetting.csv").toAbsolutePath();
+    Files.writeString(csv, "id,name\n1,a\n", StandardCharsets.UTF_8);
+
+    try {
+      server = newServerWithDefaultDatabaseImport("file://" + csv + " WITH documentsSkipEntries = 'not-a-number'");
+
+      assertThatThrownBy(() -> server.start())
+          .as("a WITH setting value the importer cannot use (issue #7461) is the other in-band FAIL this startup "
+              + "command has to answer for, not just an unreadable source")
+          .isInstanceOf(CommandExecutionException.class)
+          .hasMessageContaining(DB_NAME)
+          .hasMessageContaining("not-a-number");
+
+      assertThat(server.getStatus()).isEqualTo(ArcadeDBServer.STATUS.OFFLINE);
+    } finally {
+      Files.deleteIfExists(csv);
+    }
   }
 
   private static ArcadeDBServer newServerWithDefaultDatabaseImport(final String importCommandParams) {

--- a/server/src/test/java/com/arcadedb/server/Issue7484StartupImportFailureTest.java
+++ b/server/src/test/java/com/arcadedb/server/Issue7484StartupImportFailureTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.exception.CommandExecutionException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7484: the {@code import:} form of {@code arcadedb.server.defaultDatabases} ran the {@code IMPORT DATABASE}
+ * SQL statement and threw its one-row result set away:
+ * <pre>
+ * try (final var rs = database.command("sql", "import database " + commandParams)) {
+ *   // drain not needed: the import command produces no rows we consume here.
+ * }
+ * </pre>
+ * {@code ImportDatabaseStatement} reports exactly one class of failure in band rather than by throwing - a failed
+ * {@code probeOnly} probe, and (since issue #7461) a {@code WITH ...} setting value the importer refuses - both as
+ * the single row {@code {"result":"FAIL","reason":...}}. Discarding that row meant a server booted with
+ * {@code -Darcadedb.server.defaultDatabases="mydb[root]{import:file:///bad-source WITH probeOnly = true}"} came up
+ * with {@code mydb} created and EMPTY, with nothing in the log saying the import was refused or why.
+ * <p>
+ * The fix reads the row and, on anything but {@code OK}, aborts startup the same way a failing {@code restore:}
+ * startup command already does - the two commands now answer a bad source the same way, rather than one failing
+ * loudly and the other succeeding silently with an empty database.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7484StartupImportFailureTest extends StaticBaseServerTest {
+  private static final String DB_NAME = "import7484db";
+
+  private ArcadeDBServer server;
+
+  @BeforeEach
+  @Override
+  public void beginTest() {
+    super.beginTest();
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    if (server != null && server.isStarted())
+      server.stop();
+    server = null;
+    super.endTest();
+  }
+
+  @Test
+  void aFailingImportStartupCommandAbortsStartupWithTheReason() {
+    server = newServerWithDefaultDatabaseImport(
+        "file://target/does-not-exist-7484.csv WITH probeOnly = true");
+
+    assertThatThrownBy(() -> server.start())
+        .as("a probeOnly probe against a source that does not exist is the one failure ImportDatabaseStatement "
+            + "reports in band rather than by throwing - discarding that row used to let startup succeed silently")
+        .isInstanceOf(CommandExecutionException.class)
+        .hasMessageContaining(DB_NAME)
+        .hasMessageContaining("import:");
+
+    assertThat(server.isStarted())
+        .as("startup must not report success for a default database whose import was refused")
+        .isFalse();
+  }
+
+  private static ArcadeDBServer newServerWithDefaultDatabaseImport(final String importCommandParams) {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.SERVER_ROOT_PATH, "./target");
+    config.setValue(GlobalConfiguration.SERVER_ROOT_PASSWORD, DEFAULT_PASSWORD_FOR_TESTS);
+    config.setValue(GlobalConfiguration.SERVER_HTTP_IO_THREADS, 2);
+    config.setValue(GlobalConfiguration.TYPE_DEFAULT_BUCKETS, 2);
+    config.setValue(GlobalConfiguration.SERVER_DEFAULT_DATABASES, DB_NAME + "[root]{import:" + importCommandParams + "}");
+    return new ArcadeDBServer(config);
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/Issue7484StartupImportFailureTest.java
+++ b/server/src/test/java/com/arcadedb/server/Issue7484StartupImportFailureTest.java
@@ -46,6 +46,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * The fix reads the row and, on anything but {@code OK}, aborts startup the same way a failing {@code restore:}
  * startup command already does - the two commands now answer a bad source the same way, rather than one failing
  * loudly and the other succeeding silently with an empty database.
+ * <p>
+ * Security, the HTTP service and every plugin are already started by the point {@code loadDefaultDatabases()} runs,
+ * so a caller that only rethrows leaves all of it running with {@code status} stuck at {@code STARTING} - the
+ * exact state {@code isStarted() == false} cannot tell apart from a clean {@code OFFLINE}. The fix calls
+ * {@code stop()} before rethrowing, the same recovery the {@code SERVER_UP} lifecycle event's own failure handler
+ * already uses, so the server reaches {@code OFFLINE} with nothing left running.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -81,9 +87,11 @@ class Issue7484StartupImportFailureTest extends StaticBaseServerTest {
         .hasMessageContaining(DB_NAME)
         .hasMessageContaining("import:");
 
-    assertThat(server.isStarted())
-        .as("startup must not report success for a default database whose import was refused")
-        .isFalse();
+    assertThat(server.getStatus())
+        .as("the server must fully unwind back to OFFLINE - security, the HTTP listener and every plugin already "
+            + "started by this point stopped again - not merely fail to reach ONLINE while everything it already "
+            + "brought up (and status == STARTING) is left running")
+        .isEqualTo(ArcadeDBServer.STATUS.OFFLINE);
   }
 
   private static ArcadeDBServer newServerWithDefaultDatabaseImport(final String importCommandParams) {


### PR DESCRIPTION
## Summary

Four small, independently-filed follow-ups from the #7341/#7342/#7461 sweeps, all in the importer's limit-enforcement and progress-reporting plumbing:

- **#7485** — `XMLImporterFormat.analyze()` read its entries cap from the misspelled, default-less options-map key `analyzingLimitEntries` instead of the real `ImporterSettings` field `analysisLimitEntries` (default 10000, already honoured by `CSVImporterFormat.analyze()`). `-analysisLimitEntries` did nothing on XML, and with neither flag passed XML schema analysis was unbounded. Now reads the real field, keeps the old key as a deprecated alias when a caller still passes it explicitly, and adds the equivalent `-analysisLimitBytes` guard CSV already has — measured via the `XMLStreamReader`'s own character offset rather than the underlying buffered stream's read-ahead position, for the same granularity CSV's tokenizer already gets from `currentChar()`.

- **#7482** — `-parsingLimitEntries` was enforced only by `XMLImporterFormat` and the vector route; CSV (documents/vertices/edges), JSON, Jsonl and RDF imported the whole source while `SourceDiscovery` logged the limit as if it were in effect. `-parsingLimitBytes` was enforced nowhere. Both are now enforced across all five formats. The JSON array reader is drained via `skipValue()` before `endArray()` once the cap trips, so the limit can stop mid-array without leaving the reader in a state `endArray()` rejects.

- **#7484** — the startup `import:` form of `arcadedb.server.defaultDatabases` discarded the `IMPORT DATABASE` statement's one-row result set. A `probeOnly` probe or a refused `WITH` setting value — the two failures `ImportDatabaseStatement` reports in band as `{"result":"FAIL","reason":...}` rather than by throwing — left the default database created and silently empty, with nothing in the log. The fix reads the row and aborts startup on `FAIL`, the same way a failing `restore:` startup command already does, so the two commands answer a bad source consistently.

- **#7483** — `ServerControlPlane.scheduleImportCounters()` sampled `ImporterContext`'s raw per-phase `parsed` counter, which resets to 0 at every phase boundary (`beginPhase()`, #7342). A multi-phase `IMPORT DATABASE` (documents + vertices + edges) made the SSE/`GET /api/v1/progress` stream report a count that climbed, dropped back near zero at each phase boundary, then climbed again. Fixed to prefer the monotonic `ImporterContext#getParsedTotal()`, falling back to the raw field for a server running against an older `arcadedb-integration` build. `FormatImporter`'s console "Parsed" log line had the identical defect (raised in a comment on the issue) and gets the same fix, so the CLI log and the server's progress stream now agree.

## Test plan

- [x] New regression tests: `Issue7485XmlAnalysisLimitTest`, `Issue7482ParsingLimitAppliesToAllFormatsTest`, `Issue7483ConsoleProgressMonotonicTest` (integration module); `Issue7483ImportProgressCounterMonotonicTest`, `Issue7484StartupImportFailureTest` (server module)
- [x] `mvn -o -pl integration test -Dtest=com.arcadedb.integration.importer.**` — full importer suite green (no regressions)
- [x] `mvn -o -pl server test` targeted at the default-databases/restore/import/control-plane test classes — green
- [x] Full reactor `mvn -o compile` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Parsing limits for entries and bytes are now consistently enforced across CSV, JSON, JSONL, RDF, and XML imports, including skipped or malformed rows.
  * XML analysis now respects entry and byte limits, with support for the legacy limit option.
  * Import progress remains accurate and continuous across multiple import phases.
  * Startup now reports database import failures and stops cleanly, leaving the server offline instead of continuing with an empty database.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->