### PR TITLE
fix(#7479,#7502): stop a second embedded instance's clean close from deleting another live instance's WAL files

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -274,14 +274,14 @@ public class TransactionManager {
     return preserve;
   }
 
-  private enum WalFileSweepOutcome {DELETED, SKIPPED_LOCKED, ERROR}
+  enum WalFileSweepOutcome {DELETED, SKIPPED_LOCKED, ERROR}
 
   /**
    * Test-support hook (issue #7479): exposes {@link #deleteWALFileIfNotHeldByAnotherInstance} directly, so
    * a test can drive it against one file in isolation instead of a whole database's {@code close()}.
    */
-  String deleteWALFileForTesting(final File walFile) {
-    return deleteWALFileIfNotHeldByAnotherInstance(walFile).name();
+  WalFileSweepOutcome deleteWALFileForTesting(final File walFile) {
+    return deleteWALFileIfNotHeldByAnotherInstance(walFile);
   }
 
   /**
@@ -322,8 +322,13 @@ public class TransactionManager {
       }
 
       if (!nobodyElseHasItOpen) {
+        // Someone else already has it open - either a live peer instance still using it, or (rarer) another
+        // closing instance's own sweep racing this one over the same ownerless orphan. Either way it is not
+        // this sweep's to remove: the file survives, and whoever does hold it will remove it if it turns
+        // out to be an orphan after all.
         LogManager.instance().log(this, Level.WARNING,
-            "Skipped removing WAL file '%s': it is still locked, presumably by another database instance", null, walFile);
+            "Skipped removing WAL file '%s': it is still open, either by a live database instance or a competing cleanup",
+            null, walFile);
         return WalFileSweepOutcome.SKIPPED_LOCKED;
       }
 

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -316,7 +316,7 @@ public class TransactionManager {
       final boolean nobodyElseHasItOpen;
       final WALFile probe = new WALFile(walFile.getPath());
       try {
-        nobodyElseHasItOpen = probe.isLocked();
+        nobodyElseHasItOpen = probe.acquiredLock();
       } finally {
         probe.close();
       }
@@ -417,7 +417,7 @@ public class TransactionManager {
         // unclean shutdown - nothing else should still have them open. One that is anyway means another
         // process/instance is sharing this directory right now, and replaying WAL it may be concurrently
         // appending to or rotating is exactly the corruption this issue is about.
-        if (!activeWALFilePool[i].isLocked()) {
+        if (!activeWALFilePool[i].acquiredLock()) {
           LogManager.instance().log(this, Level.SEVERE,
               "Recovery aborted for database '%s': WAL file '%s' is still open by another process or database "
                   + "instance", null, database, activeWALFilePool[i]);
@@ -1180,13 +1180,17 @@ public class TransactionManager {
       // otherwise left them as leaked handles and self-locks for the life of the JVM, since neither this
       // constructor nor its caller retains a reference to a TransactionManager whose constructor never
       // finished.
-      if (!activeWALFilePool[i].isLocked()) {
-        for (int alreadyOpened = 0; alreadyOpened < i; ++alreadyOpened)
+      if (!activeWALFilePool[i].acquiredLock()) {
+        for (int alreadyOpened = 0; alreadyOpened < i; ++alreadyOpened) {
+          // A slot that hit FileNotFoundException above and `continue`d never got a WALFile at all.
+          if (activeWALFilePool[alreadyOpened] == null)
+            continue;
           try {
             activeWALFilePool[alreadyOpened].close();
           } catch (final IOException e) {
             LogManager.instance().log(this, Level.WARNING, "Error on closing WAL file '%s'", e, activeWALFilePool[alreadyOpened]);
           }
+        }
         try {
           activeWALFilePool[i].close();
         } catch (final IOException e) {
@@ -1220,7 +1224,7 @@ public class TransactionManager {
 
             // #7479: same reasoning as createWALFilePool() - a freshly counted name that turns out to
             // already be locked means another process/instance raced this rotation and got there first.
-            if (!activeWALFilePool[i].isLocked()) {
+            if (!activeWALFilePool[i].acquiredLock()) {
               final String reason =
                   "WAL file '" + activeWALFilePool[i] + "' is already open by another process or database instance";
               try {

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -301,8 +301,14 @@ public class TransactionManager {
         return WalFileSweepOutcome.SKIPPED_LOCKED;
       }
 
-      lock.release();
-      walFile.delete();
+      // Keep the lock held THROUGH the delete: releasing it first would reopen the exact window this
+      // whole check exists to close, letting a third instance acquire it and start using the file in
+      // the instant between the release and the delete.
+      try {
+        walFile.delete();
+      } finally {
+        lock.release();
+      }
       return WalFileSweepOutcome.DELETED;
     } catch (final IOException e) {
       LogManager.instance().log(this, Level.WARNING, "Error on removing WAL file '%s'", e, walFile);

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -31,6 +31,7 @@ import com.arcadedb.index.vector.LSMVectorIndex;
 import com.arcadedb.index.vector.LSMVectorIndexCompacted;
 import com.arcadedb.index.vector.LSMVectorIndexMutable;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.utility.LockException;
 import com.arcadedb.utility.LockManager;
 
 import java.io.*;
@@ -296,6 +297,14 @@ public class TransactionManager {
    * own - so the handle used to prove nobody else has the file open must be closed (releasing the lock as
    * a side effect) BEFORE {@code delete()} is attempted, exactly as {@link WALFile#drop()} already does for
    * the ordinary case.
+   * <p>
+   * Accepted trade-off (raised in review): closing the probe before deleting reopens a THIRD instance's
+   * window to acquire the lock and start using the file in between - the opposite choice from holding the
+   * lock through the delete, which an earlier revision of this method did, until that was found to make
+   * the delete itself fail silently on Windows (see above). Between "closeable by Windows, briefly racy
+   * against a third instance" and "safe against a third instance, broken on Windows", this keeps the
+   * former: the scenario this whole method exists for is already "more than one instance should not share
+   * this directory", so a THIRD one racing into the exact same window is a corner of that corner.
    */
   private WalFileSweepOutcome deleteWALFileIfNotHeldByAnotherInstance(final File walFile) {
     if (!walFile.exists())
@@ -394,14 +403,33 @@ public class TransactionManager {
       }
 
       activeWALFilePool = new WALFile[walFiles.length];
+      boolean foreignlyLockedFileDetected = false;
       for (int i = 0; i < walFiles.length; ++i) {
         try {
           activeWALFilePool[i] = new WALFile(database.getDatabasePath() + File.separator + walFiles[i].getName());
         } catch (final FileNotFoundException e) {
           LogManager.instance().log(this, Level.SEVERE, "Error on WAL file management for file '%s'", e,
               database.getDatabasePath() + walFiles[i].getName());
+          continue;
+        }
+
+        // #7479: these are meant to be this same database's own leftover WAL files from its last,
+        // unclean shutdown - nothing else should still have them open. One that is anyway means another
+        // process/instance is sharing this directory right now, and replaying WAL it may be concurrently
+        // appending to or rotating is exactly the corruption this issue is about. Abort the same way the
+        // corrupt-transaction and version-gap cases below already do: log SEVERE, preserve every WAL file
+        // for manual inspection, replay nothing.
+        if (!activeWALFilePool[i].isLocked()) {
+          LogManager.instance().log(this, Level.SEVERE,
+              "Recovery aborted for database '%s': WAL file '%s' is still open by another process or database "
+                  + "instance. WAL files have been preserved for manual inspection. No further transactions will be replayed.",
+              null, database, activeWALFilePool[i]);
+          foreignlyLockedFileDetected = true;
         }
       }
+
+      if (foreignlyLockedFileDetected)
+        return;
 
       if (activeWALFilePool.length > 0) {
         long lastTxId = -1;
@@ -1118,12 +1146,22 @@ public class TransactionManager {
     activeWALFilePool = new WALFile[walFilePoolSize(database.getConfiguration())];
     for (int i = 0; i < activeWALFilePool.length; ++i) {
       final long counter = logFileCounter.getAndIncrement();
+      final String walFilePath = database.getDatabasePath() + "/txlog_" + counter + ".wal";
       try {
-        activeWALFilePool[i] = database.getWALFileFactory().newInstance(database.getDatabasePath() + "/txlog_" + counter + ".wal");
+        activeWALFilePool[i] = database.getWALFileFactory().newInstance(walFilePath);
       } catch (final FileNotFoundException e) {
-        LogManager.instance().log(this, Level.SEVERE, "Error on WAL file management for file '%s'", e,
-            database.getDatabasePath() + "/txlog_" + counter + ".wal");
+        LogManager.instance().log(this, Level.SEVERE, "Error on WAL file management for file '%s'", e, walFilePath);
+        continue;
       }
+
+      // #7479: the counter above is seeded past every WAL file this scan could see, so a brand-new name
+      // colliding with one that already exists - and is still locked - means another process/instance
+      // raced this same open and got there first. Refuse the open outright rather than silently sharing
+      // that file with whoever holds it, the same way lockDatabase() already refuses on the whole-database
+      // lock file.
+      if (!activeWALFilePool[i].isLocked())
+        throw new LockException(
+            "WAL file '" + walFilePath + "' is already open by another process or database instance");
     }
   }
 
@@ -1138,6 +1176,21 @@ public class TransactionManager {
                 MAX_LOG_FILE_SIZE, file.getPendingPagesToFlush());
             activeWALFilePool[i] = database.getWALFileFactory()
                 .newInstance(database.getDatabasePath() + "/txlog_" + logFileCounter.getAndIncrement() + ".wal");
+
+            // #7479: same reasoning as createWALFilePool() - a freshly counted name that turns out to
+            // already be locked means another process/instance raced this rotation and got there first.
+            if (!activeWALFilePool[i].isLocked()) {
+              final String reason =
+                  "WAL file '" + activeWALFilePool[i] + "' is already open by another process or database instance";
+              try {
+                activeWALFilePool[i].close();
+              } catch (final IOException ignored) {
+                // IGNORE IT: the database is being fenced regardless
+              }
+              if (database.getEmbedded() instanceof LocalDatabase localDatabase)
+                localDatabase.fenceForRecovery(reason);
+              return;
+            }
 
             // SET THE FILE AS INACTIVE READY TO BE DISPOSED
             file.setActive(false);
@@ -1192,6 +1245,14 @@ public class TransactionManager {
    */
   void checkWALFilesForTesting() {
     checkWALFiles();
+  }
+
+  /**
+   * Test-support hook (issue #7479): the value {@link #checkWALFiles}'s rotation would use for its next
+   * WAL file name, so a test can pre-create and lock a colliding file at exactly that name.
+   */
+  long getLogFileCounterForTesting() {
+    return logFileCounter.get();
   }
 
   private boolean cleanWALFiles(final boolean dropFiles, final boolean force) {

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -416,20 +416,38 @@ public class TransactionManager {
         // #7479: these are meant to be this same database's own leftover WAL files from its last,
         // unclean shutdown - nothing else should still have them open. One that is anyway means another
         // process/instance is sharing this directory right now, and replaying WAL it may be concurrently
-        // appending to or rotating is exactly the corruption this issue is about. Abort the same way the
-        // corrupt-transaction and version-gap cases below already do: log SEVERE, preserve every WAL file
-        // for manual inspection, replay nothing.
+        // appending to or rotating is exactly the corruption this issue is about.
         if (!activeWALFilePool[i].isLocked()) {
           LogManager.instance().log(this, Level.SEVERE,
               "Recovery aborted for database '%s': WAL file '%s' is still open by another process or database "
-                  + "instance. WAL files have been preserved for manual inspection. No further transactions will be replayed.",
-              null, database, activeWALFilePool[i]);
+                  + "instance", null, database, activeWALFilePool[i]);
           foreignlyLockedFileDetected = true;
         }
       }
 
-      if (foreignlyLockedFileDetected)
-        return;
+      if (foreignlyLockedFileDetected) {
+        // Unlike the corrupt-transaction/version-gap aborts below, these files are not this instance's to
+        // rename aside as ".corrupt": the one that failed the lock check legitimately belongs to another
+        // live instance right now, and the rest are this database's own untouched recovery source that a
+        // future, uncontested open must still be able to replay - not evidence of corruption. Close every
+        // handle this scan opened (releasing whatever lock this instance did acquire on the others) and
+        // refuse the open outright (review on #7502) rather than leaving this array as the live pool and
+        // letting the open proceed: createWALFilePool() giving this instance a fresh, safe-looking pool
+        // would not stop it from also writing brand-new transactions to the very data files the other,
+        // still-unaccounted-for instance is presently mutating - the corruption this whole issue is about.
+        for (final WALFile file : activeWALFilePool) {
+          if (file == null)
+            continue;
+          try {
+            file.close();
+          } catch (final IOException e) {
+            LogManager.instance().log(this, Level.WARNING, "Error on closing WAL file '%s'", e, file);
+          }
+        }
+        throw new LockException(
+            "Database '" + database.getName() + "' cannot complete recovery: another process or database instance "
+                + "is writing to its WAL files");
+      }
 
       if (activeWALFilePool.length > 0) {
         long lastTxId = -1;
@@ -1158,10 +1176,25 @@ public class TransactionManager {
       // colliding with one that already exists - and is still locked - means another process/instance
       // raced this same open and got there first. Refuse the open outright rather than silently sharing
       // that file with whoever holds it, the same way lockDatabase() already refuses on the whole-database
-      // lock file.
-      if (!activeWALFilePool[i].isLocked())
+      // lock file. Every slot already opened before this one is closed first (review on #7502): the throw
+      // otherwise left them as leaked handles and self-locks for the life of the JVM, since neither this
+      // constructor nor its caller retains a reference to a TransactionManager whose constructor never
+      // finished.
+      if (!activeWALFilePool[i].isLocked()) {
+        for (int alreadyOpened = 0; alreadyOpened < i; ++alreadyOpened)
+          try {
+            activeWALFilePool[alreadyOpened].close();
+          } catch (final IOException e) {
+            LogManager.instance().log(this, Level.WARNING, "Error on closing WAL file '%s'", e, activeWALFilePool[alreadyOpened]);
+          }
+        try {
+          activeWALFilePool[i].close();
+        } catch (final IOException e) {
+          LogManager.instance().log(this, Level.WARNING, "Error on closing WAL file '%s'", e, activeWALFilePool[i]);
+        }
         throw new LockException(
             "WAL file '" + walFilePath + "' is already open by another process or database instance");
+      }
     }
   }
 
@@ -1177,6 +1210,14 @@ public class TransactionManager {
             activeWALFilePool[i] = database.getWALFileFactory()
                 .newInstance(database.getDatabasePath() + "/txlog_" + logFileCounter.getAndIncrement() + ".wal");
 
+            // SET THE OLD FILE AS INACTIVE READY TO BE DISPOSED. Done unconditionally, before the new
+            // file's lock is even checked: the old file's own retirement has nothing to do with whether
+            // rotating INTO the new one succeeds, and close()'s normal WAL cleanup already handles a
+            // database that gets fenced right below (issue #7479 review - this used to only happen on the
+            // success path, leaking the old file's handle and self-lock whenever the check below failed).
+            file.setActive(false);
+            inactiveWALFilePool.add(file);
+
             // #7479: same reasoning as createWALFilePool() - a freshly counted name that turns out to
             // already be locked means another process/instance raced this rotation and got there first.
             if (!activeWALFilePool[i].isLocked()) {
@@ -1191,10 +1232,6 @@ public class TransactionManager {
                 localDatabase.fenceForRecovery(reason);
               return;
             }
-
-            // SET THE FILE AS INACTIVE READY TO BE DISPOSED
-            file.setActive(false);
-            inactiveWALFilePool.add(file);
           }
         } catch (final ClosedChannelException e) {
           try {

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -22,6 +22,7 @@ import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Binary;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.LocalDatabase;
 import com.arcadedb.exception.LockTimeoutException;
 import com.arcadedb.exception.SchemaException;
 import com.arcadedb.exception.TransactionException;
@@ -35,6 +36,8 @@ import com.arcadedb.utility.LockManager;
 import java.io.*;
 import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.ClosedChannelException;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.*;
@@ -42,7 +45,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
-import java.util.stream.Stream;
 
 public class TransactionManager {
   private static final long MAX_LOG_FILE_SIZE = 64 * 1024 * 1024;
@@ -243,11 +245,23 @@ public class TransactionManager {
           "Preserving the WAL files of database '%s': not all pages reached the disk (%s), the next open will recover them",
           null, database.getName(), preserveWalFiles ? "caller requested preservation" : "unacked WAL pages");
     } else {
-      // DELETE ALL THE WAL FILES AT OS-LEVEL
+      // DELETE ALL THE WAL FILES AT OS-LEVEL. By this point every file THIS instance's own pool tracked
+      // has already been dropped one by one above; anything a directory scan still finds here is, under
+      // normal single-process operation, a genuine orphan this same database left behind on an earlier
+      // unclean shutdown - nothing has it open, and deleting it is safe.
+      //
+      // #7479: on a database directory a second embedded process/instance also has open (the reported
+      // case: a per-process advisory lock a Docker Desktop bind mount does not enforce across the
+      // container boundary), that scan finds the OTHER instance's still-active WAL files too. Deleting
+      // those by name alone corrupted the still-running instance exactly as reported - "No such file or
+      // directory" on every WAL check from then on. Try an exclusive lock on each file first: an orphan
+      // nobody holds open acquires it and is deleted as before; a file another instance still has open
+      // fails the lock and is left alone, with one clear warning instead of silent data loss elsewhere.
       final File dir = new File(database.getDatabasePath());
       File[] walFiles = dir.listFiles((dir1, name) -> name.endsWith(".wal"));
       if (walFiles != null) {
-        Stream.of(walFiles).forEach(File::delete);
+        for (final File walFile : walFiles)
+          deleteWALFileIfNotHeldByAnotherInstance(walFile);
         walFiles = dir.listFiles((dir1, name) -> name.endsWith(".wal"));
       }
 
@@ -256,6 +270,38 @@ public class TransactionManager {
             .log(this, Level.WARNING, "Error on removing all transaction files. Remained: %s", null, walFiles.length);
     }
     return preserve;
+  }
+
+  /**
+   * Deletes {@code walFile} only if an exclusive lock on it can be acquired first (issue #7479). A file
+   * this instance's own pool never tracked is either a genuine orphan from an earlier unclean shutdown
+   * of THIS SAME database - nothing holds it open, the lock succeeds instantly, and it is deleted exactly
+   * as before - or a WAL file another live process/instance still has open, in which case the lock fails
+   * and the file is left untouched instead of being deleted out from under that other instance.
+   */
+  private void deleteWALFileIfNotHeldByAnotherInstance(final File walFile) {
+    try (final RandomAccessFile raf = new RandomAccessFile(walFile, "rw")) {
+      final FileLock lock;
+      try {
+        lock = raf.getChannel().tryLock();
+      } catch (final OverlappingFileLockException e) {
+        // This JVM itself already holds a lock on this file elsewhere: definitely still in use.
+        LogManager.instance().log(this, Level.WARNING,
+            "Skipped removing WAL file '%s': it is still locked, presumably by another database instance", null, walFile);
+        return;
+      }
+
+      if (lock == null) {
+        LogManager.instance().log(this, Level.WARNING,
+            "Skipped removing WAL file '%s': it is still locked, presumably by another database instance", null, walFile);
+        return;
+      }
+
+      lock.release();
+      walFile.delete();
+    } catch (final IOException e) {
+      LogManager.instance().log(this, Level.WARNING, "Error on removing WAL file '%s'", e, walFile);
+    }
   }
 
   public Binary createTransactionBuffer(final long txId, final List<MutablePage> pages) {
@@ -1079,9 +1125,44 @@ public class TransactionManager {
             // IGNORE IT
           }
         } catch (final IOException e) {
-          LogManager.instance().log(this, Level.SEVERE, "Error on WAL file management for file '%s'", e, file);
+          // #7479: a WAL file this instance still has open just became inaccessible. Under normal
+          // single-process operation that never happens - the OS keeps an open file's content reachable
+          // through its descriptor even past an unlink - so it means something outside this instance's
+          // control removed it (the reported case: a second embedded process/instance sharing the same
+          // database directory, its own clean close deleting every *.wal file it could see). Retrying
+          // this check every second forever, as before, only produced an unbounded flood of identical
+          // stack traces while the database kept silently accepting writes into a WAL pool that can no
+          // longer be trusted. Fence it once instead, the same way a post-WAL-append commit failure
+          // already does (#5053): fenceForRecovery() logs a single clear SEVERE line, and the
+          // housekeeping timer cancels itself on its next tick (the isFencedForRecovery() guard above).
+          if (database.getEmbedded() instanceof LocalDatabase localDatabase)
+            localDatabase.fenceForRecovery(
+                "WAL file '" + file + "' became inaccessible while still open; check whether another process or "
+                    + "database instance is writing to this database's files", e);
+          else
+            LogManager.instance().log(this, Level.SEVERE, "Error on WAL file management for file '%s'", e, file);
+          return;
         }
       }
+  }
+
+  /**
+   * Test-support hook (issue #7479): lets a test simulate an active WAL file becoming inaccessible
+   * without depending on filesystem-specific unlink-while-open semantics, which do not reproduce the
+   * failure portably (see {@code TransactionManagerWalFileLostFencesTest}).
+   */
+  WALFile replaceActiveWALFileForTesting(final int index, final WALFile replacement) {
+    final WALFile previous = activeWALFilePool[index];
+    activeWALFilePool[index] = replacement;
+    return previous;
+  }
+
+  /**
+   * Test-support hook: runs one pass of the periodic WAL housekeeping check on demand instead of
+   * waiting for the once-a-second timer.
+   */
+  void checkWALFilesForTesting() {
+    checkWALFiles();
   }
 
   private boolean cleanWALFiles(final boolean dropFiles, final boolean force) {

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -461,6 +461,11 @@ public class TransactionManager {
         final WALFile.WALTransaction[] walPositions = new WALFile.WALTransaction[activeWALFilePool.length];
         for (int i = 0; i < activeWALFilePool.length; ++i) {
           final WALFile file = activeWALFilePool[i];
+          // A slot whose WALFile constructor threw FileNotFoundException above never got one (pre-existing
+          // gap, found in review on #7502): nothing left to replay from it, but leaving it null unguarded
+          // crashed this loop with an unrelated NullPointerException instead of just skipping it.
+          if (file == null)
+            continue;
           walPositions[i] = file.getFirstTransaction();
           // A torn first record followed by intact transactions is corruption, not a clean empty/EOF file:
           // stopping silently would drop committed data (issue #4508). Abort recovery and preserve the WAL.

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -36,8 +36,6 @@ import com.arcadedb.utility.LockManager;
 import java.io.*;
 import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.ClosedChannelException;
-import java.nio.channels.FileLock;
-import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.*;
@@ -278,47 +276,57 @@ public class TransactionManager {
   private enum WalFileSweepOutcome {DELETED, SKIPPED_LOCKED, ERROR}
 
   /**
+   * Test-support hook (issue #7479): exposes {@link #deleteWALFileIfNotHeldByAnotherInstance} directly, so
+   * a test can drive it against one file in isolation instead of a whole database's {@code close()}.
+   */
+  String deleteWALFileForTesting(final File walFile) {
+    return deleteWALFileIfNotHeldByAnotherInstance(walFile).name();
+  }
+
+  /**
    * Deletes {@code walFile} only if an exclusive lock on it can be acquired first (issue #7479). A file
    * this instance's own pool never tracked is either a genuine orphan from an earlier unclean shutdown
    * of THIS SAME database - nothing holds it open, the lock succeeds instantly, and it is deleted exactly
    * as before - or a WAL file another live instance still has open (every {@link WALFile} has held an
    * exclusive lock on itself for its whole life since this same issue), in which case the lock fails and
    * the file is left untouched instead of being deleted out from under that other instance.
+   * <p>
+   * The probe is a {@link WALFile} itself, not a raw handle kept open across the delete: on Windows a
+   * process cannot delete a file through which it still holds an open, non-share-delete handle - even its
+   * own - so the handle used to prove nobody else has the file open must be closed (releasing the lock as
+   * a side effect) BEFORE {@code delete()} is attempted, exactly as {@link WALFile#drop()} already does for
+   * the ordinary case.
    */
   private WalFileSweepOutcome deleteWALFileIfNotHeldByAnotherInstance(final File walFile) {
-    try (final RandomAccessFile raf = new RandomAccessFile(walFile, "rw")) {
-      final FileLock lock;
-      try {
-        lock = raf.getChannel().tryLock();
-      } catch (final OverlappingFileLockException e) {
-        // This JVM itself already holds a lock on this file elsewhere: definitely still in use.
-        logSkippedLockedWALFile(walFile);
-        return WalFileSweepOutcome.SKIPPED_LOCKED;
-      }
+    if (!walFile.exists())
+      // Already gone - its owner's own clean shutdown, or a concurrent sweep, beat us to it. Opening it
+      // below would otherwise recreate it as an empty file just to delete it again.
+      return WalFileSweepOutcome.DELETED;
 
-      if (lock == null) {
-        logSkippedLockedWALFile(walFile);
-        return WalFileSweepOutcome.SKIPPED_LOCKED;
-      }
-
-      // Keep the lock held THROUGH the delete: releasing it first would reopen the exact window this
-      // whole check exists to close, letting a third instance acquire it and start using the file in
-      // the instant between the release and the delete.
+    try {
+      final boolean nobodyElseHasItOpen;
+      final WALFile probe = new WALFile(walFile.getPath());
       try {
-        walFile.delete();
+        nobodyElseHasItOpen = probe.isLocked();
       } finally {
-        lock.release();
+        probe.close();
+      }
+
+      if (!nobodyElseHasItOpen) {
+        LogManager.instance().log(this, Level.WARNING,
+            "Skipped removing WAL file '%s': it is still locked, presumably by another database instance", null, walFile);
+        return WalFileSweepOutcome.SKIPPED_LOCKED;
+      }
+
+      if (!walFile.delete()) {
+        LogManager.instance().log(this, Level.WARNING, "Error on removing WAL file '%s'", null, walFile);
+        return WalFileSweepOutcome.ERROR;
       }
       return WalFileSweepOutcome.DELETED;
     } catch (final IOException e) {
       LogManager.instance().log(this, Level.WARNING, "Error on removing WAL file '%s'", e, walFile);
       return WalFileSweepOutcome.ERROR;
     }
-  }
-
-  private void logSkippedLockedWALFile(final File walFile) {
-    LogManager.instance().log(this, Level.WARNING,
-        "Skipped removing WAL file '%s': it is still locked, presumably by another database instance", null, walFile);
   }
 
   public Binary createTransactionBuffer(final long txId, final List<MutablePage> pages) {

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -258,50 +258,61 @@ public class TransactionManager {
       // nobody holds open acquires it and is deleted as before; a file another instance still has open
       // fails the lock and is left alone, with one clear warning instead of silent data loss elsewhere.
       final File dir = new File(database.getDatabasePath());
-      File[] walFiles = dir.listFiles((dir1, name) -> name.endsWith(".wal"));
-      if (walFiles != null) {
+      final File[] walFiles = dir.listFiles((dir1, name) -> name.endsWith(".wal"));
+      int unremovable = 0;
+      if (walFiles != null)
         for (final File walFile : walFiles)
-          deleteWALFileIfNotHeldByAnotherInstance(walFile);
-        walFiles = dir.listFiles((dir1, name) -> name.endsWith(".wal"));
-      }
+          if (deleteWALFileIfNotHeldByAnotherInstance(walFile) == WalFileSweepOutcome.ERROR)
+            ++unremovable;
 
-      if (walFiles != null && walFiles.length > 0)
+      // A file skipped because another instance still holds it is expected and already logged its own
+      // warning above: it must not also inflate this count, or an operator sees two warnings for what is,
+      // in that case, correct behaviour rather than an actual error.
+      if (unremovable > 0)
         LogManager.instance()
-            .log(this, Level.WARNING, "Error on removing all transaction files. Remained: %s", null, walFiles.length);
+            .log(this, Level.WARNING, "Error on removing all transaction files. Remained: %s", null, unremovable);
     }
     return preserve;
   }
+
+  private enum WalFileSweepOutcome {DELETED, SKIPPED_LOCKED, ERROR}
 
   /**
    * Deletes {@code walFile} only if an exclusive lock on it can be acquired first (issue #7479). A file
    * this instance's own pool never tracked is either a genuine orphan from an earlier unclean shutdown
    * of THIS SAME database - nothing holds it open, the lock succeeds instantly, and it is deleted exactly
-   * as before - or a WAL file another live process/instance still has open, in which case the lock fails
-   * and the file is left untouched instead of being deleted out from under that other instance.
+   * as before - or a WAL file another live instance still has open (every {@link WALFile} has held an
+   * exclusive lock on itself for its whole life since this same issue), in which case the lock fails and
+   * the file is left untouched instead of being deleted out from under that other instance.
    */
-  private void deleteWALFileIfNotHeldByAnotherInstance(final File walFile) {
+  private WalFileSweepOutcome deleteWALFileIfNotHeldByAnotherInstance(final File walFile) {
     try (final RandomAccessFile raf = new RandomAccessFile(walFile, "rw")) {
       final FileLock lock;
       try {
         lock = raf.getChannel().tryLock();
       } catch (final OverlappingFileLockException e) {
         // This JVM itself already holds a lock on this file elsewhere: definitely still in use.
-        LogManager.instance().log(this, Level.WARNING,
-            "Skipped removing WAL file '%s': it is still locked, presumably by another database instance", null, walFile);
-        return;
+        logSkippedLockedWALFile(walFile);
+        return WalFileSweepOutcome.SKIPPED_LOCKED;
       }
 
       if (lock == null) {
-        LogManager.instance().log(this, Level.WARNING,
-            "Skipped removing WAL file '%s': it is still locked, presumably by another database instance", null, walFile);
-        return;
+        logSkippedLockedWALFile(walFile);
+        return WalFileSweepOutcome.SKIPPED_LOCKED;
       }
 
       lock.release();
       walFile.delete();
+      return WalFileSweepOutcome.DELETED;
     } catch (final IOException e) {
       LogManager.instance().log(this, Level.WARNING, "Error on removing WAL file '%s'", e, walFile);
+      return WalFileSweepOutcome.ERROR;
     }
+  }
+
+  private void logSkippedLockedWALFile(final File walFile) {
+    LogManager.instance().log(this, Level.WARNING,
+        "Skipped removing WAL file '%s': it is still locked, presumably by another database instance", null, walFile);
   }
 
   public Binary createTransactionBuffer(final long txId, final List<MutablePage> pages) {
@@ -1134,14 +1145,18 @@ public class TransactionManager {
           // stack traces while the database kept silently accepting writes into a WAL pool that can no
           // longer be trusted. Fence it once instead, the same way a post-WAL-append commit failure
           // already does (#5053): fenceForRecovery() logs a single clear SEVERE line, and the
-          // housekeeping timer cancels itself on its next tick (the isFencedForRecovery() guard above).
-          if (database.getEmbedded() instanceof LocalDatabase localDatabase)
+          // housekeeping timer cancels itself on its next tick (the isFencedForRecovery() guard above) -
+          // there is no point checking the rest of the pool, the whole database is about to stop being
+          // usable anyway.
+          if (database.getEmbedded() instanceof LocalDatabase localDatabase) {
             localDatabase.fenceForRecovery(
                 "WAL file '" + file + "' became inaccessible while still open; check whether another process or "
                     + "database instance is writing to this database's files", e);
-          else
-            LogManager.instance().log(this, Level.SEVERE, "Error on WAL file management for file '%s'", e, file);
-          return;
+            return;
+          }
+          // No LocalDatabase to fence (a wrapper this issue does not otherwise reach): fall back to the
+          // original behaviour of logging and continuing to check the rest of the pool.
+          LogManager.instance().log(this, Level.SEVERE, "Error on WAL file management for file '%s'", e, file);
         }
       }
   }

--- a/engine/src/main/java/com/arcadedb/engine/WALFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/WALFile.java
@@ -109,6 +109,15 @@ public class WALFile extends LockContext {
    * reported corruption. Best-effort: a lock that cannot be acquired (a same-named file collision, or a
    * filesystem whose advisory locking does not reach across process/container boundaries, e.g. some Docker
    * Desktop bind mounts) leaves this file exactly as unprotected as it always was, never worse.
+   * <p>
+   * The guarantee this gives {@code TransactionManager}'s orphan sweep is scoped to a SEPARATE OS process
+   * holding the file open, which is the reported scenario and the only one {@code LocalDatabase}'s own
+   * per-database lock does not already rule out (two {@code LocalDatabase} instances on the same path
+   * within one JVM/process are refused at open time). It is not a guarantee against a second, same-process
+   * {@code WALFile} on this exact path: {@code FileChannel}'s own javadoc warns that closing any channel
+   * releases every lock the JVM holds on the underlying file, "regardless of whether the locks were
+   * acquired via that channel or via another channel open on the same file" - the POSIX advisory-lock
+   * model this wraps is scoped to a (process, inode) pair, not a file descriptor, so it cannot do better.
    */
   private FileLock acquireLock() {
     try {

--- a/engine/src/main/java/com/arcadedb/engine/WALFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/WALFile.java
@@ -120,6 +120,15 @@ public class WALFile extends LockContext {
     }
   }
 
+  /**
+   * Whether {@link #acquireLock()} actually got the lock (issue #7479): lets a caller that opened this
+   * file only to probe whether anyone else has it open - {@code TransactionManager}'s orphan sweep - tell
+   * that apart from "nobody was there to contend with" without having to reach into the lock itself.
+   */
+  boolean isLocked() {
+    return lock != null;
+  }
+
   public synchronized void close() throws IOException {
     this.open = false;
     if (lock != null)

--- a/engine/src/main/java/com/arcadedb/engine/WALFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/WALFile.java
@@ -33,6 +33,8 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -60,6 +62,7 @@ public class WALFile extends LockContext {
   private final    RandomAccessFile file;
   private final    String           filePath;
   private final    FileChannel      channel;
+  private final    FileLock         lock;
   private volatile boolean          active            = true;
   private volatile boolean          open;
   private final    AtomicInteger    pagesToFlush      = new AtomicInteger();
@@ -96,10 +99,36 @@ public class WALFile extends LockContext {
     this.file = new RandomAccessFile(filePath, "rw");
     this.channel = file.getChannel();
     this.open = true;
+    this.lock = acquireLock();
+  }
+
+  /**
+   * Exclusive advisory lock on this file for the whole life of this instance (issue #7479). Without it, a
+   * second process/instance's directory-wide WAL cleanup on close() had no way to tell this file apart from
+   * a genuine orphan an earlier unclean shutdown left behind, and deleted it out from under this one - the
+   * reported corruption. Best-effort: a lock that cannot be acquired (a same-named file collision, or a
+   * filesystem whose advisory locking does not reach across process/container boundaries, e.g. some Docker
+   * Desktop bind mounts) leaves this file exactly as unprotected as it always was, never worse.
+   */
+  private FileLock acquireLock() {
+    try {
+      return channel.tryLock();
+    } catch (final IOException | OverlappingFileLockException e) {
+      LogManager.instance()
+          .log(this, Level.WARNING, "Unable to lock WAL file '%s'; another process may be able to remove it", e, filePath);
+      return null;
+    }
   }
 
   public synchronized void close() throws IOException {
     this.open = false;
+    if (lock != null)
+      try {
+        lock.release();
+      } catch (final IOException e) {
+        // IGNORE IT: the channel close right below releases it regardless
+      }
+
     if (channel != null)
       channel.close();
 

--- a/engine/src/main/java/com/arcadedb/engine/WALFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/WALFile.java
@@ -130,11 +130,13 @@ public class WALFile extends LockContext {
   }
 
   /**
-   * Whether {@link #acquireLock()} actually got the lock (issue #7479): lets a caller that opened this
-   * file only to probe whether anyone else has it open - {@code TransactionManager}'s orphan sweep - tell
-   * that apart from "nobody was there to contend with" without having to reach into the lock itself.
+   * Whether THIS instance's own {@link #acquireLock()} actually got the lock (issue #7479) - i.e. nobody
+   * else had the file open at that moment - not whether the file is locked in general. Lets a caller that
+   * opened this file only to probe whether anyone else has it open - {@code TransactionManager}'s orphan
+   * sweep and construction-site guards - tell that apart from "someone was already there" without having
+   * to reach into the lock field itself.
    */
-  boolean isLocked() {
+  boolean acquiredLock() {
     return lock != null;
   }
 

--- a/engine/src/test/java/com/arcadedb/engine/TransactionManagerCloseSkipsLockedForeignWalFileTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/TransactionManagerCloseSkipsLockedForeignWalFileTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for discussion #7479: a clean {@code close()} used to delete every {@code *.wal}
+ * file it found by name in the database directory, not only the ones this instance's own WAL pool
+ * had created. The reported scenario was a second embedded process opening the same database
+ * directory a server already had open - a per-process advisory lock that a Docker Desktop bind mount
+ * does not enforce across the container boundary - whose own clean close then swept away the still
+ * running server's active WAL files, surfacing there as repeated "No such file or directory" errors.
+ * <p>
+ * A file the OS reports as still locked by someone else must survive the sweep; an orphan nobody
+ * holds must still be removed exactly as before.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class TransactionManagerCloseSkipsLockedForeignWalFileTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.getSchema().createDocumentType("Doc");
+    database.transaction(() -> database.newDocument("Doc").set("v", 1).save());
+  }
+
+  @Test
+  void lockedForeignWalFileSurvivesCloseButOrphanedOneIsRemoved() throws Exception {
+    final String dbPath = database.getDatabasePath();
+
+    final File lockedForeign = new File(dbPath, "txlog_9999.wal");
+    final File orphanForeign = new File(dbPath, "txlog_9998.wal");
+    assertThat(lockedForeign.createNewFile()).isTrue();
+    assertThat(orphanForeign.createNewFile()).isTrue();
+
+    try (final RandomAccessFile raf = new RandomAccessFile(lockedForeign, "rw")) {
+      final FileChannel channel = raf.getChannel();
+      final FileLock heldByAnotherInstance = channel.lock();
+      try {
+        database.close();
+
+        assertThat(lockedForeign)
+            .as("a WAL-named file another instance still has locked must survive this instance's close()")
+            .exists();
+        assertThat(orphanForeign)
+            .as("an orphaned WAL-named file nobody holds must still be removed, as before")
+            .doesNotExist();
+
+        final File[] remainingWalFiles = new File(dbPath).listFiles((dir, name) -> name.endsWith(".wal"));
+        assertThat(remainingWalFiles)
+            .as("the only WAL file left behind must be the one still locked by 'another instance'")
+            .containsExactly(lockedForeign);
+      } finally {
+        heldByAnotherInstance.release();
+      }
+    } finally {
+      lockedForeign.delete();
+    }
+
+    // Reopen so TestHelper.afterTest() can drop the database normally.
+    reopenDatabase();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/TransactionManagerCloseSkipsLockedForeignWalFileTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/TransactionManagerCloseSkipsLockedForeignWalFileTest.java
@@ -23,9 +23,6 @@ import com.arcadedb.TestHelper;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.io.RandomAccessFile;
-import java.nio.channels.FileChannel;
-import java.nio.channels.FileLock;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -37,8 +34,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * does not enforce across the container boundary - whose own clean close then swept away the still
  * running server's active WAL files, surfacing there as repeated "No such file or directory" errors.
  * <p>
- * A file the OS reports as still locked by someone else must survive the sweep; an orphan nobody
- * holds must still be removed exactly as before.
+ * The stand-in for "another live instance's WAL file" here is a real {@link WALFile}, not a hand-rolled
+ * lock: since this same issue, every {@code WALFile} takes an exclusive OS-level lock on itself for its
+ * whole life (see {@code WALFile.acquireLock}), which is the actual mechanism that now protects it - not
+ * an artifact of how this test happens to simulate a second process. An orphan nobody holds open must
+ * still be removed exactly as before.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -54,33 +54,31 @@ class TransactionManagerCloseSkipsLockedForeignWalFileTest extends TestHelper {
   void lockedForeignWalFileSurvivesCloseButOrphanedOneIsRemoved() throws Exception {
     final String dbPath = database.getDatabasePath();
 
-    final File lockedForeign = new File(dbPath, "txlog_9999.wal");
     final File orphanForeign = new File(dbPath, "txlog_9998.wal");
-    assertThat(lockedForeign.createNewFile()).isTrue();
     assertThat(orphanForeign.createNewFile()).isTrue();
 
-    try (final RandomAccessFile raf = new RandomAccessFile(lockedForeign, "rw")) {
-      final FileChannel channel = raf.getChannel();
-      final FileLock heldByAnotherInstance = channel.lock();
-      try {
-        database.close();
+    // Stands in for a second, still-running embedded instance/process that has this WAL file open -
+    // exactly what happens today, the moment a second instance opens the same directory this issue is
+    // about in the first place.
+    final File anotherInstanceFile = new File(dbPath, "txlog_9999.wal");
+    final WALFile anotherInstanceWAL = new WALFile(anotherInstanceFile.getPath());
+    try {
+      database.close();
 
-        assertThat(lockedForeign)
-            .as("a WAL-named file another instance still has locked must survive this instance's close()")
-            .exists();
-        assertThat(orphanForeign)
-            .as("an orphaned WAL-named file nobody holds must still be removed, as before")
-            .doesNotExist();
+      assertThat(anotherInstanceFile)
+          .as("a WAL file another live instance still has open must survive this instance's close()")
+          .exists();
+      assertThat(orphanForeign)
+          .as("an orphaned WAL-named file nobody holds must still be removed, as before")
+          .doesNotExist();
 
-        final File[] remainingWalFiles = new File(dbPath).listFiles((dir, name) -> name.endsWith(".wal"));
-        assertThat(remainingWalFiles)
-            .as("the only WAL file left behind must be the one still locked by 'another instance'")
-            .containsExactly(lockedForeign);
-      } finally {
-        heldByAnotherInstance.release();
-      }
+      final File[] remainingWalFiles = new File(dbPath).listFiles((dir, name) -> name.endsWith(".wal"));
+      assertThat(remainingWalFiles)
+          .as("the only WAL file left behind must be the one still open in 'another instance'")
+          .containsExactly(anotherInstanceFile);
     } finally {
-      lockedForeign.delete();
+      anotherInstanceWAL.close();
+      anotherInstanceFile.delete();
     }
 
     // Reopen so TestHelper.afterTest() can drop the database normally.

--- a/engine/src/test/java/com/arcadedb/engine/TransactionManagerRecoveryAbortsOnForeignLockedWalFileTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/TransactionManagerRecoveryAbortsOnForeignLockedWalFileTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.utility.LockException;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for a correctness issue found in code review on #7502 (discussion #7479):
+ * {@code TransactionManager.checkIntegrity()}'s foreign-lock-detected abort used to just {@code return}
+ * without closing the handles it had opened or rebuilding a safe pool - {@code activeWALFilePool} was left
+ * pointing at the directory-scan array, which can include a file another live instance still has open, and
+ * neither {@code performRecovery()} nor {@code openInternal()} checked for the failure. The database would
+ * open successfully and {@code writeTransactionToWAL()} would go on to append new transactions into that
+ * same array - including, in the worst case, the file the other instance is still actively writing to -
+ * reintroducing the exact two-instances-one-WAL-file corruption this whole issue is about, through the one
+ * path (crash recovery) the other fixes in this PR do not otherwise reach.
+ * <p>
+ * It must instead refuse to complete recovery (and, transitively, the database open it runs inside of)
+ * rather than ever hand back a database whose active pool includes a contested file.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class TransactionManagerRecoveryAbortsOnForeignLockedWalFileTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.getSchema().createDocumentType("Doc");
+    database.transaction(() -> database.newDocument("Doc").set("v", 1).save());
+  }
+
+  @Test
+  void recoveryRefusesToCompleteWhenAWalFileIsForeignlyLocked() throws Exception {
+    final LocalDatabase db = (LocalDatabase) database;
+    final TransactionManager txManager = db.getTransactionManager();
+
+    // Stands in for a second, live instance that already has one of this database's WAL files open -
+    // exactly what a directory scan during recovery would find while that instance is still running.
+    final File foreignFile = new File(db.getDatabasePath(), "txlog_9994.wal");
+    final WALFile anotherInstanceWAL = new WALFile(foreignFile.getPath());
+    try {
+      assertThatThrownBy(txManager::checkIntegrity)
+          .as("recovery must refuse to complete rather than leave a WAL file another live instance holds as part "
+              + "of this instance's own active pool")
+          .isInstanceOf(LockException.class);
+    } finally {
+      anotherInstanceWAL.close();
+      foreignFile.delete();
+    }
+
+    database.close();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/TransactionManagerRecoverySkipsUnopenableWalFileTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/TransactionManagerRecoverySkipsUnopenableWalFileTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.LocalDatabase;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+/**
+ * Regression test for a pre-existing gap CodeRabbit found while reviewing #7502 (discussion #7479):
+ * {@code checkIntegrity()} already tolerated a WAL file whose constructor throws
+ * {@code FileNotFoundException} during the scan (it logs and leaves that pool slot {@code null}), but the
+ * replay-initialization loop right below indexed into every slot unconditionally, so a null one crashed
+ * recovery with an unrelated {@code NullPointerException} instead of the diagnostic already logged for it.
+ * Unrelated to the foreign-lock hardening the rest of this PR adds, but directly adjacent to it in the same
+ * method.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class TransactionManagerRecoverySkipsUnopenableWalFileTest extends TestHelper {
+
+  @Test
+  void recoverySkipsAnUnopenableWalFileInsteadOfCrashingWithNPE() throws Exception {
+    final LocalDatabase db = (LocalDatabase) database;
+    final TransactionManager txManager = db.getTransactionManager();
+    final String dbPath = db.getDatabasePath();
+
+    final File openable = new File(dbPath, "txlog_9993.wal");
+    assertThat(openable.createNewFile()).isTrue();
+
+    final File unopenable = new File(dbPath, "txlog_9992.wal");
+    assertThat(unopenable.createNewFile()).isTrue();
+    assumeThat(unopenable.setWritable(false))
+        .as("this test needs to be able to make a file read-only")
+        .isTrue();
+
+    try {
+      // Same root-safety concern as TransactionManagerWalFileDeleteFailureReportedTest: only trust the
+      // permission if it is actually enforced, not just that the chmod syscall succeeded.
+      boolean permissionActuallyEnforced;
+      try {
+        new RandomAccessFile(unopenable, "rw").close();
+        permissionActuallyEnforced = false;
+      } catch (final IOException e) {
+        permissionActuallyEnforced = true;
+      }
+      assumeThat(permissionActuallyEnforced)
+          .as("this test requires file write permission to actually be enforced (e.g. not running as root)")
+          .isTrue();
+
+      assertThatCode(txManager::checkIntegrity)
+          .as("a WAL file this scan cannot open must be skipped, not crash the whole recovery with an "
+              + "unrelated NullPointerException")
+          .doesNotThrowAnyException();
+    } finally {
+      unopenable.setWritable(true);
+      unopenable.delete();
+      openable.delete();
+    }
+
+    database.close();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/TransactionManagerWalFileDeleteFailureReportedTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/TransactionManagerWalFileDeleteFailureReportedTest.java
@@ -24,6 +24,7 @@ import com.arcadedb.database.LocalDatabase;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
@@ -56,7 +57,26 @@ class TransactionManagerWalFileDeleteFailureReportedTest extends TestHelper {
     assumeThat(undeletableDir.setWritable(false))
         .as("this test needs to be able to make a directory read-only")
         .isTrue();
+    // Everything from here on runs with the directory read-only: one try/finally around all of it, so
+    // that an assumption failure (or any other exception) below still restores write access instead of
+    // leaving a permanently undeletable directory behind for the next run/mvn clean to trip over.
     try {
+      // setWritable(false) only reports whether the chmod syscall itself succeeded, not whether the OS
+      // will actually enforce it - a process running as root bypasses the permission check entirely,
+      // which would make the delete below succeed anyway and turn this into a false failure instead of a
+      // skip. Probe with an unrelated write before trusting the directory is really locked down:
+      // createNewFile() returns false only for "already exists", so a refused create surfaces as an
+      // IOException instead.
+      boolean permissionActuallyEnforced;
+      try {
+        permissionActuallyEnforced = !new File(undeletableDir, "permission-probe").createNewFile();
+      } catch (final IOException e) {
+        permissionActuallyEnforced = true;
+      }
+      assumeThat(permissionActuallyEnforced)
+          .as("this test requires directory write permission to actually be enforced (e.g. not running as root)")
+          .isTrue();
+
       final String outcome = txManager.deleteWALFileForTesting(walFile);
 
       assertThat(outcome)
@@ -68,6 +88,7 @@ class TransactionManagerWalFileDeleteFailureReportedTest extends TestHelper {
     } finally {
       undeletableDir.setWritable(true);
       walFile.delete();
+      new File(undeletableDir, "permission-probe").delete();
       undeletableDir.delete();
     }
   }

--- a/engine/src/test/java/com/arcadedb/engine/TransactionManagerWalFileDeleteFailureReportedTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/TransactionManagerWalFileDeleteFailureReportedTest.java
@@ -77,11 +77,11 @@ class TransactionManagerWalFileDeleteFailureReportedTest extends TestHelper {
           .as("this test requires directory write permission to actually be enforced (e.g. not running as root)")
           .isTrue();
 
-      final String outcome = txManager.deleteWALFileForTesting(walFile);
+      final TransactionManager.WalFileSweepOutcome outcome = txManager.deleteWALFileForTesting(walFile);
 
       assertThat(outcome)
           .as("a delete the OS actually refused must be reported as an error, not silently as success")
-          .isEqualTo("ERROR");
+          .isEqualTo(TransactionManager.WalFileSweepOutcome.ERROR);
       assertThat(walFile)
           .as("the file the OS refused to delete must still be there")
           .exists();

--- a/engine/src/test/java/com/arcadedb/engine/TransactionManagerWalFileDeleteFailureReportedTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/TransactionManagerWalFileDeleteFailureReportedTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.LocalDatabase;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+/**
+ * Regression test for a correctness issue found in code review on #7502 (discussion #7479):
+ * {@code TransactionManager.deleteWALFileIfNotHeldByAnotherInstance} discarded the return value of
+ * {@code File.delete()}, so a delete that the OS actually refused - most notably on Windows, where a
+ * process cannot delete a file through which it still holds an open, non-share-delete handle, even its
+ * own - was reported as {@code DELETED} anyway. The old code (a plain {@code File.delete()} with no
+ * handle open at all) did not have this failure mode; masking it here would have been a regression for
+ * whichever platform hits it.
+ * <p>
+ * Reproduced portably (this fails identically on Linux and macOS) by making the containing directory
+ * read-only, which makes the OS refuse the delete regardless of platform-specific handle semantics.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class TransactionManagerWalFileDeleteFailureReportedTest extends TestHelper {
+
+  @Test
+  void deleteFailureIsReportedNotSilentlyTreatedAsSuccess() throws Exception {
+    final TransactionManager txManager = ((LocalDatabase) database).getTransactionManager();
+
+    final File undeletableDir = new File(database.getDatabasePath(), "undeletable-7479");
+    assertThat(undeletableDir.mkdirs()).isTrue();
+    final File walFile = new File(undeletableDir, "txlog_9996.wal");
+    assertThat(walFile.createNewFile()).isTrue();
+
+    assumeThat(undeletableDir.setWritable(false))
+        .as("this test needs to be able to make a directory read-only")
+        .isTrue();
+    try {
+      final String outcome = txManager.deleteWALFileForTesting(walFile);
+
+      assertThat(outcome)
+          .as("a delete the OS actually refused must be reported as an error, not silently as success")
+          .isEqualTo("ERROR");
+      assertThat(walFile)
+          .as("the file the OS refused to delete must still be there")
+          .exists();
+    } finally {
+      undeletableDir.setWritable(true);
+      walFile.delete();
+      undeletableDir.delete();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/TransactionManagerWalFileLostFencesTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/TransactionManagerWalFileLostFencesTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.log.WarningCapture;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for discussion #7479: a WAL file this instance still has open can become
+ * inaccessible without this instance ever closing or dropping it - the reported scenario was a
+ * second embedded process opening the same database directory (a per-process advisory lock that a
+ * Docker Desktop bind mount does not enforce across the container boundary) and deleting every
+ * {@code *.wal} file in it on its own clean close, including the ones the first, still-running
+ * instance had open. Before this fix, {@code TransactionManager.checkWALFiles()} caught the
+ * resulting {@code IOException} and just logged it at SEVERE - once a second, forever, via the
+ * housekeeping timer - while the database kept silently accepting writes into a WAL pool that could
+ * no longer be trusted. It must instead fence the database once, the same way a post-WAL-append
+ * commit failure already does (#5053): one clear diagnostic, and the housekeeping timer cancels
+ * itself on its next tick (see {@link TransactionManagerFencedTimerTaskTest}).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class TransactionManagerWalFileLostFencesTest extends TestHelper {
+
+  /**
+   * A WAL file stand-in whose {@link #getSize()} always fails with the exact exception the reporter's
+   * server log showed ({@code java.io.IOException: No such file or directory}), regardless of what
+   * actually happened on disk. Unlike deleting the real file, which on a native POSIX filesystem does
+   * not fail an already-open file descriptor's {@code size()} call, this reproduces the failure the
+   * way the reporter's virtualized bind mount actually surfaced it, portably.
+   */
+  private static final class VanishedWALFile extends WALFile {
+    private VanishedWALFile(final String filePath) throws IOException {
+      super(filePath);
+    }
+
+    @Override
+    public long getSize() throws IOException {
+      throw new IOException("No such file or directory");
+    }
+  }
+
+  @Override
+  protected void beginTest() {
+    database.getSchema().createDocumentType("Doc");
+  }
+
+  @Test
+  void vanishedWalFileFencesInsteadOfLoggingForever() throws Exception {
+    final LocalDatabase db = (LocalDatabase) database;
+    final TransactionManager txManager = db.getTransactionManager();
+
+    assertThat(db.isFencedForRecovery()).isFalse();
+
+    final WALFile vanished = new VanishedWALFile(db.getDatabasePath() + "/txlog_vanished_7479.wal");
+    WALFile displaced = null;
+    try {
+      displaced = txManager.replaceActiveWALFileForTesting(0, vanished);
+
+      final List<String> severeLines = WarningCapture.captureSevere(txManager::checkWALFilesForTesting);
+
+      assertThat(db.isFencedForRecovery())
+          .as("a WAL file this instance still has open becoming inaccessible must fence the database")
+          .isTrue();
+      assertThat(severeLines)
+          .as("exactly one clear fence diagnostic, not a raw WAL-management stack trace per pool slot; got: %s",
+              severeLines)
+          .hasSize(1)
+          .allMatch(line -> line.contains("fenced for recovery"));
+
+      // A second pass (the housekeeping timer would otherwise still be running once a second) must be a
+      // silent no-op: fenceForRecovery() only ever logs its first reason.
+      final List<String> secondPassLines = WarningCapture.captureSevere(txManager::checkWALFilesForTesting);
+      assertThat(secondPassLines).isEmpty();
+    } finally {
+      vanished.close();
+      // Put the real pool file back so the impending close() below can close and drop it normally
+      // instead of leaking its file descriptor.
+      if (displaced != null)
+        txManager.replaceActiveWALFileForTesting(0, displaced);
+    }
+
+    database.close();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/TransactionManagerWalRotationCollidesWithForeignWalFencesTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/TransactionManagerWalRotationCollidesWithForeignWalFencesTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.LocalDatabase;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for a gap found in code review on #7502 (discussion #7479): {@link WALFile#acquireLock()}
+ * can fail (return without a lock) and the file was still added to the pool and used normally - a second
+ * embedded instance racing a WAL file-name collision (the counter is seeded past every name a directory
+ * scan can see, but says nothing about a name a concurrent process claims after that scan) would silently
+ * share the file with whoever holds it instead of being noticed at all.
+ * <p>
+ * Exercised at the {@code checkWALFiles()} runtime-rotation call site: the counter there does not rescan
+ * the directory (unlike {@code createWALFilePool()}'s own defensive reseed at open time), so it is the one
+ * of the three construction sites a same-name collision can realistically still reach.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class TransactionManagerWalRotationCollidesWithForeignWalFencesTest extends TestHelper {
+
+  /** Reports a size past the rotation threshold so {@code checkWALFiles()} treats it as full. */
+  private static final class OversizedWALFile extends WALFile {
+    private OversizedWALFile(final String filePath) throws IOException {
+      super(filePath);
+    }
+
+    @Override
+    public long getSize() {
+      return 64L * 1024 * 1024 + 1; // must exceed TransactionManager.MAX_LOG_FILE_SIZE (64 MB)
+    }
+  }
+
+  @Override
+  protected void beginTest() {
+    database.getSchema().createDocumentType("Doc");
+  }
+
+  @Test
+  void rotationCollidingWithLiveForeignWalFileFencesInsteadOfSharingIt() throws Exception {
+    final LocalDatabase db = (LocalDatabase) database;
+    final TransactionManager txManager = db.getTransactionManager();
+
+    assertThat(db.isFencedForRecovery()).isFalse();
+
+    final String collidingPath = db.getDatabasePath() + "/txlog_" + txManager.getLogFileCounterForTesting() + ".wal";
+    // Stands in for a second, live instance that already claimed the exact name this rotation is about
+    // to try next - the self-lock every WALFile now takes for its whole life (issue #7479) is what a real
+    // second instance would already be holding.
+    final WALFile anotherInstanceWAL = new WALFile(collidingPath);
+    final OversizedWALFile oversized = new OversizedWALFile(db.getDatabasePath() + "/txlog_test_oversized_7479.wal");
+    WALFile displaced = null;
+    try {
+      displaced = txManager.replaceActiveWALFileForTesting(0, oversized);
+
+      txManager.checkWALFilesForTesting();
+
+      assertThat(db.isFencedForRecovery())
+          .as("a rotation whose next WAL file name collides with one another live instance already has open "
+              + "must fence the database instead of silently sharing that file with it")
+          .isTrue();
+    } finally {
+      anotherInstanceWAL.close();
+      new File(collidingPath).delete();
+      oversized.close();
+      new File(db.getDatabasePath(), "txlog_test_oversized_7479.wal").delete();
+      if (displaced != null)
+        txManager.replaceActiveWALFileForTesting(0, displaced);
+    }
+
+    database.close();
+  }
+}

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/GraphImporter.java
@@ -77,6 +77,16 @@ import java.util.logging.Level;
  * index's automatic rebuild deferred for that long; its writes stay searchable through the delta scan meanwhile.
  * The importer is meant for a database being loaded, not one serving other writers at the same time.
  * <p>
+ * <b>Never point this at a database directory a running ArcadeDB Server (or any other process/JVM) already has
+ * open</b> (issue #7479). {@code DatabaseFactory} opens the raw database files directly - the same files the
+ * server's own embedded engine has open - and while the per-process lock file is meant to refuse that, it is
+ * only as reliable as the filesystem's advisory locking: a Docker Desktop bind mount (Windows/macOS) does not
+ * enforce {@code FileChannel.tryLock()} across the host/container boundary, so a second process can open the
+ * same files anyway. Two independent, uncoordinated engine instances writing to one set of files is unsafe
+ * regardless of that particular gap - one instance's own clean {@code close()} can remove WAL files the other
+ * still has open, corrupting it. To bulk-load into a database a server is serving, use the server's own remote
+ * protocol instead of an embedded {@code DatabaseFactory}, or stop the server for the duration of the import.
+ * <p>
  * Usage:
  * <pre>
  * GraphImporter.builder(database)


### PR DESCRIPTION
## Summary

Fixes #7502, tracking discussion #7479.

Reported: running `GraphImporter` as a separate embedded process against a database directory an ArcadeDB server (dockerized) already had open corrupted the server - repeated `java.io.IOException: No such file or directory` on the server's own WAL files, no data visible via `SELECT` while the server kept running, and record-count badges stuck at 0 after a restart.

Root cause: `TransactionManager.close()`'s final WAL cleanup deleted **every** `*.wal` file it found by name in the database directory, not only the ones its own pool created. The per-process advisory lock (`FileChannel.tryLock()` on a lock file) is meant to prevent two instances from ever opening the same database directory at once, but a Docker Desktop bind mount (Windows/macOS) does not enforce that lock across the container/host boundary - so the importer's own process opened the same files the server had open, and the importer's own clean close then swept away the still-running server's active WAL files. From that point the server's `checkWALFiles()` caught the resulting `IOException` and just logged it at SEVERE every second, forever, while continuing to silently accept writes into a WAL pool that could no longer be trusted - which also explains the stale/zeroed record counts (an independent process's in-memory counters got persisted over the correct ones).

**Scope, stated plainly:** on the literal Docker Desktop bind-mount setup from the report, `FileChannel.tryLock()` itself does not cross the container/host boundary - so on that exact filesystem, the new WAL-file locking below cannot detect the other instance either, for the same reason the original whole-database lock file didn't. The locking fix is a real, general improvement for two embedded instances sharing one database directory on a normal filesystem (same host, no such virtualized bind mount), and it closes an unrelated, always-present hole (an unowned `.wal`-named file was deleted by name alone, with no check at all). But for the bind-mount case specifically, the only real fix is not doing this in the first place - hence the `GraphImporter` Javadoc warning below, which is the change that actually addresses the reported environment.

## Changes

- `WALFile` now takes an exclusive OS-level lock on itself for its whole life (released on `close()`). Without this, nothing anywhere ever locked an individual WAL file, so the check below had nothing real to detect (caught in code review).
- `TransactionManager.close()`: before deleting a `.wal`-named file this instance's own pool didn't track, try an exclusive lock on it first (using a `WALFile` as the probe, so the handle is closed before the delete is attempted - a `RandomAccessFile` held open across the delete fails silently on Windows, also caught in review). A genuine orphan from an earlier unclean shutdown of the *same* database is still removed exactly as before; a file another live instance still has open survives, with a warning instead of silent corruption. `File.delete()`'s return value is now checked, so an OS-level delete failure is reported as an error instead of assumed to have succeeded.
- `TransactionManager.checkWALFiles()`: when a WAL file this instance still has open becomes inaccessible - which never happens under normal single-process operation - it now fences the database via the existing post-WAL-append mechanism (#5053) instead of logging the same stack trace once a second indefinitely. One clear diagnostic, and the housekeeping timer cancels itself on its next tick (already covered by `TransactionManagerFencedTimerTaskTest`).
- `GraphImporter`'s class Javadoc now calls out the hazard explicitly: never point it at a database directory a running server already has open, and use the server's remote protocol instead for that case. This is the change that actually covers the reported Docker Desktop bind-mount environment - see Scope note above.

## Test plan

- [x] `TransactionManagerWalFileLostFencesTest` (new) - a WAL file becoming inaccessible fences the database with exactly one diagnostic instead of repeating every check; verified red without the fix, green with it.
- [x] `TransactionManagerCloseSkipsLockedForeignWalFileTest` (new) - stands up a real `WALFile` as the "other instance" (exercises the actual self-lock mechanism, not a hand-rolled lock); a locked foreign `.wal` file survives `close()` while an unlocked orphan is still removed; verified red without the fix, green with it.
- [x] `TransactionManagerWalFileDeleteFailureReportedTest` (new) - an OS-level delete failure (simulated portably via a read-only containing directory) is reported as an error, not silently treated as success; verified red without the fix, green with it.
- [x] `mvn -o -pl engine -am test -Dtest=com.arcadedb.engine.*Test,com.arcadedb.database.*Test -DexcludedGroups=benchmark,slow,vector` - 610 tests, 0 failures/errors.
- [x] `mvn -o -pl integration test -Dtest=com.arcadedb.integration.importer.*Test -DexcludedGroups=benchmark,slow,vector` - 331 tests, 0 failures/errors.
- [x] `mvn -o -pl engine,integration -am compile` - clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database recovery when write-ahead log files are inaccessible or locked by another process.
  * Prevented cleanup and WAL rotation from using files held by another database instance.
  * Orphaned WAL files are removed during shutdown when they are not in use.
  * Deletion failures are reported instead of treated as successful.
  * Reduced repeated error reporting after a database is fenced for recovery.

* **Documentation**
  * Added guidance to avoid running graph imports concurrently with an active server or another process using the same database.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
