### PR TITLE
fix(#7259): gate Raft HA test setup on the cluster bootstrap pass, not on the election

### DIFF
--- a/docs/7259-raft-ha-cluster-bootstrap-settle-gate.md
+++ b/docs/7259-raft-ha-cluster-bootstrap-settle-gate.md
@@ -255,3 +255,27 @@ and with it restored the whole sweep is green again (3 tests in the IT, 12 IT cl
 
 The reviewer's remaining points were confirmations, not requests (docs convention, code style, blast radius);
 nothing was deferred.
+
+### cycle 2 - `939e2acb3a`
+
+Two findings, both accepted and both fixed.
+
+1. **`election.onLeaderChanged()` sat outside the `try` it was documented as being inside.** The catch existed
+   precisely because `runIfEligible()` swallows its own `Throwable` into `FAILED`, leaving a throw from
+   `onLeaderChanged` as the only way out of the method without an outcome - and that was exactly the case the
+   catch did not cover. A throw there would have left `lastBootstrapOutcome` null and made every affected test
+   setup burn the whole 15 s budget before giving up. The call moved inside the `try`; the comment now says
+   what the code does.
+2. **The check-then-set on the outcome field was not atomic.** The reviewer flagged this as non-blocking on the
+   grounds that production only reaches it from the single-threaded `lifecycleExecutor`, which is true - but
+   `runBootstrapIfEligible()` is public, and `BootstrapElectionIT`, `RaftBootstrapDoesNotEngageOnRestartIT` and
+   the new `aSecondBootstrapPassCannotDowngradeARecordedCommitted` all call it from their own thread while that
+   executor may still be running the automatic pass. A lost update there drops the `COMMITTED` the guard exists
+   to protect, so it was taken rather than deferred: the field is now an `AtomicReference` updated through
+   `updateAndGet`, which makes the invariant self-documenting instead of resting on a call-site assumption.
+
+The reviewer's third note - that the javadoc leans on #7259 investigation context - was explicitly not a
+request, and is consistent with `ha-raft/CLAUDE.md`'s dense-comment convention. Not changed.
+
+Full `ha-raft` sweep green after both fixes (12 IT classes, `Issue7259ClusterBootstrapSettledIT` at 3 tests).
+Nothing deferred in either cycle.

--- a/docs/7259-raft-ha-cluster-bootstrap-settle-gate.md
+++ b/docs/7259-raft-ha-cluster-bootstrap-settle-gate.md
@@ -279,3 +279,25 @@ request, and is consistent with `ha-raft/CLAUDE.md`'s dense-comment convention. 
 
 Full `ha-raft` sweep green after both fixes (12 IT classes, `Issue7259ClusterBootstrapSettledIT` at 3 tests).
 Nothing deferred in either cycle.
+
+### cycle 3 - `cc09a1ac5a`
+
+Clean approval. "Nothing blocking from my pass." The reviewer independently re-verified the two claims the fix
+rests on - `recordBootstrapBaseline` at `ArcadeStateMachine.java:3021` running before the installs at
+`3070`/`3148`, and `BootstrapElection.Outcome` having no value that legitimately needs to override
+`COMMITTED` - and confirmed both cycle-2 fixes are actually present in the diff rather than only described in
+the PR body. One awareness note, explicitly not a request for change: `runBootstrapIfEligible()` catches
+`RuntimeException | Error`, which is broad, but rethrows immediately after one cheap atomic write. Left as is.
+
+## Final state
+
+`clean-approval` after 3 review cycles, 0 items deferred.
+
+| cycle | head | outcome |
+|---|---|---|
+| 1 | `6c26219230` | one real defect: a second bootstrap pass could downgrade a recorded `COMMITTED` and switch the gate back off. Fixed + pinned by a new test. |
+| 2 | `939e2acb3a` | two accepted: `onLeaderChanged()` outside the `try` documented as covering it; non-atomic check-then-set on the outcome field. Both fixed. |
+| 3 | `cc09a1ac5a` | clean approval, nothing blocking. |
+
+Follow-ups left open for the developer: **#7518**, **#7519** (both named in the PR body under Known gaps) and
+**#7520** (pre-existing red on `main`, found here but not caused here).

--- a/docs/7259-raft-ha-cluster-bootstrap-settle-gate.md
+++ b/docs/7259-raft-ha-cluster-bootstrap-settle-gate.md
@@ -114,7 +114,8 @@ database?", which the two points above disqualify. Hence the one production chan
 
 **`RaftHAServer`** (production, additive): `runBootstrapIfEligible()` now records the pass's outcome in a
 volatile field, readable through `getLastBootstrapOutcome()`. `null` means no pass has finished on this node;
-any value means one has, and only `COMMITTED` means it committed a baseline.
+any value means one has, and only `COMMITTED` means it committed a baseline. A recorded `COMMITTED` is
+**sticky** - see the review cycle below for why.
 
 **`BaseRaftHATest.waitAllReplicasAreConnected()`**: after the election it calls the new
 `waitForClusterBootstrapToSettle()`, which
@@ -208,3 +209,49 @@ Filed as **#7520**; not touched here.
   reached another way, and it gates no production client - also #7519.
 - The `waitForReplicationIsCompleted` give-ups (**#7518**) remain: a test can still be told replication
   completed when nothing waited.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/7522
+
+## Review cycles
+
+### cycle 1 - `6c26219230`
+
+The `claude` reviewer found one real correctness defect, verified in the tree before it was accepted:
+
+> `recordBootstrapOutcome` unconditionally overwrites `lastBootstrapOutcome`, and
+> `runBootstrapIfEligible()` is not guaranteed to run once per term.
+
+Checked and confirmed:
+
+- `ArcadeStateMachine.notifyLeaderChanged` submits `runBootstrapIfEligible()` inside
+  `if (newLeaderId.equals(raftHA.getLocalPeerId()))` with **no** term guard, while the logging immediately
+  above it records that Ratis sometimes fires a same-term re-notification;
+- `BootstrapElection.onLeaderChanged()` is `attemptedThisTerm.clear()`, and `runBootstrapIfEligible()` calls it
+  itself, so the per-term short-circuit does not stop a second pass either - it re-evaluates `isFirstFormation`,
+  which is now closed, and returns `SKIPPED_NOT_FIRST_FORMATION`;
+- `BootstrapElectionIT.runBootstrapShortCircuitsAfterFirstFormation` already drives exactly that shape from a
+  test.
+
+Before this PR that second return value was discarded. Capturing it made a downgrade possible, and
+`awaitTerminalBootstrapOutcome` treats `SKIPPED_NOT_FIRST_FORMATION` as terminal-and-nothing-to-wait-for - so
+the gate would have switched itself back off, reopening #7259 behind a rarer condition.
+
+**Fixed** by making `COMMITTED` sticky in `recordBootstrapOutcome`: a later pass cannot commit a second
+baseline (`isFirstFormation` closes on the first one), so anything that follows a `COMMITTED` is a report that
+there was nothing left to do, never a revision of what happened.
+
+**Pinned** by `Issue7259ClusterBootstrapSettledIT.aSecondBootstrapPassCannotDowngradeARecordedCommitted`, which
+calls `runBootstrapIfEligible()` a second time on the leader and asserts the recorded outcome is still
+`COMMITTED`. With the sticky guard removed it fails:
+
+```
+[ERROR] Issue7259ClusterBootstrapSettledIT.aSecondBootstrapPassCannotDowngradeARecordedCommitted -- FAILURE!
+[ERROR] Tests run: 3, Failures: 1
+```
+
+and with it restored the whole sweep is green again (3 tests in the IT, 12 IT classes in `ha-raft`).
+
+The reviewer's remaining points were confirmations, not requests (docs convention, code style, blast radius);
+nothing was deferred.

--- a/docs/7259-raft-ha-cluster-bootstrap-settle-gate.md
+++ b/docs/7259-raft-ha-cluster-bootstrap-settle-gate.md
@@ -1,0 +1,210 @@
+# #7259 - BoltFollowerForwardingIT fails on main with a two-node schema divergence
+
+## Symptom
+
+`BoltFollowerForwardingIT.writeCommandThroughFollowerIsForwardedToLeader` fails on `main` with
+
+```
+com.arcadedb.exception.SchemaException: Type with name 'BoltFollowerWrite' was not found
+  ... at BoltFollowerForwardingIT.writeCommandThroughFollowerIsForwardedToLeader(BoltFollowerForwardingIT.java:116)
+  Suppressed: DatabaseComparator$DatabaseAreNotIdentical: Types: DB1 5 <> DB2 6
+```
+
+`DB1` is server 0, `DB2` is server 1 (`BaseGraphServerTest.checkDatabasesAreIdentical` compares
+`getServerToCheck()[0]` against each of the others). 5 is the base fixture's type count, 6 is the base plus
+`BoltFollowerWrite`, so **server 0 is the node missing the type**.
+
+## Evidence: what the failing CI run actually did
+
+The `integration-test-reports` artifact of run
+[34155171656](https://github.com/ArcadeData/arcadedb/actions/runs/34155171656) carries the full per-server log
+for the failing test. Reconstructed:
+
+```
+19:43:12.020  [BoltFollowerForwardingIT] <ArcadeDB_2> Raft leader elected on server 2   <- waitAllReplicasAreConnected() returned HERE
+19:43:12.047  [ArcadeStateMachine] Leader elected: ArcadeDB_2 (term=1)
+19:43:12.465  [BootstrapElection]  Bootstrap source for 'graph': peer=localhost_2436, lastTxId=7, fingerprint=f7484120...
+19:43:12.675  [ArcadeStateMachine] Database 'graph' bootstrap mismatch (local fp=92f3e044..., baseline fp=f7484120...); reinstalling from leader-shipped full snapshot
+19:43:12.679  [ArcadeStateMachine] Database 'graph' bootstrap mismatch (...); reinstalling from leader-shipped full snapshot
+19:43:12.680  [ArcadeStateMachine] Database 'graph' bootstrapped locally (fingerprint matches cluster baseline)   <- the leader
+19:43:12.695  [SnapshotHttpHandler] Serving database snapshot for 'graph'...   (x2, from the leader)
+19:43:12.812  [ArcadeStateMachine] Database 'graph' reinstalled after bootstrap mismatch
+19:43:12.824  [ArcadeStateMachine] Database 'graph' reinstalled after bootstrap mismatch
+19:43:15.429  [DriverFactory]      Driver instance created for 'bolt://localhost:57687'   <- BASE_BOLT_PORT + 0, so followerIndex = 0
+19:43:19.420  END OF THE TEST
+```
+
+Two facts follow directly:
+
+1. **The test was released while the cluster was still bootstrapping.** `waitAllReplicasAreConnected()` returned
+   the instant a leader existed (12.020). The per-database bootstrap - `BootstrapElection` sampling the peers,
+   committing a `BOOTSTRAP_FINGERPRINT_ENTRY`, and each mismatching peer **replacing its entire `graph`
+   directory** with a full snapshot pulled from the leader - only started at 12.465 and finished at 12.824. The
+   test body (`findLeaderIndex()` -> `createVertexType` -> `waitForAllServers()`) ran inside that window.
+2. **Both followers reinstalled; the leader did not.** The reinstall is not an exceptional path here, even
+   though `BaseGraphServerTest.prepareDatabase` byte-copies server 0's database directory to every peer before
+   startup: by sampling time the fingerprints had diverged anyway (`92f3e044...` against the chosen baseline
+   `f7484120...`). The window is therefore opened on runs of `BaseRaftHATest` subclasses generally, and only the
+   timing decides whether a test's own writes land inside it.
+
+The node that lost the type (server 0) is also the node the Bolt driver wrote through
+(`bolt://localhost:57687` = `BASE_BOLT_PORT + 0`).
+
+## The invariant
+
+**A Raft HA test must not issue its first write until the cluster's first-formation bootstrap pass has finished
+on every started peer - including any full-snapshot reinstall that pass decided to perform.**
+
+## Completeness
+
+### Commands run
+
+```
+$ grep -rln "extends BaseRaftHATest" --include='*.java' . | wc -l
+147
+
+$ grep -rn "waitAllReplicasAreConnected()" --include='*.java' .
+ha-raft/.../BaseRaftHATest.java:295:  protected void waitAllReplicasAreConnected() {      <- the override
+server/.../BaseGraphServerTest.java:338:    waitAllReplicasAreConnected();                 <- the only call site
+server/.../BaseGraphServerTest.java:345:  protected void waitAllReplicasAreConnected() {   <- the non-Raft base
+
+$ grep -n "recordBootstrapBaseline(dbName\|installFromLeaderForBootstrap(dbName)" ha-raft/.../ArcadeStateMachine.java
+3021:    recordBootstrapBaseline(dbName, new BootstrapBaseline(chosenFingerprint, chosenLastTxId));
+3070:      installFromLeaderForBootstrap(dbName);
+3148:      installFromLeaderForBootstrap(dbName);
+
+$ grep -n "applyWithRetry(index" -A 12 ha-raft/.../ArcadeStateMachine.java
+930:      });                                               <- applyWithRetry returns (the reinstall is inside it)
+933:      updateLastAppliedTermIndex(termIndex.getTerm(), index);   <- only THEN is the applied index published
+```
+
+### Why the recorded baseline is not the signal
+
+The obvious gate - "every peer answers a non-null `ArcadeStateMachine.getBootstrapBaseline(db)`" - does not
+work, and the greps above are why:
+
+- `recordBootstrapBaseline` runs at line 3021, at the **top** of `applyBootstrapFingerprintEntry`, while both
+  `installFromLeaderForBootstrap` calls are at 3070/3148. A peer therefore publishes a non-null baseline while
+  the full-database reinstall it triggered is still in flight - which is exactly the state the gate exists to
+  keep a test out of.
+- On the "superseded" path (`persistedApplied >= 0 && persistedApplied < index`) the method returns before 3021
+  and records nothing at all, so a null baseline cannot tell "not yet" from "never will" and the wait would
+  burn its whole budget on every such cluster.
+
+The applied index does work: `updateLastAppliedTermIndex` at 933 runs only after `applyWithRetry` at 930 has
+returned, and the reinstall is inside it.
+
+### What the wait needed that nothing published
+
+Nothing on the server answered "has the bootstrap pass finished?", only "did it commit a baseline for this
+database?", which the two points above disqualify. Hence the one production change in this PR:
+`RaftHAServer.getLastBootstrapOutcome()`, recorded by `runBootstrapIfEligible()`.
+
+### Entry-point coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| `BaseGraphServerTest.startServers()` -> `BaseRaftHATest.waitAllReplicasAreConnected()` -> test body writes (all 147 subclasses, `BoltFollowerForwardingIT` among them) | yes - the new two-part gate | yes - `Issue7259ClusterBootstrapSettledIT`, which fails with the gate removed (see below), plus `BoltFollowerForwardingIT` green |
+| `RaftHAServer.getLastBootstrapOutcome()` reachable at runtime (new production code) | yes - written by `runBootstrapIfEligible()`, which `ArcadeStateMachine.notifyLeaderChanged` submits on every election | yes - the IT asserts it is non-null on the leader of a real 3-node cluster |
+| `BaseRaftHATest.restartServer(int)` re-forming a cluster mid-test | argued - bootstrap cannot re-engage after first formation (`BootstrapElection.isFirstFormation`, issue #4800), so there is no reinstall window to gate; `RaftBootstrapDoesNotEngageOnRestartIT` pins it and is green in the sweep below | n/a |
+| `waitForReplicationIsCompleted()`'s two silent give-ups (no leader within 3 s; 30 s budget expiry) | **no** - filed as #7518 | no |
+| A production client writing into the first-formation bootstrap window (no harness involved) | **no** - filed as #7519 | no |
+
+## Fix
+
+**`RaftHAServer`** (production, additive): `runBootstrapIfEligible()` now records the pass's outcome in a
+volatile field, readable through `getLastBootstrapOutcome()`. `null` means no pass has finished on this node;
+any value means one has, and only `COMMITTED` means it committed a baseline.
+
+**`BaseRaftHATest.waitAllReplicasAreConnected()`**: after the election it calls the new
+`waitForClusterBootstrapToSettle()`, which
+
+1. waits for the leader's pass to report a terminal outcome, re-resolving the leader across a `TRANSFERRED`
+   (leadership moves to the elected source, whose own pass re-runs the protocol) and returning at once on
+   anything that is not `COMMITTED` - so a cluster that disables bootstrap pays none of the budget;
+2. on `COMMITTED`, waits until every started peer's published applied index has reached the highest in the
+   cluster.
+
+It is not an assertion: exhausting the budget falls through, and `slowWaitReport` turns that into a `GAVE UP`
+line. It shares `RESYNC_RETRY_TIMEOUT_MS` as its budget rather than defining its own, because `slowWaitReport`
+names that constant in every line it emits.
+
+## Verification
+
+```
+$ mvn -o -pl ha-raft -Dit.test='RaftBootstrap*IT,BootstrapElectionIT,Issue7259ClusterBootstrapSettledIT' -DskipITs=false verify
+RaftBootstrapFromLocalDatabaseIT ............ Tests run: 1, Failures: 0
+Issue7259ClusterBootstrapSettledIT .......... Tests run: 2, Failures: 0
+RaftBootstrapTimeoutFallbackIT .............. Tests run: 1, Failures: 0
+RaftBootstrapFingerprintMismatchSameLsnIT ... Tests run: 1, Failures: 0
+RaftBootstrapLateNewerJoinerIT .............. Tests run: 1, Failures: 0
+RaftBootstrapDoesNotEngageOnRestartIT ....... Tests run: 1, Failures: 0
+RaftBootstrapPicksHighestLastTxIdIT ......... Tests run: 1, Failures: 0
+BootstrapElectionIT ......................... Tests run: 3, Failures: 0
+RaftBootstrapLeadershipTransferIT ........... Tests run: 1, Failures: 0
+BUILD SUCCESS
+```
+
+plus `RaftLeaderFailoverIT` and `RaftQuorumLostIT` (green in an earlier sweep, both left-a-server-down shapes),
+and the IT the issue was filed against:
+
+```
+$ mvn -o -pl bolt -Dit.test=BoltFollowerForwardingIT -DskipITs=false verify
+... WARNI [BoltFollowerForwardingIT] TEST SLOW WAIT: cluster bootstrap settle satisfied after 2594 ms ...
+BoltFollowerForwardingIT .................... Tests run: 1, Failures: 0
+BUILD SUCCESS
+```
+
+The gate satisfies in 2.5-7.7 s across those runs, so what it waits for is real work the tests were previously
+racing, not a no-op. No run hit the budget.
+
+**The regression test can fail.** With `waitForClusterBootstrapToSettle()` commented out of
+`waitAllReplicasAreConnected()` and nothing else changed:
+
+```
+[ERROR] Issue7259ClusterBootstrapSettledIT.bootstrapPassHasReportedAndEveryPeerHasCaughtUpBeforeTheTestBodyRuns -- FAILURE!
+[ERROR] Tests run: 2, Failures: 1
+```
+
+The second method (`aTypeCreatedRightAfterStartupReachesEveryPeer`) passes either way on a workstation - the
+divergence itself has never reproduced locally, which is stated in the issue and is why the first method exists.
+
+## Adversarial pass
+
+The orchestrator's Phase 1.5 spawns a subagent that has not seen the author's reasoning. **No `Task` tool was
+available in this session**, so the pass was run as a self-directed adversarial re-read of the finished diff
+instead. That is weaker by construction - it had been persuaded already - and is recorded as such. Two findings
+came out of it and both were fixed before the PR opened:
+
+1. **A timed-out gate reported itself as satisfied.** The first draft funnelled "the pass committed nothing"
+   and "the pass never reported inside the budget" through one `boolean` and logged
+   `reportSlowWait(..., satisfied = true)` for both. A full 15 s burn would therefore have printed the word the
+   instrument reserves for a wait that finished - hiding exactly the regression `slowWaitReport` exists to
+   catch. `awaitTerminalBootstrapOutcome` now returns the outcome (or `null` on timeout) and the two cases are
+   reported differently.
+2. **The applied-index check allocated an `int[]` and a `long[]` per poll round.** Replaced with a single
+   lowest/highest pass, which is also the honest statement of what it checks.
+
+A third reading was raised and rejected with evidence: that `getLastAppliedTermIndex()` could be seeded from a
+Ratis snapshot marker running ahead of what a peer applied (`ha-raft/CLAUDE.md`, "Replay position comes only
+from the Ratis snapshot marker"). It cannot bite here - the gate runs at first cluster formation, where the
+Raft log is empty and there is no snapshot to seed from - and the existing `waitForReplicationIsCompleted`
+reads the same value, so the gate is no weaker than the wait it sits beside.
+
+## Pre-existing red, unrelated
+
+`ArcadeStateMachinePerDatabaseHaltTest` fails both its methods on `main` with the #7259 diff fully reverted.
+Filed as **#7520**; not touched here.
+
+## Residual risk
+
+- **The byte-level mechanism of the divergence is not established.** Both orderings that can be reasoned about
+  statically preserve the type (schema entry before the bootstrap entry -> the superseded guard skips the
+  reinstall; after -> the reinstall runs first and the entry applies on top, both on the single apply thread).
+  An earlier reading blamed a torn snapshot served from the leader's live directory; that reading is **wrong**
+  and was removed - `SnapshotHttpHandler` serves a point-in-time `PageSnapshot` under `executeInReadLock`, with
+  `suspendFlushAndExecute` as the fallback. What remains unexplained is filed as **#7519**.
+- This fix removes the overlap the failure needed in the test harness. It does not prove the hazard cannot be
+  reached another way, and it gates no production client - also #7519.
+- The `waitForReplicationIsCompleted` give-ups (**#7518**) remain: a test can still be told replication
+  completed when nothing waited.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -329,7 +329,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * Written only through {@link #recordBootstrapOutcome}, which never lets a later pass overwrite a recorded
    * {@code COMMITTED}. Issue #7259.
    */
-  private volatile BootstrapElection.Outcome lastBootstrapOutcome;
+  private final AtomicReference<BootstrapElection.Outcome> lastBootstrapOutcome = new AtomicReference<>();
 
   public RaftHAServer(final ArcadeDBServer arcadeServer, final ContextConfiguration configuration) {
     this.arcadeServer = arcadeServer;
@@ -1152,13 +1152,15 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     final BootstrapElection election = bootstrapElection;
     if (election == null)
       return recordBootstrapOutcome(BootstrapElection.Outcome.SKIPPED_DISABLED);
-    election.onLeaderChanged();
     try {
+      // onLeaderChanged() is INSIDE the try on purpose: runIfEligible() swallows its own Throwable into
+      // FAILED, so the only way out of this method without an outcome is a throw from onLeaderChanged, and
+      // leaving it outside would mean the one case this catch exists for is the one it does not cover.
+      election.onLeaderChanged();
       return recordBootstrapOutcome(election.runIfEligible());
     } catch (final RuntimeException | Error e) {
-      // runIfEligible() swallows its own Throwable into FAILED, so this only fires if the pass dies before
-      // that catch (e.g. onLeaderChanged). Publish a terminal outcome anyway: a caller waiting for the pass
-      // to finish must not be left waiting out its whole budget on a pass that already died.
+      // Publish a terminal outcome anyway: a caller waiting for the pass to finish must not be left waiting
+      // out its whole budget on a pass that already died.
       recordBootstrapOutcome(BootstrapElection.Outcome.FAILED);
       throw e;
     }
@@ -1181,8 +1183,12 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * {@code runBootstrapIfEligible()} a second time. Issue #7259.
    */
   private BootstrapElection.Outcome recordBootstrapOutcome(final BootstrapElection.Outcome outcome) {
-    if (lastBootstrapOutcome != BootstrapElection.Outcome.COMMITTED)
-      lastBootstrapOutcome = outcome;
+    // An AtomicReference rather than a volatile with a check-then-set: production only reaches this from the
+    // single-threaded lifecycleExecutor, but runBootstrapIfEligible() is public and several tests call it
+    // directly from their own thread while that executor may still be running the automatic pass. A lost
+    // update there would drop the COMMITTED this method exists to protect.
+    lastBootstrapOutcome.updateAndGet(
+        current -> current == BootstrapElection.Outcome.COMMITTED ? current : outcome);
     return outcome;
   }
 
@@ -1198,7 +1204,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * {@code COMMITTED} is sticky for the node's life; see {@link #recordBootstrapOutcome}. Issue #7259.
    */
   public BootstrapElection.Outcome getLastBootstrapOutcome() {
-    return lastBootstrapOutcome;
+    return lastBootstrapOutcome.get();
   }
 
   @Override

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -316,6 +316,17 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   private          ClusterTokenProvider      tokenProvider;
   private volatile int                       restartFailureCount   = 0;
   private volatile BootstrapElection         bootstrapElection;
+  /**
+   * Outcome of the most recent {@link #runBootstrapIfEligible()} pass on this node, or {@code null} while no
+   * pass has finished yet.
+   * <p>
+   * The distinction it publishes is "the bootstrap pass has not finished" versus "it finished and here is what
+   * it decided", which nothing else on this server answers: {@link ArcadeStateMachine#getBootstrapBaseline}
+   * turns non-null in the MIDDLE of the apply that may still be replacing the whole database directory from a
+   * leader-shipped snapshot, and a peer on which the bootstrap was never eligible records no baseline at all,
+   * so a null baseline cannot tell "not yet" from "never will". Issue #7259.
+   */
+  private volatile BootstrapElection.Outcome lastBootstrapOutcome;
 
   public RaftHAServer(final ArcadeDBServer arcadeServer, final ContextConfiguration configuration) {
     this.arcadeServer = arcadeServer;
@@ -1137,9 +1148,35 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   public BootstrapElection.Outcome runBootstrapIfEligible() {
     final BootstrapElection election = bootstrapElection;
     if (election == null)
-      return BootstrapElection.Outcome.SKIPPED_DISABLED;
+      return recordBootstrapOutcome(BootstrapElection.Outcome.SKIPPED_DISABLED);
     election.onLeaderChanged();
-    return election.runIfEligible();
+    try {
+      return recordBootstrapOutcome(election.runIfEligible());
+    } catch (final RuntimeException | Error e) {
+      // runIfEligible() swallows its own Throwable into FAILED, so this only fires if the pass dies before
+      // that catch (e.g. onLeaderChanged). Publish a terminal outcome anyway: a caller waiting for the pass
+      // to finish must not be left waiting out its whole budget on a pass that already died.
+      recordBootstrapOutcome(BootstrapElection.Outcome.FAILED);
+      throw e;
+    }
+  }
+
+  private BootstrapElection.Outcome recordBootstrapOutcome(final BootstrapElection.Outcome outcome) {
+    lastBootstrapOutcome = outcome;
+    return outcome;
+  }
+
+  /**
+   * The outcome of the most recent bootstrap pass that finished on this node, or {@code null} while none has.
+   * <p>
+   * Only the leader runs a pass ({@link ArcadeStateMachine#notifyLeaderChanged} submits it), so on a follower
+   * this stays {@code null} for the node's whole life. A non-null value means the pass RETURNED: for
+   * {@link BootstrapElection.Outcome#COMMITTED} at least one {@code BOOTSTRAP_FINGERPRINT_ENTRY} was committed -
+   * the commit goes through {@code RaftGroupCommitter.submitAndWait}, which blocks on the quorum reply - and
+   * every other value means this pass committed nothing. Issue #7259.
+   */
+  public BootstrapElection.Outcome getLastBootstrapOutcome() {
+    return lastBootstrapOutcome;
   }
 
   @Override

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -324,7 +324,10 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * it decided", which nothing else on this server answers: {@link ArcadeStateMachine#getBootstrapBaseline}
    * turns non-null in the MIDDLE of the apply that may still be replacing the whole database directory from a
    * leader-shipped snapshot, and a peer on which the bootstrap was never eligible records no baseline at all,
-   * so a null baseline cannot tell "not yet" from "never will". Issue #7259.
+   * so a null baseline cannot tell "not yet" from "never will".
+   * <p>
+   * Written only through {@link #recordBootstrapOutcome}, which never lets a later pass overwrite a recorded
+   * {@code COMMITTED}. Issue #7259.
    */
   private volatile BootstrapElection.Outcome lastBootstrapOutcome;
 
@@ -1161,8 +1164,25 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     }
   }
 
+  /**
+   * Records {@code outcome} as this node's last bootstrap result, except that a recorded
+   * {@link BootstrapElection.Outcome#COMMITTED} is never overwritten.
+   * <p>
+   * A later pass on the same node CANNOT commit a second baseline - {@code isFirstFormation} closes the moment
+   * the first one is applied - so every outcome that follows a {@code COMMITTED} is a report that there was
+   * nothing left to do, not a revision of what happened. Letting one overwrite would turn "this cluster
+   * committed a baseline" into "it did not", and a reader waiting on the reinstall that baseline triggers would
+   * be released in the middle of it.
+   * <p>
+   * That is not hypothetical. {@code ArcadeStateMachine.notifyLeaderChanged} submits
+   * {@link #runBootstrapIfEligible()} on every notification naming this node leader, with no term guard, and
+   * its own comment records that Ratis sometimes fires a same-term re-notification; the second pass then
+   * returns {@code SKIPPED_NOT_FIRST_FORMATION}. Tests reach the same shape deliberately by calling
+   * {@code runBootstrapIfEligible()} a second time. Issue #7259.
+   */
   private BootstrapElection.Outcome recordBootstrapOutcome(final BootstrapElection.Outcome outcome) {
-    lastBootstrapOutcome = outcome;
+    if (lastBootstrapOutcome != BootstrapElection.Outcome.COMMITTED)
+      lastBootstrapOutcome = outcome;
     return outcome;
   }
 
@@ -1170,10 +1190,12 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * The outcome of the most recent bootstrap pass that finished on this node, or {@code null} while none has.
    * <p>
    * Only the leader runs a pass ({@link ArcadeStateMachine#notifyLeaderChanged} submits it), so on a follower
-   * this stays {@code null} for the node's whole life. A non-null value means the pass RETURNED: for
+   * this stays {@code null} for the node's whole life. A non-null value means a pass RETURNED: for
    * {@link BootstrapElection.Outcome#COMMITTED} at least one {@code BOOTSTRAP_FINGERPRINT_ENTRY} was committed -
    * the commit goes through {@code RaftGroupCommitter.submitAndWait}, which blocks on the quorum reply - and
-   * every other value means this pass committed nothing. Issue #7259.
+   * every other value means no pass on this node has committed anything.
+   * <p>
+   * {@code COMMITTED} is sticky for the node's life; see {@link #recordBootstrapOutcome}. Issue #7259.
    */
   public BootstrapElection.Outcome getLastBootstrapOutcome() {
     return lastBootstrapOutcome;

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BaseRaftHATest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BaseRaftHATest.java
@@ -29,6 +29,7 @@ import com.arcadedb.server.ServerPlugin;
 import com.arcadedb.utility.FileUtils;
 
 import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.server.protocol.TermIndex;
 
 import java.io.File;
 import java.util.Arrays;
@@ -299,6 +300,7 @@ public abstract class BaseRaftHATest extends BaseGraphServerTest {
         final RaftHAPlugin plugin = getRaftPlugin(i);
         if (plugin != null && plugin.isLeader()) {
           LogManager.instance().log(this, Level.INFO, "Raft leader elected on server %d", i);
+          waitForClusterBootstrapToSettle();
           serversSynchronized = true;
           return;
         }
@@ -313,6 +315,165 @@ public abstract class BaseRaftHATest extends BaseGraphServerTest {
     LogManager.instance().log(this, Level.WARNING, "Timeout waiting for Raft leader election");
     // Set true to unblock test setup; individual tests will fail if no leader is actually present.
     serversSynchronized = true;
+  }
+
+  /**
+   * Second half of the setup gate: an elected leader is not a ready cluster (issue #7259).
+   * <p>
+   * After the election the leader runs {@code BootstrapElection} on its lifecycle executor - it samples every
+   * peer's {@code (fingerprint, lastTxId)} for each database, picks a baseline, and commits one
+   * {@code BOOTSTRAP_FINGERPRINT_ENTRY} per database. Every peer whose copy does not match that baseline then
+   * <b>replaces its entire database directory</b> with a full snapshot pulled from the leader, inside the
+   * {@code applyTransaction} call for that entry. That reinstall is not an exceptional path here: in the CI run
+   * that produced #7259 BOTH followers took it, on a fixture whose database directory
+   * {@code BaseGraphServerTest.prepareDatabase} had byte-copied from server 0 to every peer before startup
+   * (local fp {@code 92f3e044...} against the chosen baseline {@code f7484120...}).
+   * <p>
+   * Without this gate a test body starts the moment the election finishes and races all of it. In the run that
+   * produced issue #7259 the election landed at {@code 12.020}, the baseline was chosen at {@code 12.465} and
+   * both followers finished reinstalling at {@code 12.812} / {@code 12.824}, so the test's
+   * {@code createVertexType} and its Bolt write both fell inside the window, and one follower came out of it
+   * without the type - permanently, and with no error logged on either side.
+   * <p>
+   * The gate is in two parts, and the first is what makes the second safe to wait on:
+   * <ol>
+   *   <li>Wait for the leader's bootstrap pass to report a terminal outcome
+   *       ({@link RaftHAServer#getLastBootstrapOutcome()}). Anything other than {@code COMMITTED} means the
+   *       pass committed nothing, so there is nothing to wait for and the gate returns immediately - a cluster
+   *       that disables bootstrap pays no part of the budget. {@code TRANSFERRED} means leadership moved to the
+   *       elected source, whose own pass re-runs the protocol, so the gate re-resolves the leader and asks
+   *       again.</li>
+   *   <li>On {@code COMMITTED}, wait for every started peer's last-applied index to reach the highest applied
+   *       index in the cluster. Ratis publishes a peer's applied index only after {@code applyTransaction} has
+   *       RETURNED for it, so a peer still downloading and swapping in a snapshot inside that call is still
+   *       reported behind - which is exactly the state that must not be released into a test body.</li>
+   * </ol>
+   * The baseline recorded by {@code ArcadeStateMachine} is deliberately NOT the signal:
+   * {@code recordBootstrapBaseline} runs at the TOP of the apply, before {@code installFromLeaderForBootstrap},
+   * so a peer answers a non-null baseline while the reinstall it triggered is still in flight. It is also never
+   * recorded at all on the "superseded" path, so a null baseline cannot tell "not yet" from "never will".
+   * <p>
+   * The gate is deliberately NOT an assertion. A cluster on which the pass never reports is a cluster whose
+   * tests must keep working: the wait falls through after its budget, and {@link #slowWaitReport} turns that
+   * into a GAVE UP line so the case leaves a trace rather than being mistaken for a fast one.
+   */
+  protected void waitForClusterBootstrapToSettle() {
+    final long startMs = System.currentTimeMillis();
+    // RESYNC_RETRY_TIMEOUT_MS and not a budget of its own: slowWaitReport names that constant in every line
+    // it emits, so a caller that waits on a different one reports a budget it never had. Sharing it is also
+    // the right size - the settle took 2.5-7.7 s across the ha-raft bootstrap ITs on a loaded workstation and
+    // 804 ms on the CI runner of #7259 - and overshooting costs nothing here, since exhausting the budget
+    // falls through rather than failing.
+    final long deadline = startMs + RESYNC_RETRY_TIMEOUT_MS;
+
+    final BootstrapElection.Outcome outcome = awaitTerminalBootstrapOutcome(deadline);
+    if (outcome == null) {
+      // The pass never reported inside the budget. That IS a give-up, and it is reported as one: a line reading
+      // "satisfied" here would hide a 15 s burn behind the word the instrument uses for a wait that finished.
+      reportSlowWait("cluster bootstrap settle", startMs, false);
+      return;
+    }
+    if (outcome != BootstrapElection.Outcome.COMMITTED) {
+      // The pass finished and committed nothing - bootstrap disabled, not first formation, no databases. There
+      // is no entry to wait for, so this is a wait that finished, not one that gave up.
+      reportSlowWait("cluster bootstrap settle", startMs, true);
+      return;
+    }
+
+    while (System.currentTimeMillis() < deadline) {
+      if (everyStartedServerAppliedTheHighestIndex()) {
+        reportSlowWait("cluster bootstrap settle", startMs, true);
+        return;
+      }
+      if (!sleepQuietly(100))
+        return;
+    }
+    reportSlowWait("cluster bootstrap settle", startMs, false);
+  }
+
+  /**
+   * Waits for the leader's bootstrap pass to report an outcome the cluster will not revise, and returns it -
+   * or {@code null} when none showed up inside {@code deadline} (or the wait was interrupted).
+   * <p>
+   * Two outcomes are not terminal for the CLUSTER even though they are terminal for the pass that produced
+   * them, and both are waited through rather than returned:
+   * <ul>
+   *   <li>{@code TRANSFERRED} - the old leader handed leadership to the elected source without committing
+   *       anything, and the source's own leader-change callback re-runs the protocol. The loop re-resolves the
+   *       leader and reads the new one's outcome.</li>
+   *   <li>{@code NOT_LEADER} - the pass found it was no longer leader by the time it ran. The node this loop is
+   *       reading IS the leader now, so the pass that matters is a later one that has not finished yet.</li>
+   * </ul>
+   */
+  private BootstrapElection.Outcome awaitTerminalBootstrapOutcome(final long deadline) {
+    while (System.currentTimeMillis() < deadline) {
+      final RaftHAPlugin leader = currentLeaderPlugin();
+      final BootstrapElection.Outcome outcome =
+          leader == null ? null : leader.getRaftHAServer().getLastBootstrapOutcome();
+      if (outcome != null && outcome != BootstrapElection.Outcome.TRANSFERRED
+          && outcome != BootstrapElection.Outcome.NOT_LEADER)
+        return outcome;
+      if (!sleepQuietly(100))
+        return null;
+    }
+    return null;
+  }
+
+  /**
+   * The plugin of the peer that currently reports itself leader, or {@code null} while none does. Unlike
+   * {@link #findLeaderIndex()} this does not wait: the callers here are already inside their own bounded loop
+   * and a nested 30 s wait would make the budget they think they are spending a fiction.
+   */
+  private RaftHAPlugin currentLeaderPlugin() {
+    for (int i = 0; i < getServerCount(); i++) {
+      final RaftHAPlugin plugin = getRaftPlugin(i);
+      if (plugin != null && plugin.isLeader() && plugin.getRaftHAServer() != null)
+        return plugin;
+    }
+    return null;
+  }
+
+  /**
+   * Whether every started peer has published an applied index equal to the highest one any started peer
+   * publishes. Reads {@code startedServers()} rather than every configured index so a test that deliberately
+   * leaves a server down is not held here for the full budget.
+   * <p>
+   * Comparing the lowest reading against the highest, rather than every reading against the leader's, keeps the
+   * answer honest whichever peer is ahead: the reinstalling follower is the one that lags, and it lags whoever
+   * applied the bootstrap entry first, which is not always the leader. An empty started set leaves both at their
+   * sentinels and compares unequal, which is the safe answer - there is nothing to release a test against.
+   */
+  private boolean everyStartedServerAppliedTheHighestIndex() {
+    long lowest = Long.MAX_VALUE;
+    long highest = Long.MIN_VALUE;
+    for (final int i : startedServers()) {
+      final RaftHAPlugin plugin = getRaftPlugin(i);
+      if (plugin == null || plugin.getRaftHAServer() == null)
+        return false;
+      final TermIndex termIndex = plugin.getRaftHAServer().getStateMachine().getLastAppliedTermIndex();
+      if (termIndex == null)
+        return false;
+      final long applied = termIndex.getIndex();
+      if (applied < lowest)
+        lowest = applied;
+      if (applied > highest)
+        highest = applied;
+    }
+    return lowest == highest;
+  }
+
+  /**
+   * Sleeps, answering {@code false} when the wait was interrupted so the caller abandons its loop rather than
+   * spinning on an already-interrupted thread.
+   */
+  private static boolean sleepQuietly(final long millis) {
+    try {
+      Thread.sleep(millis);
+      return true;
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
   }
 
   /**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7259ClusterBootstrapSettledIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7259ClusterBootstrapSettledIT.java
@@ -24,6 +24,7 @@ import org.apache.ratis.server.protocol.TermIndex;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
  * Regression test for issue #7259.
@@ -47,6 +48,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  *   <li>{@link #aTypeCreatedRightAfterStartupReachesEveryPeer()} pins what the gate buys, which is the shape
  *       {@code BoltFollowerForwardingIT} asserts through Bolt: a type created on the leader immediately after
  *       setup returns is present on every peer, and the databases compare identical.</li>
+ *   <li>{@link #aSecondBootstrapPassCannotDowngradeARecordedCommitted()} pins the one thing that would
+ *       silently switch the gate back off: the recorded outcome surviving a second pass.</li>
  * </ul>
  */
 class Issue7259ClusterBootstrapSettledIT extends BaseRaftHATest {
@@ -85,6 +88,41 @@ class Issue7259ClusterBootstrapSettledIT extends BaseRaftHATest {
               reading behind here is a peer that may still be replacing its whole database directory from a \
               leader-shipped snapshot (issue #7259)""", i)
           .isGreaterThanOrEqualTo(highest);
+  }
+
+  /**
+   * A second bootstrap pass on the same leader must not downgrade a recorded {@code COMMITTED}.
+   * <p>
+   * {@code ArcadeStateMachine.notifyLeaderChanged} submits {@code runBootstrapIfEligible()} on every
+   * notification naming this node leader, with no term guard, and its own comment records that Ratis sometimes
+   * fires a same-term re-notification. The second pass finds {@code isFirstFormation} closed - the first
+   * baseline is applied - and returns {@code SKIPPED_NOT_FIRST_FORMATION}. If that overwrote the recorded
+   * {@code COMMITTED}, {@link BaseRaftHATest#waitForClusterBootstrapToSettle()} would read "nothing was
+   * committed, nothing to wait for" and release a test body while followers were still reinstalling: issue
+   * #7259 reopened, behind a rarer condition. This drives the same shape deliberately.
+   */
+  @Test
+  void aSecondBootstrapPassCannotDowngradeARecordedCommitted() {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final RaftHAServer leader = getRaftPlugin(leaderIndex).getRaftHAServer();
+    // Only a recorded COMMITTED can be downgraded, so a fixture that legitimately committed nothing has nothing
+    // to say here. It does commit on this fixture; the assumption keeps the test from going green for the wrong
+    // reason if that ever stops being true.
+    assumeThat(leader.getLastBootstrapOutcome())
+        .as("this fixture is expected to commit a bootstrap baseline")
+        .isEqualTo(BootstrapElection.Outcome.COMMITTED);
+
+    final BootstrapElection.Outcome second = leader.runBootstrapIfEligible();
+    assertThat(second)
+        .as("the second pass must find first formation closed and commit nothing of its own")
+        .isNotEqualTo(BootstrapElection.Outcome.COMMITTED);
+    assertThat(leader.getLastBootstrapOutcome())
+        .as("The recorded outcome must still be COMMITTED after a second pass returned %s. A later pass cannot "
+            + "commit a second baseline, so it reports that there was nothing left to do - not that the first "
+            + "commit did not happen (issue #7259)", second)
+        .isEqualTo(BootstrapElection.Outcome.COMMITTED);
   }
 
   @Test

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7259ClusterBootstrapSettledIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7259ClusterBootstrapSettledIT.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.database.Database;
+
+import org.apache.ratis.server.protocol.TermIndex;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7259.
+ * <p>
+ * A Raft HA test used to be released by {@link BaseRaftHATest#waitAllReplicasAreConnected()} the instant a
+ * leader was elected, while the cluster's per-database bootstrap was still ahead of it: {@code
+ * BootstrapElection} samples the peers, commits a {@code BOOTSTRAP_FINGERPRINT_ENTRY}, and every peer whose
+ * copy does not match the chosen baseline <b>replaces its whole database directory</b> with a full snapshot
+ * pulled from the leader. In the run that produced #7259 that sequence started 445 ms after the election and
+ * finished 800 ms after it, so {@code BoltFollowerForwardingIT}'s own {@code createVertexType} and its Bolt
+ * write both landed inside the window, and one of the two followers came out of it without the type -
+ * permanently, and with no error on either side.
+ * <p>
+ * Each test here pins one half of the gate:
+ * <ul>
+ *   <li>{@link #bootstrapPassHasReportedAndEveryPeerHasCaughtUpBeforeTheTestBodyRuns()} pins the gate itself,
+ *       through the two readings it is built on - the leader's terminal bootstrap outcome, and every started
+ *       peer's published applied index. The applied index is the load-bearing one: Ratis publishes it only
+ *       after {@code applyTransaction} has RETURNED, so a peer still swapping in a snapshot inside that call
+ *       still reads behind.</li>
+ *   <li>{@link #aTypeCreatedRightAfterStartupReachesEveryPeer()} pins what the gate buys, which is the shape
+ *       {@code BoltFollowerForwardingIT} asserts through Bolt: a type created on the leader immediately after
+ *       setup returns is present on every peer, and the databases compare identical.</li>
+ * </ul>
+ */
+class Issue7259ClusterBootstrapSettledIT extends BaseRaftHATest {
+
+  private static final String VERTEX_TYPE = "Issue7259BootstrapRace";
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Test
+  void bootstrapPassHasReportedAndEveryPeerHasCaughtUpBeforeTheTestBodyRuns() {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    assertThat(getRaftPlugin(leaderIndex).getRaftHAServer().getLastBootstrapOutcome())
+        .as("""
+            The leader's bootstrap pass must have reported a terminal outcome before the test body starts. \
+            While it has not, a BOOTSTRAP_FINGERPRINT_ENTRY - and the full-database reinstall applying it can \
+            trigger on a follower - is still ahead of anything this test writes (issue #7259)""")
+        .isNotNull();
+
+    long highest = -1;
+    for (final int i : startedServers()) {
+      final TermIndex applied = getRaftPlugin(i).getRaftHAServer().getStateMachine().getLastAppliedTermIndex();
+      assertThat(applied).as("Server %d must publish an applied index", i).isNotNull();
+      if (applied.getIndex() > highest)
+        highest = applied.getIndex();
+    }
+    for (final int i : startedServers())
+      assertThat(getRaftPlugin(i).getRaftHAServer().getStateMachine().getLastAppliedTermIndex().getIndex())
+          .as("""
+              Server %d must have applied every entry the cluster has applied before the test body starts. \
+              Ratis publishes an applied index only once applyTransaction has returned for it, so a peer \
+              reading behind here is a peer that may still be replacing its whole database directory from a \
+              leader-shipped snapshot (issue #7259)""", i)
+          .isGreaterThanOrEqualTo(highest);
+  }
+
+  @Test
+  void aTypeCreatedRightAfterStartupReachesEveryPeer() {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+    leaderDb.transaction(() -> {
+      if (!leaderDb.getSchema().existsType(VERTEX_TYPE))
+        leaderDb.getSchema().createVertexType(VERTEX_TYPE);
+    });
+
+    waitForAllServers();
+
+    for (final int i : startedServers())
+      assertThat(getServerDatabase(i, getDatabaseName()).getSchema().existsType(VERTEX_TYPE))
+          .as("Server %d (leader=%d) must hold the type created on the leader right after startup", i, leaderIndex)
+          .isTrue();
+
+    checkDatabasesAreIdentical();
+  }
+}


### PR DESCRIPTION
Closes #7259

`BaseRaftHATest.waitAllReplicasAreConnected()` released a test body the instant a Raft leader existed, while the cluster's first-formation bootstrap was still ahead of it. That pass has the leader sample every peer's `(fingerprint, lastTxId)`, commit a `BOOTSTRAP_FINGERPRINT_ENTRY`, and each peer whose copy does not match the chosen baseline **replace its entire database directory** with a full snapshot pulled from the leader, inside the `applyTransaction` call for that entry. The retained CI log of run [34155171656](https://github.com/ArcadeData/arcadedb/actions/runs/34155171656) shows the election at `12.020`, the baseline chosen at `12.465` and both followers finishing their reinstall at `12.812`/`12.824` - so `BoltFollowerForwardingIT`'s `createVertexType` and its Bolt write both landed inside that window, and one follower came out of it permanently without the type, with no error on either side. The setup gate now waits for the pass to finish everywhere before releasing the test, which closes the overlap the failure needed.

The gate is in two parts. First it waits for the leader's bootstrap pass to report a terminal outcome, re-resolving the leader across a `TRANSFERRED` and returning immediately on anything that is not `COMMITTED` - so a cluster that disables bootstrap pays none of the budget. Then, on `COMMITTED`, it waits for every started peer's published applied index to reach the highest in the cluster: Ratis publishes that index only after `applyTransaction` has RETURNED, so a peer still downloading and swapping in a snapshot inside that call still reads behind. The recorded baseline is deliberately **not** the signal - `recordBootstrapBaseline` runs at the top of the apply, *before* `installFromLeaderForBootstrap`, so a peer answers a non-null baseline mid-reinstall, and the "superseded" path never records one at all. The gate never asserts: exhausting its budget falls through and the existing `slowWaitReport` instrument turns that into a `GAVE UP` line. `RaftHAServer.getLastBootstrapOutcome()` is the single production addition, because nothing on the server answered "has the bootstrap pass finished?" as opposed to "did it commit a baseline for this database?".

## Test plan

- [x] `Issue7259ClusterBootstrapSettledIT` (new) - 2 tests green. One pins the gate through the two readings it is built on, the other pins what the gate buys (a type created right after setup reaches every peer, and `checkDatabasesAreIdentical()` passes).
- [x] **The regression test can fail**: with `waitForClusterBootstrapToSettle()` commented out of `waitAllReplicasAreConnected()` and nothing else changed, `bootstrapPassHasReportedAndEveryPeerHasCaughtUpBeforeTheTestBodyRuns` fails.
- [x] `mvn -o -pl bolt -Dit.test=BoltFollowerForwardingIT -DskipITs=false verify` - green, and the log shows the new gate waiting 2.7 s inside that very test.
- [x] `mvn -o -pl ha-raft -Dit.test='RaftBootstrap*IT,BootstrapElectionIT,Issue7259ClusterBootstrapSettledIT,RaftLeaderFailoverIT,RaftQuorumLostIT' -DskipITs=false verify` - all green. Covers the bootstrap-disabled, leadership-transfer, restart (`RaftBootstrapDoesNotEngageOnRestartIT`) and server-stopped (`RaftQuorumLostIT`, `RaftLeaderFailoverIT`) shapes, i.e. every case where a naive gate would hang for its whole budget. None did; the settle satisfies in 2.5-7.7 s.
- [x] `mvn -o -pl ha-raft -am -DskipTests install` compiles clean.

## Coverage

| Entry point | Covered by fix? | Covered by a test? |
|---|---|---|
| `BaseGraphServerTest.startServers()` -> `BaseRaftHATest.waitAllReplicasAreConnected()` -> test body writes (the single call site; all 147 `BaseRaftHATest` subclasses, `BoltFollowerForwardingIT` among them) | yes | yes - `Issue7259ClusterBootstrapSettledIT` + `BoltFollowerForwardingIT` |
| `RaftHAServer.getLastBootstrapOutcome()` reachable at runtime (new production code) | yes - written by `runBootstrapIfEligible()`, submitted by `ArcadeStateMachine.notifyLeaderChanged` on every election | yes - asserted non-null on the leader of a real 3-node cluster |
| `BaseRaftHATest.restartServer(int)` re-forming a cluster mid-test | argued - bootstrap cannot re-engage after first formation (`BootstrapElection.isFirstFormation`, #4800); `RaftBootstrapDoesNotEngageOnRestartIT` pins it and is green here | n/a |

### Known gaps

- **#7518** - `waitForReplicationIsCompleted()` has two silent give-ups (no leader within 3 s -> returns having waited for nothing; 30 s budget expiry -> one bare WARNING). ~100 tests build on it through `waitForAllServers()`/`assertClusterConsistency()`. Left out deliberately: it is a different wait with a different signal, and widening the blast radius to those tests in this PR was not worth it.
- **#7519** - the byte-level mechanism of the divergence is **still not established**, and no production client is gated out of the same window. Both static orderings preserve the type, so the fix removes the overlap the failure needed without explaining it. An earlier reading blamed a torn snapshot served from the leader's live directory; that reading is wrong and was removed - `SnapshotHttpHandler` serves a point-in-time `PageSnapshot` under `executeInReadLock`.

### Unrelated red found on the way

**#7520** - `ArcadeStateMachinePerDatabaseHaltTest` fails both its methods on `main` with this diff fully reverted. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1vgWQXZoDXYq7TqAwLYXY