### PR TITLE
fix(#7510): refresh a peer's cached permissions when a replicated group entry is applied

### DIFF
--- a/docs/7510-replicated-group-permission-refresh.md
+++ b/docs/7510-replicated-group-permission-refresh.md
@@ -251,3 +251,34 @@ change to an existing path, not only to the new one.
 ## Known gaps
 
 - **#7529** - no metric, gauge or success-path signal for the refresh; an operator cannot observe convergence.
+
+## Review cycles
+
+### Cycle 1 - `6223154d36`
+
+`claude` reviewed and found no correctness bug. Two items were actioned:
+
+1. *"Worth a quick sanity check that nothing currently depends on the old SEVERE-per-file-reload log line
+   (e.g. alerting rules)."* **Checked, no change needed.**
+   `grep -rn "Error on reloading file"` over the repo returns the log statement itself
+   (`SecurityGroupFileRepository.java:192`) and this tracking doc, and nothing else - no test asserts on it, no
+   chart or rule references it. The concern is also narrower than it reads: that SEVERE line is untouched and
+   still fires when `load()` itself throws (an unreadable or unparseable file). What no longer reaches it is a
+   per-database refresh failure inside the callback, which used to abandon the remaining databases.
+2. *"no test for the executor-rejected-after-`stopService()` fallback path."* **Real, and worth more than it
+   looked.** Added `anEntryAppliedOnceTheRefreshExecutorIsShutDownStillInstallsTheDocument`: the property is
+   not tidiness but that `applyReplicatedGroups` must not throw there, because on the Raft apply path an
+   unexpected `RuntimeException` is not the caught "a local write failed" case - it is the "this node cannot
+   apply a committed entry" case that reaches the node-wide halt (#4798).
+
+   Writing it surfaced a **defect in the first commit**. The test passed even with `throw e` injected into the
+   `catch`, i.e. it never reached the branch it named: `shutdownNow()` DISCARDS the queued refresh task, so
+   `permissionRefreshPending` stayed wedged at `true` and every later `scheduleReplicatedPermissionRefresh()`
+   returned at the compare-and-set without ever touching the executor. Harmless in production - `stopService()`
+   means the server is going down and `ArcadeDBServer.startInternal()` builds a fresh `ServerSecurity` - but it
+   made which of the two shutdown behaviours you got depend on whether a worker had picked the task up yet, and
+   the silent one is the wrong default. `stopService()` now clears the flag next to the `shutdownNow()`, so a
+   group entry applied after shutdown deterministically takes the rejection path that logs the fallback. With
+   that, the injected `throw e` makes the new test fail, which is the proof it reaches the branch.
+
+Re-run after the changes: `Issue7510...Test` 8/8; the connected security suite 90/90.

--- a/docs/7510-replicated-group-permission-refresh.md
+++ b/docs/7510-replicated-group-permission-refresh.md
@@ -1,0 +1,253 @@
+# #7510 - HA: a replicated group change reaches a peer's cached permissions only on the security reload tick
+
+Branch: `fix/7510-replicated-group-permission-refresh`
+
+## Problem
+
+#7373 made a group change replicate, so `server-groups.json` converges on every node immediately. The state
+*derived* from that document does not: each open `DatabaseInternal` has a per-user
+`ServerSecurityDatabaseUser` cache, and only `ServerSecurity.updateSchema` re-derives it.
+
+- On the node that served the request, `ServerControlPlane.saveGroup` / `deleteGroup` call
+  `refreshPermissionsOf(database)` synchronously, so the 200 means "enforced here".
+- On a peer, `ServerSecurity.applyReplicatedGroups` deliberately does not: it runs on the Raft
+  state-machine apply thread, which must never block. The peer picks the change up through
+  `SecurityGroupFileRepository`'s file watcher, up to `arcadedb.server.security.reloadEvery` ms later.
+
+For a **narrowed** permission that is a security lag: a database already open on the peer keeps granting the
+old, wider access for the length of the reload interval, while `GET /server/groups` on that same peer already
+reports the new definition. Invisible from every surface an operator can check.
+
+## Root cause
+
+`applyReplicatedGroups` installs the document (`SecurityGroupFileRepository.applyReplicated`) and returns.
+Nothing on that path re-derives the cached permissions, and the apply thread may not do the work itself.
+
+## Invariant the fix establishes
+
+> Once a `SECURITY_GROUPS_ENTRY` has been applied on a node, the cached per-database permissions of the
+> principals already connected to that node are re-derived from the newly installed document without waiting
+> for the `arcadedb.server.security.reloadEvery` tick - and the re-derivation never runs on the Raft
+> state-machine apply thread.
+
+## Completeness
+
+### Commands run
+
+```
+$ grep -rn --include='*.java' 'applyReplicatedGroups(' --exclude-dir=test . | grep '/src/main/'
+ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java:3692:      server.getSecurity().applyReplicatedGroups(payload);
+server/src/main/java/com/arcadedb/server/security/ServerSecurity.java:1067:  public void applyReplicatedGroups(final String groupsJson) {
+```
+
+One production caller: `ArcadeStateMachine.applySecurityGroupsEntry`. Every replicated group mutation -
+`saveGroupClusterWide`, `deleteGroupClusterWide` and the joining-peer `seedGroupsClusterWide` - funnels
+through `HAServerPlugin.replicateSecurityGroups` into that single entry type, so one fix covers all three
+producers.
+
+```
+$ grep -rn --include='*.java' -e 'getSecurity()\.saveGroup' -e 'getSecurity()\.deleteGroup' \
+      -e 'security\.saveGroup' -e 'security\.deleteGroup' . | grep '/src/main/'
+server/src/main/java/com/arcadedb/server/ServerControlPlane.java:643:    server.getSecurity().saveGroupClusterWide(database, name, normalized);
+server/src/main/java/com/arcadedb/server/ServerControlPlane.java:663:    if (!server.getSecurity().deleteGroupClusterWide(database, name))
+```
+
+Both transports (HTTP `PostGroupHandler`/`DeleteGroupHandler`, gRPC `ArcadeDbGrpcAdminService`) reach the
+group store only through `ServerControlPlane`. No `src/main` caller of the node-local `saveGroup`/
+`deleteGroup` exists outside `ServerSecurity` itself.
+
+```
+$ grep -rn --include='*.java' '\.updateSchema(' */src/main/java
+engine/src/main/java/com/arcadedb/database/LocalDatabase.java:2966:          security.updateSchema(this);
+engine/src/main/java/com/arcadedb/schema/LocalSchema.java:3146:      security.updateSchema(database);
+server/src/main/java/com/arcadedb/server/ServerControlPlane.java:677:        security.updateSchema((DatabaseInternal) server.getDatabase(databaseName));
+```
+
+Plus the `onReload` lambda in the `ServerSecurity` constructor (line 112), which the grep above misses because
+the call is unqualified. Those are every refresher of the cache.
+
+```
+$ grep -rn --include='*.java' 'applyReplicated[A-Za-z]*(' ha-raft/src/main/java server/src/main/java
+... ArcadeStateMachine.java:3648:      server.getSecurity().applyReplicatedUsers(payload);
+... ArcadeStateMachine.java:3692:      server.getSecurity().applyReplicatedGroups(payload);
+... ArcadeStateMachine.java:3723:      server.getSecurity().applyReplicatedApiTokens(payload);
+```
+
+The two siblings of the same shape are argued below rather than changed.
+
+### Entry-point coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| `applySecurityGroupsEntry` -> `applyReplicatedGroups`, replicated **save** (narrowing) | yes | yes - `aReplicatedRevocationReachesTheCachedPrincipalWithoutTheReloadTick` |
+| `applySecurityGroupsEntry` -> `applyReplicatedGroups`, replicated **save** (widening) | yes | yes - `aReplicatedGrantReachesTheCachedPrincipalWithoutTheReloadTick` |
+| `applySecurityGroupsEntry` -> `applyReplicatedGroups`, replicated **delete** (`deleteGroupClusterWide`) | yes | yes - `aReplicatedGroupDeletionReachesTheCachedPrincipalWithoutTheReloadTick` |
+| `applySecurityGroupsEntry` -> `applyReplicatedGroups`, joining-peer **seed** (`seedGroupsClusterWide`) | yes | yes - `aSeededGroupDocumentRefreshesTheJoiningPeer` |
+| `applyReplicatedGroups` on the **persist-failure** path (document in force, method throws) | yes | yes - `aRefreshIsScheduledEvenWhenTheReplicatedDocumentCouldNotBePersisted` |
+| the refresh must NOT run on the Raft apply thread | yes | yes - `theRefreshRunsOffTheCallingApplyThread` |
+| a burst of entries must not lose the last document | yes | yes - `aBurstOfRepliesConvergesOnTheLastDocument` |
+| `ServerControlPlane.saveGroup` / `deleteGroup` on the serving node | pre-existing (`refreshPermissionsOf`), unchanged | pre-existing `Issue6806GroupPermissionRefreshIT` |
+| `ServerSecurity.saveGroup` / `deleteGroup` called directly (non-HA fallback of `saveGroupClusterWide`) | argued | - |
+| `applyReplicatedUsers` | argued | - |
+| `applyReplicatedApiTokens` | argued | - |
+| `SecurityGroupFileRepository` watcher tick (hand-edited file) | argued - unchanged, now the fallback | pre-existing |
+
+### Arguments (with evidence)
+
+- **`ServerSecurity.saveGroup`/`deleteGroup` direct calls.** The grep above shows no `src/main` caller outside
+  `ServerSecurity`. The only reachable one is `saveGroupClusterWide`/`deleteGroupClusterWide`'s non-HA
+  fallback, and both are entered from `ServerControlPlane`, which calls `refreshPermissionsOf` on the next
+  line. So the single-node path is already refreshed; there is nothing async about it.
+- **`applyReplicatedUsers`.** It rebuilds the whole `users` map from the payload -
+  `newUsers.put(name, new ServerSecurityUser(server, userJson))` for every entry - and publishes it in one
+  reference swap. Every `ServerSecurityUser` in the new map is a fresh object whose `databaseCache` is empty,
+  so its permissions are derived from the *current* group document the first time it is used. There is no
+  stale derived state for a refresh to fix.
+- **`applyReplicatedApiTokens`.** An API-token principal is not in the `users` map at all:
+  `authenticateByApiToken` builds a `ServerSecurityUser` per request and gives it a synthetic group config
+  taken from the token document (`withSyntheticGroupConfig`), which `refreshDatabaseConfiguration` explicitly
+  never widens with the file groups. So a replicated token document is read fresh on every request, and
+  `updateSchema` could not reach such a principal even if it ran.
+- **The watcher tick.** Untouched. `SecurityGroupFileRepository.applyReplicated` still writes the file without
+  updating `fileLastUpdated`, so the watcher still fires and still refreshes. It is now a redundant fallback
+  behind the immediate refresh rather than the only mechanism, and it remains the path a hand-edited file
+  takes.
+
+### Reachability
+
+`applyReplicatedGroups` is called from `ArcadeStateMachine.applySecurityGroupsEntry`, which the state machine
+dispatches for `RaftLogEntryType.SECURITY_GROUPS_ENTRY` (`ArcadeStateMachine:933`). No flag gates it. The new
+executor is a field of `ServerSecurity`, which the server constructs unconditionally, and the refresh is
+submitted from the apply itself - no configuration has to be turned on.
+
+## Fix
+
+`ServerSecurity` gains a dedicated single-worker executor (`arcadedb-security-permission-refresh`) and a
+coalescing `scheduleReplicatedPermissionRefresh()`, which `applyReplicatedGroups` calls right after the
+document is published - including on the path that then throws the persistence failure, because the document
+is in force from that moment either way.
+
+- **Off the apply thread.** The submit is non-blocking, so the invariant at the head of
+  `applyReplicatedGroups` ("never blocks, never takes the monitor") still holds. No caller-runs policy: running
+  the sweep on the caller is exactly what the hand-off exists to prevent, so the executor aborts and logs, and
+  the watcher tick remains the fallback.
+- **Coalescing.** An `AtomicBoolean` keeps at most one refresh queued. The flag is cleared at the *start* of the
+  sweep, not at the end, so a document applied while a sweep is running always schedules another one. Worst
+  case is one redundant, idempotent sweep; the case that must not happen - the last document never being swept -
+  cannot.
+- **Not a new JVM-wide pool.** One worker, `corePoolSize` 0 (no thread until the first group change), 30 s
+  keep-alive, a 4-deep queue that coalescing keeps at a depth of at most 1. It follows
+  `ArcadeStateMachine.snapshotInstallExecutor`, the existing precedent for "get off the Ratis thread", rather
+  than `DedicatedThreadPool`, which is for JVM-wide shared pools with `PoolMetrics` bindings - this one is per
+  server instance (HA tests run several servers in one JVM) and idle in every steady state.
+- The sweep itself is the body the `onReload` watcher callback already ran, extracted to
+  `refreshOpenDatabasePermissions()` and now shared by both, with a per-database `try/catch` so a database
+  dropped mid-sweep cannot kill the worker or skip the rest.
+
+## Residual risk
+
+- The refresh is asynchronous **by design**: between the Raft apply and the sweep there is a window of
+  milliseconds in which a peer still answers from the old document. It cannot be closed without blocking the
+  apply thread. It replaces a window of `arcadedb.server.security.reloadEvery` (default measured in seconds).
+- If the executor rejects (only reachable after `stopService`), the refresh falls back to the watcher tick and
+  says so at WARNING.
+- `ServerControlPlane.refreshPermissionsOf` on the serving node is left synchronous, so the node that answered
+  the request still enforces before it replies. That means one redundant sweep per change on that node.
+
+## Changes
+
+- `server/src/main/java/com/arcadedb/server/security/ServerSecurity.java`
+  - new `permissionRefreshExecutor` (single worker, `corePoolSize` 0, 30 s keep-alive, 4-deep queue,
+    `AbortPolicy`, daemon thread `arcadedb-security-permission-refresh`) and `permissionRefreshPending` flag;
+  - new `refreshOpenDatabasePermissions()` - the sweep the `onReload` watcher callback used to inline, now
+    shared, with a per-database `try/catch`;
+  - new `scheduleReplicatedPermissionRefresh()` - the lossless coalescing hand-off;
+  - `applyReplicatedGroups` calls it right after the document is published, before the persistence failure is
+    reported;
+  - `stopService()` shuts the executor down;
+  - the javadoc that said the caches are "NOT refreshed from here" now says what actually happens.
+- `server/src/test/java/com/arcadedb/server/security/Issue7510ReplicatedGroupPermissionRefreshTest.java` - new.
+
+## Test results
+
+TDD: with `scheduleReplicatedPermissionRefresh()` removed from `applyReplicatedGroups`, all 7 new tests fail
+(each on its own `await` assertion, `ConditionTimeout`). With the fix:
+
+```
+$ mvn -o -pl server -Dtest=Issue7510ReplicatedGroupPermissionRefreshTest test
+Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
+
+$ mvn -o -pl server -Dtest='Issue7510*,Issue7373*,Issue7137*,Issue6806*Test,SecurityGroup*Test,
+      ServerSecurity*Test,ApiTokenConfigurationTest,DatabaseUserContextTest,RootPasswordFromFileTest,
+      ConcurrentSaltCacheTest,SecurityUserFileRepositoryTest' test
+Tests run: 89, Failures: 0, Errors: 0, Skipped: 0
+
+$ mvn -o -pl ha-raft -Dtest='*Security*Test' test
+Tests run: 15, Failures: 0, Errors: 0, Skipped: 0
+```
+
+`Issue7373ReplicatedGroupAuthorizationTest` is the one to watch: it deliberately pins that the apply does not
+refresh synchronously, and it still passes - the hand-off is asynchronous, so the apply still returns before
+the sweep, which is what that test asserts.
+
+**Not run locally:** the server integration tests (`Issue6806GroupPermissionRefreshIT`,
+`Issue5269FileAccessRefreshIT`, `ServerSecurityIT`). Port 2480 was already held by another process on this
+machine (`lsof -nP -iTCP:2480 -sTCP:LISTEN` returned two live listeners), and server ITs bind fixed ports, so a
+local run would report authentication errors rather than anything about this change. They run in CI.
+
+## Adversarial pass
+
+The orchestrator's Phase 1.5 asks for an independent subagent, deliberately kept ignorant of the author's
+reasoning. **The `Task` tool is disabled in this session**, so that independence could not be had; the pass below
+was run by the same agent that wrote the patch, against the issue body and the diff, and is weaker for it. Each
+finding was checked against the tree.
+
+1. **Does the executor survive a server restart?** If `ServerSecurity` outlived `stop()`/`start()`, the
+   `shutdownNow()` in `stopService()` would leave a permanently dead executor and the refresh would silently
+   never happen again - a worse bug than the one being fixed. **Not real:**
+   `ArcadeDBServer.startInternal()` does `security = new ServerSecurity(this, configuration, ...)`
+   (`ArcadeDBServer.java:399`), so every start builds a fresh instance and a fresh executor.
+
+2. **Is iterating `server.getDatabaseNames()` from a background thread safe?** **Not a new hazard:** the backing
+   field is `private final ConcurrentMap<String, ServerDatabase> databases = new ConcurrentHashMap<>()`
+   (`ArcadeDBServer.java:186`), so the returned key set iterates weakly-consistently. The watcher callback has
+   iterated it from a `Timer` thread all along.
+
+3. **A database CLOSED on the peer when the entry is applied is skipped by the sweep, and
+   `ServerSecurityUser.databaseCache` is keyed by name and survives a close** - so a reopen could serve the
+   permissions derived from the previous document, forever. **Not real:** `LocalDatabase.open()` calls
+   `security.updateSchema(this)` on every open (`LocalDatabase.java:2965-2966`), so a reopened database
+   re-derives from the document in force at that moment. Worth stating, because the row is not covered by the
+   sweep and the reason it is safe is somewhere else entirely.
+
+4. **`Issue7373ReplicatedGroupAuthorizationTest` still passes, but its comments now describe the world before
+   this patch** - "on a peer the group file's watcher does, on the reloadEvery tick", "the lag issue #7510
+   tracks". Left alone, that is a comment asserting an invariant the code no longer holds, which the
+   verified-claims rule says is worse than no comment. **Real, fixed here, comments only.** The assertions and
+   every line of test logic are untouched - `git diff` on that file shows no changed line that is not a comment
+   or javadoc - and the prose now says what actually pins the test: the apply still does not walk the databases
+   on the calling thread, and this fixture's mocked server reports no open databases, so the scheduled sweep has
+   nothing to walk and cannot interfere.
+
+5. **Nothing reports that the refresh happened.** The success path is silent, the two failure paths log at
+   WARNING, and the executor is not in `PoolMetrics`. An operator narrowing a permission still cannot see when
+   the other nodes started enforcing it, which was half of what #7510 complained about. **Real, out of scope,
+   filed as #7529** - this PR closes the lag; being able to observe it is a separate change.
+
+6. **Is the 20 s `await` in the new tests a wall-clock latency assertion?** It is a tripwire between "refreshed
+   by the apply" (milliseconds) and "waiting for the hourly `reloadEvery`", with three orders of magnitude of
+   headroom, and widening it can only make a run greener. That reasoning is now in the test's class javadoc so
+   the next person does not read it as a latency budget.
+
+### Behaviour change worth flagging to a reviewer
+
+Extracting the watcher's inline sweep into `refreshOpenDatabasePermissions()` added a per-database `try/catch`.
+On the watcher path a failing database used to abandon the rest of the sweep and surface as a SEVERE
+"Error on reloading file ... after was changed" from `SecurityGroupFileRepository.load()`'s timer; it is now a
+WARNING naming the database, and the remaining databases are still refreshed. That is deliberate - on the
+refresh worker an escaping exception would also take out the sweep the next group change needs - but it is a
+change to an existing path, not only to the new one.
+
+## Known gaps
+
+- **#7529** - no metric, gauge or success-path signal for the refresh; an operator cannot observe convergence.

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -50,7 +50,12 @@ import java.security.SecureRandom;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.util.*;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
 import static com.arcadedb.GlobalConfiguration.SERVER_SECURITY_ALGORITHM;
@@ -95,6 +100,37 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
   private static final long                               PASSWORD_LOCKOUT_MS   = 30_000;
   private final        ConcurrentHashMap<String, long[]>  passwordFailures      = new ConcurrentHashMap<>();
 
+  /**
+   * Runs the per-database permission refresh a replicated group change needs, OFF the Raft state-machine apply
+   * thread (issue #7510).
+   * <p>
+   * {@link #applyReplicatedGroups} may not do the sweep itself: it runs on the apply thread, which must never
+   * block, and the sweep walks every open database. Before this existed the peers had no refresh at all and
+   * picked the change up only when {@code SecurityGroupFileRepository}'s watcher next ticked - so for the
+   * length of {@code arcadedb.server.security.reloadEvery} a peer kept granting a permission the cluster had
+   * already narrowed, while {@code GET /server/groups} on that same peer already reported the new definition.
+   * <p>
+   * One worker with {@code corePoolSize} 0, so a server that never edits a group never creates the thread, and
+   * {@link ThreadPoolExecutor.AbortPolicy} rather than caller-runs: running the sweep on the caller is exactly
+   * the outcome the hand-off exists to prevent. The queue is four deep against a coalescing flag that keeps at
+   * most one refresh queued, so a rejection is only reachable after {@link #stopService}; it is logged and the
+   * watcher tick remains the fallback.
+   * <p>
+   * Not one of the JVM-wide {@code DedicatedThreadPool}s: this one belongs to a single server instance - HA
+   * tests run several servers in one JVM - and is idle in every steady state. It follows
+   * {@code ArcadeStateMachine.snapshotInstallExecutor}, the existing precedent for getting off the Ratis thread.
+   */
+  private final        ThreadPoolExecutor                 permissionRefreshExecutor = createPermissionRefreshExecutor();
+  private final        AtomicBoolean                      permissionRefreshPending  = new AtomicBoolean();
+
+  private static ThreadPoolExecutor createPermissionRefreshExecutor() {
+    return new ThreadPoolExecutor(0, 1, 30L, TimeUnit.SECONDS, new ArrayBlockingQueue<>(4), r -> {
+      final Thread thread = new Thread(r, "arcadedb-security-permission-refresh");
+      thread.setDaemon(true);
+      return thread;
+    }, new ThreadPoolExecutor.AbortPolicy());
+  }
+
   public ServerSecurity(final ArcadeDBServer server, final ContextConfiguration configuration, final String configPath) {
     this.server = server;
     this.algorithm = configuration.getValueAsString(SERVER_SECURITY_ALGORITHM);
@@ -108,9 +144,7 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
 
     usersRepository = new SecurityUserFileRepository(configPath);
     groupRepository = new SecurityGroupFileRepository(configPath, checkConfigReloadEveryMs).onReload(latestConfiguration -> {
-      for (final String databaseName : server.getDatabaseNames()) {
-        updateSchema(server.getDatabase(databaseName));
-      }
+      refreshOpenDatabasePermissions();
       return null;
     });
 
@@ -210,6 +244,10 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     users = new ConcurrentHashMap<>();
     if (groupRepository != null)
       groupRepository.stop();
+
+    // Interrupting rather than draining: a sweep in flight is re-deriving permissions of databases this server
+    // is closing anyway, and every task it could still be holding is idempotent and re-run by the next change.
+    permissionRefreshExecutor.shutdownNow();
   }
 
   public ServerSecurityUser authenticate(final String userName, final String userPassword, final String databaseName) {
@@ -594,6 +632,62 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
 
     for (final ServerSecurityUser user : users.values())
       user.refreshDatabaseConfiguration(database, groupConfiguration);
+  }
+
+  /**
+   * Re-derives the cached permissions of every database this server currently has open, from the group document
+   * in force right now.
+   * <p>
+   * Every database rather than a named one, because the trigger is a whole replaced group document and nothing
+   * in it says which database changed - the watcher callback has always swept them all for the same reason, and
+   * this is that loop, now shared with {@link #scheduleReplicatedPermissionRefresh}.
+   * <p>
+   * A failure on one database is logged and the sweep continues: a database dropped between
+   * {@code getDatabaseNames()} and {@code getDatabase()} must not cost the databases after it their refresh, and
+   * on the refresh worker an escaping exception would also kill the sweep the next group change needs.
+   */
+  private void refreshOpenDatabasePermissions() {
+    if (server == null)
+      return;
+
+    for (final String databaseName : server.getDatabaseNames()) {
+      try {
+        updateSchema(server.getDatabase(databaseName));
+      } catch (final Exception e) {
+        LogManager.instance().log(this, Level.WARNING,
+            "Could not refresh the cached permissions of database '%s' after a group change; the principals "
+                + "already connected to it keep the previous permissions until the next refresh", e, databaseName);
+      }
+    }
+  }
+
+  /**
+   * Queues the {@link #refreshOpenDatabasePermissions} sweep a replicated group change needs, without blocking
+   * the caller (issue #7510). Safe to call from the Raft state-machine apply thread, which is the only caller.
+   * <p>
+   * At most one refresh is queued at a time. The pending flag is cleared at the START of the sweep rather than
+   * at its end, which is what makes the coalescing lossless: an entry applied while a sweep is running always
+   * finds the flag clear and queues another one, so the last document to be published is always swept. The
+   * price is at most one redundant sweep, and the sweep is idempotent - it re-derives from whatever document is
+   * in force when it runs.
+   */
+  private void scheduleReplicatedPermissionRefresh() {
+    if (!permissionRefreshPending.compareAndSet(false, true))
+      // A refresh is already queued and has not started reading the document yet, so it will pick this one up.
+      return;
+
+    try {
+      permissionRefreshExecutor.execute(() -> {
+        permissionRefreshPending.set(false);
+        refreshOpenDatabasePermissions();
+      });
+    } catch (final RejectedExecutionException e) {
+      permissionRefreshPending.set(false);
+      LogManager.instance().log(this, Level.WARNING,
+          "Could not schedule the permission refresh for a replicated group change; the principals already "
+              + "connected to this node keep the previous permissions until the '%s' watcher next reloads "
+              + "(arcadedb.server.security.reloadEvery)", e, SecurityGroupFileRepository.FILE_NAME);
+    }
   }
 
   public String getEncodedHash(final String password, final String salt, final int iterations) {
@@ -1058,11 +1152,15 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
    * is in force, are the group half of issue #7137: see
    * {@link SecurityGroupFileRepository#applyReplicated}.
    * <p>
-   * The per-database permission caches are NOT refreshed from here: {@code ServerSecurity.updateSchema} opens
-   * and walks each database, which is blocking work this thread may not do. The peers pick the change up through
-   * {@code SecurityGroupFileRepository}'s file watcher, on the {@code arcadedb.server.security.reloadEvery}
-   * interval, which is the same mechanism a hand-edited group file has always gone through. The node that served
-   * the request refreshes immediately, in {@code ServerControlPlane}.
+   * The per-database permission caches are not refreshed on THIS thread - {@code updateSchema} walks every open
+   * database, which is blocking work the apply thread may not do - but they are refreshed:
+   * {@link #scheduleReplicatedPermissionRefresh} hands the sweep to a single-worker executor that runs it in
+   * milliseconds (issue #7510). Until that existed, a peer converged only when
+   * {@code SecurityGroupFileRepository}'s watcher next ticked, so for the length of
+   * {@code arcadedb.server.security.reloadEvery} it kept granting a permission the cluster had already narrowed.
+   * The watcher is still there and is still what a hand-edited group file goes through; it is now the fallback
+   * rather than the mechanism. The node that served the request refreshes synchronously, in
+   * {@code ServerControlPlane}, so its 200 still means "enforced here".
    */
   public void applyReplicatedGroups(final String groupsJson) {
     final JSONObject root = new JSONObject(groupsJson);
@@ -1085,6 +1183,13 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
               + "discard the versionless file and fall back to the DEFAULT group definitions");
 
     final Exception persistFailure = groupRepository.applyReplicated(root);
+
+    // Scheduled here, BEFORE the persistence failure is reported, because the document is in force from the
+    // line above whether or not it reached the disk - that is the whole point of the publish-before-persist
+    // ordering. Refreshing only on the happy path would leave this node enforcing the previous groups for as
+    // long as the volume stayed broken, which is the case that ordering exists to prevent (issue #7510).
+    scheduleReplicatedPermissionRefresh();
+
     if (persistFailure != null) {
       LogManager.instance().log(this, Level.SEVERE,
           "Could not write the replicated group document to '%s'. The new groups ARE in effect on this node from "

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -248,6 +248,12 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     // Interrupting rather than draining: a sweep in flight is re-deriving permissions of databases this server
     // is closing anyway, and every task it could still be holding is idempotent and re-run by the next change.
     permissionRefreshExecutor.shutdownNow();
+    // Cleared because shutdownNow() DISCARDS the queued task that would otherwise have cleared it. Leaving it
+    // set would wedge the flag at true, and every later schedule would return at the compare-and-set instead of
+    // reaching the executor - so a group entry applied during shutdown would take the silent path rather than
+    // the rejection path that logs the fallback. The executor is gone either way; which of the two happens
+    // should not depend on whether a worker had picked the task up yet.
+    permissionRefreshPending.set(false);
   }
 
   public ServerSecurityUser authenticate(final String userName, final String userPassword, final String databaseName) {

--- a/server/src/test/java/com/arcadedb/server/security/Issue7373ReplicatedGroupAuthorizationTest.java
+++ b/server/src/test/java/com/arcadedb/server/security/Issue7373ReplicatedGroupAuthorizationTest.java
@@ -44,16 +44,21 @@ import static org.mockito.Mockito.when;
  * <b>authorization decision</b> on a peer, rather than to a file.
  * <p>
  * The two halves are deliberately separate in the fix, and this test is what makes that separation visible.
- * {@link ServerSecurity#applyReplicatedGroups} installs the document and nothing else - it runs on the Raft
- * state-machine apply thread, which may not block, and {@link ServerSecurity#updateSchema} opens and walks every
- * database. The cached {@code ServerSecurityDatabaseUser} of an already-connected principal therefore keeps
- * answering from the PREVIOUS document until the refresh runs: on the node that served the request
- * {@code ServerControlPlane} runs it immediately, and on a peer the group file's watcher does, on the
- * {@code arcadedb.server.security.reloadEvery} tick (issue #7510 is about closing that lag).
+ * {@link ServerSecurity#applyReplicatedGroups} installs the document and does not walk the databases on the
+ * calling thread - it runs on the Raft state-machine apply thread, which may not block, and
+ * {@link ServerSecurity#updateSchema} walks every open database. So the cached
+ * {@code ServerSecurityDatabaseUser} of an already-connected principal is not re-derived by the time the apply
+ * returns; the refresh is a separate step.
  * <p>
- * So both assertions below matter, and the first one is not a bug being pinned as a feature - it is the reason
- * #7510 exists, stated in a form that will fail if someone makes the apply blocking by calling
- * {@code updateSchema} from it.
+ * Since issue #7510 that step is no longer only the group file's watcher: the apply hands the sweep to a
+ * single-worker executor, so a peer converges in milliseconds instead of on the
+ * {@code arcadedb.server.security.reloadEvery} tick. That does not change what this test pins, because the
+ * server here is a Mockito mock whose {@code getDatabaseNames()} answers empty - the scheduled sweep has no
+ * database to walk, and the mocked {@link DatabaseInternal} below was never registered with a server at all.
+ * What stays asserted is therefore exactly the invariant that must not be broken: the apply returns without
+ * having done the walk itself. The test would fail if someone made it blocking by calling
+ * {@code updateSchema} from the apply thread. {@code Issue7510ReplicatedGroupPermissionRefreshTest} covers the
+ * other half - that the sweep does then happen, promptly, on another thread.
  */
 class Issue7373ReplicatedGroupAuthorizationTest {
 
@@ -109,16 +114,18 @@ class Issue7373ReplicatedGroupAuthorizationTest {
     assertThat(security.getDatabaseGroupsConfiguration(DATABASE).getJSONObject(GROUP).getJSONArray("access"))
         .as("the document itself is revoked immediately on the peer").isEmpty();
 
-    // ...but the apply does not walk the databases, so the principal that was already connected still answers
-    // from its cache. That is the lag issue #7510 tracks, and asserting it here is what would fail if someone
-    // "fixed" it by calling updateSchema() from the state-machine apply thread.
+    // ...but the apply does not walk the databases ON THIS THREAD, so the principal that was already connected
+    // still answers from its cache when the call returns. Asserting it here is what would fail if someone
+    // "fixed" issue #7510 by calling updateSchema() from the state-machine apply thread instead of handing it
+    // off. The hand-off cannot interfere: this fixture's mocked server reports no open databases.
     assertThat(alice.getDatabaseUser(database))
         .as("getDatabaseUser caches per database, and nothing in the apply clears it").isSameAs(cached);
     assertThat(cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA))
         .as("the cached principal has not been refreshed yet").isTrue();
 
-    // The refresh is the second half: ServerControlPlane runs it on the serving node, the group file's watcher
-    // runs it on a peer. Once it has run, the replicated revocation is enforced against the live principal.
+    // The refresh is the second half: ServerControlPlane runs it synchronously on the serving node, and on a
+    // peer the executor the apply schedules runs it (issue #7510), with the group file's watcher behind that as
+    // the fallback. Once it has run, the replicated revocation is enforced against the live principal.
     security.updateSchema(database);
 
     assertThat(cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA))

--- a/server/src/test/java/com/arcadedb/server/security/Issue7510ReplicatedGroupPermissionRefreshTest.java
+++ b/server/src/test/java/com/arcadedb/server/security/Issue7510ReplicatedGroupPermissionRefreshTest.java
@@ -1,0 +1,442 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.engine.FileManager;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.security.SecurityDatabaseUser.DATABASE_ACCESS;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.HAServerPlugin;
+import com.arcadedb.server.ServerControlPlane;
+import com.arcadedb.server.ServerDatabase;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression test for issue #7510.
+ * <p>
+ * #7373 made a group change replicate, so {@code server-groups.json} converges on every node at once. What did
+ * not converge is the state <i>derived</i> from it: each open database caches the permissions of the principals
+ * connected to it, and only {@link ServerSecurity#updateSchema} re-derives them. The node that served the
+ * request refreshes synchronously in {@code ServerControlPlane}; a peer had nothing at all, so it kept
+ * enforcing the PREVIOUS document until {@code SecurityGroupFileRepository}'s file watcher happened to tick -
+ * up to {@code arcadedb.server.security.reloadEvery} later. For a permission the operator had just narrowed
+ * that is a window in which the peer grants access the cluster has already revoked, while
+ * {@code GET /server/groups} on that same peer already shows the new definition.
+ * <p>
+ * Every test here runs with {@code reloadEvery} set to an hour, so the watcher cannot be what makes them pass:
+ * convergence inside a few seconds can only come from the refresh the apply now schedules itself.
+ * <p>
+ * {@link #CONVERGENCE} is that separation and nothing finer - a tripwire between "the apply refreshed" and "we
+ * are waiting for the hourly tick", with three orders of magnitude of headroom. It is not a latency budget, and
+ * the refresh takes milliseconds in practice: widening it can only make a run greener, so a slow or stalled CI
+ * box is not a reason to loosen it and a passing run is not evidence about how fast the refresh is.
+ */
+class Issue7510ReplicatedGroupPermissionRefreshTest {
+
+  private static final String   CONFIG_PATH  = "target/test-security-7510";
+  private static final String   DATABASE     = "graph";
+  private static final String   GROUP        = "editors";
+  /** Long enough that the group file's watcher cannot be the mechanism under test. */
+  private static final int      NEVER_RELOAD = 60 * 60 * 1000;
+  /** Separates "refreshed by the apply" from "waiting for {@link #NEVER_RELOAD}"; see the class javadoc. */
+  private static final Duration CONVERGENCE  = Duration.ofSeconds(20);
+
+  private FixtureServer  server;
+  private ServerSecurity security;
+  private ServerDatabase database;
+
+  @BeforeEach
+  void setUp() {
+    GlobalConfiguration.SERVER_SECURITY_SALT_ITERATIONS.setValue(1000);
+    final File dir = new File(CONFIG_PATH);
+    if (dir.exists())
+      FileUtils.deleteRecursively(dir);
+    assertThat(dir.mkdirs()).isTrue();
+
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.SERVER_ROOT_PATH, "./target");
+    configuration.setValue(GlobalConfiguration.SERVER_SECURITY_RELOAD_EVERY, NEVER_RELOAD);
+
+    server = new FixtureServer(configuration);
+    security = new ServerSecurity(server, configuration, CONFIG_PATH);
+    server.setSecurity(security);
+
+    database = mockDatabase(DATABASE);
+    server.register(database);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (security != null)
+      security.stopService();
+    GlobalConfiguration.SERVER_SECURITY_SALT_ITERATIONS.reset();
+    FileUtils.deleteRecursively(new File(CONFIG_PATH));
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // The peer's half: what a SECURITY_GROUPS_ENTRY does to a principal already connected there
+  // -------------------------------------------------------------------------------------------
+
+  /** The direction that matters: a narrowed permission must stop granting without waiting for the tick. */
+  @Test
+  void aReplicatedRevocationReachesTheCachedPrincipalWithoutTheReloadTick() {
+    security.applyReplicatedGroups(documentGranting(new JSONArray().put("updateSchema")));
+    final ServerSecurityDatabaseUser cached = connectedPrincipal();
+    assertThat(cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA))
+        .as("the grant is in force before the revocation").isTrue();
+
+    security.applyReplicatedGroups(documentGranting(new JSONArray()));
+
+    await().atMost(CONVERGENCE).untilAsserted(() -> assertThat(
+        cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA))
+        .as("the peer must stop granting the revoked permission without waiting for reloadEvery")
+        .isFalse());
+
+    // The same cached instance, so this is a refresh and not the cache being rebuilt behind the test's back.
+    assertThat(security.getUser("alice").getDatabaseUser(database)).isSameAs(cached);
+  }
+
+  /** The other direction, so the test cannot pass by denying everything. */
+  @Test
+  void aReplicatedGrantReachesTheCachedPrincipalWithoutTheReloadTick() {
+    security.applyReplicatedGroups(documentGranting(new JSONArray()));
+    final ServerSecurityDatabaseUser cached = connectedPrincipal();
+    assertThat(cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA)).isFalse();
+
+    security.applyReplicatedGroups(documentGranting(new JSONArray().put("updateSchema")));
+
+    await().atMost(CONVERGENCE).untilAsserted(() -> assertThat(
+        cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA)).isTrue());
+  }
+
+  /**
+   * A deletion travels as the same entry type - {@code deleteGroupClusterWide} replicates the whole document
+   * with the group removed - so the peer must lose the permissions the group carried, not merely the entry in
+   * {@code GET /server/groups}.
+   */
+  @Test
+  void aReplicatedGroupDeletionReachesTheCachedPrincipalWithoutTheReloadTick() {
+    security.applyReplicatedGroups(documentGranting(new JSONArray().put("updateSchema")));
+    final ServerSecurityDatabaseUser cached = connectedPrincipal();
+    assertThat(cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA)).isTrue();
+
+    // The document deleteGroupClusterWide() submits: the whole file, without that group.
+    security.applyReplicatedGroups(new JSONObject()
+        .put("version", ServerSecurity.LATEST_VERSION)
+        .put("databases", new JSONObject().put(DATABASE, new JSONObject().put("groups", new JSONObject())))
+        .toString());
+
+    await().atMost(CONVERGENCE).untilAsserted(() -> assertThat(
+        cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA))
+        .as("a deleted group must stop granting on the peer too").isFalse());
+  }
+
+  /**
+   * End to end through the producer both transports share: {@code ServerControlPlane.saveGroup} on the node
+   * that serves the request (HTTP {@code PostGroupHandler} and gRPC {@code ArcadeDbGrpcAdminService} both call
+   * it), with the submitted document handed to a second {@link ServerSecurity} standing in for a peer.
+   */
+  @Test
+  void aGroupNarrowedOnTheLeaderReachesAPeersCachedPrincipal() {
+    final CapturingHAPlugin ha = new CapturingHAPlugin();
+    server.setHA(ha);
+
+    final FixtureServer peerServer = new FixtureServer(server.getConfiguration());
+    final File peerDir = new File(CONFIG_PATH, "peer");
+    assertThat(peerDir.mkdirs()).isTrue();
+    final ServerSecurity peer = new ServerSecurity(peerServer, server.getConfiguration(), peerDir.getPath());
+    peerServer.setSecurity(peer);
+    final ServerDatabase peerDatabase = mockDatabase(DATABASE);
+    peerServer.register(peerDatabase);
+
+    try {
+      final ServerControlPlane controlPlane = new ServerControlPlane(server);
+      controlPlane.saveGroup(DATABASE, GROUP, group(new JSONArray().put("updateSchema")));
+      peer.applyReplicatedGroups(ha.lastDocument());
+
+      final ServerSecurityDatabaseUser cached = connectedPrincipal(peer, peerDatabase);
+      assertThat(cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA))
+          .as("the peer starts with the grant the leader replicated").isTrue();
+
+      controlPlane.saveGroup(DATABASE, GROUP, group(new JSONArray()));
+      peer.applyReplicatedGroups(ha.lastDocument());
+
+      await().atMost(CONVERGENCE).untilAsserted(() -> assertThat(
+          cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA)).isFalse());
+    } finally {
+      peer.stopService();
+    }
+  }
+
+  /**
+   * The refresh must be scheduled on the path that then throws. A write failure leaves the document in force in
+   * memory by design (issue #7137/#7373), so the derived permissions have to follow it - refreshing only on the
+   * happy path would leave the node enforcing the previous groups for as long as the volume stayed broken,
+   * which is precisely the case the publish-before-persist ordering exists to prevent.
+   */
+  @Test
+  void aRefreshIsScheduledEvenWhenTheReplicatedDocumentCouldNotBePersisted() throws Exception {
+    security.applyReplicatedGroups(documentGranting(new JSONArray().put("updateSchema")));
+    final ServerSecurityDatabaseUser cached = connectedPrincipal();
+    assertThat(cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA)).isTrue();
+
+    makeGroupFileUnwritable();
+
+    assertThatThrownBy(() -> security.applyReplicatedGroups(documentGranting(new JSONArray())))
+        .as("the caller still learns the document did not reach the disk")
+        .isInstanceOf(ReplicatedSecurityConfigPersistenceException.class);
+
+    await().atMost(CONVERGENCE).untilAsserted(() -> assertThat(
+        cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA))
+        .as("the revocation IS in force in memory, so the cached principal must follow it").isFalse());
+  }
+
+  /**
+   * The constraint the hand-off exists for: {@code applyReplicatedGroups} runs on the Raft state-machine apply
+   * thread, which must never block, so the sweep - which walks every open database - must happen on another
+   * one.
+   */
+  @Test
+  void theRefreshRunsOffTheCallingApplyThread() {
+    security.applyReplicatedGroups(documentGranting(new JSONArray().put("updateSchema")));
+    final ServerSecurityDatabaseUser cached = connectedPrincipal();
+    server.sweepThreads.clear();
+
+    final String applyThread = Thread.currentThread().getName();
+    security.applyReplicatedGroups(documentGranting(new JSONArray()));
+
+    await().atMost(CONVERGENCE).untilAsserted(() -> assertThat(
+        cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA)).isFalse());
+
+    // Copied before asserting: a coalesced second sweep may still be appending to the live list.
+    assertThat(new ArrayList<>(server.sweepThreads))
+        .as("the sweep must not have run on the thread that applied the entry").isNotEmpty()
+        .doesNotContain(applyThread)
+        .allSatisfy(name -> assertThat(name).startsWith("arcadedb-security-permission-refresh"));
+  }
+
+  /**
+   * The refreshes are coalesced, so a burst of entries must still converge on the LAST document rather than on
+   * whichever one a sweep happened to read. The final document here revokes, so a lost update leaves the peer
+   * granting a permission the cluster has revoked - the failure this test exists to catch.
+   */
+  @Test
+  void aBurstOfReplicatedEntriesConvergesOnTheLastDocument() {
+    security.applyReplicatedGroups(documentGranting(new JSONArray().put("updateSchema")));
+    final ServerSecurityDatabaseUser cached = connectedPrincipal();
+
+    for (int i = 0; i < 200; i++)
+      security.applyReplicatedGroups(documentGranting(
+          i % 2 == 0 ? new JSONArray() : new JSONArray().put("updateSchema")));
+    security.applyReplicatedGroups(documentGranting(new JSONArray()));
+
+    await().atMost(CONVERGENCE).untilAsserted(() -> assertThat(
+        cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA))
+        .as("the last document wins; a coalesced refresh must not drop it").isFalse());
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Fixtures
+  // -------------------------------------------------------------------------------------------
+
+  private ServerSecurityDatabaseUser connectedPrincipal() {
+    return connectedPrincipal(security, database);
+  }
+
+  private static ServerSecurityDatabaseUser connectedPrincipal(final ServerSecurity target,
+      final ServerDatabase targetDatabase) {
+    final ServerSecurityUser alice = target.createUser(new JSONObject()
+        .put("name", "alice")
+        .put("password", target.encodePassword("alice-password"))
+        .put("databases", new JSONObject().put(DATABASE, new JSONArray().put(GROUP))));
+    return alice.getDatabaseUser(targetDatabase);
+  }
+
+  /** One group definition, in the shape {@code ServerControlPlane.saveGroup} normalizes a request body into. */
+  private static JSONObject group(final JSONArray databaseAccess) {
+    return new JSONObject()
+        .put("access", databaseAccess)
+        .put("resultSetLimit", -1L)
+        .put("readTimeout", -1L)
+        .put("types", new JSONObject().put("*", new JSONObject().put("access",
+            new JSONArray().put("createRecord").put("readRecord").put("updateRecord").put("deleteRecord"))));
+  }
+
+  /** A whole group document, in the shape a {@code SECURITY_GROUPS_ENTRY} carries. */
+  private static String documentGranting(final JSONArray databaseAccess) {
+    return new JSONObject()
+        .put("version", ServerSecurity.LATEST_VERSION)
+        .put("databases", new JSONObject().put(DATABASE,
+            new JSONObject().put("groups", new JSONObject().put(GROUP, group(databaseAccess)))))
+        .toString();
+  }
+
+  /**
+   * Makes the group file unpersistable in a way that holds on every platform and does not depend on the test
+   * running as an unprivileged user: the target path becomes a non-empty directory, so the publishing rename
+   * cannot replace it. Same device the users half of issue #7137 uses.
+   */
+  private static void makeGroupFileUnwritable() throws Exception {
+    final File asDirectory = new File(CONFIG_PATH, SecurityGroupFileRepository.FILE_NAME);
+    FileUtils.deleteRecursively(asDirectory);
+    assertThat(asDirectory.mkdirs()).isTrue();
+    assertThat(new File(asDirectory, "occupied").createNewFile()).isTrue();
+  }
+
+  private static ServerDatabase mockDatabase(final String name) {
+    final FileManager fileManager = mock(FileManager.class);
+    when(fileManager.getFiles()).thenReturn(List.of());
+
+    final Schema schema = mock(Schema.class);
+    when(schema.getTypes()).thenReturn(List.of());
+
+    final ServerDatabase db = mock(ServerDatabase.class);
+    when(db.getName()).thenReturn(name);
+    when(db.getFileManager()).thenReturn(fileManager);
+    when(db.getSchema()).thenReturn(schema);
+    return db;
+  }
+
+  /** Records the document each mutation submits, the way the Raft broker would ship it to the peers. */
+  private static class CapturingHAPlugin implements HAServerPlugin {
+    private final List<String> groupDocuments = Collections.synchronizedList(new ArrayList<>());
+
+    String lastDocument() {
+      return groupDocuments.getLast();
+    }
+
+    @Override
+    public void replicateSecurityGroups(final String groupsJson) {
+      groupDocuments.add(groupsJson);
+    }
+
+    @Override
+    public ELECTION_STATUS getElectionStatus() {
+      return ELECTION_STATUS.DONE;
+    }
+
+    @Override
+    public void startService() {
+    }
+
+    @Override
+    public boolean isLeader() {
+      return true;
+    }
+
+    @Override
+    public String getLeaderName() {
+      return "leader";
+    }
+
+    @Override
+    public String getClusterName() {
+      return "test";
+    }
+
+    @Override
+    public Map<String, Object> getStats() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public int getConfiguredServers() {
+      return 3;
+    }
+
+    @Override
+    public String getLeaderAddress() {
+      return null;
+    }
+
+    @Override
+    public String getReplicaAddresses() {
+      return "";
+    }
+
+    @Override
+    public void shutdownRemoteServer(final String serverName) {
+    }
+
+    @Override
+    public void disconnectCluster() {
+    }
+  }
+
+  /**
+   * An {@link ArcadeDBServer} that is never started: the fixture supplies the security store and the open
+   * databases, and records which thread asked for each one - which is how the "not on the apply thread"
+   * assertion is made, since the sweep is the only thing here that calls {@code getDatabase}.
+   */
+  private static final class FixtureServer extends ArcadeDBServer {
+    private final Map<String, ServerDatabase> openDatabases = new LinkedHashMap<>();
+    final         List<String>                sweepThreads  = Collections.synchronizedList(new ArrayList<>());
+    private       ServerSecurity              security;
+
+    private FixtureServer(final ContextConfiguration configuration) {
+      super(configuration);
+    }
+
+    private void setSecurity(final ServerSecurity security) {
+      this.security = security;
+    }
+
+    private void register(final ServerDatabase database) {
+      openDatabases.put(database.getName(), database);
+    }
+
+    @Override
+    public ServerSecurity getSecurity() {
+      return security;
+    }
+
+    @Override
+    public Set<String> getDatabaseNames() {
+      return openDatabases.keySet();
+    }
+
+    @Override
+    public ServerDatabase getDatabase(final String databaseName) {
+      sweepThreads.add(Thread.currentThread().getName());
+      return openDatabases.get(databaseName);
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/security/Issue7510ReplicatedGroupPermissionRefreshTest.java
+++ b/server/src/test/java/com/arcadedb/server/security/Issue7510ReplicatedGroupPermissionRefreshTest.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
@@ -271,6 +272,35 @@ class Issue7510ReplicatedGroupPermissionRefreshTest {
     await().atMost(CONVERGENCE).untilAsserted(() -> assertThat(
         cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA))
         .as("the last document wins; a coalesced refresh must not drop it").isFalse());
+  }
+
+  /**
+   * The fallback path, and the reason it is a {@code catch} and not an escaping exception: once the executor is
+   * shut down it rejects, and {@code applyReplicatedGroups} runs on the Raft state-machine apply thread, where
+   * an unexpected {@code RuntimeException} is NOT the "a local write failed" case that is caught and reported -
+   * it is the "this node cannot apply a committed entry" case that reaches the node-wide halt (issue #4798).
+   * A shutdown racing one last group entry must therefore cost the refresh, not the node.
+   */
+  @Test
+  void anEntryAppliedOnceTheRefreshExecutorIsShutDownStillInstallsTheDocument() {
+    security.applyReplicatedGroups(documentGranting(new JSONArray().put("updateSchema")));
+
+    // Wait for the first sweep to have actually run before shutting down. Without this the test passes for the
+    // wrong reason: shutdownNow() would discard a still-queued task, and the schedule below would return at the
+    // coalescing compare-and-set without ever reaching the executor - so the rejection path this test names
+    // would not be exercised at all.
+    await().atMost(CONVERGENCE).untilAsserted(() -> assertThat(server.sweepThreads).isNotEmpty());
+
+    security.stopService();
+
+    final String revoked = documentGranting(new JSONArray());
+    assertThatCode(() -> security.applyReplicatedGroups(revoked))
+        .as("a rejected refresh must not turn into an exception the state machine halts the node on")
+        .doesNotThrowAnyException();
+
+    // And the document itself is still installed, so the node that comes back up reads the revoked definition.
+    assertThat(security.getDatabaseGroupsConfiguration(DATABASE).getJSONObject(GROUP).getJSONArray("access"))
+        .as("the entry is applied even though its refresh could not be scheduled").isEmpty();
   }
 
   // -------------------------------------------------------------------------------------------


### PR DESCRIPTION
Closes #7510

#7373 made a group change replicate, so `server-groups.json` converges on every node at once. The state
*derived* from it did not: each open database caches the permissions of the principals connected to it, and only
`ServerSecurity.updateSchema` re-derives them. The node that served the request refreshes synchronously in
`ServerControlPlane`; a peer had nothing at all, and picked the change up only when
`SecurityGroupFileRepository`'s file watcher next ticked - so for the length of
`arcadedb.server.security.reloadEvery` a peer kept granting a permission the cluster had already narrowed,
while `GET /server/groups` on that same peer already reported the new definition, which is a lag no operator
surface could show. `applyReplicatedGroups` now hands that sweep to a dedicated single-worker executor rather
than skipping it: the apply stays non-blocking (the invariant it runs under on the Raft state-machine thread)
and the peer converges in milliseconds. The hand-off is scheduled *before* the persistence failure is reported,
because the document is in force from the moment it is published whether or not it reached the disk - the whole
point of the publish-before-persist ordering #7137/#7373 established - and refreshes coalesce through a pending
flag cleared at the **start** of the sweep, so an entry applied while a sweep is running always queues another
one and the last document can never be dropped. The watcher is untouched, is now the fallback behind the
immediate refresh, and is still the path a hand-edited group file takes.

## Test plan

- [ ] `mvn -o -pl server -Dtest=Issue7510ReplicatedGroupPermissionRefreshTest test` - 7 tests. Every one runs
      with `arcadedb.server.security.reloadEvery` set to an hour, so the file watcher cannot be what makes them
      pass: convergence within seconds can only come from the refresh the apply schedules.
- [ ] Remove the `scheduleReplicatedPermissionRefresh()` call from `applyReplicatedGroups` and re-run: all 7
      fail, each on its own `await` assertion (verified - `ConditionTimeout` x7).
- [ ] `mvn -o -pl server -Dtest='Issue7510*,Issue7373*,Issue7137*,Issue6806*Test,SecurityGroup*Test,ServerSecurity*Test,ApiTokenConfigurationTest,DatabaseUserContextTest,RootPasswordFromFileTest,ConcurrentSaltCacheTest,SecurityUserFileRepositoryTest' test` - 89 pass.
- [ ] `mvn -o -pl ha-raft -Dtest='*Security*Test' test` - 15 pass.
- [ ] Manual, 3-node cluster: connect a principal to a database on node B, `POST /server/groups` on node A
      narrowing that principal's group, then immediately exercise the revoked permission on **node B**. It must
      be denied without waiting for `reloadEvery`.

**Not run locally:** the server integration tests (`Issue6806GroupPermissionRefreshIT`,
`Issue5269FileAccessRefreshIT`, `ServerSecurityIT`). Port 2480 was already held by two other listeners on this
machine, and server ITs bind fixed ports, so a local run would have reported authentication errors rather than
anything about this change. They run in CI.

## Coverage

Every replicated group mutation - `saveGroupClusterWide`, `deleteGroupClusterWide` and the joining-peer
`seedGroupsClusterWide` - funnels through one entry type into `ArcadeStateMachine.applySecurityGroupsEntry` ->
`ServerSecurity.applyReplicatedGroups`, which is the single place the fix lands. Covered, each by its own test:

| Entry point | Test |
|---|---|
| replicated **save**, narrowing | `aReplicatedRevocationReachesTheCachedPrincipalWithoutTheReloadTick` |
| replicated **save**, widening | `aReplicatedGrantReachesTheCachedPrincipalWithoutTheReloadTick` |
| replicated **delete** | `aReplicatedGroupDeletionReachesTheCachedPrincipalWithoutTheReloadTick` |
| end to end through `ServerControlPlane.saveGroup`, the point HTTP and gRPC share, onto a second `ServerSecurity` standing in for a peer | `aGroupNarrowedOnTheLeaderReachesAPeersCachedPrincipal` |
| the **persist-failure** path, where the document is in force and the method then throws | `aRefreshIsScheduledEvenWhenTheReplicatedDocumentCouldNotBePersisted` |
| the sweep must not run on the Raft apply thread | `theRefreshRunsOffTheCallingApplyThread` |
| a burst of entries must converge on the LAST document | `aBurstOfReplicatedEntriesConvergesOnTheLastDocument` |

Paths deliberately not changed, with the evidence:

- **`ServerControlPlane.saveGroup`/`deleteGroup` on the serving node** - already refreshes synchronously via
  `refreshPermissionsOf`, so its 200 still means "enforced here". Left synchronous on purpose; the cost is one
  redundant, idempotent sweep on that node.
- **`ServerSecurity.saveGroup`/`deleteGroup` called directly** - no `src/main` caller outside `ServerSecurity`;
  the only reachable one is the non-HA fallback of `saveGroupClusterWide`, entered from `ServerControlPlane`,
  which refreshes on the next line.
- **`applyReplicatedUsers`** - rebuilds the whole `users` map with fresh `ServerSecurityUser` objects whose
  `databaseCache` is empty, so there is no stale derived state for a refresh to fix.
- **`applyReplicatedApiTokens`** - an API-token principal is built per request by `authenticateByApiToken` with
  a synthetic group config from the token document, never enters the `users` map, and is never widened by the
  file groups.
- **A database CLOSED on the peer when the entry is applied** is skipped by the sweep, and
  `ServerSecurityUser.databaseCache` is keyed by name and survives a close - but `LocalDatabase.open()` calls
  `security.updateSchema(this)` (`LocalDatabase.java:2965-2966`), so a reopen re-derives from the document in
  force at that moment.

### Known gaps

- **#7529** - nothing reports *whether* the refresh happened: the success path is silent, the two failure paths
  log at WARNING, and the executor is not wired into `PoolMetrics`. An operator narrowing a permission still
  cannot observe when the other nodes started enforcing it, which was half of what #7510 complained about. This
  PR closes the lag; making it observable is a separate change.

## Two things worth a reviewer's attention

1. **`Issue7373ReplicatedGroupAuthorizationTest` is touched, comments only.** Its javadoc described the world
   before this patch ("on a peer the group file's watcher does, on the reloadEvery tick"), which would leave a
   comment asserting an invariant the code no longer holds. Every assertion and every line of test logic is
   unchanged - `git diff` on that file shows no changed line that is not a comment or javadoc. The prose now
   says what actually pins it: the apply still does not walk the databases on the calling thread, and that
   fixture's mocked server reports no open databases, so the scheduled sweep has nothing to walk and cannot
   interfere.
2. **A behaviour change on an existing path.** Extracting the watcher's inline sweep into
   `refreshOpenDatabasePermissions()` added a per-database `try/catch`. A failing database used to abandon the
   rest of the watcher's sweep and surface as a SEVERE from `SecurityGroupFileRepository.load()`'s timer; it is
   now a WARNING naming the database, and the remaining databases are still refreshed. Deliberate - on the
   refresh worker an escaping exception would also take out the sweep the next group change needs - but it is
   not confined to the new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEJXCdUGW61QSXqyurphpt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Replicated security-group permission changes now refresh cached access more promptly, without waiting for the file-watcher interval.
  * Permission grants, revocations, and group deletions are applied consistently across open databases, including when configuration persistence encounters an error.
  * Permission refreshes no longer block replicated operation processing.

* **Documentation**
  * Added documentation covering replicated permission refresh behavior, remaining asynchronous timing, and observability considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->