### PR TITLE
fix(#7521): retry the addPeer security seed and report a residual failure as 503

### DIFF
--- a/docs/7521-addpeer-security-seed-readiness.md
+++ b/docs/7521-addpeer-security-seed-readiness.md
@@ -1,0 +1,230 @@
+# Issue #7521 - HA addPeer: a peer whose security seed failed is admitted and serves traffic with its own stale credentials
+
+Branch: `fix/7521-addpeer-security-seed-readiness`
+
+## The report
+
+`PostAddPeerHandler` admits the peer first and seeds the three security documents afterwards, best-effort. A
+failed seed was logged and reported in a `warning` field of an HTTP **200**, and nothing stopped the new peer
+from serving requests. It falls back to whatever its own `config/` directory holds - for a node re-added after
+time out of the cluster, a user dropped since, a group narrowed since, or **a token revoked since** still
+authenticates and authorizes on that one node until the next cluster-wide change of that kind happens to occur.
+Behind a load balancer that reads as an intermittent success against a credential the operator believes is dead.
+
+The seeds are submitted as Raft entries, so the usual failure is "no quorum right now" - the same condition that
+makes `addPeer` interesting in the first place.
+
+## Root cause
+
+`ServerSecurity.seedSecurityStateClusterWide()` made exactly **one** attempt per document.
+`RaftTransactionBroker.replicateSecurity*` is `groupCommitter.submitAndWait(...)`, so the call blocks until the
+entry commits and its dominant failure mode is a momentarily absent quorum. A single attempt against a transient
+failure is the wrong shape: retrying costs an admin call a few seconds, not retrying leaves a committed cluster
+member running on its own credentials indefinitely.
+
+The second half is reporting. `PostAddPeerHandler` returned 200 with a `warning` field. An operator's join
+automation reads the status code.
+
+## Completeness
+
+### The invariant
+
+> Every path on which one node admits another to the cluster seeds **all three** security documents - users,
+> groups, API tokens - each read under the security monitor and retried within a bounded budget; and when a
+> document still has not committed, the caller learns it through the operation's own failure channel rather than
+> through a flat success.
+
+### Enumerating the ways to violate it
+
+Every production caller that admits a peer:
+
+```
+$ grep -rn "\.addPeer(\|\.connectCluster(" --include="*.java" */src/main | grep -v RaftClusterManager.java
+grpc-client/.../RemoteGrpcServer.java:797:    call("connect cluster", stub -> stub.connectCluster(
+grpcw/.../ArcadeDbGrpcAdminService.java:935:      controlPlane.connectCluster(req.getServerAddress());
+ha-raft/.../RaftHAPlugin.java:483:    raft.addPeer(target.peer(), target.name());
+ha-raft/.../RaftHAPlugin.java:501:    raftHAServer.addPeer(peerId, address, name);
+ha-raft/.../RaftHAServer.java:2917:    clusterManager.addPeer(peerId, address, name);
+ha-raft/.../RaftHAServer.java:2922:    clusterManager.addPeer(newPeer, name);
+ha-raft/.../PostAddPeerHandler.java:62:    raftHAServer.addPeer(peerId, address, name.isEmpty() ? null : name);
+server/.../ServerControlPlane.java:208:      ha.connectCluster(serverAddress);
+server/.../http/handler/PostServerCommandHandler.java:206:    controlPlane.connectCluster(serverAddress);
+```
+
+Every production caller of the seed:
+
+```
+$ grep -rn "replicateSecurityUsers(\|replicateSecurityGroups(\|replicateSecurityApiTokens(\|seedSecurityStateClusterWide(" --include="*.java" */src/main
+...
+ha-raft/.../PostAddPeerHandler.java:74:    final List<String> failedSeeds = ...getSecurity().seedSecurityStateClusterWide();
+server/.../ServerControlPlane.java:226:      ha.replicateSecurityUsers(server.getSecurity().getUsersJsonPayload());
+server/.../ServerSecurity.java:422,448,475,1024,1043,1187,1208   (the mutation paths, not admissions)
+```
+
+Two things fell out of this that the report did not name:
+
+1. **`ServerControlPlane.connectCluster` seeded the users document only** - it never grew the groups and
+   API-token half #7373 gave the add-peer route - **and it read the payload outside the security monitor**,
+   calling `getUsersJsonPayload()` directly. That method's javadoc has always said the caller must hold the
+   monitor; this is the exact window #7373 closed on the other route, still open on this one.
+
+2. **The Kubernetes auto-join seeds nothing at all**, because it is a self-join with no admitting node:
+
+```
+$ grep -n "replicateSecurity\|seedSecurity\|addPeer" ha-raft/src/main/java/com/arcadedb/server/ha/raft/KubernetesAutoJoin.java
+(no matches)
+```
+
+### Entry-point coverage table
+
+| Entry point | Covered by the fix? | Covered by a test? |
+|---|---|---|
+| `POST /api/v1/cluster/peer` -> `PostAddPeerHandler` | yes - bounded retry, and a residual failure is 503 with `failedSeeds`, not a 200 with a `warning` | yes - `Issue7521AddPeerSeedFailureIsReportedTest` (5 methods) |
+| `connect cluster` (HTTP `POST /api/v1/server`, gRPC `ConnectCluster`) -> `ServerControlPlane.connectCluster` | yes - now seeds all three documents through `seedSecurityStateClusterWide`, under the monitor, with the same retry | yes - `Issue7521SecuritySeedRetryTest`, the four `connectCluster*` methods |
+| `ServerSecurity.seedSecurityStateClusterWide` itself (the shared mechanism both routes call) | yes - `seedSecurityStateClusterWide(long)` retries only the documents that failed, re-reading each under the monitor, with capped exponential backoff and interrupt-aware sleeps | yes - `Issue7521SecuritySeedRetryTest`, the seven mechanism methods |
+| Kubernetes StatefulSet scale-up -> `KubernetesAutoJoin` self-join | **no - filed as #7531** | no |
+| Readiness gate on security convergence (the window between a peer catching up and the seed being submitted; and `connect cluster` having no in-band failure channel) | **no - filed as #7532** | no |
+| `RemoteGrpcServer.connectCluster`, `ArcadeDbGrpcAdminService`, `PostServerCommandHandler` | argued - these are transports that call `ServerControlPlane.connectCluster`; they add no seeding of their own, so the row above covers them. Evidence: the grep in "Enumerating" shows `ha.replicateSecurity*` appears in neither | covered transitively |
+
+### Why the readiness gate (the issue's second option) was not taken here
+
+The issue offered two shapes and noted the second composes better with #7511. It was not taken because:
+
+- it is a readiness-contract change, and it needs a deadlock answer - a node that joins and is never seeded
+  (nobody mutates security; or #7531's self-join path, where no seed is ever issued) must not report NOT_READY
+  forever, or a rolling restart stalls;
+- the existing test `Issue7401ServerControlPlaneConnectClusterTest.aFailingUsersSeedDoesNotFailTheJoin` pins
+  that a failed seed must not fail the join on that verb, and this workflow does not modify existing tests.
+
+Both are written up in #7532 with the evidence, rather than left implicit.
+
+### Residual risk
+
+1. The seed is still submitted **after** the membership change, so a peer can catch up and report READY before
+   the first seed attempt is made. The retry shortens the failure case; it cannot close that window. #7532.
+2. `connect cluster` still cannot report a residual seed failure in-band - it returns `void` and an existing
+   contract forbids failing the join - so on that verb the failure reaches the operator only as a SEVERE log
+   line. #7532.
+3. A pod that joins through the Kubernetes auto-join is never seeded by anyone. #7531.
+4. The retry budget is wall-clock. An admission issued while the cluster has genuinely lost quorum for longer
+   than `arcadedb.ha.securitySeedRetryTimeout` (default 3 s) still reports the residual failure - by design:
+   holding an HTTP worker thread indefinitely is worse than answering 503 and letting the operator re-POST.
+
+## The change
+
+| File | What |
+|---|---|
+| `engine/.../GlobalConfiguration.java` | new `HA_SECURITY_SEED_RETRY_TIMEOUT` (`arcadedb.ha.securitySeedRetryTimeout`, `Long`, default `3000`). `0` restores the single best-effort attempt. |
+| `server/.../security/ServerSecurity.java` | new `seedSecurityStateClusterWide(long retryBudgetMs)`. Retries only the documents that failed, re-reading each under the monitor, backoff 250 ms doubling to a 1000 ms cap and never past the deadline, interrupt restores the flag and returns. The no-argument form delegates with `0`, so its existing callers and their tests keep the single-attempt contract. |
+| `ha-raft/.../PostAddPeerHandler.java` | uses the retrying form with the configured budget; logs SEVERE on a residual failure; response building extracted to `addPeerResponse`, which answers **503** with `error` + a machine-readable `failedSeeds` array, still reporting `result` because the peer *is* a member. |
+| `server/.../ServerControlPlane.java` | `connectCluster` now seeds through `seedSecurityStateClusterWide(budget)` instead of a bare `ha.replicateSecurityUsers(getUsersJsonPayload())` - all three documents, under the monitor, with the retry. Still does not fail the join; logs SEVERE. |
+| `server/.../openapi/PluginApiSpec.java` | `POST /api/v1/cluster/peer` documents the 503 and what it means. |
+| `studio/.../js/studio-cluster.js` | the add-peer `fail` handler refreshes the cluster view on a 503, because the peer *is* a member. |
+
+### Reachability
+
+- `PostAddPeerHandler` is constructed at `RaftHAPlugin:264` (`routes.addExactPath("/api/v1/cluster/peer", new PostAddPeerHandler(httpServer, this))`), so the changed code is on a live route.
+- `ServerControlPlane.connectCluster` is reached from `PostServerCommandHandler:206` (HTTP) and `ArcadeDbGrpcAdminService:935` (gRPC).
+- No flag gates either off: the new setting changes how long the retry runs, not whether the seed happens.
+
+## Tests
+
+New:
+
+- `server/src/test/java/com/arcadedb/server/security/Issue7521SecuritySeedRetryTest.java` - 11 methods.
+  Retry succeeds within the budget; a permanent failure is reported once the budget is spent and *was* retried;
+  only the failing documents are retried; a retry re-reads rather than resubmitting the first payload (driven by
+  having the failing submit revoke a token before it throws, so a stale resubmit would resurrect it); the
+  no-argument form and a zero budget both stay single-attempt; an interrupt ends the retry with the flag
+  restored; the three `connectCluster` parity/monitor/no-fail-the-join properties; and that a seed which cannot
+  run at all still leaves the join standing.
+- `ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7521AddPeerSeedFailureIsReportedTest.java` - 5 methods
+  on `PostAddPeerHandler.addPeerResponse`: 200 when clean, 503 when not, the failing documents named in prose
+  and as a list, the `error`/`detail` split, and the membership half still reported.
+
+### Proof the tests can fail
+
+Production behaviour reverted in place, tests re-run, then restored:
+
+- `seedSecurityStateClusterWide(long)` deadline forced to `now + 0` and `connectCluster` put back to the
+  users-only, outside-the-monitor seed: **8 of 10 failed**. The 2 that stayed green are
+  `theNoArgumentFormStillMakesExactlyOneAttemptPerDocument` and `aZeroBudgetDisablesTheRetryRatherThanLooping
+  Forever`, which pin a contract that holds before *and* after - correct.
+- `addPeerResponse` forced back to 200: `anAdmissionWhoseSeedDidNotCommitIsNotReportedAsSuccess` failed, the
+  other 3 stayed green (they assert body content, which the pre-fix shape also carried).
+
+### Regression runs
+
+All with `-Dmaven.repo.local=<worktree>/.m2repo`.
+
+| Selection | Result |
+|---|---|
+| `server`: `com.arcadedb.server.security.*Test`, `...http.handler.openapi.*Test`, `com.arcadedb.server.*Test` | 333 run, 0 failures |
+| `server`: `Issue7373...Test`, `Issue7401ServerControlPlaneConnectClusterTest`, `GetReadyHandlerHATest`, `Issue7521SecuritySeedRetryTest` | 49 run, 0 failures |
+| `server`: `PluginApiSpecTest`, `RoutePathNormalizerTest` | 28 run, 0 failures |
+| `ha-raft`: `HAConfigDefaultsTest`, `Issue7521AddPeerSeedFailureIsReportedTest`, `Issue7401JoinPriorityTest`, `ConfigValidationTest` | 21 run, 0 failures |
+| `engine`: `Issue7124BooleanSettingStrictCoercionTest`, `Issue7163DatabaseScopeCallbackTest`, `GlobalConfigurationTest` | 29 run, 0 failures |
+
+Not run, environmental: `DynamicMembershipTest` and the `*IT` classes in both modules could not bind their
+ports - another agent on this machine holds 2434 and 2480 (`java.net.BindException: Address already in use` for
+`0.0.0.0:2434`). Neither touches the seeding code.
+
+One existing test got slower rather than red: `Issue7401ServerControlPlaneConnectClusterTest
+.aFailingUsersSeedDoesNotFailTheJoin` now spends the default 3 s budget retrying a seed that is rigged never to
+commit. That is the new behaviour being exercised, not a regression.
+
+## Impact
+
+- An operator's join automation now sees a 503 where it used to see a 200 with a field it did not read. That is
+  the intended behaviour change and it is documented in the OpenAPI spec; re-POSTing the same peer is idempotent
+  on the membership change and reissues the seed.
+- A peer joined through `connect cluster` now receives the group document and the API-token store, which it
+  never did before.
+- `arcadedb.ha.securitySeedRetryTimeout=0` restores the previous single-attempt behaviour exactly.
+
+
+## Adversarial pass
+
+The skill asks for one `general-purpose` subagent, deliberately kept ignorant of the author's reasoning, to
+write the follow-up issue it would file against this patch. **No `Task` tool exists in this environment**
+(`ToolSearch` for it returns nothing), so the pass was run by the author against the diff instead. That is
+weaker - the author has already been convinced - and it is recorded as such rather than claimed as the
+isolated pass. It still produced three findings, all real, all fixed here:
+
+1. **`connectCluster` could now fail the join it is forbidden to fail.** The old code had
+   `server.getSecurity().getUsersJsonPayload()` *inside* a `try/catch (Exception)`; the rewrite put the
+   `getSecurity()` dereference outside every catch. `seedSecurityStateClusterWide` collects a per-document
+   failure rather than throwing, so the per-document case was covered - but anything around it (a server with
+   no security store) would have escaped as a failed join, and by that point the peer is a committed member.
+   Fixed: the seed call is wrapped, with a SEVERE log. Pinned by
+   `connectClusterSurvivesASeedThatCannotRunAtAll`.
+
+2. **The 503 body would have rendered as an unreadable Studio notification.**
+   `studio-utils.js:globalNotifyError` uses `json.error` as the notification **title** and `json.detail` as its
+   body. The first draft put the whole paragraph in `error`, so Studio would have shown a paragraph-length
+   title over the placeholder "Error on execution of the command". Fixed: split into a one-line `error` and a
+   `detail` carrying the remediation, which is the split `AbstractServerHttpHandler.error2json` uses
+   everywhere else. Pinned by `theSummaryAndTheRemediationAreSeparateFields`.
+
+3. **Studio would show the operator an error and a cluster view without the peer.**
+   `studio-cluster.js`'s add-peer handler calls `updateCluster()` only in `.done()`. A 503 means the membership
+   change *succeeded*, so the list is stale exactly when the operator most needs to see the new member. Fixed:
+   the `fail` handler refreshes on a 503.
+
+Checked and found **not** to be problems, with the evidence:
+
+- **Enum ordinal.** `HA_SECURITY_SEED_RETRY_TIMEOUT` is inserted mid-enum.
+  `grep -rn "GlobalConfiguration.*\.ordinal()\|values()\[" --include="*.java" */src/main` returns nothing,
+  so no ordinal is persisted or indexed.
+- **`ClusterManagementAuthorizationIT`.** Its two add-peer assertions are 403 (non-root) and 400 (root, empty
+  body). Both short-circuit before `raftHAServer.addPeer`, so neither reaches the seed or the new status code.
+- **`HAConfigDefaultsTest.allHAEntriesHaveNonNullDefaults`.** The new setting has a non-null default (`3000L`);
+  the test runs green.
+- **Interrupt landing in a seed call rather than in the backoff.** The seed's own exception is collected, and
+  the very next `Thread.sleep` throws `InterruptedException` immediately because the flag is set - so the loop
+  still ends at once. Pinned by `anInterruptEndsTheRetryAndLeavesTheFlagSet`, which interrupts a thread that is
+  already retrying.
+- **The deadline is computed before the first attempt**, so a first attempt slower than the whole budget
+  yields exactly one attempt. That is the intended reading of a wall-clock budget, and it is what keeps an
+  HTTP worker thread from being held indefinitely by the retry. Listed under residual risk instead: the budget
+  bounds the *retrying*, not the blocking `submitAndWait` calls themselves.

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1904,6 +1904,18 @@ public enum GlobalConfiguration {
       "Interval in milliseconds for the Raft health monitor to check for CLOSED/EXCEPTION state and auto-recover. 0 disables.",
       Long.class, 3000L),
 
+  HA_SECURITY_SEED_RETRY_TIMEOUT("arcadedb.ha.securitySeedRetryTimeout", SCOPE.SERVER,
+      """
+      Time budget in milliseconds a peer-admission call (POST /api/v1/cluster/peer, 'connect cluster') spends \
+      retrying the security documents - server-users.jsonl, server-groups.json, server-api-tokens.json - it seeds \
+      to the newly-joined peer (issue #7521). None of them is carried by a Raft snapshot install, so a peer that \
+      does not receive the seed keeps whatever its own config directory holds: for a node re-added after time out \
+      of the cluster that is a user dropped since, a group narrowed since, or a token revoked since, still good on \
+      that one node. The usual failure is a momentarily absent quorum, which is transient and is what the retry is \
+      for; only the documents that failed are retried, with exponential backoff. 0 disables the retry and leaves \
+      the single best-effort attempt.""",
+      Long.class, 3000L),
+
   HA_RESYNC_PROGRESS_LOGGING("arcadedb.ha.resyncProgressLogging", SCOPE.SERVER,
       """
       When true (default), the leader emits a concise per-follower unreachable/reconnected narrative and a \

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostAddPeerHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostAddPeerHandler.java
@@ -18,7 +18,9 @@
  */
 package com.arcadedb.server.ha.raft;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.http.handler.AbstractServerHttpHandler;
@@ -71,23 +73,54 @@ public class PostAddPeerHandler extends AbstractServerHttpHandler {
     // here and submitting afterwards would leave a window in which a revocation commits in between, and the
     // seed - which carries a whole document - would then put the revoked token, or the deleted group, back on
     // every node. addPeer is exactly when an operator is also likely to be rotating credentials.
-    final List<String> failedSeeds = httpServer.getServer().getSecurity().seedSecurityStateClusterWide();
+    //
+    // Retried within a bounded budget rather than attempted once (issue #7521): the submit waits for a Raft
+    // commit, so its usual failure is an absent quorum at this instant - transient, and the same condition
+    // that makes an addPeer interesting in the first place.
+    final long retryBudgetMs = httpServer.getServer().getConfiguration()
+        .getValueAsLong(GlobalConfiguration.HA_SECURITY_SEED_RETRY_TIMEOUT);
+    final List<String> failedSeeds = httpServer.getServer().getSecurity()
+        .seedSecurityStateClusterWide(retryBudgetMs);
 
-    // Still best-effort: a failed seed does not roll back the peer addition, because the peer is already a
-    // cluster member and removing it again is a second failure mode rather than a repair. But the response says
-    // so rather than reporting a flat success - the operator is the one who has to reissue the seed, and they
-    // cannot do that if the only record is a WARNING in this node's log (issue #7521).
+    if (!failedSeeds.isEmpty())
+      LogManager.instance().log(this, Level.SEVERE,
+          "Peer '%s' was added but these security documents could not be seeded to it: %s. It is a cluster member "
+              + "serving requests against its own copy of them", peerId, String.join(", ", failedSeeds));
+
+    return addPeerResponse(peerId, failedSeeds);
+  }
+
+  /**
+   * The response for an admission whose membership change succeeded, given the security documents that could
+   * not be seeded to the new peer.
+   * <p>
+   * A residual failure is <b>not</b> a 200 (issue #7521). The peer addition is not rolled back - the peer is
+   * already a committed member and removing it again is a second failure mode rather than a repair - but the
+   * operator is the one who has to reissue the seed, and an operator's automation reads the status code, not a
+   * {@code warning} field inside a success body. 503 is the status that says "this ran, part of it did not
+   * land, retry it": re-POSTing the same peer is idempotent on the membership change and reissues the seed.
+   * <p>
+   * {@code result} is still present and still says the peer was added, because that half did happen and a
+   * caller that treats the whole call as a no-op would be wrong about the cluster's membership.
+   *
+   * @param failedSeeds the documents that did not commit, in the order {@code seedSecurityStateClusterWide}
+   *                    reports them; empty for a clean admission
+   */
+  static ExecutionResponse addPeerResponse(final String peerId, final List<String> failedSeeds) {
     final JSONObject response = new JSONObject().put("result", "Peer " + peerId + " added");
-    if (!failedSeeds.isEmpty()) {
-      response.put("warning", "Peer added, but the following security documents could NOT be seeded to it: "
-          + String.join(", ", failedSeeds)
-          + ". The new peer keeps its own copy of them until the next cluster-wide change of that kind; reissue "
-          + "the change, or re-run addPeer, before treating the peer as consistent");
-      LogManager.instance().log(this, Level.WARNING,
-          "Peer '%s' was added but these security documents could not be seeded to it: %s", peerId,
-          String.join(", ", failedSeeds));
-    }
+    if (failedSeeds.isEmpty())
+      return new ExecutionResponse(200, response.toString());
 
-    return new ExecutionResponse(200, response.toString());
+    // error/detail, not one long error: AbstractServerHttpHandler.error2json uses that split everywhere, and
+    // Studio's globalNotifyError renders 'error' as the notification TITLE and 'detail' as its body.
+    response.put("error", "Peer " + peerId + " was added, but these security documents could NOT be seeded to it: "
+        + String.join(", ", failedSeeds));
+    response.put("detail", "The new peer keeps its own copy of them - which for a node re-added after time out of "
+        + "the cluster can still hold a user dropped since, a group narrowed since or a token revoked since - "
+        + "until the next cluster-wide change of that kind. Re-POST the same peer to reissue the seed (the "
+        + "membership change is idempotent), or reissue the change, before treating the peer as consistent. "
+        + "Raise arcadedb.ha.securitySeedRetryTimeout if the cluster routinely needs longer to reach a quorum.");
+    response.put("failedSeeds", new JSONArray(failedSeeds));
+    return new ExecutionResponse(503, response.toString());
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7521AddPeerSeedFailureIsReportedTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7521AddPeerSeedFailureIsReportedTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.http.handler.ExecutionResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7521, the {@code POST /api/v1/cluster/peer} half.
+ * <p>
+ * The route admits the peer and then seeds it with the three security documents a Raft snapshot install does
+ * not carry. Before this, a seed that never committed was reported as HTTP <b>200</b> carrying a
+ * {@code warning} field - so an operator's automation, which reads the status code, recorded a clean
+ * admission while the new peer went on serving requests against its own config directory. For a node re-added
+ * after time out of the cluster that directory can still hold a user dropped since, a group narrowed since or
+ * a token revoked since.
+ * <p>
+ * {@link PostAddPeerHandler#addPeerResponse} is the decision this pins: which status code the handler answers
+ * with, and what the body has to carry so the operator can act on it. The membership half is deliberately not
+ * rolled back - the peer is already a committed member - so both outcomes still report it as added.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue7521AddPeerSeedFailureIsReportedTest {
+
+  @Test
+  void anAdmissionWhoseSeedsAllCommittedIs200() {
+    final ExecutionResponse response = PostAddPeerHandler.addPeerResponse("arcadedb-3", List.of());
+
+    assertThat(response.getCode()).isEqualTo(200);
+
+    final JSONObject body = new JSONObject(response.getResponse());
+    assertThat(body.getString("result")).contains("arcadedb-3");
+    assertThat(body.has("error")).as("a clean admission carries no error").isFalse();
+    assertThat(body.has("failedSeeds")).as("a clean admission carries no failure list").isFalse();
+  }
+
+  /**
+   * The status code is the assertion. A {@code warning} inside a 200 is invisible to every caller that checks
+   * the status and moves on, which is what an operator's join automation does.
+   */
+  @Test
+  void anAdmissionWhoseSeedDidNotCommitIsNotReportedAsSuccess() {
+    final ExecutionResponse response = PostAddPeerHandler.addPeerResponse("arcadedb-3", List.of("API tokens"));
+
+    assertThat(response.getCode())
+        .as("a peer serving with its own stale credentials must not read as a clean join")
+        .isEqualTo(503);
+  }
+
+  /**
+   * The operator has to know <i>which</i> documents did not land, because the remediation differs: re-issuing
+   * a user change is not the same act as re-issuing a token revocation. A machine-readable list, not only
+   * prose, so a join script can branch on it.
+   */
+  @Test
+  void theFailedDocumentsAreNamedBothInProseAndAsAList() {
+    final ExecutionResponse response = PostAddPeerHandler.addPeerResponse("arcadedb-3",
+        List.of("users", "API tokens"));
+
+    final JSONObject body = new JSONObject(response.getResponse());
+    assertThat(body.getString("error")).contains("users").contains("API tokens");
+    assertThat(body.getJSONArray("failedSeeds").toList())
+        .as("reported in the order seedSecurityStateClusterWide reports them")
+        .containsExactly("users", "API tokens");
+  }
+
+  /**
+   * Split across {@code error} and {@code detail} the way {@code AbstractServerHttpHandler.error2json} splits
+   * every other failure on this server. Studio's {@code globalNotifyError} renders {@code error} as the
+   * notification title and {@code detail} as its body, so a single long {@code error} becomes an unreadable
+   * title over the placeholder "Error on execution of the command".
+   */
+  @Test
+  void theSummaryAndTheRemediationAreSeparateFields() {
+    final ExecutionResponse response = PostAddPeerHandler.addPeerResponse("arcadedb-3", List.of("users"));
+
+    final JSONObject body = new JSONObject(response.getResponse());
+    assertThat(body.getString("error")).as("a title, not a paragraph").hasSizeLessThan(160);
+    assertThat(body.getString("detail")).contains("Re-POST").contains("securitySeedRetryTimeout");
+  }
+
+  /**
+   * The membership change did happen, and a caller that concluded from the 503 that the cluster is unchanged
+   * would be wrong about its own topology. The remediation is re-POSTing the same peer, which is idempotent
+   * on the membership change and reissues the seed - so the body says the peer was added even while failing.
+   */
+  @Test
+  void aFailedSeedStillReportsThatThePeerBecameAMember() {
+    final ExecutionResponse response = PostAddPeerHandler.addPeerResponse("arcadedb-3", List.of("groups"));
+
+    final JSONObject body = new JSONObject(response.getResponse());
+    assertThat(body.getString("result")).as("the peer IS a member").contains("arcadedb-3").contains("added");
+    assertThat(body.getString("detail")).contains("Re-POST the same peer");
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -163,8 +163,13 @@ public class ServerControlPlane {
    * have written in the configuration.
    * <p>
    * Equivalent to {@code POST /api/v1/cluster/peer} and deliberately so: the same atomic Raft
-   * membership change, and the same users seed afterwards, because {@code server-users.jsonl} lives
-   * outside the database directory and a snapshot install does not carry it.
+   * membership change, and the same seed of the three security documents afterwards, because
+   * {@code server-users.jsonl}, {@code server-groups.json} and {@code server-api-tokens.json} all live
+   * outside the database directory and a snapshot install carries none of them.
+   * <p>
+   * The one thing it does not share with that route is how a failed seed is reported. That route answers
+   * 503 (issue #7521); this verb returns nothing and an existing contract pins that a failed seed must not
+   * fail the join, so the failure reaches the operator only as a SEVERE log line. Tracked separately.
    * <p>
    * <b>Note the direction.</b> The address names the server being <em>added</em>; the cluster that
    * grows is the one this server belongs to. That is the opposite of the pre-Raft implementation this
@@ -217,16 +222,39 @@ public class ServerControlPlane {
           "Cannot connect '" + serverAddress + "' to the cluster: " + e.getMessage());
     }
 
-    // Seed the newly joined peer with the current users file, exactly as PostAddPeerHandler does after
-    // its own addPeer: server-users.jsonl lives under <server-root>/config/, outside the database
-    // directory, so snapshot install does not cover it and the new peer would run with a stale user set
-    // until the next cluster-wide user mutation. Best-effort, as it is there: the peer is already a
-    // committed member and a failure here does not - and must not - roll that back.
+    // Seed the newly joined peer with the current security documents, exactly as PostAddPeerHandler does
+    // after its own addPeer: server-users.jsonl, server-groups.json and server-api-tokens.json all live
+    // under <server-root>/config/, outside the database directory, so snapshot install covers none of them
+    // and the new peer would run with a stale user set, a stale group document and a stale token store until
+    // the next cluster-wide change of each kind.
+    //
+    // Through ServerSecurity rather than a bare replicateSecurityUsers (issue #7521). That call seeded the
+    // users document only - this verb never grew the groups and API-token half #7373 gave the add-peer route
+    // - and it read the payload OUTSIDE the security monitor, which is the window #7373 closed on the other
+    // route: a revocation committing between the read and the submit is undone on every node by a seed that
+    // carries a whole document. It also retries within a bounded budget, because the submit waits for a Raft
+    // commit and its usual failure is an absent quorum at this instant.
+    //
+    // Still best-effort in the sense that matters to the caller: the peer is already a committed member and a
+    // seed failure does not - and must not - fail the join, or the caller would retry a join that already
+    // happened. What it is not is silent.
+    //
+    // The catch is the contract, not defensiveness: NOTHING raised while seeding may escape and be read as a
+    // failed join, because by this point the peer is a committed member. seedSecurityStateClusterWide already
+    // collects a per-document failure rather than throwing, so what this covers is everything around them -
+    // a server whose security store is not installed, most of all.
     try {
-      ha.replicateSecurityUsers(server.getSecurity().getUsersJsonPayload());
+      final List<String> failedSeeds = server.getSecurity().seedSecurityStateClusterWide(
+          server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_SECURITY_SEED_RETRY_TIMEOUT));
+      if (!failedSeeds.isEmpty())
+        LogManager.instance().log(this, Level.SEVERE,
+            "Connect cluster joined '%s' but these security documents could not be seeded to it: %s. That peer is a "
+                + "cluster member serving requests against its own copy of them; reissue the change, or re-run "
+                + "connect cluster, before treating it as consistent", serverAddress, String.join(", ", failedSeeds));
     } catch (final Exception e) {
-      LogManager.instance().log(this, Level.WARNING,
-          "Users seed to '%s' after connect cluster failed (best-effort): %s", serverAddress, e.getMessage());
+      LogManager.instance().log(this, Level.SEVERE,
+          "Connect cluster joined '%s' but the security seed could not be run at all: %s. That peer is a cluster "
+              + "member serving requests against its own security documents", e, serverAddress, e.getMessage());
     }
   }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/PluginApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/PluginApiSpec.java
@@ -169,11 +169,19 @@ public class PluginApiSpec implements OpenApiContributor {
   private PathItem createAddPeerPath() {
     final Operation post = SpecBuilders.operation("addClusterPeer", "Cluster",
         "Add a peer to the cluster",
-        "Adds a peer to the Raft configuration. " + RAFT_REQUIRED);
+        """
+            Adds a peer to the Raft configuration, then seeds it with the three security documents \
+            (server-users.jsonl, server-groups.json, server-api-tokens.json) that a Raft snapshot install does \
+            not carry.
+
+            A 503 means the membership change succeeded and at least one of those seeds did not commit within \
+            arcadedb.ha.securitySeedRetryTimeout: the peer IS a cluster member and serves requests against its \
+            own copy of the documents that failed, which are named in 'failedSeeds'. Re-POST the same peer to \
+            reissue the seed - the membership change is idempotent. """ + RAFT_REQUIRED);
     post.setRequestBody(SpecBuilders.jsonBody("Peer to add", "AddPeerRequest", true));
     post.setResponses(SpecBuilders.standardResponses("200",
-        SpecBuilders.jsonResponse("Peer added", "ClusterActionResponse"),
-        "400", "401", "403", "500"));
+        SpecBuilders.jsonResponse("Peer added and seeded", "ClusterActionResponse"),
+        "400", "401", "403", "500", "503"));
 
     final PathItem pathItem = new PathItem();
     pathItem.setPost(post);

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -77,6 +77,12 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
   private static final SecureRandom                    RANDOM               = new SecureRandom();
   public static final  int                             SALT_SIZE            = 32;
 
+  // Backoff bounds for the seed retry of issue #7521. Short first wait, because the common failure is an
+  // election in flight that settles in well under a second; capped so a longer operator-configured budget
+  // becomes more attempts rather than one very long sleep at the end.
+  static final long SEED_RETRY_INITIAL_BACKOFF_MS = 250L;
+  static final long SEED_RETRY_MAX_BACKOFF_MS     = 1000L;
+
   // Reused per thread so the Basic-auth hot path avoids a getInstance provider lookup on every call.
   private static final ThreadLocal<MessageDigest>      SHA256_DIGEST        = ThreadLocal.withInitial(() -> {
     try {
@@ -1120,19 +1126,77 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
    * Each document is seeded under its own acquisition rather than all three under one, so an unrelated user
    * change is not blocked for three consecutive Raft round trips. Each is best-effort and independent: the
    * failures are collected and returned rather than thrown, so one failing seed does not skip the other two.
+   * <p>
+   * This form makes one attempt per document. An admission path wants
+   * {@link #seedSecurityStateClusterWide(long)} instead, which retries the ones that failed (issue #7521).
    *
    * @return the names of the documents that could not be seeded, empty when all three were submitted
    */
   public List<String> seedSecurityStateClusterWide() {
+    return seedSecurityStateClusterWide(0L);
+  }
+
+  /**
+   * {@link #seedSecurityStateClusterWide()} with a time budget for retrying the documents that failed (issue
+   * #7521).
+   * <p>
+   * A single best-effort attempt is the wrong shape for this failure. {@code replicateSecurity*} submits a Raft
+   * entry and waits for it to commit, so the usual way it fails is that there is no quorum <i>at this instant</i>
+   * - which is both transient and exactly the condition that makes an {@code addPeer} interesting in the first
+   * place. Retrying costs one admin call a few seconds; not retrying leaves a peer that is already a cluster
+   * member serving requests against whatever its own config directory holds.
+   * <p>
+   * Only the documents that failed are retried, and each retry re-reads the document under the monitor rather
+   * than resubmitting the payload read on the first attempt: a revocation that commits between two attempts must
+   * not be undone by the next one, which is the whole reason the read happens under the monitor at all.
+   * <p>
+   * Sleeping is done with an exponential backoff capped at {@value #SEED_RETRY_MAX_BACKOFF_MS} ms and never past
+   * the deadline. An interrupt ends the retrying immediately, restores the interrupt flag and reports whatever is
+   * still failing - a caller being torn down must not be held here.
+   *
+   * @param retryBudgetMs how long to keep retrying the failing documents; {@code 0} (or less) is the single
+   *                      best-effort attempt {@link #seedSecurityStateClusterWide()} makes
+   *
+   * @return the names of the documents that could not be seeded, empty when all three were submitted
+   */
+  public List<String> seedSecurityStateClusterWide(final long retryBudgetMs) {
     final HAServerPlugin ha = server != null ? server.getHA() : null;
     if (ha == null)
       return List.of();
 
-    final List<String> failed = new ArrayList<>(3);
-    seed(failed, "users", () -> seedUsersClusterWide(ha));
-    seed(failed, "groups", () -> seedGroupsClusterWide(ha));
-    seed(failed, "API tokens", () -> seedApiTokensClusterWide(ha));
-    return failed;
+    // Insertion-ordered so the reported failures always read users, groups, API tokens, whichever of them failed.
+    final Map<String, Runnable> pending = new LinkedHashMap<>(4);
+    pending.put("users", () -> seedUsersClusterWide(ha));
+    pending.put("groups", () -> seedGroupsClusterWide(ha));
+    pending.put("API tokens", () -> seedApiTokensClusterWide(ha));
+
+    final long deadline = System.currentTimeMillis() + Math.max(0L, retryBudgetMs);
+    long backoffMs = SEED_RETRY_INITIAL_BACKOFF_MS;
+
+    while (true) {
+      final List<String> failed = new ArrayList<>(pending.size());
+      for (final Map.Entry<String, Runnable> document : pending.entrySet())
+        seed(failed, document.getKey(), document.getValue());
+
+      if (failed.isEmpty())
+        return List.of();
+
+      final long remainingMs = deadline - System.currentTimeMillis();
+      if (remainingMs <= 0)
+        return failed;
+
+      // Retry only what failed: a document that committed must not be resubmitted, and resubmitting it would
+      // also re-read it, widening the window in which a concurrent revocation is overwritten by a stale read.
+      pending.keySet().retainAll(failed);
+
+      try {
+        Thread.sleep(Math.min(backoffMs, remainingMs));
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return failed;
+      }
+      backoffMs = Math.min(backoffMs * 2, SEED_RETRY_MAX_BACKOFF_MS);
+    }
   }
 
   private void seed(final List<String> failed, final String what, final Runnable seeding) {

--- a/server/src/test/java/com/arcadedb/server/security/Issue7521SecuritySeedRetryTest.java
+++ b/server/src/test/java/com/arcadedb/server/security/Issue7521SecuritySeedRetryTest.java
@@ -1,0 +1,441 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.HAServerPlugin;
+import com.arcadedb.server.ServerControlPlane;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7521: a peer whose security seed failed was admitted and served traffic with its
+ * own stale credentials.
+ * <p>
+ * An admission seeds the joining peer with {@code server-users.jsonl}, {@code server-groups.json} and
+ * {@code server-api-tokens.json}, none of which a Raft snapshot install carries. That seed used to be a single
+ * best-effort attempt. {@code replicateSecurity*} submits a Raft entry and waits for it to commit, so the way
+ * it usually fails is that there is no quorum <i>at this instant</i> - which is transient, and is the same
+ * condition that makes an {@code addPeer} interesting in the first place. One attempt against a transient
+ * failure leaves a committed cluster member running on whatever its own config directory holds: for a node
+ * re-added after time out of the cluster, a user dropped since, a group narrowed since, or a token revoked
+ * since is still good on that one node.
+ * <p>
+ * Two halves are pinned here: {@link ServerSecurity#seedSecurityStateClusterWide(long)}, which retries within
+ * a bounded budget, and {@link ServerControlPlane#connectCluster}, the second admission entry point - it
+ * seeded the users document alone, and read it outside the security monitor, which is exactly the window
+ * #7373 closed on the add-peer route.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue7521SecuritySeedRetryTest {
+
+  private static final String CONFIG_PATH = "target/test-security-7521";
+
+  /** Long enough for several backoff rounds, short enough that a test that must exhaust it stays quick. */
+  private static final long   BUDGET_MS   = 1_500L;
+
+  private FixtureServer      server;
+  private ServerSecurity     security;
+  private ServerControlPlane controlPlane;
+
+  @BeforeEach
+  void setUp() {
+    GlobalConfiguration.SERVER_SECURITY_SALT_ITERATIONS.setValue(1000);
+    GlobalConfiguration.HA_SECURITY_SEED_RETRY_TIMEOUT.setValue(BUDGET_MS);
+
+    final File dir = new File(CONFIG_PATH);
+    if (dir.exists())
+      FileUtils.deleteRecursively(dir);
+    assertThat(dir.mkdirs()).isTrue();
+
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.SERVER_ROOT_PATH, "./target");
+
+    server = new FixtureServer(configuration);
+    security = new ServerSecurity(server, configuration, CONFIG_PATH);
+    server.setSecurity(security);
+    controlPlane = new ServerControlPlane(server);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (security != null)
+      security.stopService();
+    GlobalConfiguration.SERVER_SECURITY_SALT_ITERATIONS.reset();
+    GlobalConfiguration.HA_SECURITY_SEED_RETRY_TIMEOUT.reset();
+    FileUtils.deleteRecursively(new File(CONFIG_PATH));
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // The retry itself
+  // -------------------------------------------------------------------------------------------
+
+  /** The failure the retry exists for: no quorum for a moment, then there is one. */
+  @Test
+  void aSeedThatFailsAndThenSucceedsWithinTheBudgetIsNotReportedAsAFailure() {
+    final SeedingHAPlugin ha = new SeedingHAPlugin();
+    ha.failUsersForFirstAttempts = 2;
+    server.setHA(ha);
+
+    assertThat(security.seedSecurityStateClusterWide(BUDGET_MS))
+        .as("a transient absence of quorum must not leave the peer running on its own documents")
+        .isEmpty();
+
+    assertThat(ha.userDocuments).as("the users document did eventually commit").hasSize(1);
+  }
+
+  /**
+   * A budget that expires with the document still not committed is reported, not swallowed. The caller turns
+   * that list into the operator's remediation, so it has to name the documents rather than merely be non-empty.
+   */
+  @Test
+  void aSeedThatNeverCommitsIsReportedOnceTheBudgetIsSpent() {
+    final SeedingHAPlugin ha = new SeedingHAPlugin();
+    ha.failUsersForFirstAttempts = Integer.MAX_VALUE;
+    server.setHA(ha);
+
+    assertThat(security.seedSecurityStateClusterWide(BUDGET_MS)).containsExactly("users");
+    assertThat(ha.usersAttempts.get()).as("it was retried, not attempted once").isGreaterThan(1);
+  }
+
+  /**
+   * A document that committed must not be resubmitted by a later round. Resubmitting it would also re-read it,
+   * and every extra read of a whole document is another chance to overwrite a revocation that committed in the
+   * meantime - the failure mode #7373 closed.
+   */
+  @Test
+  void onlyTheDocumentsThatFailedAreRetried() {
+    final SeedingHAPlugin ha = new SeedingHAPlugin();
+    ha.failUsersForFirstAttempts = Integer.MAX_VALUE;
+    server.setHA(ha);
+
+    security.seedSecurityStateClusterWide(BUDGET_MS);
+
+    assertThat(ha.usersAttempts.get()).isGreaterThan(1);
+    assertThat(ha.groupDocuments).as("the group document committed on the first round and is left alone").hasSize(1);
+    assertThat(ha.apiTokenDocuments).as("the token document committed on the first round too").hasSize(1);
+  }
+
+  /**
+   * Each retry re-reads the document under the security monitor rather than resubmitting the payload the first
+   * attempt read. Otherwise a revocation that commits between two attempts is undone cluster-wide by the next
+   * one - the seed carries a whole document - which is the bug arriving through the door meant to fix it.
+   * <p>
+   * Driven by having the failing submit revoke the token before it throws, which stands in for a revocation
+   * landing in that window.
+   */
+  @Test
+  void aRetryRereadsTheDocumentInsteadOfResubmittingTheFirstPayload() {
+    final JSONObject created = controlPlane.createApiToken("ci", "*", 0, new JSONObject());
+    final String hash = created.getString("tokenHash");
+
+    final SeedingHAPlugin ha = new SeedingHAPlugin() {
+      @Override
+      public void replicateSecurityApiTokens(final String apiTokensJson) {
+        if (apiTokenAttempts.incrementAndGet() == 1) {
+          // A revocation commits in the window between this attempt and the next one.
+          security.getApiTokenConfiguration().deleteToken(hash);
+          throw new IllegalStateException("no quorum right now");
+        }
+        apiTokenDocuments.add(apiTokensJson);
+      }
+    };
+    server.setHA(ha);
+
+    assertThat(security.seedSecurityStateClusterWide(BUDGET_MS)).isEmpty();
+
+    assertThat(ha.apiTokenDocuments).hasSize(1);
+    assertThat(ha.apiTokenDocuments.getFirst())
+        .as("the retry must not resurrect a token revoked between the two attempts")
+        .doesNotContain(hash);
+  }
+
+  /** The no-argument form is still the single best-effort attempt its callers were written against. */
+  @Test
+  void theNoArgumentFormStillMakesExactlyOneAttemptPerDocument() {
+    final SeedingHAPlugin ha = new SeedingHAPlugin();
+    ha.failUsersForFirstAttempts = Integer.MAX_VALUE;
+    server.setHA(ha);
+
+    assertThat(security.seedSecurityStateClusterWide()).containsExactly("users");
+    assertThat(ha.usersAttempts.get()).isEqualTo(1);
+  }
+
+  /**
+   * A budget of zero is the same single attempt, so an operator who sets
+   * {@code arcadedb.ha.securitySeedRetryTimeout=0} gets the old behaviour rather than an unbounded loop.
+   */
+  @Test
+  void aZeroBudgetDisablesTheRetryRatherThanLoopingForever() {
+    final SeedingHAPlugin ha = new SeedingHAPlugin();
+    ha.failUsersForFirstAttempts = Integer.MAX_VALUE;
+    server.setHA(ha);
+
+    assertThat(security.seedSecurityStateClusterWide(0L)).containsExactly("users");
+    assertThat(ha.usersAttempts.get()).isEqualTo(1);
+  }
+
+  /**
+   * An interrupt ends the retrying at once, reports what is still failing and leaves the flag set. A server
+   * being torn down must not be held in the backoff, and swallowing the interrupt would strand the shutdown.
+   */
+  @Test
+  void anInterruptEndsTheRetryAndLeavesTheFlagSet() throws Exception {
+    final SeedingHAPlugin ha = new SeedingHAPlugin();
+    ha.failUsersForFirstAttempts = Integer.MAX_VALUE;
+    server.setHA(ha);
+
+    final List<String> failed = new ArrayList<>();
+    final boolean[] interruptFlagStillSet = new boolean[1];
+
+    // A very large budget: only the interrupt can end this, so a return proves the interrupt ended it.
+    final Thread worker = new Thread(() -> {
+      failed.addAll(security.seedSecurityStateClusterWide(Long.MAX_VALUE / 4));
+      interruptFlagStillSet[0] = Thread.currentThread().isInterrupted();
+    });
+    worker.start();
+
+    // Wait until it is actually retrying before interrupting, so the interrupt lands in the backoff.
+    while (ha.usersAttempts.get() < 2 && worker.isAlive())
+      Thread.onSpinWait();
+    worker.interrupt();
+    worker.join(30_000);
+
+    assertThat(worker.isAlive()).as("the interrupt must end the retry, not be swallowed").isFalse();
+    assertThat(failed).containsExactly("users");
+    assertThat(interruptFlagStillSet[0]).as("the interrupt flag is restored for the caller").isTrue();
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // connect cluster: the second admission entry point
+  // -------------------------------------------------------------------------------------------
+
+  /**
+   * {@code connect cluster} seeded the users document and nothing else, so a peer joined through this verb got
+   * neither the group document nor the token store that #7373 made cluster-wide - it kept its own, which for a
+   * re-added node still holds the groups and tokens it had when it left.
+   */
+  @Test
+  void connectClusterSeedsAllThreeSecurityDocumentsAndNotOnlyUsers() {
+    final SeedingHAPlugin ha = new SeedingHAPlugin();
+    server.setHA(ha);
+
+    controlPlane.connectCluster("db2:2435");
+
+    assertThat(ha.userDocuments).as("users").hasSize(1);
+    assertThat(ha.groupDocuments).as("groups were never seeded by this verb").hasSize(1);
+    assertThat(ha.apiTokenDocuments).as("API tokens were never seeded by this verb").hasSize(1);
+  }
+
+  /**
+   * And each attempt re-reads the document rather than resubmitting a payload read once up front. It used to
+   * call {@code getUsersJsonPayload()} directly - whose javadoc has always said the caller must hold the
+   * security monitor - so a revocation committing between the read and the submit was undone on every node by
+   * the seed, which carries a whole document.
+   * <p>
+   * Driven by having the failing submit revoke the token before it throws, which stands in for a revocation
+   * landing in that window. A payload captured before the first attempt would still carry the revoked token.
+   */
+  @Test
+  void connectClusterRereadsTheSeededDocumentsOnEachAttempt() {
+    final JSONObject created = controlPlane.createApiToken("ci", "*", 0, new JSONObject());
+    final String hash = created.getString("tokenHash");
+
+    final SeedingHAPlugin ha = new SeedingHAPlugin() {
+      @Override
+      public void replicateSecurityApiTokens(final String apiTokensJson) {
+        if (apiTokenAttempts.incrementAndGet() == 1) {
+          security.getApiTokenConfiguration().deleteToken(hash);
+          throw new IllegalStateException("no quorum right now");
+        }
+        apiTokenDocuments.add(apiTokensJson);
+      }
+    };
+    server.setHA(ha);
+
+    controlPlane.connectCluster("db2:2435");
+
+    assertThat(ha.apiTokenDocuments).hasSize(1);
+    assertThat(ha.apiTokenDocuments.getFirst())
+        .as("the seed must not resurrect the revoked token on the joining peer")
+        .doesNotContain(hash);
+  }
+
+  /**
+   * The join is not rolled back by a failing seed, and must not be reported as failed either: the peer is
+   * already a committed member, and a caller that retried the join would be retrying something that happened.
+   * That contract predates this issue (#7401) and the retry must not change it.
+   */
+  @Test
+  void connectClusterStillDoesNotFailTheJoinWhenASeedNeverCommits() {
+    final SeedingHAPlugin ha = new SeedingHAPlugin();
+    ha.failUsersForFirstAttempts = Integer.MAX_VALUE;
+    server.setHA(ha);
+
+    controlPlane.connectCluster("db2:2435");
+
+    assertThat(ha.connectedAddress).isEqualTo("db2:2435");
+    assertThat(ha.usersAttempts.get()).as("and it did retry before giving up").isGreaterThan(1);
+  }
+
+  /**
+   * Nothing raised on the way to or around the seed may escape as a failed join either, not only a per-document
+   * failure the seed itself collects. By the time the seed runs the peer is a committed member, and a caller
+   * that saw a failure would retry a join that already happened - which is the contract the bare
+   * {@code try/catch} around the old users-only seed was really holding, and the reason the new call keeps one.
+   * <p>
+   * Driven with a server that has no security store at all, the one realistic way the call itself blows up.
+   */
+  @Test
+  void connectClusterSurvivesASeedThatCannotRunAtAll() {
+    final SeedingHAPlugin ha = new SeedingHAPlugin();
+    server.setHA(ha);
+    server.setSecurity(null);
+
+    controlPlane.connectCluster("db2:2435");
+
+    assertThat(ha.connectedAddress).as("the join must stand whatever the seed did").isEqualTo("db2:2435");
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Fixtures
+  // -------------------------------------------------------------------------------------------
+
+  /**
+   * Stands in for the Raft round trip: records each submitted document, optionally failing the users one for a
+   * configurable number of attempts, which is what an absent quorum looks like from here.
+   */
+  private static class SeedingHAPlugin implements HAServerPlugin {
+    final List<String>  userDocuments           = new ArrayList<>();
+    final List<String>  groupDocuments          = new ArrayList<>();
+    final List<String>  apiTokenDocuments       = new ArrayList<>();
+    final AtomicInteger usersAttempts           = new AtomicInteger();
+    final AtomicInteger apiTokenAttempts        = new AtomicInteger();
+    volatile int        failUsersForFirstAttempts;
+    volatile String     connectedAddress;
+
+    @Override
+    public void connectCluster(final String serverAddress) {
+      connectedAddress = serverAddress;
+    }
+
+    @Override
+    public void replicateSecurityUsers(final String usersJsonArray) {
+      if (usersAttempts.incrementAndGet() <= failUsersForFirstAttempts)
+        throw new IllegalStateException("no quorum right now");
+      userDocuments.add(usersJsonArray);
+    }
+
+    @Override
+    public void replicateSecurityGroups(final String groupsJson) {
+      groupDocuments.add(groupsJson);
+    }
+
+    @Override
+    public void replicateSecurityApiTokens(final String apiTokensJson) {
+      apiTokenAttempts.incrementAndGet();
+      apiTokenDocuments.add(apiTokensJson);
+    }
+
+    @Override
+    public ELECTION_STATUS getElectionStatus() {
+      return ELECTION_STATUS.DONE;
+    }
+
+    @Override
+    public void startService() {
+    }
+
+    @Override
+    public boolean isLeader() {
+      return true;
+    }
+
+    @Override
+    public String getLeaderName() {
+      return "leader";
+    }
+
+    @Override
+    public String getClusterName() {
+      return "test";
+    }
+
+    @Override
+    public Map<String, Object> getStats() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public int getConfiguredServers() {
+      return 3;
+    }
+
+    @Override
+    public String getLeaderAddress() {
+      return null;
+    }
+
+    @Override
+    public String getReplicaAddresses() {
+      return "";
+    }
+
+    @Override
+    public void shutdownRemoteServer(final String serverName) {
+    }
+
+    @Override
+    public void disconnectCluster() {
+    }
+  }
+
+  /** An {@link ArcadeDBServer} that is never started, so the security store can be supplied by the fixture. */
+  private static final class FixtureServer extends ArcadeDBServer {
+    private ServerSecurity security;
+
+    private FixtureServer(final ContextConfiguration configuration) {
+      super(configuration);
+    }
+
+    private void setSecurity(final ServerSecurity security) {
+      this.security = security;
+    }
+
+    @Override
+    public ServerSecurity getSecurity() {
+      return security;
+    }
+  }
+}

--- a/studio/src/main/resources/static/js/studio-cluster.js
+++ b/studio/src/main/resources/static/js/studio-cluster.js
@@ -677,7 +677,13 @@ function addPeerPrompt() {
       globalNotify("Success", "Peer " + peerId + " added", "success");
       updateCluster();
     })
-    .fail(function(jqXHR) { globalNotifyError(jqXHR.responseText); });
+    .fail(function(jqXHR) {
+      globalNotifyError(jqXHR.responseText);
+      // 503 means the membership change succeeded and a security document did not reach the new peer
+      // (issue #7521). The peer IS a member, so the cluster view has to be refreshed even though the
+      // call failed - otherwise the operator is told about an error and shown a topology without it.
+      if (jqXHR.status == 503) updateCluster();
+    });
   });
 }
 


### PR DESCRIPTION
Closes #7521

## Summary

`PostAddPeerHandler` admits the peer, then seeds it with the three security documents a Raft snapshot install
does not carry - `server-users.jsonl`, `server-groups.json`, `server-api-tokens.json`, all under
`<server-root>/config/`. That seed was a **single best-effort attempt**, and a failure was reported as HTTP
**200** with a `warning` field. `replicateSecurity*` is `groupCommitter.submitAndWait(...)`, so the way it
usually fails is that there is no quorum *at this instant* - transient, and the same condition that makes an
`addPeer` interesting in the first place. The result was a committed cluster member serving requests against
its own config directory, while the operator's join automation - which reads the status code - recorded a
clean admission. For a node re-added after time out of the cluster, that directory can still hold a user
dropped since, a group narrowed since, or **a token revoked since**.

This PR takes the first of the two shapes #7521 proposed: retry the seed with a bounded backoff before the
handler returns, and report a hard failure when it does not land. `seedSecurityStateClusterWide(long)` retries
only the documents that failed, inside a wall-clock budget (`arcadedb.ha.securitySeedRetryTimeout`, default
3 s, `0` restores the old single attempt), re-reading each under the security monitor so a revocation that
commits between two attempts is not undone by the next one. The add-peer route answers **503** with
`error`/`detail` and a machine-readable `failedSeeds` array; the membership change is deliberately *not* rolled
back (the peer is already a committed member) and the body still reports it as added, because re-POSTing the
same peer is idempotent and reissues the seed.

The completeness sweep turned up a sibling the report did not name: **`ServerControlPlane.connectCluster`
seeded the users document alone** - it never grew the groups and API-token half #7373 gave the add-peer route -
**and it read that payload outside the security monitor**, which is exactly the window #7373 closed on the
other route. It now goes through the same call. It still cannot fail the join: that contract predates this
issue (#7401) and is pinned by an existing test.

## Test plan

- [ ] `mvn -pl server test -Dtest='com.arcadedb.server.security.*Test,com.arcadedb.server.http.handler.openapi.*Test,com.arcadedb.server.*Test'` - 333 tests, green
- [ ] `mvn -pl ha-raft test -Dtest='Issue7521AddPeerSeedFailureIsReportedTest,HAConfigDefaultsTest,Issue7401JoinPriorityTest,ConfigValidationTest'` - green
- [ ] `mvn -pl engine test -Dtest='Issue7124BooleanSettingStrictCoercionTest,Issue7163DatabaseScopeCallbackTest,GlobalConfigurationTest'` - green
- [ ] The two new classes were shown to go **red** against the pre-fix code, by reverting the production
      behaviour in place and re-running: 8 of 10 in `Issue7521SecuritySeedRetryTest` (the 2 that stay green
      pin the single-attempt contract, which holds before and after), and
      `anAdmissionWhoseSeedDidNotCommitIsNotReportedAsSuccess` in the ha-raft class.
- [ ] Manual, on a 3-node cluster: stop two followers so the leader loses quorum, `POST /api/v1/cluster/peer`,
      confirm the call spends the budget and answers 503 naming all three documents in `failedSeeds`; bring a
      follower back, re-POST the same peer, confirm 200 and that the new peer holds the current users, groups
      and tokens.
- [ ] Studio: the add-peer dialog on a 503 shows the summary as the notification title with the remediation as
      its body, and the cluster table still refreshes to show the new member.

`DynamicMembershipTest` and the `*IT` classes in both modules were **not** run: another agent on this machine
holds ports 2434 and 2480, so they fail to bind (`java.net.BindException` on `0.0.0.0:2434`). Neither touches
the seeding code.

## Coverage

| Entry point | Status |
|---|---|
| `POST /api/v1/cluster/peer` -> `PostAddPeerHandler` | fixed - bounded retry; residual failure is 503 with `failedSeeds`, not 200 with a `warning` |
| `connect cluster` (HTTP `POST /api/v1/server`, gRPC `ConnectCluster`) -> `ServerControlPlane.connectCluster` | fixed - all three documents, under the monitor, same retry |
| `ServerSecurity.seedSecurityStateClusterWide` (the mechanism both routes share) | fixed - retries only what failed, re-reads under the monitor, capped backoff, interrupt-aware |
| `RemoteGrpcServer.connectCluster`, `ArcadeDbGrpcAdminService`, `PostServerCommandHandler` | transports onto `ServerControlPlane.connectCluster`; they add no seeding of their own (verified by grep, in the tracking doc) |

### Known gaps

Both filed before this PR opened:

- **#7531** - a Kubernetes StatefulSet scale-up pod self-joins via `KubernetesAutoJoin`, so there is no
  admitting node and **nobody seeds it at all**. Verified:
  `grep -n "replicateSecurity\|seedSecurity\|addPeer" KubernetesAutoJoin.java` returns no matches. Out of scope
  here because this fix is on the admitting node's side of an admission, and a self-join has no such side.
- **#7532** - the readiness half, which #7521 named as its second option. Two things survive: the seed is
  submitted *after* the membership change (pinned by an existing #7401 test), so a peer can catch up and report
  READY before the first attempt is even made; and `connect cluster` returns `void` with an existing contract
  forbidding a failed seed from failing the join, so on that verb the failure reaches the operator only as a
  SEVERE log line. Deferred because it is a readiness-contract change needing a deadlock answer, and because
  #7521 itself noted it composes with the rolling-upgrade gate #7511 would need.

## Notes

- `POST /api/v1/cluster/peer` answering 503 where it used to answer 200 is an intentional behaviour change;
  it is documented in the OpenAPI spec for that route.
- `arcadedb.ha.securitySeedRetryTimeout=0` restores the previous single-attempt behaviour exactly.
- Full analysis, the sweep commands with their output, the coverage table and the adversarial pass are in
  `docs/7521-addpeer-security-seed-readiness.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEJXCdUGW61QSXqyurphpt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Security data is now synchronized to newly joined HA peers with bounded retries.
  - Synchronization covers users, groups, and API tokens.
  - Added configuration for controlling the retry timeout.

- **Bug Fixes**
  - Failed synchronization now returns HTTP 503 with affected items clearly identified.
  - Cluster membership remains visible even when synchronization fails.
  - The Studio cluster view refreshes after reported synchronization failures.

- **Documentation**
  - Updated API documentation with synchronization behavior, error responses, and retry guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->