### PR TITLE
feat(#7401): connect cluster joins the named server instead of refusing

### DIFF
--- a/docs/7304-grpc-control-plane.md
+++ b/docs/7304-grpc-control-plane.md
@@ -104,7 +104,7 @@ ArcadeDbGrpcAdminService.java:297-298  (definition, mirrors checkRootUser)
 | `disconnect cluster` | `DisconnectCluster` | fixed here | yes (authz + non-HA rejection) |
 | `GET /health` | `Health` | fixed here | yes |
 | `GET /ready` | `Ready` | fixed here | yes |
-| `connect cluster` | `ConnectCluster` | **argued here, reversed by #7400** | yes, in #7400 (authz + non-HA rejection) |
+| `connect cluster` | `ConnectCluster` | **argued here, reversed by #7400**; implemented by #7401 | yes, in #7400 (authz + non-HA rejection) and #7401 (the join) |
 | `restore backup` | none | **filed** #7308 | - |
 | `restore database` | none | **filed** #7308 | - |
 | `import database` | none | **filed** #7308 | - |
@@ -127,7 +127,10 @@ ArcadeDbGrpcAdminService.java:297-298  (definition, mirrors checkRootUser)
   carrying the shared implementation's own message, and a later real join lands in one place for
   both transports. The shared method has since moved to `ServerControlPlane.connectCluster` and
   raises `OperationNotAvailableException` (a `CommandExecutionException` subtype), which is the arm
-  that maps to `FAILED_PRECONDITION`. Whether to implement the join at all is #7401.
+  that maps to `FAILED_PRECONDITION`. Whether to implement the join at all was #7401, and it did: the
+  verb now adds the named server to this cluster, so the `FAILED_PRECONDITION` above is what a server
+  with no HA - or an HA implementation without runtime membership - answers, not what every caller
+  gets.
 - **`POST /login` / `POST /logout` / `GET /sessions`** - HTTP sessions exist because HTTP is
   stateless per request and the browser needs a bearer token. gRPC authenticates every admin RPC
   from the `DatabaseCredentials` on the request body, enforced centrally in
@@ -277,8 +280,12 @@ findings, both correct, both fixed:
    policy refuses was never counted. The chained form silently turned nine of them from successes
    into attempts, in a PR that claimed the split changed no behaviour. Each command now has a small
    wrapper in the handler that runs the shared implementation and increments afterwards.
-   `connect cluster` is the one exception and says so: it always throws, so there is no success to
-   count after, which is what the moved implementation did too.
+   `connect cluster` was the one exception and said so: it always threw, so there was no success to
+   count after, which is what the moved implementation did too. *Issue #7401 made the verb a real
+   join, so that exception is gone - its counter is incremented after the call like every other, and
+   `http.connect-cluster` now counts successful joins rather than attempts. Noted here rather than
+   deleted because the rule this list states is the record, and the exception to it is the part a
+   reader would otherwise re-derive.*
 2. **`ExistsDatabase` disclosed the existence of databases the caller has no grant on.** The first
    attempt left it unfiltered and this document claimed that as parity with
    `GetExistsDatabaseHandler`. That was a misreading of the handler's comment, which explains why it

--- a/docs/7401-connect-cluster-implementation.md
+++ b/docs/7401-connect-cluster-implementation.md
@@ -83,6 +83,7 @@ $ grep -rn "CONNECT_CLUSTER\|connectCluster" --include='*.java' --exclude-dir=ta
 | `ServerControlPlane.connectCluster` -> `HAServerPlugin.connectCluster` default (an HA implementation without dynamic membership) | yes - `UnsupportedOperationException` is converted to `OperationNotAvailableException`, so the refusal keeps HTTP 500 / gRPC `FAILED_PRECONDITION` instead of degrading to `INTERNAL` | yes - `Issue7401ServerControlPlaneConnectClusterTest` |
 | `ServerControlPlane.connectCluster` -> the users seed | yes | yes - `Issue7401ServerControlPlaneConnectClusterTest` asserts the seed runs, runs *after* the join, and that a failing seed does not fail the join |
 | `RaftHAPlugin.connectCluster` -> address parsing / peer-id derivation | yes | yes - `Issue7401JoinTargetTest`, one case per server-list syntax the argument can use |
+| `RaftHAPlugin.connectCluster` -> the declared leader-election **priority** reaching the committed peer | yes - fixed during the review loop, see below | yes - `Issue7401JoinPriorityTest`, which reads the `SetConfigurationRequest` Ratis is asked to commit |
 | `RaftHAPlugin.connectCluster` with the Raft server not started | yes - `ServerException` | **argued**: the same guard, message and call shape as the four sibling membership methods in the same class (`addPeer`, `removePeer`, `transferLeadership`, `stepDown`). None of them has a test for it, and one here would pin the guard rather than the join |
 | `arcadedb.ha.serverList` startup path -> `parsePeerList` peer-id derivation | yes (refactor only - now calls the extracted `peerIdForAddress`) | yes - the 155 existing `ha-raft` resolver/K8s/allowlist tests still pass, and `Issue7401JoinTargetTest.theJoinPathAndTheServerListPathAgreeOnTheSameAddress` compares the two derivations directly |
 | Kubernetes scale-up -> `synthesizeK8sScaleUpPeer` peer-id derivation | yes (refactor only - same extraction) | yes - `Issue4836K8sScaleUpTest` (7 tests, unchanged, still green) |
@@ -132,11 +133,12 @@ Run and green (`-Dmaven.repo.local` isolated):
 | `grpcw` `Issue7304GrpcControlPlaneIT`, `Issue7304GrpcControlPlaneAuthorizationIT`, `Issue7400GrpcConnectClusterIT` | 83 passed |
 | `grpc-client` `Issue7304RemoteGrpcServerControlPlaneIT`, `Issue7400RemoteGrpcConnectClusterIT` | 10 passed |
 
-Two suites could not be re-run at the end of the session, because other agents on this machine held
-the fixed ports these fixtures bind. Both were green earlier in the session on the same code:
-`ha-raft` `Issue7401ConnectClusterJoinsPeerIT` (3 passed, 41 s) and the tail of the `ha-raft` unit lane
-(425 passed before `LeaveClusterTest` crashed its fork on `java.net.BindException: Address already in
-use` for the Raft port). `lsof -nP -iTCP:2434 -sTCP:LISTEN` named a foreign JVM throughout.
+`Issue7401ConnectClusterJoinsPeerIT` ran green twice: before the priority fix (3 passed, 41 s) and
+again after it (3 passed, 37 s). In between, several attempts to run it died in
+`Error occurred in starting fork` on `java.net.BindException: Address already in use` for Raft port
+2434, held by another agent's JVM on this machine (`lsof -nP -iTCP:2434 -sTCP:LISTEN`) - the fixed-port
+collision `CLAUDE.md` documents, not a property of the test. The `ha-raft` unit lane lost its tail the
+same way: 425 passed before `LeaveClusterTest` crashed its fork on the same bind.
 
 `server` `PostServerCommandHandlerIT` reported 4 failures in this environment
 (`createUserRejectsShortPassword`, `userCommandsCaseSensitivity`, `restoreDatabaseCommand`,
@@ -193,6 +195,56 @@ A third finding came from the tests rather than from reading, and is recorded un
 changed about the design** above: the first live IT assumed an unreachable peer could be added, and it
 cannot. That became #7514.
 
+## Review finding: the declared priority was parsed and then dropped
+
+The first `claude` review of PR #7517 found a real defect, and it is the most instructive thing in this
+change.
+
+`parseJoinTarget` parses a whole server-list entry, and both the object form
+(`db2:{raft:2435,priority:7}`) and the four-field positional form (`db2:2435:2481:5`) declare a
+leader-election priority. `Issue7401JoinTargetTest.theObjectFormIsAcceptedToo` asserted
+`target.peer().getPriority()` and passed throughout. One layer down, `RaftHAPlugin.connectCluster`
+handed `addPeer` an id, an address and a name, and `RaftClusterManager.addPeer` built a **fresh**
+`RaftPeer` from those three - so the priority was silently replaced by `RaftPeer.Builder`'s default.
+
+It is not cosmetic. `RaftHAServer.selectStepDownTargets` reads each live peer's `getPriority()` and,
+once any peer has a positive priority, skips the priority-0 ones as non-electable witnesses
+(`RaftHAServer.java`, the `maxPriority > 0 && peer.getPriority() <= 0` guard) - so a priority reset to
+the default changes which nodes can take leadership. Every other assertion about the join held while
+the cluster got a configuration the operator had not asked for.
+
+**Fixed by handing the parsed `RaftPeer` over whole** - a new `RaftClusterManager.addPeer(RaftPeer,
+String)`, a package-private `RaftHAServer` passthrough, and one changed line in
+`RaftHAPlugin.connectCluster` - rather than by adding a fourth `priority` argument. The two are
+equivalent today; taking the peer whole makes losing the *next* field impossible instead of merely
+tested for, and the same defect had by then occurred twice. The three-argument overload stays for
+`POST /api/v1/cluster/peer`, whose payload has no priority to pass.
+
+`Issue7401JoinPriorityTest` pins it from `parseJoinTarget` through to the `SetConfigurationRequest`,
+which is the last point the value can be lost. It was checked against the defect before being trusted:
+reintroducing the rebuild turns three of its four cases red (`expected: 7 but was: 0`), and the fourth -
+an entry with no priority, which must still be 0 - correctly stays green.
+
+`RaftAtomicMembershipTest` was deliberately **not** touched, per this project's rule against modifying
+existing tests; the new coverage lives in its own class.
+
+### What the reviewer got wrong, and the evidence
+
+The same review reported that the PR description "describes a `LeaderCommandForwarder` that forwards
+`POST/PUT/DELETE /api/v1/server/users` to the Raft leader, closing #7380". It does not, and never did:
+`gh pr view 7517 --json body` returns a body whose first line is `Closes #7401` and whose summary is
+this verb. Nothing was changed in response. Reported back on the thread rather than silently ignored.
+
+### A note on how the fix arrived
+
+An automated fix pass wrote its own version of this fix into the worktree while the review was in
+flight. It added the 4-argument plumbing and a javadoc saying "Priority carries through too" - **but
+left `RaftHAPlugin.connectCluster` calling the three-argument overload**, so the priority was still
+dropped and the new javadoc asserted something the code did not do. Its test passed only because it
+called `RaftClusterManager.addPeer` with four arguments directly, bypassing the unwired call site. It
+also edited an existing test method. Those edits were stashed rather than committed, and the fix above
+was written and verified from scratch. The follow-up it filed, **#7523**, is accurate and is kept.
+
 ## Follow-ups filed before the PR opened
 
 - **#7514** - adding an unreachable peer hangs about 60 s and reports a raw Ratis
@@ -202,6 +254,9 @@ cannot. That became #7514.
   for, which is what this verb meant before the Raft stack landed. Out of scope because it is not an
   argument mapping: it has to decide what happens to the local Raft log, and doing it silently is the
   split-brain the leader-side membership change prevents.
+- **#7523** - `POST /api/v1/cluster/peer` still cannot set a joining peer's priority: its JSON payload
+  has no field for one. Raised by the priority fix above, and left there deliberately - extending that
+  HTTP contract is a different surface from this issue's verb.
 
 ## Residual risk
 

--- a/docs/7401-connect-cluster-implementation.md
+++ b/docs/7401-connect-cluster-implementation.md
@@ -84,7 +84,7 @@ $ grep -rn "CONNECT_CLUSTER\|connectCluster" --include='*.java' --exclude-dir=ta
 | `ServerControlPlane.connectCluster` -> the users seed | yes | yes - `Issue7401ServerControlPlaneConnectClusterTest` asserts the seed runs, runs *after* the join, and that a failing seed does not fail the join |
 | `RaftHAPlugin.connectCluster` -> address parsing / peer-id derivation | yes | yes - `Issue7401JoinTargetTest`, one case per server-list syntax the argument can use |
 | `RaftHAPlugin.connectCluster` -> the declared leader-election **priority** reaching the committed peer | yes - fixed during the review loop, see below | yes - `Issue7401JoinPriorityTest`, which reads the `SetConfigurationRequest` Ratis is asked to commit |
-| `RaftHAPlugin.connectCluster` with the Raft server not started | yes - `ServerException` | **argued**: the same guard, message and call shape as the four sibling membership methods in the same class (`addPeer`, `removePeer`, `transferLeadership`, `stepDown`). None of them has a test for it, and one here would pin the guard rather than the join |
+| `RaftHAPlugin.connectCluster` with the Raft server not started | yes - `ServerException` | **argued**: the same guard, in the same place, with the same message as the sibling membership methods in this class (`addPeer`, `removePeer`, `transferLeadership`, `stepDown`, `leaveCluster`). None of them has a test for it, and one here would pin the guard rather than the join. The *type* differs and is stated here rather than glossed: `grep -n "Raft HA server not started" RaftHAPlugin.java` shows five bare `RuntimeException`s, one `TransactionException` and this one `ServerException`. Nothing observable turns on it - neither is `IllegalArgumentException` nor `OperationNotAvailableException`, so both surface as HTTP 500 / gRPC `INTERNAL` - and the more descriptive type is kept rather than matched downwards; converting the other six is unrelated churn for this PR |
 | `arcadedb.ha.serverList` startup path -> `parsePeerList` peer-id derivation | yes (refactor only - now calls the extracted `peerIdForAddress`) | yes - the 155 existing `ha-raft` resolver/K8s/allowlist tests still pass, and `Issue7401JoinTargetTest.theJoinPathAndTheServerListPathAgreeOnTheSameAddress` compares the two derivations directly |
 | Kubernetes scale-up -> `synthesizeK8sScaleUpPeer` peer-id derivation | yes (refactor only - same extraction) | yes - `Issue4836K8sScaleUpTest` (7 tests, unchanged, still green) |
 
@@ -227,6 +227,19 @@ an entry with no priority, which must still be 0 - correctly stays green.
 
 `RaftAtomicMembershipTest` was deliberately **not** touched, per this project's rule against modifying
 existing tests; the new coverage lives in its own class.
+
+### Second review cycle
+
+"A few minor points, no blockers." One was a real accuracy defect in this document and is fixed above:
+the coverage table claimed the not-started guard had the same "call shape" as its siblings, and the
+exception *type* is not the same - they throw bare `RuntimeException`, this throws `ServerException`.
+The claim was narrowed to what `grep` actually shows, the type was kept (nothing observable turns on
+it, and it is the more descriptive one), and the six siblings were left alone as unrelated churn.
+
+The other two points were flags rather than requests and needed no change: `http.connect-cluster` now
+counts successful joins instead of attempts, which is the house pattern every other wrapper in
+`PostServerCommandHandler` already follows and is annotated in `docs/7304-grpc-control-plane.md`; and
+the known gaps were noted as honestly disclosed.
 
 ### What the reviewer got wrong, and the evidence
 

--- a/docs/7401-connect-cluster-implementation.md
+++ b/docs/7401-connect-cluster-implementation.md
@@ -291,3 +291,29 @@ What this change does **not** cover, in plain language:
    so at WARNING.
 
 Nothing else: the coverage table above is the evidence, and its two argued rows carry their reasons.
+
+## Pull request
+
+<https://github.com/ArcadeData/arcadedb/pull/7517>
+
+## Review cycles
+
+| # | Head | What the review said | What changed |
+|---|---|---|---|
+| 1 | `225b3c2` | One real defect: the leader-election priority was parsed and then dropped, because `connectCluster` passed `addPeer` an id, address and name and `addPeer` rebuilt a fresh `RaftPeer`. Plus a finding that the PR description described a `LeaderCommandForwarder` closing #7380 | Fixed by handing the parsed `RaftPeer` over whole, with `Issue7401JoinPriorityTest` pinning it from the parse to the `SetConfigurationRequest`. The description finding did not hold - `gh pr view 7517 --json body` starts `Closes #7401` - and was answered on the thread |
+| 2 | `0dd64bf` | "A few minor points, no blockers." The not-started guard's claimed "call shape" parity with its siblings was wrong on the exception type; the `http.connect-cluster` metric now counts successes rather than attempts; known gaps honestly disclosed | The inaccurate claim was narrowed to what `grep` shows, in this document and in the PR body. The metric point was a flag, not a request, and matches the house pattern; no change |
+| 3 | `0226b4d` | "No blocking issues found." One non-blocking suggestion to trim this document's process narrative post-merge | Kept, with the reasoning answered on the thread: the javadoc and the OpenAPI description are the reference documentation, and the two sections named are the near-miss record a later reader could not reconstruct |
+
+An automated fix pass also wrote its own version of the priority fix into the worktree during cycle 1.
+It left the call site unwired, so the bug survived while a new javadoc claimed otherwise, and it edited
+an existing test method. Those edits were stashed, not committed (`git stash list`, two entries labelled
+"superseded"; a patch copy is outside the repo). The follow-up it filed, #7523, is accurate and kept.
+
+## Deferred items
+
+None. No `review-deferred-*.md` notes file was produced by any cycle of this PR - every finding was
+either fixed in the branch, answered with evidence on the thread, or filed as a follow-up issue.
+
+## Final state
+
+`clean-approval` after 3 cycles. Merge is the developer's.

--- a/docs/7401-connect-cluster-implementation.md
+++ b/docs/7401-connect-cluster-implementation.md
@@ -1,0 +1,225 @@
+# #7401 - `connect cluster` is a stub on every transport
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/7401
+Type: enhancement (labels `enhancement`, `server`, `ha`; milestone 26.10.1)
+
+## The decision the issue asked for
+
+#7401 raised a two-way decision and left it open:
+
+1. **implement** `connect cluster` - "a client-initiated join, routed through the Raft leader the way
+   `POST /api/v1/cluster/peer` already adds a peer. If the Raft peer route is the intended way to join,
+   `connect cluster` may simply be a thin alias for it, in which case this is small"; or
+2. **retire the verb**.
+
+**Decision: option 1, in exactly the shape the issue sketched.** `connect cluster <address>` joins the
+server at `<address>` to this server's Raft cluster, by the same atomic `Mode.ADD` membership change that
+`POST /api/v1/cluster/peer` issues. Retiring was rejected because #7400 had just added the gRPC RPC for
+contract parity, so retiring means removing a published verb from two transports for a capability the
+Raft stack already has - `RaftHAPlugin.addPeer` - and only lacked an argument mapping for.
+
+### What made the alias small
+
+`POST /api/v1/cluster/peer` takes `{peerId, address}`; `connect cluster` supplies only an address. Those
+are not two different amounts of information, because a Raft peer id in this codebase is a pure function
+of the Raft address:
+
+```
+$ grep -rn --include='*.java' "replace(':', '_')" --exclude-dir=target ha-raft/
+ha-raft/.../RaftPeerAddressResolver.java:199:      final String peerIdStr = raftAddress.replace(':', '_');
+ha-raft/.../RaftPeerAddressResolver.java:512:    final String peerIdStr = raftAddress.replace(':', '_');
+```
+
+Line 199 is `parsePeerList` (every peer named in `arcadedb.ha.serverList`); line 512 is
+`synthesizeK8sScaleUpPeer` (a StatefulSet pod past the end of that list). Both sites were reading the
+same rule from a comment, so this change extracts it into `RaftPeerAddressResolver.peerIdForAddress`
+and makes all three callers - the two above and the new join path - share it.
+
+The consequence is that `connect cluster` accepts *one entry of `arcadedb.ha.serverList` syntax* and
+derives peer id, Raft address, optional HTTP address, priority and optional `name@` display name from
+it, by running the single entry through the very parser the server list uses. So the address an operator
+writes in the command is the address they would have written in the config, and the id the joined peer
+gets is the id it gives itself.
+
+## Invariant
+
+> `connect cluster <address>`, on either transport, adds the server named by `<address>` to this node's
+> Raft configuration under the same peer id `arcadedb.ha.serverList` would give it - or refuses with a
+> reason that names `<address>`.
+
+## Completeness
+
+### Entry points
+
+```
+$ grep -rn --include='*.java' "\.connectCluster(" --exclude-dir=target . | grep /src/main/
+grpc-client/.../RemoteGrpcServer.java:792:    call("connect cluster", stub -> stub.connectCluster(
+server/.../ServerControlPlane.java:163:   * (javadoc)
+server/.../http/handler/PostServerCommandHandler.java:227:    controlPlane.connectCluster(serverAddress);
+grpcw/.../ArcadeDbGrpcAdminService.java:935:      controlPlane.connectCluster(req.getServerAddress());
+
+$ grep -rn --include='*.java' "implements HAServerPlugin" --exclude-dir=target .
+ha-raft/.../RaftHAPlugin.java:52:public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider {
+server/src/test/.../GetReadyHandlerHATest.java:168:  private static final class FakeHAPlugin implements HAServerPlugin {
+```
+
+There is no HTTP `RemoteServer` method, no console command and no Studio control for this verb:
+
+```
+$ grep -rn "connect cluster\|connectCluster" --include='*.html' --include='*.js' --include='*.ts' \
+    --exclude-dir=target --exclude-dir=node_modules .
+(no output)
+$ grep -rn "CONNECT_CLUSTER\|connectCluster" --include='*.java' --exclude-dir=target console/src network*/src
+(no output)
+```
+
+### Coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| HTTP `POST /api/v1/server` -> `connect cluster <addr>` -> `PostServerCommandHandler:144,227` | yes | yes - `Issue7401ConnectClusterJoinsPeerIT` joins a real server into a live 3-node Raft cluster over this verb and asserts the committed configuration; `Issue7400ConnectClusterHttpIT` pins the refusal statuses |
+| gRPC `ConnectCluster` -> `ArcadeDbGrpcAdminService:935` | yes | yes - `Issue7400GrpcConnectClusterIT` drives both refusal statuses (`INVALID_ARGUMENT`, `FAILED_PRECONDITION`) and `theAddressReachesTheSharedImplementationUnmodified` proves the argument survives the transport. **Argued** for the join itself: the handler is `requireServerAdmin` plus one delegating call with no logic of its own, so a gRPC repeat of the live-cluster join would exercise the same `ServerControlPlane` method the HTTP IT already drives end to end |
+| `RemoteGrpcServer.connectCluster` (Java gRPC client) | yes (wire adapter, unchanged; its javadoc documented the opposite direction and is corrected) | yes - `Issue7400RemoteGrpcConnectClusterIT` |
+| `ServerControlPlane.connectCluster` -> `HAServerPlugin.connectCluster` default (an HA implementation without dynamic membership) | yes - `UnsupportedOperationException` is converted to `OperationNotAvailableException`, so the refusal keeps HTTP 500 / gRPC `FAILED_PRECONDITION` instead of degrading to `INTERNAL` | yes - `Issue7401ServerControlPlaneConnectClusterTest` |
+| `ServerControlPlane.connectCluster` -> the users seed | yes | yes - `Issue7401ServerControlPlaneConnectClusterTest` asserts the seed runs, runs *after* the join, and that a failing seed does not fail the join |
+| `RaftHAPlugin.connectCluster` -> address parsing / peer-id derivation | yes | yes - `Issue7401JoinTargetTest`, one case per server-list syntax the argument can use |
+| `RaftHAPlugin.connectCluster` with the Raft server not started | yes - `ServerException` | **argued**: the same guard, message and call shape as the four sibling membership methods in the same class (`addPeer`, `removePeer`, `transferLeadership`, `stepDown`). None of them has a test for it, and one here would pin the guard rather than the join |
+| `arcadedb.ha.serverList` startup path -> `parsePeerList` peer-id derivation | yes (refactor only - now calls the extracted `peerIdForAddress`) | yes - the 155 existing `ha-raft` resolver/K8s/allowlist tests still pass, and `Issue7401JoinTargetTest.theJoinPathAndTheServerListPathAgreeOnTheSameAddress` compares the two derivations directly |
+| Kubernetes scale-up -> `synthesizeK8sScaleUpPeer` peer-id derivation | yes (refactor only - same extraction) | yes - `Issue4836K8sScaleUpTest` (7 tests, unchanged, still green) |
+
+No row is blank. Two rows are argued with the evidence above; every other row is fixed here with a test
+driving it through that entry point.
+
+### Reachability
+
+`RaftHAPlugin` is the `HAServerPlugin` the ServiceLoader finds whenever `arcadedb.ha.enabled=true` or
+`arcadedb.ha.serverList` is non-blank, and `ServerControlPlane` is constructed by both
+`PostServerCommandHandler` and `ArcadeDbGrpcAdminService` on every request. Nothing new sits behind a
+flag. `Issue7401ConnectClusterJoinsPeerIT` boots a real Raft cluster and drives the verb over HTTP, so
+the changed code is proved to run outside its own unit test.
+
+### What testing it changed about the design
+
+The first draft of the live IT joined an address nothing listened on, on the assumption that a committed
+Raft member need not be reachable. Ratis refused: `Mode.ADD` does not commit until the new peer has
+caught up, so the verb answered 500 after sixty one-second attempts with the `SetConfigurationRequest`
+rendered into the message. The IT was rewritten around a server that is actually running, and the
+discovery became follow-up #7514 - it is the shape of the mistake this verb invites, and it is not
+specific to it: `POST /api/v1/cluster/peer` behaves the same way.
+
+## Tests
+
+New:
+
+- `ha-raft` `Issue7401JoinTargetTest` (10) - the address-to-peer derivation, one case per accepted
+  syntax, plus the direct comparison against the server-list derivation.
+- `ha-raft` `Issue7401ConnectClusterJoinsPeerIT` (3) - a live 3-node cluster: a member is dropped from
+  the committed configuration and re-joined with `connect cluster` over HTTP, from the leader and from a
+  follower; a malformed address answers 400 and changes nothing.
+- `server` `Issue7401ServerControlPlaneConnectClusterTest` (7) - the transport-independent layer against
+  a hand-written `HAServerPlugin`: blank address, HA absent, HA without dynamic membership, address
+  passed through unmodified, users seeded after the join, a failing seed not failing the join, and a
+  genuine join failure not disguised as an unavailable operation.
+
+Run and green (`-Dmaven.repo.local` isolated):
+
+| Suite | Result |
+|---|---|
+| `ha-raft` resolver / K8s / allowlist / membership unit tests (10 classes) | 155 passed |
+| `ha-raft` `Issue7401ConnectClusterJoinsPeerIT` | 3 passed (41 s) |
+| `server` OpenAPI spec tests + `GetReadyHandlerHATest` + the new control-plane test | 153 passed |
+| `server` `Issue7400ConnectClusterHttpIT`, `OpenApiSpecGenerationIT` | 20 passed |
+| `grpcw` `Issue7304GrpcControlPlaneIT`, `Issue7304GrpcControlPlaneAuthorizationIT`, `Issue7400GrpcConnectClusterIT` | 83 passed |
+| `grpc-client` `Issue7304RemoteGrpcServerControlPlaneIT`, `Issue7400RemoteGrpcConnectClusterIT` | 10 passed |
+
+Two suites could not be re-run at the end of the session, because other agents on this machine held
+the fixed ports these fixtures bind. Both were green earlier in the session on the same code:
+`ha-raft` `Issue7401ConnectClusterJoinsPeerIT` (3 passed, 41 s) and the tail of the `ha-raft` unit lane
+(425 passed before `LeaveClusterTest` crashed its fork on `java.net.BindException: Address already in
+use` for the Raft port). `lsof -nP -iTCP:2434 -sTCP:LISTEN` named a foreign JVM throughout.
+
+`server` `PostServerCommandHandlerIT` reported 4 failures in this environment
+(`createUserRejectsShortPassword`, `userCommandsCaseSensitivity`, `restoreDatabaseCommand`,
+`importDatabaseCommandSsePathHonorsTheSameLocalUrlsFlagAtTheFetchLayer`). The class hardcodes
+`http://localhost:2480`, and `lsof -nP -iTCP:2480 -sTCP:LISTEN` showed two foreign JVMs holding that port
+throughout the run - the port-conflict failure mode `CLAUDE.md` documents. None of the four touches
+`connect cluster`, and one of them fails with `ServerIsNotTheLeaderException: Leader address is unknown`
+from a server this fixture never starts HA on.
+
+## Existing tests changed
+
+`constraints.md` forbids modifying existing tests. Five assertions had to change anyway, and this is the
+exception the issue itself creates: they pin the stub's refusal string
+(`"not supported by the current HA implementation"`), which is the sentence this issue removes. No test
+was deleted and no coverage was dropped - each changed assertion was rewritten against the new contract
+and, where the new contract is stricter, strengthened with the status code it now guarantees.
+
+| Test | Was | Now |
+|---|---|---|
+| `Issue7400ConnectClusterHttpIT.connectClusterIsRefusedAndNamesTheAddress` | body contains the address and "not supported by the current HA implementation" | body still contains the address; message is the HA-not-enabled refusal |
+| `Issue7400ConnectClusterHttpIT.connectClusterWithNoAddressIsRefusedTheSameWay` | refused the same way a filled address is | 400 with "requires the address" - a bare verb is now a client error, not a precondition failure |
+| `Issue7400GrpcConnectClusterIT.connectClusterIsRefusedByTheSharedImplementation` | FAILED_PRECONDITION + the stub string | FAILED_PRECONDITION + the HA-not-enabled refusal |
+| `Issue7400GrpcConnectClusterIT.connectClusterWithAnEmptyAddressIsRefusedTheSameWay` | FAILED_PRECONDITION + the stub string | INVALID_ARGUMENT, mirroring HTTP's 400 |
+| `Issue7400RemoteGrpcConnectClusterIT.connectClusterIsReportedThroughTheSharedErrorMapper` | the stub string | the HA-not-enabled refusal |
+
+`Issue7400GrpcConnectClusterIT.theAddressReachesTheSharedImplementationUnmodified`,
+`theClusterPairFailsThePreconditionAlike`, `theClusterPairDeniesAnAuthenticatedNonRootCaller` and
+`Issue7304GrpcControlPlaneAuthorizationIT`'s `ConnectCluster` row are untouched and still pass: the
+refusal still names the address, both halves of the pair still fail the precondition alike, and the
+authorization gate is unchanged.
+
+## Adversarial pass
+
+The orchestrator's Phase 1.5 spawns one subagent that is deliberately kept ignorant of the author's
+reasoning. **No `Task` tool was available in this session**, so that exact pass could not run. Two
+substitutes were used and are reported as what they are, not as what was asked for:
+
+1. A `code-review` subagent (general-purpose, sees the diff and the tree, not this document) was
+   launched at high effort. It had not returned by the time the PR opened; anything it raises is
+   handled in the review loop as a further commit.
+2. A self-review against the same question. It was not worthless - it found two things, and both are
+   in the diff:
+   - **A comment asserting something the code does not establish.** An earlier draft said "Replicating
+     users is a leader operation, so this is also how a command that landed on a follower gets its join
+     without its seed." Reading `RaftGroupCommitter.submitAndWait` shows no leader gate at all - the
+     entry goes through a Ratis client, which routes writes to the leader - and `PostAddPeerHandler`
+     calls `replicateSecurityUsers` with no leader check either. The sentence was removed rather than
+     softened: it was an inference dressed as a fact, and the kind this project's constraints forbid.
+   - **An inference stated as a fact about `KubernetesAutoJoin`.** "runs at startup, before the node has
+     committed anything of its own" became "runs from `start()` and only while this node knows no leader
+     of its own", which is what its retry continuation condition actually says.
+
+A third finding came from the tests rather than from reading, and is recorded under **What testing it
+changed about the design** above: the first live IT assumed an unreachable peer could be added, and it
+cannot. That became #7514.
+
+## Follow-ups filed before the PR opened
+
+- **#7514** - adding an unreachable peer hangs about 60 s and reports a raw Ratis
+  `SetConfigurationRequest` as the error. Found by this work, affects `POST /api/v1/cluster/peer`
+  equally, and is the most likely operator mistake with either entry point.
+- **#7515** - there is still no way to make an already-running node join a cluster it was not configured
+  for, which is what this verb meant before the Raft stack landed. Out of scope because it is not an
+  argument mapping: it has to decide what happens to the local Raft log, and doing it silently is the
+  split-brain the leader-side membership change prevents.
+
+## Residual risk
+
+What this change does **not** cover, in plain language:
+
+1. **The joined server must already be running and reachable.** Naming one that is not costs about a
+   minute and produces an unreadable error (#7514). The verb does not probe first.
+2. **It cannot make this node join someone else's cluster** (#7515). The address names the server being
+   added, not a cluster to be joined - the reversal of the pre-Raft meaning, argued in
+   `ServerControlPlane.connectCluster`'s javadoc and in this document.
+3. **No leader routing of its own.** A request landing on a follower works because the Ratis client
+   under the membership change reaches the leader - asserted by
+   `Issue7401ConnectClusterJoinsPeerIT.connectClusterIssuedOnAFollowerStillJoinsThePeer`, not assumed -
+   but nothing in the HTTP layer forwards it, exactly as `POST /api/v1/cluster/peer` does not.
+4. **No Studio control.** `grep` over the static resources finds no UI for either half of the pair, and
+   this change adds none; it was not there to fix.
+5. **The users seed is best-effort**, as it is on the add-peer route it copies. A seed that fails leaves
+   the peer a committed member with a stale user set until the next cluster-wide user change, and says
+   so at WARNING.
+
+Nothing else: the coverage table above is the evidence, and its two argued rows carry their reasons.

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
@@ -779,14 +779,19 @@ public class RemoteGrpcServer implements AutoCloseable {
   }
 
   /**
-   * Asks this server to join the cluster reachable at {@code serverAddress} ({@code <host>:<port>}),
-   * the client half of the pair {@link #disconnectCluster()} completes (issue #7400).
+   * Joins the server named by {@code serverAddress} to the cluster of the server this client is
+   * connected to, the other half of the pair {@link #disconnectCluster()} completes (issue #7400).
    * <p>
-   * Reaches the same {@code ServerControlPlane.connectCluster} the HTTP {@code connect cluster} verb
-   * calls. The current HA stack does not implement a client-initiated join, so today this raises the
-   * server's own refusal through {@code GrpcClientErrorMapper} rather than joining anything; issue
-   * #7401 carries that decision. The address is sent as given - the server refuses before reading it,
-   * exactly as the HTTP verb does.
+   * <b>Note the direction</b>, which issue #7401 settled and which is the opposite of what this
+   * javadoc claimed when the RPC shipped: the address names the server being <em>added</em>, and the
+   * server this client is talking to is the one whose cluster grows. It is the operator-facing alias
+   * of {@code POST /api/v1/cluster/peer}. A node cannot be made to join a foreign cluster this way -
+   * a running Raft node would have to discard its own log first - so that is not what this does.
+   * <p>
+   * {@code serverAddress} is one entry of {@code arcadedb.ha.serverList}: {@code host},
+   * {@code host:raftPort}, the longer positional forms or the {@code host:&#123;raft:..,http:..&#125;}
+   * object form, optionally prefixed {@code name@}. It is sent as given; the server validates it for
+   * every transport, and surfaces a refusal through {@code GrpcClientErrorMapper}.
    */
   public void connectCluster(final String serverAddress) {
     call("connect cluster", stub -> stub.connectCluster(

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue7400RemoteGrpcConnectClusterIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue7400RemoteGrpcConnectClusterIT.java
@@ -35,8 +35,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * one nobody can use, which is why #7304 drove every service method from here too.
  * <p>
  * What is proved is that the proto, the service and the client agree over a real channel - and that
- * the server's own refusal survives the trip. The current HA stack does not implement the verb on
- * either transport (issue #7401); parity of the answer is the subject here, not a working join.
+ * the server's own refusal survives the trip. This fixture runs no HA, so the refusal is that HA is not
+ * enabled; the join the verb performs when it is arrived with issue #7401.
  */
 class Issue7400RemoteGrpcConnectClusterIT extends BaseGraphServerTest {
 
@@ -74,7 +74,7 @@ class Issue7400RemoteGrpcConnectClusterIT extends BaseGraphServerTest {
   void connectClusterIsReportedThroughTheSharedErrorMapper() {
     assertThatThrownBy(() -> server.connectCluster("localhost:2425"))
         .isInstanceOf(RemoteException.class)
-        .hasMessageContaining("not supported by the current HA implementation");
+        .hasMessageContaining("not running with High Availability module enabled");
   }
 
   /**

--- a/grpc/src/main/proto/arcadedb-server.proto
+++ b/grpc/src/main/proto/arcadedb-server.proto
@@ -1039,9 +1039,9 @@ service ArcadeDbAdminService {
   rpc DisconnectCluster (DisconnectClusterRequest) returns (DisconnectClusterResponse);
   // The other half of the cluster pair (issue #7400). A thin adapter over the same
   // ServerControlPlane.connectCluster the HTTP `connect cluster` verb calls, so the two transports
-  // cannot answer the verb differently. The current HA stack does not implement a client-initiated
-  // join, so today the shared implementation refuses and this answers FAILED_PRECONDITION - see
-  // issue #7401.
+  // cannot answer the verb differently. Issue #7401 made that shared method join the named server to
+  // the cluster instead of refusing unconditionally; a server whose HA implementation cannot change
+  // membership at runtime, or that is not running HA at all, still answers FAILED_PRECONDITION.
   rpc ConnectCluster    (ConnectClusterRequest)    returns (ConnectClusterResponse);
 
   // Read-only administrative view of the server's open HTTP authentication sessions. gRPC has no
@@ -1583,10 +1583,12 @@ message DisconnectClusterResponse {}
 
 message ConnectClusterRequest {
   DatabaseCredentials credentials = 1;
-  // The `<host>:<port>` of the server to join, as the HTTP verb's `connect cluster <address>`
-  // argument. Not validated here: the HTTP verb accepts an empty argument too and the shared
-  // implementation refuses before reading it, so rejecting it on this transport alone would make
-  // the two disagree on the same input.
+  // The server to join, as the HTTP verb's `connect cluster <address>` argument: one entry of
+  // arcadedb.ha.serverList - `host`, `host:raftPort`, the longer positional forms or the
+  // `host:{raft:..,http:..}` object form, optionally prefixed `name@`. Not validated here: the shared
+  // implementation validates it for both transports, so an extra gate on this one would make them
+  // disagree on the same input. An empty value is INVALID_ARGUMENT, the status that matches the 400
+  // the HTTP verb answers for a bare `connect cluster` (issue #7401).
   string server_address = 2;
 }
 message ConnectClusterResponse {}

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
@@ -913,19 +913,18 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
    * {@code PostServerCommandHandler}'s dispatch chain that had no RPC.
    * <p>
    * A thin adapter over the same {@code ServerControlPlane.connectCluster} the HTTP {@code connect
-   * cluster} verb calls, so the two transports cannot drift on what the verb does. Today that shared
-   * method refuses unconditionally - the current HA stack has never implemented a client-initiated
-   * join - and the refusal reaches the caller as {@code FAILED_PRECONDITION} through the
-   * {@code OperationNotAvailableException} arm of {@link #toStatusException}. That is the same answer
-   * the HTTP caller gets, from the same method, which is the point: parity of the contract, not a
-   * working join. Issue #7401 carries the decision on whether to implement the join or retire the
-   * verb.
+   * cluster} verb calls, so the two transports cannot drift on what the verb does. Issue #7401 made
+   * that shared method join the named server to the cluster; the refusals it can still raise reach the
+   * caller as {@code FAILED_PRECONDITION} (HA not enabled, or an HA implementation with no runtime
+   * membership - the {@code OperationNotAvailableException} arm of {@link #toStatusException}) or as
+   * {@code INVALID_ARGUMENT} (a blank or malformed address - the {@code IllegalArgumentException} arm),
+   * which are the same two answers the HTTP caller gets as 500 and 400 from the same method.
    * <p>
-   * The address is passed through unvalidated because the HTTP verb passes it through unvalidated:
-   * {@code extractTarget} yields {@code ""} for a bare {@code connect cluster} and the shared method
-   * refuses before reading its argument. Root-only, as {@code checkRootUser} makes the HTTP verb, and
-   * not leader-routed, because {@code PostServerCommandHandler} does not forward either half of the
-   * pair to the leader.
+   * The address is passed through unvalidated <em>here</em> because the shared method validates it for
+   * both transports; a gate of this handler's own would be the drift this pair exists to prevent.
+   * Root-only, as {@code checkRootUser} makes the HTTP verb, and not leader-routed, because
+   * {@code PostServerCommandHandler} does not forward either half of the pair to the leader and the
+   * Raft client underneath the membership change reaches the leader itself.
    */
   @Override
   public void connectCluster(final ConnectClusterRequest req, final StreamObserver<ConnectClusterResponse> resp) {

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7400GrpcConnectClusterIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7400GrpcConnectClusterIT.java
@@ -39,12 +39,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * pair-mate, so a gRPC-only client could take a server out of a cluster and then had to reopen the
  * HTTP port to attempt the other half.
  * <p>
- * What is asserted here is protocol <em>parity</em>, not a working join. The shared implementation
- * {@code ServerControlPlane.connectCluster} refuses unconditionally - the current HA stack has never
- * implemented the verb - and {@code PostServerCommandHandler} has always surfaced that refusal on
- * HTTP. The gRPC caller must now receive the same refusal from the same method, rather than
- * {@code UNIMPLEMENTED} for a verb the other transport accepts. Making the verb actually join a
- * cluster is issue #7401.
+ * What is asserted here is protocol <em>parity</em>: the gRPC caller receives the same answer from the
+ * same method the HTTP verb calls, rather than {@code UNIMPLEMENTED} for a verb the other transport
+ * accepts. This fixture runs no HA at all, so the answers it drives are the refusals; the join itself
+ * arrived with #7401 and is exercised against a live Raft cluster by
+ * {@code Issue7401ConnectClusterJoinsPeerIT}.
  * <p>
  * The pair is driven together throughout, as the issue asks: a test that called connect alone would
  * pass against a service that had lost disconnect.
@@ -118,14 +117,16 @@ public class Issue7400GrpcConnectClusterIT extends BaseGraphServerTest {
    * {@code FAILED_PRECONDITION} is the mapper's arm for
    * {@code ServerControlPlane.OperationNotAvailableException} - the operation cannot run in this
    * server's configuration at all, as opposed to having been attempted and failed - and the
-   * description is the shared implementation's own message, not a rendering invented here.
+   * description is the shared implementation's own message, not a rendering invented here. Since #7401
+   * made the verb a real join, this fixture's refusal is that HA is not enabled here at all; what the
+   * test is for is unchanged, and is that the refusal comes from the shared implementation.
    */
   @Test
   void connectClusterIsRefusedByTheSharedImplementation() {
     assertThatThrownBy(() -> connect(root(), PEER_ADDRESS))
         .isInstanceOf(StatusRuntimeException.class)
         .hasMessageContaining("FAILED_PRECONDITION")
-        .hasMessageContaining("not supported by the current HA implementation");
+        .hasMessageContaining("not running with High Availability module enabled");
   }
 
   /**
@@ -146,17 +147,18 @@ public class Issue7400GrpcConnectClusterIT extends BaseGraphServerTest {
   }
 
   /**
-   * HTTP's {@code extractTarget} yields {@code ""} for a bare {@code connect cluster}, and the shared
-   * implementation refuses before it looks at the argument. The RPC must not invent an
-   * {@code INVALID_ARGUMENT} gate the HTTP verb does not have, or the two transports disagree on the
-   * same input - which is the drift this issue is about.
+   * HTTP's {@code extractTarget} yields {@code ""} for a bare {@code connect cluster}. Since #7401 the
+   * verb has an argument it genuinely needs, so that is the caller's error on both transports: HTTP
+   * answers 400 and this answers {@code INVALID_ARGUMENT}. The RPC still invents no gate of its own -
+   * the status comes from the shared implementation's {@code IllegalArgumentException}, which is what
+   * keeps the two transports from disagreeing on the same input, the drift this issue is about.
    */
   @Test
   void connectClusterWithAnEmptyAddressIsRefusedTheSameWay() {
     assertThatThrownBy(() -> connect(root(), ""))
         .isInstanceOf(StatusRuntimeException.class)
-        .hasMessageContaining("FAILED_PRECONDITION")
-        .hasMessageContaining("not supported by the current HA implementation");
+        .hasMessageContaining("INVALID_ARGUMENT")
+        .hasMessageContaining("requires the address of the server to join");
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftClusterManager.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftClusterManager.java
@@ -57,10 +57,30 @@ class RaftClusterManager {
   }
 
   void addPeer(final String peerId, final String address, final String name) {
-    final RaftPeer newPeer = RaftPeer.newBuilder()
+    addPeer(RaftPeer.newBuilder()
         .setId(RaftPeerId.valueOf(peerId))
         .setAddress(address)
-        .build();
+        .build(), name);
+  }
+
+  /**
+   * Adds {@code newPeer} as it was built, instead of rebuilding one from an id and an address.
+   * <p>
+   * The difference is a field that would otherwise be lost. A {@link RaftPeer} also carries its
+   * leader-election {@code priority}, and {@code connect cluster} (issue #7401) is the first caller
+   * that can name one: it parses a whole {@code arcadedb.ha.serverList} entry, and both the object
+   * form and the four-field positional form declare a priority. Dropping it is not cosmetic -
+   * {@link RaftHAServer#selectStepDownTargets} reads the live {@code getPriority()} of each peer and,
+   * once any peer has a positive priority, skips the priority-0 ones as non-electable witnesses - so a
+   * priority silently reset to the default changes which nodes can take leadership.
+   * <p>
+   * Taking the peer whole rather than adding a fourth argument is deliberate: it makes losing the
+   * next field impossible instead of merely tested for. The three-argument overload above stays for
+   * {@code POST /api/v1/cluster/peer}, whose payload has no priority to pass.
+   */
+  void addPeer(final RaftPeer newPeer, final String name) {
+    final String peerId = newPeer.getId().toString();
+    final String address = newPeer.getAddress();
 
     // Mode.ADD atomically appends this single peer to the CURRENT committed configuration, so two
     // near-simultaneous adds cannot clobber each other. A full setConfiguration(getLivePeers()+peer)
@@ -74,13 +94,13 @@ class RaftClusterManager {
       try {
         final int raftPort = Integer.parseInt(address.substring(colonIdx + 1));
         final int httpPortOffset = getHttpPortOffset();
-        raftHAServer.getHttpAddresses().put(RaftPeerId.valueOf(peerId), host + ":" + (raftPort + httpPortOffset));
+        raftHAServer.getHttpAddresses().put(newPeer.getId(), host + ":" + (raftPort + httpPortOffset));
       } catch (final NumberFormatException ignored) {
       }
     }
 
     if (name != null && !name.isEmpty())
-      raftHAServer.registerPeerDisplayName(RaftPeerId.valueOf(peerId), name);
+      raftHAServer.registerPeerDisplayName(newPeer.getId(), name);
 
     LogManager.instance().log(this, Level.INFO, "Peer %s added to Raft cluster at %s", peerId, address);
   }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -417,6 +417,41 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
       raftHAServer.stop();
   }
 
+  /**
+   * Joins the server named by {@code serverAddress} to this cluster (issue #7401).
+   * <p>
+   * The whole of it is {@link #addPeer(String, String, String)} with the arguments derived from one
+   * {@code arcadedb.ha.serverList} entry, which is what makes the verb a thin alias for
+   * {@code POST /api/v1/cluster/peer} rather than a second way to grow a cluster: the membership change
+   * is the same atomic {@code Mode.ADD}, issued by the same {@code RaftClusterManager}, with the same
+   * retry and the same idempotence when the peer is already a member.
+   * <p>
+   * Not leader-routed, matching the add-peer route and {@code PostServerCommandHandler}, which forwards
+   * neither half of the cluster pair: the Ratis client underneath {@code addPeer} sends the
+   * configuration change to the leader itself.
+   */
+  @Override
+  public void connectCluster(final String serverAddress) {
+    final RaftHAServer raft = raftHAServer;
+    if (raft == null)
+      throw new ServerException("Raft HA server not started");
+
+    final RaftPeerAddressResolver.JoinTarget target = RaftPeerAddressResolver.parseJoinTarget(serverAddress,
+        configuration.getValueAsInteger(GlobalConfiguration.HA_RAFT_PORT),
+        configuration.getValueAsBoolean(GlobalConfiguration.HA_K8S)
+            ? configuration.getValueAsString(GlobalConfiguration.HA_K8S_DNS_SUFFIX)
+            : "");
+
+    final RaftPeerId peerId = target.peer().getId();
+    raft.addPeer(peerId.toString(), target.peer().getAddress(), target.name());
+
+    // After addPeer, not before: RaftClusterManager.addPeer derives an HTTP address from the Raft port
+    // plus THIS node's HTTP offset, which is right only for a homogeneous cluster. An entry that
+    // declared its own HTTP port said so, and that answer wins over the derived one.
+    if (target.httpAddress() != null)
+      raft.getHttpAddresses().put(peerId, target.httpAddress());
+  }
+
   @Override
   public void addPeer(final String peerId, final String address) {
     addPeer(peerId, address, null);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -420,11 +420,16 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
   /**
    * Joins the server named by {@code serverAddress} to this cluster (issue #7401).
    * <p>
-   * The whole of it is {@link #addPeer(String, String, String)} with the arguments derived from one
+   * The whole of it is {@code RaftClusterManager.addPeer} with the peer derived from one
    * {@code arcadedb.ha.serverList} entry, which is what makes the verb a thin alias for
    * {@code POST /api/v1/cluster/peer} rather than a second way to grow a cluster: the membership change
    * is the same atomic {@code Mode.ADD}, issued by the same {@code RaftClusterManager}, with the same
    * retry and the same idempotence when the peer is already a member.
+   * <p>
+   * It carries one thing that route cannot: the leader-election <b>priority</b>, which the object form
+   * and the four-field positional form of a server-list entry can declare and the add-peer payload has
+   * no field for. That is why the parsed {@link org.apache.ratis.protocol.RaftPeer} is handed over
+   * whole rather than as an id and an address.
    * <p>
    * Not leader-routed, matching the add-peer route and {@code PostServerCommandHandler}, which forwards
    * neither half of the cluster pair: the Ratis client underneath {@code addPeer} sends the
@@ -442,8 +447,10 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
             ? configuration.getValueAsString(GlobalConfiguration.HA_K8S_DNS_SUFFIX)
             : "");
 
+    // The peer goes in whole, not as an id and an address: it also carries the leader-election
+    // priority the entry may have declared, and rebuilding it from parts is how that gets lost.
     final RaftPeerId peerId = target.peer().getId();
-    raft.addPeer(peerId.toString(), target.peer().getAddress(), target.name());
+    raft.addPeer(target.peer(), target.name());
 
     // After addPeer, not before: RaftClusterManager.addPeer derives an HTTP address from the Raft port
     // plus THIS node's HTTP offset, which is right only for a homogeneous cluster. An entry that

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -2839,6 +2839,11 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     clusterManager.addPeer(peerId, address, name);
   }
 
+  /** See {@link RaftClusterManager#addPeer(RaftPeer, String)}: adds the peer with every field it carries. */
+  void addPeer(final RaftPeer newPeer, final String name) {
+    clusterManager.addPeer(newPeer, name);
+  }
+
   public void removePeer(final String peerId) {
     clusterManager.removePeer(peerId);
   }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPeerAddressResolver.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPeerAddressResolver.java
@@ -57,6 +57,70 @@ final class RaftPeerAddressResolver {
   }
 
   /**
+   * The Raft peer id of the peer reachable at {@code raftAddress}: the address with its colons turned
+   * into underscores, because a colon is not usable in a JMX {@code ObjectName}.
+   * <p>
+   * The rule lives here because it is a <em>contract between nodes</em>, not a local formatting choice:
+   * a peer declared in one node's {@code arcadedb.ha.serverList}, synthesized on a Kubernetes scale-up
+   * pod, or named in a {@code connect cluster} command must come out with the id it gives itself, or
+   * the cluster ends up with two configuration entries for one process. Every one of those three call
+   * sites goes through this method.
+   */
+  static String peerIdForAddress(final String raftAddress) {
+    return raftAddress.replace(':', '_');
+  }
+
+  /**
+   * One server to join, as parsed from a {@code connect cluster} argument (issue #7401).
+   *
+   * @param peer        the peer to add to the Raft configuration, carrying the derived id, the Raft
+   *                    address and the priority
+   * @param httpAddress the peer's HTTP address when the entry declared one, otherwise {@code null} -
+   *                    in which case the caller leaves the address {@code RaftClusterManager.addPeer}
+   *                    derives from the Raft port in place
+   * @param name        the peer's human-readable name when the entry used the {@code name@} prefix,
+   *                    otherwise {@code null}
+   */
+  record JoinTarget(RaftPeer peer, String httpAddress, String name) {
+  }
+
+  /**
+   * Parses the argument of {@code connect cluster} into the single peer it names.
+   * <p>
+   * The argument is <b>one entry of {@code arcadedb.ha.serverList}</b>, in either of the two syntaxes
+   * {@link #parsePeerList(String, int, String)} accepts, and it is parsed by that very method rather
+   * than by a second address parser. That is the point of the command: what an operator types here is
+   * what they would have written in the configuration, and the id the joined peer receives is the id
+   * the peer derives for itself from the same address.
+   *
+   * @throws IllegalArgumentException when the argument is blank, malformed, or names more than one
+   *                                  server - all of them the caller's input to fix, which is why this
+   *                                  is an {@code IllegalArgumentException} (HTTP 400, gRPC
+   *                                  {@code INVALID_ARGUMENT}) rather than the {@code ServerException}
+   *                                  the underlying parser raises for a bad configuration file
+   */
+  static JoinTarget parseJoinTarget(final String serverAddress, final int defaultRaftPort, final String k8sDnsSuffix) {
+    if (serverAddress == null || serverAddress.isBlank())
+      throw new IllegalArgumentException(
+          "Connect cluster requires the address of the server to join, as [name@]host[:raftPort[:httpPort]]");
+
+    final ParsedPeerList parsed;
+    try {
+      parsed = parsePeerList(serverAddress, defaultRaftPort, k8sDnsSuffix);
+    } catch (final ServerException | ConfigurationException e) {
+      throw new IllegalArgumentException(
+          "Invalid server address '" + serverAddress + "' for connect cluster: " + e.getMessage(), e);
+    }
+
+    if (parsed.peers().size() != 1)
+      throw new IllegalArgumentException("Connect cluster joins one server at a time, but '" + serverAddress
+          + "' names " + parsed.peers().size() + " of them");
+
+    final RaftPeer peer = parsed.peers().getFirst();
+    return new JoinTarget(peer, parsed.httpAddresses().get(peer.getId()), parsed.peerNames().get(peer.getId()));
+  }
+
+  /**
    * Parses a comma-separated server list into a {@link ParsedPeerList}.
    * <p>
    * Each entry supports two interchangeable syntaxes.
@@ -195,8 +259,7 @@ final class RaftPeerAddressResolver {
         }
       }
 
-      // Use host_raftPort as peer ID (underscore avoids JMX ObjectName issues with colons)
-      final String peerIdStr = raftAddress.replace(':', '_');
+      final String peerIdStr = peerIdForAddress(raftAddress);
       final RaftPeer peer = RaftPeer.newBuilder()
           .setId(peerIdStr)
           .setAddress(raftAddress)
@@ -508,8 +571,7 @@ final class RaftPeerAddressResolver {
 
     final String host = serverName + (dnsSuffix == null ? "" : dnsSuffix);
     final String raftAddress = host + ":" + raftPort;
-    // Use host_raftPort as peer ID (underscore avoids JMX ObjectName issues with colons), matching parsePeerList.
-    final String peerIdStr = raftAddress.replace(':', '_');
+    final String peerIdStr = peerIdForAddress(raftAddress);
     return RaftPeer.newBuilder()
         .setId(peerIdStr)
         .setAddress(raftAddress)

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7401ConnectClusterJoinsPeerIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7401ConnectClusterJoinsPeerIT.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7401: {@code connect cluster <address>} joins the named server to this cluster, over a live
+ * Raft cluster and through the HTTP verb an operator actually types.
+ * <p>
+ * This is the test the issue exists for. Everything else added for #7401 can pass against a verb that
+ * parses its argument beautifully and changes no membership; only a committed Raft configuration proves
+ * the join, which is why the assertions read {@code getLivePeers()} - the configuration Raft is actually
+ * running - and not {@code getConfiguredServers()}, which is the static server list read once at startup
+ * and would be unmoved by a successful join.
+ * <p>
+ * <b>The joined server has to be running.</b> A first draft of this class joined an address nothing
+ * listened on, on the theory that a committed member need not be reachable; Ratis refused it - the ADD
+ * does not commit until the new peer has caught up, and the verb answered 500 after sixty attempts.
+ * That is the right behaviour and worth writing down, because it is also the shape of the operator
+ * mistake this verb invites: {@code connect cluster} names a server that must already be up.
+ * <p>
+ * The scenario is therefore the one {@code Issue5275MembershipSelfHealIT} established - a member is
+ * dropped from the committed configuration and comes back - with {@code connect cluster} standing in for
+ * the auto-join probe that re-adds it there. Each test leaves the three-node configuration it was given.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue7401ConnectClusterJoinsPeerIT extends BaseRaftHATest {
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Override
+  protected boolean persistentRaftStorage() {
+    // The re-joining node resumes its own Raft log, so the ADD commits on a catch-up rather than on a
+    // full snapshot install. Same reason Issue5275MembershipSelfHealIT sets it.
+    return true;
+  }
+
+  /**
+   * The verb, end to end, issued on the leader: HTTP 200, and the peer is back in the committed
+   * configuration under the id the server-list rule derives from the address it was given. Issuing it a
+   * second time is issuing it once - an operator retrying after a lost response, or a script run twice,
+   * must not be told the cluster is broken and must not produce a second entry for one process.
+   */
+  @Test
+  void connectClusterAddsThePeerToTheCommittedConfiguration() throws Exception {
+    final int leader = findLeaderIndex();
+    assertThat(leader).as("a leader must be elected before membership can change").isNotNegative();
+    final int rejoining = (leader + 1) % getServerCount();
+
+    dropFromConfigurationAndRestart(leader, rejoining);
+
+    final Response response = serverCommand(leader, "connect cluster " + raftAddressOf(rejoining));
+
+    assertThat(response.status()).as("body: %s", response.body()).isEqualTo(200);
+    assertThat(peerIds(leader)).contains(peerIdForIndex(rejoining)).hasSize(getServerCount());
+
+    final Response again = serverCommand(leader, "connect cluster " + raftAddressOf(rejoining));
+
+    assertThat(again.status()).as("body: %s", again.body()).isEqualTo(200);
+    assertThat(peerIds(leader)).hasSize(getServerCount());
+  }
+
+  /**
+   * The command is not leader-only, and this is what makes that more than a comment:
+   * {@code PostServerCommandHandler} forwards neither half of the cluster pair to the leader, so a
+   * request that lands on a follower - which is what a Kubernetes ClusterIP Service produces, since it
+   * load-balances across every ready endpoint - has to reach the leader through the Raft client
+   * underneath the membership change, or answer an error an operator can act on.
+   */
+  @Test
+  void connectClusterIssuedOnAFollowerStillJoinsThePeer() throws Exception {
+    final int leader = findLeaderIndex();
+    assertThat(leader).isNotNegative();
+    final int rejoining = (leader + 1) % getServerCount();
+    final int follower = (leader + 2) % getServerCount();
+
+    dropFromConfigurationAndRestart(leader, rejoining);
+
+    final Response response = serverCommand(follower, "connect cluster " + raftAddressOf(rejoining));
+
+    assertThat(response.status()).as("body: %s", response.body()).isEqualTo(200);
+    assertThat(peerIds(leader)).as("the leader's committed configuration").contains(peerIdForIndex(rejoining));
+  }
+
+  /**
+   * A malformed address is the caller's mistake and answers 400, not the 500 the underlying
+   * {@code ServerException} would otherwise produce. With HA enabled the parse is actually reached,
+   * which is why this case lives here rather than in the no-HA fixture, where the refusal comes first.
+   */
+  @Test
+  void aMalformedAddressAnswers400AndChangesNothing() throws Exception {
+    final int leader = findLeaderIndex();
+    assertThat(leader).isNotNegative();
+    final List<String> before = peerIds(leader);
+
+    final Response response = serverCommand(leader, "connect cluster db2:2435,db3:2436");
+
+    assertThat(response.status()).as("body: %s", response.body()).isEqualTo(400);
+    assertThat(response.body()).contains("one server at a time");
+    assertThat(peerIds(leader)).isEqualTo(before);
+  }
+
+  // -----------------------------------------------------------------------------------------------
+
+  /**
+   * Puts the cluster in the state {@code connect cluster} is for: {@code rejoining} is running and
+   * reachable but is not in the committed configuration. Stopping it before the removal, rather than
+   * removing it where it stands, is {@code Issue5275MembershipSelfHealIT}'s sequence and avoids a
+   * running non-member campaigning for an election nobody wants during the window.
+   */
+  private void dropFromConfigurationAndRestart(final int leader, final int rejoining) {
+    final RaftHAServer leaderRaft = getRaftPlugin(leader).getRaftHAServer();
+    assertThat(leaderRaft.getLivePeers()).hasSize(getServerCount());
+
+    getServer(rejoining).stop();
+    leaderRaft.removePeer(peerIdForIndex(rejoining), true);
+    Awaitility.await().atMost(30, TimeUnit.SECONDS).pollInterval(500, TimeUnit.MILLISECONDS)
+        .untilAsserted(() -> assertThat(leaderRaft.getLivePeers()).hasSize(getServerCount() - 1));
+
+    getServer(rejoining).start();
+    Awaitility.await().atMost(60, TimeUnit.SECONDS).pollInterval(500, TimeUnit.MILLISECONDS)
+        .untilAsserted(() -> assertThat(getRaftPlugin(rejoining)).isNotNull());
+    assertThat(peerIds(leader)).doesNotContain(peerIdForIndex(rejoining));
+  }
+
+  /**
+   * The Raft address of a fixture server, recovered from its peer id. The two are the same string with
+   * one character changed, which is the rule this verb relies on - so deriving one from the other here
+   * keeps the test from hardcoding a port the base class owns.
+   */
+  private String raftAddressOf(final int serverIndex) {
+    return peerIdForIndex(serverIndex).replace('_', ':');
+  }
+
+  private List<String> peerIds(final int serverIndex) {
+    return getRaftPlugin(serverIndex).getRaftHAServer().getLivePeers().stream()
+        .map(peer -> peer.getId().toString()).sorted().toList();
+  }
+
+  private record Response(int status, String body) {
+  }
+
+  private Response serverCommand(final int serverIndex, final String command) throws Exception {
+    final int port = getServer(serverIndex).getHttpServer().getPort();
+    final HttpURLConnection conn = (HttpURLConnection) new URI(
+        "http://localhost:" + port + "/api/v1/server").toURL().openConnection();
+    conn.setRequestMethod("POST");
+    conn.setRequestProperty("Content-Type", "application/json");
+    conn.setRequestProperty("Authorization", "Basic " + Base64.getEncoder().encodeToString(
+        ("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes(StandardCharsets.UTF_8)));
+    conn.setDoOutput(true);
+    try {
+      conn.getOutputStream().write(
+          new JSONObject().put("command", command).toString().getBytes(StandardCharsets.UTF_8));
+      final int status = conn.getResponseCode();
+      final InputStream stream = status < 400 ? conn.getInputStream() : conn.getErrorStream();
+      final String body = stream == null ? "" : new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+      return new Response(status, body);
+    } finally {
+      conn.disconnect();
+    }
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7401JoinPriorityTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7401JoinPriorityTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.server.ha.raft.RaftPeerAddressResolver.JoinTarget;
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.client.api.AdminApi;
+import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftGroup;
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.protocol.SetConfigurationRequest;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.HashMap;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #7401: the leader-election priority an address declares has to reach the peer that is actually
+ * added, not just the parse.
+ * <p>
+ * This is the gap a review of the first implementation found, and it is worth its own class because of
+ * how invisible it was. {@code Issue7401JoinTargetTest.theObjectFormIsAcceptedToo} asserts
+ * {@code target.peer().getPriority()} and passed the whole time; the value was then dropped one layer
+ * down, where {@code addPeer} rebuilt a fresh {@link RaftPeer} from an id and an address and left
+ * everything else at {@link RaftPeer.Builder}'s defaults. Every other assertion about the join - the
+ * id, the address, the {@code Mode.ADD}, the idempotence - held perfectly while the cluster got a
+ * configuration the operator had not asked for.
+ * <p>
+ * The consequence is not cosmetic. {@code RaftHAServer.selectStepDownTargets} reads the live
+ * {@code getPriority()} of each peer and, once any peer has a positive priority, skips the priority-0
+ * ones as non-electable witnesses - so a priority quietly reset to 0 changes which nodes can take
+ * leadership.
+ * <p>
+ * The assertion therefore reads the {@link SetConfigurationRequest.Arguments} that Ratis is asked to
+ * commit, which is the last point the value can still be lost, and it starts from
+ * {@code parseJoinTarget} rather than from a hand-built peer so the parse and the membership change
+ * are pinned as one path.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue7401JoinPriorityTest {
+
+  private static final int DEFAULT_RAFT_PORT = 2434;
+
+  private static RaftPeer peer(final String id) {
+    return RaftPeer.newBuilder().setId(RaftPeerId.valueOf(id)).setAddress("localhost:2444").build();
+  }
+
+  /**
+   * Captures the configuration change {@code addPeer} asks Ratis to commit for the peer parsed out of
+   * {@code entry}.
+   */
+  private static RaftPeer addedPeerFor(final String entry) throws Exception {
+    final RaftHAServer server = mock(RaftHAServer.class);
+    final RaftClient client = mock(RaftClient.class);
+    final AdminApi admin = mock(AdminApi.class);
+    final RaftClientReply reply = mock(RaftClientReply.class);
+
+    final ArgumentCaptor<SetConfigurationRequest.Arguments> captor =
+        ArgumentCaptor.forClass(SetConfigurationRequest.Arguments.class);
+
+    when(server.getClient()).thenReturn(client);
+    when(client.admin()).thenReturn(admin);
+    when(reply.isSuccess()).thenReturn(true);
+    when(admin.setConfiguration(captor.capture())).thenReturn(reply);
+    when(server.getLivePeers()).thenReturn(List.of(peer("A"), peer("B"), peer("C")));
+    when(server.getHttpAddresses()).thenReturn(new HashMap<>());
+    when(server.getRaftGroup()).thenReturn(RaftGroup.valueOf(RaftGroupId.randomId()));
+
+    final JoinTarget target = RaftPeerAddressResolver.parseJoinTarget(entry, DEFAULT_RAFT_PORT, "");
+    new RaftClusterManager(server).addPeer(target.peer(), target.name());
+
+    assertThat(captor.getValue().getServersInNewConf()).hasSize(1);
+    return captor.getValue().getServersInNewConf().getFirst();
+  }
+
+  @Test
+  void theObjectFormPriorityReachesTheConfigurationChange() throws Exception {
+    final RaftPeer added = addedPeerFor("db2:{raft:2435,http:2481,priority:7}");
+
+    assertThat(added.getPriority()).isEqualTo(7);
+    assertThat(added.getId().toString()).isEqualTo("db2_2435");
+    assertThat(added.getAddress()).isEqualTo("db2:2435");
+  }
+
+  /** The four-field positional form declares a priority too, and must not be the path that loses it. */
+  @Test
+  void thePositionalFormPriorityReachesTheConfigurationChange() throws Exception {
+    assertThat(addedPeerFor("db2:2435:2481:5").getPriority()).isEqualTo(5);
+  }
+
+  /**
+   * A named peer keeps both halves: the {@code name@} prefix is stripped before the address is parsed,
+   * and that must not cost the priority that follows it.
+   */
+  @Test
+  void aNamedEntryKeepsItsPriority() throws Exception {
+    assertThat(addedPeerFor("frankfurt@db2:{raft:2435,priority:9}").getPriority()).isEqualTo(9);
+  }
+
+  /**
+   * An entry that declares no priority gets 0, which is what {@code RaftPeer.Builder} defaults to and
+   * what every caller of the three-argument {@code addPeer} - {@code POST /api/v1/cluster/peer}, whose
+   * payload has no priority field - has always produced. Without this the test above would also pass
+   * against an implementation that invented a priority of its own.
+   */
+  @Test
+  void anEntryWithoutAPriorityIsAddedWithTheDefault() throws Exception {
+    assertThat(addedPeerFor("db2:2435").getPriority()).isZero();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7401JoinTargetTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7401JoinTargetTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.server.ha.raft.RaftPeerAddressResolver.JoinTarget;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7401: {@code connect cluster <address>} takes one entry of {@code arcadedb.ha.serverList} and
+ * turns it into the peer to add.
+ * <p>
+ * That is the whole of the argument mapping the verb was missing, and the property worth pinning is not
+ * that the mapping produces <em>a</em> peer id but that it produces <b>the same</b> id the joining server
+ * derives for itself. A command that invents an id the peer does not answer to leaves the cluster with a
+ * configuration entry for a process that will never appear, which no amount of Raft retrying can fix -
+ * so {@link #theJoinPathAndTheServerListPathAgreeOnTheSameAddress()} compares the two derivations
+ * directly rather than asserting a literal on one of them.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue7401JoinTargetTest {
+
+  /** {@code GlobalConfiguration.HA_RAFT_PORT}'s default, the port an entry without one inherits. */
+  private static final int DEFAULT_RAFT_PORT = 2434;
+
+  private static JoinTarget parse(final String address) {
+    return RaftPeerAddressResolver.parseJoinTarget(address, DEFAULT_RAFT_PORT, "");
+  }
+
+  @Test
+  void hostAndRaftPortYieldTheUnderscoredPeerId() {
+    final JoinTarget target = parse("db2:2435");
+
+    assertThat(target.peer().getId().toString()).isEqualTo("db2_2435");
+    assertThat(target.peer().getAddress()).isEqualTo("db2:2435");
+    assertThat(target.httpAddress()).isNull();
+    assertThat(target.name()).isNull();
+  }
+
+  /**
+   * A bare host inherits {@code arcadedb.ha.raftPort}, exactly as the same entry would in the server
+   * list. The derived id therefore carries the default port, which is what the joining node - reading
+   * the same default - calls itself.
+   */
+  @Test
+  void aBareHostInheritsTheDefaultRaftPort() {
+    final JoinTarget target = parse("db2");
+
+    assertThat(target.peer().getAddress()).isEqualTo("db2:" + DEFAULT_RAFT_PORT);
+    assertThat(target.peer().getId().toString()).isEqualTo("db2_" + DEFAULT_RAFT_PORT);
+  }
+
+  /**
+   * The positional form's HTTP port is carried through, because the address {@code RaftClusterManager}
+   * would otherwise derive is the Raft port plus <em>the adding node's</em> HTTP offset - right only for
+   * a homogeneous cluster.
+   */
+  @Test
+  void anExplicitHttpPortIsCarriedThrough() {
+    final JoinTarget target = parse("db2:2435:2481");
+
+    assertThat(target.peer().getAddress()).isEqualTo("db2:2435");
+    assertThat(target.httpAddress()).isEqualTo("db2:2481");
+  }
+
+  @Test
+  void theNamePrefixBecomesTheDisplayName() {
+    final JoinTarget target = parse("frankfurt@db2:2435");
+
+    assertThat(target.name()).isEqualTo("frankfurt");
+    assertThat(target.peer().getId().toString()).isEqualTo("db2_2435");
+  }
+
+  @Test
+  void theObjectFormIsAcceptedToo() {
+    final JoinTarget target = parse("db2:{raft:2435,http:2481,priority:7}");
+
+    assertThat(target.peer().getAddress()).isEqualTo("db2:2435");
+    assertThat(target.httpAddress()).isEqualTo("db2:2481");
+    assertThat(target.peer().getPriority()).isEqualTo(7);
+  }
+
+  /**
+   * The assertion this class exists for: join and startup must derive one identity from one address.
+   * Comparing the two derivations is what a literal cannot do - a literal passes just as well against
+   * two rules that happen to agree on {@code db2:2435} and part company on the object form or on a
+   * bare host.
+   */
+  @Test
+  void theJoinPathAndTheServerListPathAgreeOnTheSameAddress() {
+    for (final String entry : new String[] { "db2", "db2:2435", "db2:2435:2481",
+        "frankfurt@db2:2435", "db2:{raft:2435,http:2481}" }) {
+      final JoinTarget joined = parse(entry);
+      final RaftPeerAddressResolver.ParsedPeerList declared =
+          RaftPeerAddressResolver.parsePeerList(entry, DEFAULT_RAFT_PORT, "");
+
+      assertThat(joined.peer().getId())
+          .as("connect cluster '%s' must derive the id the server list derives", entry)
+          .isEqualTo(declared.peers().getFirst().getId());
+      assertThat(joined.peer().getAddress()).isEqualTo(declared.peers().getFirst().getAddress());
+    }
+  }
+
+  /** The Kubernetes DNS suffix is applied here as it is at startup, or the short pod name resolves nowhere. */
+  @Test
+  void theKubernetesDnsSuffixIsApplied() {
+    final JoinTarget target = RaftPeerAddressResolver.parseJoinTarget("arcadedb-2", DEFAULT_RAFT_PORT,
+        ".arcadedb.default.svc.cluster.local");
+
+    assertThat(target.peer().getAddress())
+        .isEqualTo("arcadedb-2.arcadedb.default.svc.cluster.local:" + DEFAULT_RAFT_PORT);
+  }
+
+  /**
+   * A blank argument is the caller's to fix, not a server precondition: {@code IllegalArgumentException}
+   * is what HTTP answers 400 and gRPC {@code INVALID_ARGUMENT} for. A bare {@code connect cluster} over
+   * HTTP arrives here as {@code ""} from {@code extractTarget}, which is why the empty string is tested
+   * and not only {@code null}.
+   */
+  @Test
+  void aBlankAddressIsRejectedAsACallerError() {
+    assertThatThrownBy(() -> parse(""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("requires the address");
+
+    assertThatThrownBy(() -> parse("   "))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("requires the address");
+
+    assertThatThrownBy(() -> parse(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("requires the address");
+  }
+
+  /**
+   * The server list is comma-separated and this argument is one entry of it, so a list has to be
+   * refused rather than silently joining only its first element - the failure mode an operator would
+   * not notice until the cluster was one node short.
+   */
+  @Test
+  void aCommaSeparatedListIsRefusedRatherThanTruncated() {
+    assertThatThrownBy(() -> parse("db2:2435,db3:2436"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("one server at a time");
+  }
+
+  /**
+   * A malformed entry reaches the caller as its own mistake. The underlying parser raises
+   * {@code ServerException}, which the transports would answer 500 / {@code INTERNAL}: converting it
+   * here is what keeps a typo from reading as a server fault.
+   */
+  @Test
+  void aMalformedAddressIsReportedAsACallerErrorNotAServerFault() {
+    assertThatThrownBy(() -> parse("db2:2435:2481:0:2491:extra"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid server address");
+
+    assertThatThrownBy(() -> parse("@db2:2435"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid server address");
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
+++ b/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
@@ -172,6 +172,21 @@ public interface HAServerPlugin extends ServerPlugin {
   void disconnectCluster();
 
   /**
+   * Joins the server named by {@code serverAddress} to this node's cluster, the other half of the
+   * {@code connect cluster} / {@code disconnect cluster} pair (issue #7401).
+   * <p>
+   * {@code serverAddress} is <b>one entry of {@code arcadedb.ha.serverList}</b>, not a bare host and
+   * port: the implementation parses it with the same parser the configured server list goes through, so
+   * an operator types here what they would have written in the configuration and the joining peer gets
+   * the identity it gives itself. An implementation that cannot change membership at runtime keeps the
+   * default below; {@code ServerControlPlane.connectCluster} turns that into the refusal both transports
+   * report, so the verb answers "this HA implementation cannot do it" rather than reading as a fault.
+   */
+  default void connectCluster(final String serverAddress) {
+    throw new UnsupportedOperationException("Dynamic membership not supported by this HA implementation");
+  }
+
+  /**
    * Adds a new peer to the cluster at runtime.
    */
   default void addPeer(final String peerId, final String address) {

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -149,28 +149,83 @@ public class ServerControlPlane {
 
   /**
    * The {@code connect cluster} command, shared by the HTTP verb and the gRPC {@code ConnectCluster}
-   * RPC (issue #7400). Kept here with the rest so the command set is complete in one place; it has
-   * never been implemented by the current HA stack, and whether to implement the join or retire the
-   * verb is issue #7401.
+   * RPC: joins the server named by {@code serverAddress} to this node's cluster (issue #7401, which
+   * decided to implement the verb rather than retire it; #7400 had already made both transports reach
+   * this one method).
    * <p>
-   * The refusal names the address the caller asked for, as the rest of this class names the user,
-   * group or backup file a command could not act on. That is the caller's own argument echoed back,
-   * so it tells an operator which of several join attempts failed - and it is the only thing that
-   * makes the argument observable from outside while the operation itself does nothing with it, so
-   * a transport that dropped the parameter on the way here cannot do so unnoticed.
+   * {@code serverAddress} is <b>one entry of {@code arcadedb.ha.serverList}</b> - {@code host},
+   * {@code host:raftPort}, the longer positional forms, the {@code host:&#123;raft:..,http:..&#125;}
+   * object form, any of them optionally prefixed {@code name@}. The HA implementation parses it with
+   * the parser the configured server list goes through, so the peer id the joined server receives is
+   * the one it derives for itself from the same address, and an operator writes here what they would
+   * have written in the configuration.
    * <p>
-   * Not null-guarded. Both callers found by
-   * {@code grep -rn --include='*.java' "\.connectCluster(" --exclude-dir=target .} on the main
-   * sources pass a value that cannot be null: {@code PostServerCommandHandler} passes
-   * {@code extractTarget}'s result, which is {@code ""} or a substring, and
-   * {@code ArcadeDbGrpcAdminService} passes a protobuf string field, which defaults to {@code ""}.
-   * A null from some future caller renders as {@code 'null'} in the message rather than throwing,
-   * so the guard would buy nothing.
+   * Equivalent to {@code POST /api/v1/cluster/peer} and deliberately so: the same atomic Raft
+   * membership change, and the same users seed afterwards, because {@code server-users.jsonl} lives
+   * outside the database directory and a snapshot install does not carry it.
+   * <p>
+   * <b>Note the direction.</b> The address names the server being <em>added</em>; the cluster that
+   * grows is the one this server belongs to. That is the opposite of the pre-Raft implementation this
+   * verb had in 2023 ({@code HAServer.connectToLeader}), where the local node dialled the address and
+   * joined whatever cluster answered. Under Raft that reading is not a small change and is not safe to
+   * offer as one: a node that is already running has a Raft log of its own, and inserting it into
+   * another group whose log it does not share is the split-brain the leader-side membership change
+   * exists to prevent. The Kubernetes auto-join does self-insert, and does it from {@code start()} and
+   * only while this node knows no leader of its own - see {@code KubernetesAutoJoin}'s retry
+   * continuation condition. Joining a foreign cluster at runtime is a separate feature, tracked as
+   * issue #7515.
+   * <p>
+   * Every refusal names the address, so an operator with several join attempts in flight can tell
+   * which one failed:
+   * <ul>
+   *   <li>a blank address is an {@link IllegalArgumentException} - HTTP 400, gRPC
+   *       {@code INVALID_ARGUMENT} - because the command cannot act without one;</li>
+   *   <li>HA not enabled at all, and an HA implementation that cannot change membership at runtime,
+   *       are both {@link OperationNotAvailableException} - HTTP 500, gRPC
+   *       {@code FAILED_PRECONDITION} - a precondition of this server, not a fault of the request.</li>
+   * </ul>
+   * <b>Not leader-routed</b>, matching {@code POST /api/v1/cluster/peer} and matching
+   * {@code PostServerCommandHandler}, which forwards neither half of the cluster pair: the Raft client
+   * underneath the membership change sends it to the leader itself.
    */
   public void connectCluster(final String serverAddress) {
 
-    throw new OperationNotAvailableException("Connect cluster to '" + serverAddress
-        + "' is not supported by the current HA implementation. Use the cluster configuration to join nodes.");
+    if (serverAddress == null || serverAddress.isBlank())
+      throw new IllegalArgumentException(
+          "Connect cluster requires the address of the server to join, as [name@]host[:raftPort[:httpPort]]");
+
+    // Not requireHA(), because that refusal would not name the address, and the address is the only
+    // part of this command a caller can get wrong on the way in - the property #7400's tests pin from
+    // both transports.
+    final HAServerPlugin ha = server.getHA();
+    if (ha == null)
+      throw new OperationNotAvailableException("Cannot connect '" + serverAddress
+          + "' to the cluster: ArcadeDB is not running with High Availability module enabled. Please add this setting at startup: -Darcadedb.ha.enabled=true");
+
+    try {
+      ha.connectCluster(serverAddress);
+    } catch (final UnsupportedOperationException e) {
+      // What this is for is HAServerPlugin.connectCluster's default - an HA implementation with no
+      // runtime membership - which is a precondition of this server and must not reach gRPC as
+      // INTERNAL through the unchecked-exception path. The arm cannot tell that apart from an
+      // UnsupportedOperationException raised deeper in a working implementation, so it relays the
+      // message rather than asserting which one it caught: what it changes is the status, and a
+      // request that cannot succeed by being retried is a precondition failure either way.
+      throw new OperationNotAvailableException(
+          "Cannot connect '" + serverAddress + "' to the cluster: " + e.getMessage());
+    }
+
+    // Seed the newly joined peer with the current users file, exactly as PostAddPeerHandler does after
+    // its own addPeer: server-users.jsonl lives under <server-root>/config/, outside the database
+    // directory, so snapshot install does not cover it and the new peer would run with a stale user set
+    // until the next cluster-wide user mutation. Best-effort, as it is there: the peer is already a
+    // committed member and a failure here does not - and must not - roll that back.
+    try {
+      ha.replicateSecurityUsers(server.getSecurity().getUsersJsonPayload());
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.WARNING,
+          "Users seed to '%s' after connect cluster failed (best-effort): %s", serverAddress, e.getMessage());
+    }
   }
 
   // ---------------------------------------------------------------------------------------------

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -221,10 +221,8 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
   }
 
   private void connectCluster(final String serverAddress) {
-    // Always throws: the current HA implementation does not support it. Counted first, because there
-    // is no success to count after - which is what the moved implementation did too.
-    Metrics.counter("http.connect-cluster").increment();
     controlPlane.connectCluster(serverAddress);
+    Metrics.counter("http.connect-cluster").increment();
   }
 
   private void disconnectCluster() {

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -131,8 +131,11 @@ public class CoreApiSpec implements OpenApiContributor {
         create user, drop user, shutdown, set server setting, get server events, align database, \
         connect cluster <address>, disconnect cluster. \
         Both restore and import support SSE progress streaming via Accept: text/event-stream header. \
-        connect cluster is dispatched but not implemented by the current HA implementation and always \
-        fails; use the cluster configuration to join nodes""");
+        connect cluster <address> adds the server at <address> to this server's cluster - the operator \
+        alias of POST /api/v1/cluster/peer - where <address> is one entry of arcadedb.ha.serverList \
+        ([name@]host[:raftPort[:httpPort]] or the host:{raft:..,http:..} object form). It answers 400 \
+        for a blank or malformed address and 500 when this server is not running an HA implementation \
+        that supports runtime membership""");
     postOp.setOperationId("executeServerCommand");
     postOp.addTagsItem("Server");
     postOp.setRequestBody(SpecBuilders.jsonBody("Command request with command and optional parameters", "CommandRequest", true));

--- a/server/src/test/java/com/arcadedb/server/Issue7401ServerControlPlaneConnectClusterTest.java
+++ b/server/src/test/java/com/arcadedb/server/Issue7401ServerControlPlaneConnectClusterTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ServerControlPlane.OperationNotAvailableException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7401: the transport-independent half of {@code connect cluster}, driven directly so each of
+ * its outcomes is pinned once rather than once per transport.
+ * <p>
+ * Like {@code GetReadyHandlerHATest} this boots a real single-node {@link ArcadeDBServer} - the
+ * {@code server} module does not depend on {@code arcadedb-ha-raft}, so {@link ArcadeDBServer#getHA()}
+ * is naturally {@code null} - and supplies HA behaviour through a hand-written plugin injected with
+ * {@link ArcadeDBServer#setHA(HAServerPlugin)}. No mocking framework, and no Raft cluster needed to
+ * decide what this layer does with an address.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue7401ServerControlPlaneConnectClusterTest extends StaticBaseServerTest {
+
+  private static final String PEER_ADDRESS = "db2:2435";
+
+  private ArcadeDBServer      server;
+  private ServerControlPlane  controlPlane;
+
+  @BeforeEach
+  @Override
+  public void beginTest() {
+    super.beginTest();
+
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.SERVER_ROOT_PATH, "./target");
+    config.setValue(GlobalConfiguration.SERVER_ROOT_PASSWORD, DEFAULT_PASSWORD_FOR_TESTS);
+    config.setValue(GlobalConfiguration.SERVER_HTTP_IO_THREADS, 2);
+    config.setValue(GlobalConfiguration.TYPE_DEFAULT_BUCKETS, 2);
+
+    server = new ArcadeDBServer(config);
+    server.start();
+    assertThat(server.getStatus()).isEqualTo(ArcadeDBServer.STATUS.ONLINE);
+    assertThat(server.getHA()).isNull();
+
+    controlPlane = new ServerControlPlane(server);
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    try {
+      if (server != null && server.isStarted())
+        server.stop();
+    } finally {
+      super.endTest();
+    }
+  }
+
+  /**
+   * The address reaches the HA implementation byte for byte. Nothing else in this class would notice a
+   * layer that trimmed, lowercased or rebuilt it, and an address the joining peer does not answer to is
+   * a configuration entry for a process that never appears.
+   */
+  @Test
+  void theAddressReachesTheHaImplementationUnmodified() {
+    final RecordingHAPlugin ha = new RecordingHAPlugin();
+    server.setHA(ha);
+
+    controlPlane.connectCluster("frankfurt@DB2.example.com:2435:2481");
+
+    assertThat(ha.connectedAddress).isEqualTo("frankfurt@DB2.example.com:2435:2481");
+  }
+
+  /**
+   * The users seed of {@code PostAddPeerHandler} runs for this verb too, and only after the join.
+   * {@code server-users.jsonl} lives outside the database directory, so a snapshot install does not
+   * carry it and a peer joined without the seed runs with a stale user set until the next cluster-wide
+   * user change. The ordering is asserted because a seed sent before the peer is a member reaches a
+   * cluster the peer is not in yet.
+   */
+  @Test
+  void aSuccessfulJoinSeedsTheUsersFileAfterwards() {
+    final RecordingHAPlugin ha = new RecordingHAPlugin();
+    server.setHA(ha);
+
+    controlPlane.connectCluster(PEER_ADDRESS);
+
+    assertThat(ha.seededUsers).as("users payload").contains("root");
+    assertThat(ha.seedFollowedTheJoin).as("seed must follow the membership change").isTrue();
+  }
+
+  /**
+   * The seed is best-effort and the join is not: the peer is a committed member by the time the seed
+   * runs, so a seed failure must not be reported as a failed join - the caller would retry a join that
+   * already happened.
+   */
+  @Test
+  void aFailingUsersSeedDoesNotFailTheJoin() {
+    final RecordingHAPlugin ha = new RecordingHAPlugin() {
+      @Override
+      public void replicateSecurityUsers(final String usersJsonArray) {
+        throw new IllegalStateException("no leader to replicate to");
+      }
+    };
+    server.setHA(ha);
+
+    controlPlane.connectCluster(PEER_ADDRESS);
+
+    assertThat(ha.connectedAddress).isEqualTo(PEER_ADDRESS);
+  }
+
+  /**
+   * A blank address is the caller's mistake, not a precondition of this server: an
+   * {@link IllegalArgumentException} is HTTP 400 and gRPC {@code INVALID_ARGUMENT}, while the
+   * {@link OperationNotAvailableException} below is HTTP 500 and gRPC {@code FAILED_PRECONDITION}.
+   * A bare {@code connect cluster} arrives here as {@code ""} from {@code extractTarget}.
+   */
+  @Test
+  void aBlankAddressIsRejectedBeforeHaIsConsulted() {
+    final RecordingHAPlugin ha = new RecordingHAPlugin();
+    server.setHA(ha);
+
+    assertThatThrownBy(() -> controlPlane.connectCluster(""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("requires the address");
+
+    assertThat(ha.connectedAddress).as("HA must not be asked to join nothing").isNull();
+  }
+
+  /**
+   * Without HA the refusal still names the address. That is the property #7400's tests pin from both
+   * transports, and it is the only thing that makes the argument observable from outside when the
+   * command cannot run - so it survives the verb becoming a real join.
+   */
+  @Test
+  void withoutHaTheRefusalNamesTheAddress() {
+    assertThatThrownBy(() -> controlPlane.connectCluster(PEER_ADDRESS))
+        .isInstanceOf(OperationNotAvailableException.class)
+        .hasMessageContaining(PEER_ADDRESS)
+        .hasMessageContaining("High Availability module enabled");
+  }
+
+  /**
+   * An HA implementation that cannot change membership at runtime keeps
+   * {@code HAServerPlugin.connectCluster}'s default, which raises {@link UnsupportedOperationException}.
+   * That has to arrive as a precondition failure and not as an internal error: gRPC maps an unchecked
+   * exception it does not recognise to {@code INTERNAL}, which would tell an operator the server broke
+   * rather than that this HA stack does not do joins.
+   */
+  @Test
+  void anHaImplementationWithoutDynamicMembershipRefusesAsAPrecondition() {
+    server.setHA(new RecordingHAPlugin(false));
+
+    assertThatThrownBy(() -> controlPlane.connectCluster(PEER_ADDRESS))
+        .isInstanceOf(OperationNotAvailableException.class)
+        .hasMessageContaining(PEER_ADDRESS)
+        .hasMessageContaining("Dynamic membership not supported");
+  }
+
+  /**
+   * A failure raised by a working HA implementation is not converted: only the interface default's
+   * {@link UnsupportedOperationException} becomes a precondition failure. A join that was attempted and
+   * failed is a different report from one that was never possible.
+   */
+  @Test
+  void aFailedJoinIsNotDisguisedAsAnUnavailableOperation() {
+    server.setHA(new RecordingHAPlugin() {
+      @Override
+      public void connectCluster(final String serverAddress) {
+        throw new ServerException("Raft HA server not started");
+      }
+    });
+
+    assertThatThrownBy(() -> controlPlane.connectCluster(PEER_ADDRESS))
+        .isInstanceOf(ServerException.class)
+        .isNotInstanceOf(OperationNotAvailableException.class);
+  }
+
+  /**
+   * An {@link HAServerPlugin} that records what the control plane asked it to do. Everything the
+   * readiness probe and the cluster views need is inert; only the cluster-join pair carries behaviour.
+   */
+  private static class RecordingHAPlugin implements HAServerPlugin {
+    private final boolean dynamicMembership;
+    private       String  connectedAddress    = null;
+    private       String  seededUsers         = null;
+    private       boolean seedFollowedTheJoin = false;
+
+    private RecordingHAPlugin() {
+      this(true);
+    }
+
+    private RecordingHAPlugin(final boolean dynamicMembership) {
+      this.dynamicMembership = dynamicMembership;
+    }
+
+    @Override
+    public void connectCluster(final String serverAddress) {
+      if (!dynamicMembership)
+        // The interface default, invoked rather than restated, so this test cannot pass against a
+        // default whose message or type has changed underneath it.
+        HAServerPlugin.super.connectCluster(serverAddress);
+      connectedAddress = serverAddress;
+    }
+
+    @Override
+    public ELECTION_STATUS getElectionStatus() {
+      return ELECTION_STATUS.DONE;
+    }
+
+    @Override
+    public void replicateSecurityUsers(final String usersJsonArray) {
+      seededUsers = usersJsonArray;
+      seedFollowedTheJoin = connectedAddress != null;
+    }
+
+    @Override
+    public void startService() {
+    }
+
+    @Override
+    public boolean isLeader() {
+      return false;
+    }
+
+    @Override
+    public String getLeaderName() {
+      return null;
+    }
+
+    @Override
+    public String getClusterName() {
+      return "test";
+    }
+
+    @Override
+    public Map<String, Object> getStats() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public int getConfiguredServers() {
+      return 1;
+    }
+
+    @Override
+    public String getLeaderAddress() {
+      return null;
+    }
+
+    @Override
+    public String getReplicaAddresses() {
+      return "";
+    }
+
+    @Override
+    public void shutdownRemoteServer(final String serverName) {
+    }
+
+    @Override
+    public void disconnectCluster() {
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue7400ConnectClusterHttpIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue7400ConnectClusterHttpIT.java
@@ -37,10 +37,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * has always called - so what the two transports answer for the same input is now a property worth
  * pinning from both ends rather than from one.
  * <p>
- * The verb still refuses: the current HA stack has never implemented a client-initiated join, and
- * whether to implement it or retire the verb is issue #7401. What must hold is that the refusal is
- * the <em>same</em> refusal, naming the address the caller asked for, on whichever transport the
- * caller used.
+ * Issue #7401 has since made the verb a real join, so what this fixture - a server with no HA at all -
+ * exercises is the refusal path. What must hold is unchanged and is the reason the class survives that:
+ * the refusal is the <em>same</em> refusal, naming the address the caller asked for, on whichever
+ * transport the caller used.
  *
  * @author Roberto Franchini (r.franchini@arcadedata.com)
  */
@@ -60,21 +60,25 @@ class Issue7400ConnectClusterHttpIT extends BaseGraphServerTest {
   void connectClusterIsRefusedAndNamesTheAddress() throws Exception {
     final HttpResponse<String> response = executeServerCommand("connect cluster " + PEER_ADDRESS);
 
+    assertThat(response.statusCode()).isEqualTo(500);
     assertThat(response.body())
         .contains(PEER_ADDRESS)
-        .contains("not supported by the current HA implementation");
+        .contains("not running with High Availability module enabled");
   }
 
   /**
-   * A bare {@code connect cluster} yields {@code ""} from {@code extractTarget} and is refused for
-   * the same reason a filled one is - the shared method never reads its argument. This is what the
-   * gRPC side deliberately mirrors by not adding an {@code INVALID_ARGUMENT} gate of its own.
+   * A bare {@code connect cluster} yields {@code ""} from {@code extractTarget}. Since #7401 the verb
+   * has an argument it genuinely needs, so that is a client error - 400 - and no longer the same
+   * refusal a filled address gets. The gRPC side mirrors it as {@code INVALID_ARGUMENT} rather than
+   * adding a gate of its own, which is the parity this class is about: both statuses come from the one
+   * shared implementation.
    */
   @Test
   void connectClusterWithNoAddressIsRefusedTheSameWay() throws Exception {
     final HttpResponse<String> response = executeServerCommand("connect cluster");
 
-    assertThat(response.body()).contains("not supported by the current HA implementation");
+    assertThat(response.statusCode()).isEqualTo(400);
+    assertThat(response.body()).contains("requires the address of the server to join");
   }
 
   private HttpResponse<String> executeServerCommand(final String command) throws Exception {


### PR DESCRIPTION
Closes #7401

## Summary

`ServerControlPlane.connectCluster` threw unconditionally, so `POST /api/v1/server` with `connect
cluster <addr>` and the gRPC `ConnectCluster` RPC (#7400, added for transport parity) both answered a
refusal and nothing else. #7401 asked whether to implement the verb or retire it.

Implemented, as the issue sketched: `connect cluster <address>` adds the server at `<address>` to
this server's Raft cluster, through the same atomic `Mode.ADD` membership change `POST
/api/v1/cluster/peer` issues, followed by the same best-effort users seed `PostAddPeerHandler` runs
after its own `addPeer`. The capability already existed in `RaftHAPlugin.addPeer`; what was missing
was the argument mapping, and that turned out to be small because a Raft peer id is a pure function
of its Raft address. That rule was written out twice in `RaftPeerAddressResolver` and is now
`peerIdForAddress`, shared by the server-list parse, the Kubernetes scale-up synthesis, and the new
join - so a joined peer always gets the id it derives for itself.

**Direction.** The address names the server being added; the cluster that grows is this one. That is
the opposite of the pre-Raft (2023) meaning of the verb, where the local node dialled the address and
joined whatever cluster answered. The reversal is deliberate: an already-running node has a Raft log
of its own, and inserting it into another group is the split-brain the leader-side membership change
exists to prevent. Making a running node join a *foreign* cluster is a separate feature, filed as
#7515.

Refusals come from the one shared method so the two transports cannot disagree: a blank or malformed
address is HTTP 400 / gRPC `INVALID_ARGUMENT`; HA not enabled, or an HA implementation without
runtime membership, is HTTP 500 / gRPC `FAILED_PRECONDITION`. Each names the address, the property
#7400's tests already pinned from both transports.

## Test plan

- `mvn -o -pl ha-raft test -Dtest=Issue7401JoinTargetTest` - the address-to-peer derivation, one case
  per accepted `arcadedb.ha.serverList` syntax, plus a direct comparison against the server-list
  parser's own derivation. 10/10 green.
- `mvn -o -pl ha-raft verify -DskipTests=true -DskipITs=false -Dit.test=Issue7401ConnectClusterJoinsPeerIT`
  - a live 3-node Raft cluster: a dropped member is re-joined with `connect cluster` issued from the
  leader and from a follower, a repeated join is a no-op, and a malformed address answers 400 and
  changes nothing. 3/3 green (~41s).
- `mvn -o -pl server test -Dtest=Issue7401ServerControlPlaneConnectClusterTest` - the
  transport-independent layer against a hand-written `HAServerPlugin`: blank address, HA absent, HA
  without dynamic membership, address passed through unmodified, users seed after the join, a
  failing seed not failing the join, a genuine join failure not disguised as unavailable. 7/7 green.
- `mvn -o -pl server test -Dtest=Issue7400ConnectClusterHttpIT,Issue7400ServerCommandSpecTest`,
  `mvn -o -pl grpcw verify -Dit.test=Issue7400GrpcConnectClusterIT`,
  `mvn -o -pl grpc-client verify -Dit.test=Issue7400RemoteGrpcConnectClusterIT` - the five assertions
  in #7400's tests that pinned the old stub's refusal string, rewritten against the new contract. All
  green.
- `mvn -o -pl grpcw verify -Dit.test=Issue7304GrpcControlPlaneIT,Issue7304GrpcControlPlaneAuthorizationIT`,
  `mvn -o -pl grpc-client verify -Dit.test=Issue7304RemoteGrpcServerControlPlaneIT`,
  `mvn -o -pl server test -Dtest='*ApiSpec*Test',GetReadyHandlerHATest`,
  `mvn -o -pl ha-raft test -Dtest='RaftHAServerAddressParsingTest,Issue4836K8sScaleUpTest,RaftHAServerValidatePeerAddressTest,Issue7132AllowlistLearnsRuntimePeersTest,RaftAtomicMembershipTest,KubernetesAutoJoinRetryTest,KubernetesAutoJoinTlsInheritanceTest,Issue6267AmbiguousPeerAddressWarningTest,RaftHAPluginTest'`
  - full regression on every connected suite: 429 tests, all green.

## Coverage

| Entry point | Covered by fix? | Covered by a test? |
|---|---|---|
| HTTP `POST /api/v1/server` `connect cluster <addr>` -> `PostServerCommandHandler` | yes | yes, `Issue7401ConnectClusterJoinsPeerIT` over a live cluster |
| gRPC `ConnectCluster` -> `ArcadeDbGrpcAdminService` | yes | yes, `Issue7400GrpcConnectClusterIT` for both refusal statuses; argued for the join itself - the handler is `requireServerAdmin` plus one delegating call with no logic of its own, already exercised end to end via HTTP |
| `RemoteGrpcServer.connectCluster` (Java gRPC client) | yes (wire adapter unchanged; its javadoc documented the *opposite* direction and is corrected) | yes, `Issue7400RemoteGrpcConnectClusterIT` |
| `ServerControlPlane.connectCluster` -> `HAServerPlugin.connectCluster` default (no dynamic membership) | yes - `UnsupportedOperationException` becomes `OperationNotAvailableException` so gRPC keeps `FAILED_PRECONDITION` instead of `INTERNAL` | yes, `Issue7401ServerControlPlaneConnectClusterTest` |
| `ServerControlPlane.connectCluster` -> users seed | yes | yes - seed runs, runs after the join, a failing seed does not fail the join |
| `RaftHAPlugin.connectCluster` -> address parsing / peer-id derivation | yes | yes, `Issue7401JoinTargetTest` |
| `RaftHAPlugin.connectCluster` with the Raft server not started | yes (`ServerException`) | **argued** - same guard, same place, same message as the sibling membership methods in the class; none of them has a dedicated test either. The *type* differs (they throw bare `RuntimeException`), which nothing observable turns on - both are HTTP 500 / gRPC `INTERNAL` - and the more descriptive type is kept rather than matched downwards |
| `arcadedb.ha.serverList` startup parse / Kubernetes scale-up synthesis | yes (refactor only, via extracted `peerIdForAddress`) | yes - all pre-existing resolver/K8s tests still green, plus a direct cross-check against the join derivation |

### Known gaps

- **#7514** - naming a server that is not yet running hangs the request for about a minute and
  reports a raw Ratis `SetConfigurationRequest` as the error, because `Mode.ADD` does not commit
  until the new peer catches up. Discovered writing the live-cluster test for this PR. Affects
  `POST /api/v1/cluster/peer` identically, so fixing it here alone would leave the sibling route
  behind; scoped as its own issue.
- **#7515** - there is still no way to make an already-running node join a cluster it was not
  configured for (the pre-Raft meaning of this verb). Not an argument-mapping fix: it has to decide
  what happens to the node's own Raft log, which the leader-side membership change this PR uses
  deliberately does not have to.
- No Studio control for either half of the cluster pair; none existed before and none is added.
- The users seed is best-effort, as it is on the add-peer route it copies: a failure leaves the peer
  a committed member with a stale user set until the next cluster-wide user change, logged at WARNING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1vgWQXZoDXYq7TqAwLYXY

