### PR TITLE
fix(#7509): compare-and-set a replicated security document so a concurrent change on another node is not lost

### DIFF
--- a/docs/7509-ha-replicated-security-document-cas.md
+++ b/docs/7509-ha-replicated-security-document-cas.md
@@ -1,0 +1,129 @@
+# #7509 - a replicated security document is read-modify-write, so a concurrent admin change on another node is lost
+
+## The defect
+
+All three replicated security documents - the user list (`SECURITY_USERS_ENTRY`), the group document
+(`SECURITY_GROUPS_ENTRY`) and the API-token document (`SECURITY_API_TOKENS_ENTRY`) - are replicated as the
+**whole document**: the submitter reads the current one, mutates a copy, and submits the result.
+
+`ServerSecurity.createUserClusterWide` serialises that read-compute-submit sequence with
+`synchronized (this)`. That monitor is per-node. Node B doing the same thing at the same time builds its
+payload from its own view; Raft linearises the two entries and the second one carries a document that was
+built without the first one in it. The first change is reverted on every node, including the one that
+accepted it and answered 200.
+
+## Root cause
+
+There is no conditional apply. Every `SECURITY_*_ENTRY` is applied unconditionally, so the last writer of the
+log wins whatever it happened to read.
+
+## The invariant the fix establishes
+
+> A replicated security document entry that was built from version V of that document is applied only when
+> every node's current version of that document is still V; otherwise nothing is installed anywhere and the
+> submitter is told, so a concurrent change made on another node can never be silently overwritten.
+
+## Completeness
+
+### Entry points that submit a replicated security document
+
+```
+$ grep -rn --include='*.java' "replicateSecurityUsers(\|replicateSecurityGroups(\|replicateSecurityApiTokens(" . | grep "/src/main/"
+ha-raft/.../RaftTransactionBroker.java:441,449,457     (transport)
+ha-raft/.../RaftHAPlugin.java:204,209,219,224,234,239  (transport)
+server/.../HAServerPlugin.java:308,323,338             (interface)
+server/.../ServerSecurity.java:422   createUserClusterWide
+server/.../ServerSecurity.java:448   updateUserClusterWide
+server/.../ServerSecurity.java:475   dropUserClusterWide
+server/.../ServerSecurity.java:1024  saveGroupClusterWide
+server/.../ServerSecurity.java:1043  deleteGroupClusterWide
+server/.../ServerSecurity.java:1151  seedUsersClusterWide        (seed)
+server/.../ServerSecurity.java:1158  seedGroupsClusterWide       (seed)
+server/.../ServerSecurity.java:1165  seedApiTokensClusterWide    (seed)
+server/.../ServerSecurity.java:1187  createApiTokenClusterWide
+server/.../ServerSecurity.java:1208  deleteApiTokenClusterWide
+server/.../ServerControlPlane.java:226 connectCluster users seed  <-- reads OUTSIDE the monitor, seeds users only
+```
+
+### Apply sites
+
+```
+$ grep -rn --include='*.java' "applyReplicatedUsers(\|applyReplicatedGroups(\|applyReplicatedApiTokens(" . | grep "/src/main/"
+ha-raft/.../ArcadeStateMachine.java:3648, 3692, 3723
+server/.../ServerSecurity.java:840, 1067, 1220
+```
+
+### Coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| `ServerSecurity.createUserClusterWide` | yes - CAS on the users version | yes |
+| `ServerSecurity.updateUserClusterWide` | yes | yes |
+| `ServerSecurity.dropUserClusterWide` (also the `SecurityManager.dropUser` / Cypher `DROP USER` door) | yes | yes |
+| `ServerSecurity.saveGroupClusterWide` | yes - CAS on the groups version | yes |
+| `ServerSecurity.deleteGroupClusterWide` | yes | yes |
+| `ServerSecurity.createApiTokenClusterWide` | yes - CAS on the API-token version | yes |
+| `ServerSecurity.deleteApiTokenClusterWide` | yes | yes |
+| `seedUsers/Groups/ApiTokensClusterWide` (peer seeding) | deliberately UNCONDITIONAL, but stamps the new version so every node converges | yes |
+| `ServerControlPlane.connectCluster` users seed | yes - rerouted to `seedSecurityStateClusterWide()`, so it reads under the monitor and seeds all three documents | yes |
+| wire: `SECURITY_*_ENTRY` from a peer that predates the fix (no CAS section) | applies unconditionally, exactly as today | yes (codec test) |
+
+## Design
+
+The version is a **per-document-type monotonic counter that is part of the replicated state**, not something
+derived from the node's local documents. That distinction is the whole safety argument:
+
+- Deriving the check from a digest of the local document would make the accept/reject decision depend on
+  per-node state that can legitimately differ (a node's own `root` password hash before the first seed, a
+  hand-edited group file, the file watcher). Two nodes reaching different decisions on the same committed
+  entry is divergence - the failure #6808 and #7373 exist to prevent - which is strictly worse than the lost
+  update being fixed.
+- A counter that is only ever advanced by an apply is identical on every node that has applied the same
+  prefix of the log, so every node reaches the same verdict on every entry.
+
+The counter has to survive a restart, or a restarted node would disagree with its peers, so it is persisted
+next to the documents in `server-security-versions.json` (absent = 0 on every node, which is what an upgrading
+cluster converges on).
+
+The entry carries `(expectedVersion, newVersion)` in a `RaftLogEntryCodec` **extension section** (the #7138
+forward-compatibility frame), so a peer that predates the fix skips the section and applies unconditionally -
+today's behaviour - rather than halting on an unknown field.
+
+`expectedVersion = -1` means "apply unconditionally" and is what peer seeding submits: a seed must never be
+refused, because the joining peer has nothing yet. It still carries a `newVersion`, so every node ends on the
+same counter.
+
+## Residual risk
+
+- A node whose `server-security-versions.json` write fails (a full or read-only config volume, the #7137
+  condition) keeps the new document in force in memory but reloads a stale counter after a restart, and then
+  disagrees with its peers about the next entry. Filed as a follow-up; see below.
+- Automatic re-read-and-retry on the submitting node is **not** implemented: the conflict surfaces to the
+  caller as an error. The reported failure is that a lost update is *silent*; it no longer is. Filed as a
+  follow-up.
+
+## Adversarial pass
+
+The orchestrator's `Task` tool was not available in this session, so no subagent could be spawned in ignorance of
+the above. The pass was run by hand against the staged diff and the issue body instead; that is weaker, and it is
+recorded here rather than claimed as an isolated review.
+
+| Finding | Disposition |
+|---|---|
+| During a rolling upgrade a peer with #7138 but not #7509 skips the compare-and-set section and applies an entry the upgraded nodes refuse - divergent verdicts on a committed entry | **Real, out of scope.** Filed as #7540 with the interim mitigation. Closing it needs a cluster-wide capability signal the HA layer does not have. |
+| The counter is written to its own file, so a failed write leaves a node that disagrees with its peers after a restart | **Real, out of scope.** Filed as #7536 (it needs a per-document format change, `server-users.jsonl` included). |
+| A conflict is reported to the caller but never re-read and retried | **Real, out of scope.** Filed as #7537. The reported defect is that the lost update was SILENT, and it no longer is. |
+| The submitter reads the document and the counter a moment apart, so it can stamp a version the apply refuses | **Real, fixed here by ordering**: the apply records the counter AFTER installing the document, so the only reachable window is a spurious refusal (costs a retry), never an accepted stale entry. Written into `recordReplicatedSecurityVersion`'s javadoc, because the opposite order silently reintroduces the bug. |
+| `checkReplicatedSecurityVersion` runs before the payload is parsed, so a conflicting entry that is ALSO unreadable is refused instead of halting the node | **Not a defect.** Every node reaches the same verdict - the conflict is decided on the counter, which is identical everywhere - so the unreadable payload is parsed nowhere and diverges nothing. |
+| `recordReplicatedSecurityVersion` does file I/O on the Raft apply thread, which `applyReplicatedUsers` documents as a no-blocking thread | **Not a defect.** That invariant is about not taking the `ServerSecurity` monitor and not waiting on a lock the blocked submitter holds; the apply already writes the document itself on this thread. `SecurityDocumentVersions.saveLock` is taken by nothing but its own writer, and no submitter path calls `record`. The cost is one extra fsync per security entry, on a path that runs when an operator changes a user. |
+| A conflicting `createApiTokenClusterWide` might leave a minted token behind on the serving node | **Not a defect.** `mintToken` builds the document without installing anything; installation happens in the apply. Already pinned by `Issue7373ClusterWideGroupsAndTokensTest.aMintWhoseEntryFailsLeavesNoTokenOnTheServingNode`, which still passes. |
+
+## Tests
+
+- `server`: `Issue7509ReplicatedSecurityDocumentCasTest` - 12 tests, one race per fixed entry point plus the
+  seed, restart and no-versions paths. With the compare-and-set disabled, 7 of the 12 fail - one for each of the
+  seven submitting entry points.
+- `ha-raft`: `Issue7509SecurityEntryCasCodecTest` - 7 tests, the wire round trip plus the two compatibility
+  directions (an entry with no section, and an unknown section that must still be skipped).
+- Regression: `server` 105 tests (the whole `com.arcadedb.server.security` package plus the control-plane
+  tests) and `ha-raft` 96 tests (codec, extension-section, and every security-entry apply test) all pass.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -47,6 +47,9 @@ import com.arcadedb.server.ha.raft.ratis.RatisSnapshotDigestWarningFilter;
 import com.arcadedb.server.security.ApiTokenConfiguration;
 import com.arcadedb.server.security.ReplicatedSecurityConfigPersistenceException;
 import com.arcadedb.server.security.ReplicatedUsersPersistenceException;
+import com.arcadedb.server.security.SecurityDocumentConflictException;
+import com.arcadedb.server.security.SecurityDocumentVersions;
+import com.arcadedb.server.security.SecurityDocumentVersions.Document;
 import com.arcadedb.server.security.SecurityGroupFileRepository;
 import com.arcadedb.server.security.SecurityUserFileRepository;
 import com.arcadedb.utility.FileUtils;
@@ -3638,15 +3641,59 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * can diverge replicated state is a property of the apply, not of the entry's database scoping, so a future
    * node-scoped entry that CAN diverge still reaches the halt it needs.
    */
+  /**
+   * The version the submitter of a security entry built its payload from, or
+   * {@link SecurityDocumentVersions#UNCONDITIONAL} when the entry carries no compare-and-set section at all
+   * (issue #7509) - which is every entry produced by a node that predates the fix. Reading a missing section as
+   * "apply regardless" is what keeps a mixed-version cluster behaving as it did instead of refusing entries no
+   * node can satisfy.
+   */
+  private static long expectedVersionOf(final RaftLogEntryCodec.SecurityCas cas) {
+    return cas != null ? cas.expectedVersion() : SecurityDocumentVersions.UNCONDITIONAL;
+  }
+
+  /** The version a security entry establishes, or {@link SecurityDocumentVersions#NO_VERSION} when it carries none. */
+  private static long newVersionOf(final RaftLogEntryCodec.SecurityCas cas) {
+    return cas != null ? cas.newVersion() : SecurityDocumentVersions.NO_VERSION;
+  }
+
+  /**
+   * Turns a refused security entry into the NON-HALTING failure classification (issue #7509).
+   * <p>
+   * A conflict is not "this node cannot read a committed entry its peers applied" - the case #4798 argues must
+   * reach the node-wide halt. It is the opposite: the node read the entry perfectly well and every other node
+   * reaches the same verdict on it, because the counter compared is advanced only by an apply and so is
+   * identical everywhere the same prefix of the log has been applied. Nothing diverges, nothing is installed,
+   * and the submitter is told so it can re-read and reissue. Halting on it would turn two operators pressing
+   * save in the same second into a downed node.
+   */
+  private ReplicationException securityDocumentConflict(final SecurityDocumentConflictException e,
+      final String documentFileName) {
+    LogManager.instance().log(this, Level.WARNING,
+        "Refused a replicated change to '%s': it was built from version %d and this node is at version %d, so "
+            + "another node changed the same document concurrently. Nothing was installed; the change has to be "
+            + "re-read and reissued", e, documentFileName, e.getExpectedVersion(), e.getCurrentVersion());
+    return new ReplicationException(e.getMessage(), e);
+  }
+
   private void applySecurityUsersEntry(final RaftLogEntryCodec.DecodedEntry decoded) {
     final String payload = decoded.usersJson();
     if (payload == null) {
       LogManager.instance().log(this, Level.WARNING, "SECURITY_USERS_ENTRY has null payload, skipping");
       return;
     }
+    final RaftLogEntryCodec.SecurityCas cas = decoded.securityCas();
+    try {
+      server.getSecurity().checkReplicatedSecurityVersion(Document.USERS, expectedVersionOf(cas));
+    } catch (final SecurityDocumentConflictException e) {
+      throw securityDocumentConflict(e, SecurityUserFileRepository.FILE_NAME);
+    }
     try {
       server.getSecurity().applyReplicatedUsers(payload);
     } catch (final ReplicatedUsersPersistenceException e) {
+      // The list IS in force in memory - that is what #7137 changed - so the counter has to follow it, or this
+      // node would keep comparing against a version it no longer holds and refuse the next entry its peers accept.
+      server.getSecurity().recordReplicatedSecurityVersion(Document.USERS, newVersionOf(cas));
       LogManager.instance().log(this, Level.SEVERE,
           "Could not fully apply a replicated user list on this node: %s. The node keeps running and, when the "
               + "list reached memory, is already enforcing it - but it is not durable: a restart before this is "
@@ -3665,6 +3712,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
     // from applyReplicatedUsers BEFORE any mutation. That is not "the disk is full", it is "this node cannot
     // read a committed entry its peers applied", and it still reaches the node-wide halt - the case #4798
     // argues must never be skipped quietly. Catching RuntimeException here would have downgraded it silently.
+    server.getSecurity().recordReplicatedSecurityVersion(Document.USERS, newVersionOf(cas));
     HALog.log(this, HALog.DETAILED, "Applied SECURITY_USERS_ENTRY (%d bytes)", payload.length());
   }
 
@@ -3688,9 +3736,16 @@ public class ArcadeStateMachine extends BaseStateMachine {
       LogManager.instance().log(this, Level.WARNING, "SECURITY_GROUPS_ENTRY has null payload, skipping");
       return;
     }
+    final RaftLogEntryCodec.SecurityCas cas = decoded.securityCas();
+    try {
+      server.getSecurity().checkReplicatedSecurityVersion(Document.GROUPS, expectedVersionOf(cas));
+    } catch (final SecurityDocumentConflictException e) {
+      throw securityDocumentConflict(e, SecurityGroupFileRepository.FILE_NAME);
+    }
     try {
       server.getSecurity().applyReplicatedGroups(payload);
     } catch (final ReplicatedSecurityConfigPersistenceException e) {
+      server.getSecurity().recordReplicatedSecurityVersion(Document.GROUPS, newVersionOf(cas));
       LogManager.instance().log(this, Level.SEVERE,
           "Could not fully apply a replicated group document on this node: %s. The node keeps running and is "
               + "already authorizing against the new groups - but they are not durable: a restart before this is "
@@ -3701,6 +3756,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
           "Failed to persist the replicated group document locally; the node is already authorizing against the "
               + "new groups in memory, only their durability to disk failed", e);
     }
+    server.getSecurity().recordReplicatedSecurityVersion(Document.GROUPS, newVersionOf(cas));
     HALog.log(this, HALog.DETAILED, "Applied SECURITY_GROUPS_ENTRY (%d bytes)", payload.length());
   }
 
@@ -3719,9 +3775,16 @@ public class ArcadeStateMachine extends BaseStateMachine {
       LogManager.instance().log(this, Level.WARNING, "SECURITY_API_TOKENS_ENTRY has null payload, skipping");
       return;
     }
+    final RaftLogEntryCodec.SecurityCas cas = decoded.securityCas();
+    try {
+      server.getSecurity().checkReplicatedSecurityVersion(Document.API_TOKENS, expectedVersionOf(cas));
+    } catch (final SecurityDocumentConflictException e) {
+      throw securityDocumentConflict(e, ApiTokenConfiguration.FILE_NAME);
+    }
     try {
       server.getSecurity().applyReplicatedApiTokens(payload);
     } catch (final ReplicatedSecurityConfigPersistenceException e) {
+      server.getSecurity().recordReplicatedSecurityVersion(Document.API_TOKENS, newVersionOf(cas));
       LogManager.instance().log(this, Level.SEVERE,
           "Could not fully apply a replicated API-token document on this node: %s. The node keeps running and is "
               + "already enforcing the new token set - a revoked token does NOT authenticate here any more - but it "
@@ -3733,6 +3796,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
           "Failed to persist the replicated API-token document locally; the node is already enforcing the new token "
               + "set in memory, only its durability to disk failed", e);
     }
+    server.getSecurity().recordReplicatedSecurityVersion(Document.API_TOKENS, newVersionOf(cas));
     HALog.log(this, HALog.DETAILED, "Applied SECURITY_API_TOKENS_ENTRY (%d bytes)", payload.length());
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -27,6 +27,7 @@ import com.arcadedb.server.HAServerPlugin;
 import com.arcadedb.server.ServerException;
 import com.arcadedb.server.monitor.HAReplicationStatsProvider;
 import com.arcadedb.server.http.HttpServer;
+import com.arcadedb.server.security.SecurityDocumentVersions;
 
 import io.undertow.server.handlers.PathHandler;
 import org.apache.ratis.protocol.RaftPeerId;
@@ -202,11 +203,16 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
 
   @Override
   public void replicateSecurityUsers(final String usersJsonArray) {
+    replicateSecurityUsers(usersJsonArray, SecurityDocumentVersions.UNCONDITIONAL, SecurityDocumentVersions.NO_VERSION);
+  }
+
+  @Override
+  public void replicateSecurityUsers(final String usersJsonArray, final long expectedVersion, final long newVersion) {
     if (raftHAServer == null)
       throw new TransactionException("Raft HA server not started");
 
     try {
-      raftHAServer.getTransactionBroker().replicateSecurityUsers(usersJsonArray);
+      raftHAServer.getTransactionBroker().replicateSecurityUsers(usersJsonArray, expectedVersion, newVersion);
     } catch (final TransactionException e) {
       throw e;
     } catch (final Exception e) {
@@ -217,11 +223,16 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
 
   @Override
   public void replicateSecurityGroups(final String groupsJson) {
+    replicateSecurityGroups(groupsJson, SecurityDocumentVersions.UNCONDITIONAL, SecurityDocumentVersions.NO_VERSION);
+  }
+
+  @Override
+  public void replicateSecurityGroups(final String groupsJson, final long expectedVersion, final long newVersion) {
     if (raftHAServer == null)
       throw new TransactionException("Raft HA server not started");
 
     try {
-      raftHAServer.getTransactionBroker().replicateSecurityGroups(groupsJson);
+      raftHAServer.getTransactionBroker().replicateSecurityGroups(groupsJson, expectedVersion, newVersion);
     } catch (final TransactionException e) {
       throw e;
     } catch (final Exception e) {
@@ -232,11 +243,18 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
 
   @Override
   public void replicateSecurityApiTokens(final String apiTokensJson) {
+    replicateSecurityApiTokens(apiTokensJson, SecurityDocumentVersions.UNCONDITIONAL,
+        SecurityDocumentVersions.NO_VERSION);
+  }
+
+  @Override
+  public void replicateSecurityApiTokens(final String apiTokensJson, final long expectedVersion,
+      final long newVersion) {
     if (raftHAServer == null)
       throw new TransactionException("Raft HA server not started");
 
     try {
-      raftHAServer.getTransactionBroker().replicateSecurityApiTokens(apiTokensJson);
+      raftHAServer.getTransactionBroker().replicateSecurityApiTokens(apiTokensJson, expectedVersion, newVersion);
     } catch (final TransactionException e) {
       throw e;
     } catch (final Exception e) {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
@@ -20,8 +20,10 @@ package com.arcadedb.server.ha.raft;
 
 import com.arcadedb.compression.CompressionFactory;
 import com.arcadedb.network.binary.ReplicatedEntryTooLargeException;
+import com.arcadedb.server.security.SecurityDocumentVersions;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -133,6 +135,32 @@ public final class RaftLogEntryCodec {
 
   /** Bytes one extension frame spends on its header ({@link #EXTENSION_MAGIC} + length). */
   private static final int EXTENSION_HEADER_BYTES = 8;
+
+  /**
+   * Extension-section id of the compare-and-set versions a node-scoped security entry carries (issue #7509).
+   * ASCII {@code "SCAS"}, so it is recognisable in a hex dump next to {@link #EXTENSION_MAGIC}'s {@code "ADBX"}.
+   * <p>
+   * It rides in an extension section rather than in the entry body precisely because a peer that predates the
+   * fix must not halt on it: {@code SECURITY_USERS_ENTRY} has existed since #6808, so a two-long field appended
+   * to its body would have been read as a length and refused as a corrupt entry - which for a node-scoped entry
+   * is the node-wide halt, on every not-yet-upgraded peer, permanently. Skipped, the entry applies exactly as it
+   * does today.
+   */
+  static final int SECURITY_CAS_SECTION_ID = 0x53434153;
+
+  /** Bytes the {@link #SECURITY_CAS_SECTION_ID} section's payload occupies: the id plus two longs. */
+  private static final int SECURITY_CAS_SECTION_BYTES = 4 + 8 + 8;
+
+  /**
+   * The compare-and-set versions of a node-scoped security entry (issue #7509): the version of the document the
+   * submitter built the payload from, and the version the payload establishes.
+   * <p>
+   * Null on an entry produced by a node that predates the fix, which the applier reads as
+   * {@code (UNCONDITIONAL, NO_VERSION)} - apply regardless, touch no counter - so a mixed-version cluster
+   * behaves exactly as it did before rather than refusing entries nobody can satisfy.
+   */
+  public record SecurityCas(long expectedVersion, long newVersion) {
+  }
 
   /**
    * Appends one self-describing extension section to an entry being encoded. Call this AFTER the type's own
@@ -325,8 +353,37 @@ public final class RaftLogEntryCodec {
        * predates this section, and every entry produced with {@code arcadedb.ha.schemaDelta} off. When it is
        * set, {@code schemaJson} is empty and the applier merges the delta into its own schema instead.
        */
-      SchemaDelta.Payload schemaDelta
+      SchemaDelta.Payload schemaDelta,
+      /**
+       * The compare-and-set versions of a node-scoped security entry (issue #7509). Null on every other entry
+       * type, and on a security entry produced by a node that predates the fix - which the applier reads as
+       * "apply unconditionally and leave the counter alone".
+       */
+      SecurityCas securityCas
   ) {
+    /**
+     * The shape every entry that carries no compare-and-set versions has: everything but {@code securityCas},
+     * which is null (issue #7509). Kept so that adding the component did not change how the other sixteen entry
+     * shapes are built, here or by anything outside this class.
+     */
+    public DecodedEntry(final RaftLogEntryType type, final String databaseName, final byte[] walData,
+        final Map<Integer, Integer> bucketRecordDelta, final String schemaJson, final Map<Integer, String> filesToAdd,
+        final Map<Integer, String> filesToRemove, final List<byte[]> walEntries,
+        final List<Map<Integer, Integer>> bucketDeltas, final String usersJson, final boolean forceSnapshot,
+        final String bootstrapFingerprint, final long bootstrapLastTxId, final List<TsSealedBlob> sealedFileBlobs,
+        final boolean moreChunksFollow, final List<TsSealedChunk> sealedFileChunks,
+        final SchemaDelta.Payload schemaDelta) {
+      this(type, databaseName, walData, bucketRecordDelta, schemaJson, filesToAdd, filesToRemove, walEntries,
+          bucketDeltas, usersJson, forceSnapshot, bootstrapFingerprint, bootstrapLastTxId, sealedFileBlobs,
+          moreChunksFollow, sealedFileChunks, schemaDelta, null);
+    }
+
+    /** This entry with {@code cas} attached, used once the trailing extension sections have been read. */
+    DecodedEntry withSecurityCas(final SecurityCas cas) {
+      return new DecodedEntry(type, databaseName, walData, bucketRecordDelta, schemaJson, filesToAdd, filesToRemove,
+          walEntries, bucketDeltas, usersJson, forceSnapshot, bootstrapFingerprint, bootstrapLastTxId, sealedFileBlobs,
+          moreChunksFollow, sealedFileChunks, schemaDelta, cas);
+    }
   }
 
   /**
@@ -669,7 +726,17 @@ public final class RaftLogEntryCodec {
    * three security entries share.
    */
   public static ByteString encodeSecurityUsersEntry(final String usersJson) {
-    return encodeSecurityEntry(RaftLogEntryType.SECURITY_USERS_ENTRY, usersJson);
+    return encodeSecurityEntry(RaftLogEntryType.SECURITY_USERS_ENTRY, usersJson,
+        SecurityDocumentVersions.UNCONDITIONAL, SecurityDocumentVersions.NO_VERSION);
+  }
+
+  /**
+   * Encodes a security-users entry that carries the compare-and-set versions of issue #7509: the users version
+   * the submitter built the payload from and the version it establishes.
+   */
+  public static ByteString encodeSecurityUsersEntry(final String usersJson, final long expectedVersion,
+      final long newVersion) {
+    return encodeSecurityEntry(RaftLogEntryType.SECURITY_USERS_ENTRY, usersJson, expectedVersion, newVersion);
   }
 
   /**
@@ -677,7 +744,14 @@ public final class RaftLogEntryCodec {
    * Same wire shape as {@link #encodeSecurityUsersEntry}; the type byte is what tells the two apart.
    */
   public static ByteString encodeSecurityGroupsEntry(final String groupsJson) {
-    return encodeSecurityEntry(RaftLogEntryType.SECURITY_GROUPS_ENTRY, groupsJson);
+    return encodeSecurityEntry(RaftLogEntryType.SECURITY_GROUPS_ENTRY, groupsJson,
+        SecurityDocumentVersions.UNCONDITIONAL, SecurityDocumentVersions.NO_VERSION);
+  }
+
+  /** {@link #encodeSecurityUsersEntry(String, long, long)} for the group document (issue #7509). */
+  public static ByteString encodeSecurityGroupsEntry(final String groupsJson, final long expectedVersion,
+      final long newVersion) {
+    return encodeSecurityEntry(RaftLogEntryType.SECURITY_GROUPS_ENTRY, groupsJson, expectedVersion, newVersion);
   }
 
   /**
@@ -685,16 +759,31 @@ public final class RaftLogEntryCodec {
    * (issue #7373). The document carries token hashes, never token material.
    */
   public static ByteString encodeSecurityApiTokensEntry(final String apiTokensJson) {
-    return encodeSecurityEntry(RaftLogEntryType.SECURITY_API_TOKENS_ENTRY, apiTokensJson);
+    return encodeSecurityEntry(RaftLogEntryType.SECURITY_API_TOKENS_ENTRY, apiTokensJson,
+        SecurityDocumentVersions.UNCONDITIONAL, SecurityDocumentVersions.NO_VERSION);
+  }
+
+  /** {@link #encodeSecurityUsersEntry(String, long, long)} for the API-token document (issue #7509). */
+  public static ByteString encodeSecurityApiTokensEntry(final String apiTokensJson, final long expectedVersion,
+      final long newVersion) {
+    return encodeSecurityEntry(RaftLogEntryType.SECURITY_API_TOKENS_ENTRY, apiTokensJson, expectedVersion, newVersion);
   }
 
   /**
    * The shared body of every node-scoped security entry.
    * <p>
-   * Binary format: type byte, empty databaseName (UTF), jsonLength (int), UTF-8 bytes.
+   * Binary format: type byte, empty databaseName (UTF), jsonLength (int), UTF-8 bytes, then the
+   * {@link #SECURITY_CAS_SECTION_ID} extension section carrying the two compare-and-set versions (issue #7509).
    * The empty databaseName slot keeps the decoder symmetric with other entry types.
+   * <p>
+   * The section is written unconditionally, including when both versions are the "no compare-and-set" sentinels:
+   * emitting it only sometimes would mean an entry's shape depended on its content, and a decoder cannot tell an
+   * absent section from one that was dropped. A peer that predates #7138 halts on any trailing frame and so must
+   * not be in the cluster at all by now; one that has #7138 but not this fix skips the section and applies the
+   * entry exactly as it does today.
    */
-  private static ByteString encodeSecurityEntry(final RaftLogEntryType type, final String json) {
+  private static ByteString encodeSecurityEntry(final RaftLogEntryType type, final String json,
+      final long expectedVersion, final long newVersion) {
     try {
       final ByteArrayOutputStream baos = new ByteArrayOutputStream();
       final DataOutputStream dos = new DataOutputStream(baos);
@@ -705,11 +794,25 @@ public final class RaftLogEntryCodec {
       dos.writeInt(bytes.length);
       dos.write(bytes);
 
+      writeExtensionSection(dos, encodeSecurityCasSection(expectedVersion, newVersion));
+
       dos.flush();
       return ByteString.copyFrom(baos.toByteArray());
     } catch (final IOException e) {
       throw new IllegalStateException("Failed to encode " + type + " entry", e);
     }
+  }
+
+  /** The {@link #SECURITY_CAS_SECTION_ID} section's payload: its own id, then the two versions. */
+  private static byte[] encodeSecurityCasSection(final long expectedVersion, final long newVersion)
+      throws IOException {
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream(SECURITY_CAS_SECTION_BYTES);
+    final DataOutputStream dos = new DataOutputStream(baos);
+    dos.writeInt(SECURITY_CAS_SECTION_ID);
+    dos.writeLong(expectedVersion);
+    dos.writeLong(newVersion);
+    dos.flush();
+    return baos.toByteArray();
   }
 
   /**
@@ -776,7 +879,7 @@ public final class RaftLogEntryCodec {
       final RaftLogEntryType type = RaftLogEntryType.fromId(typeByte);
       if (type == null)
         return new DecodedEntry(null, null, null, null, null, null, null, null, null, null, false, null, -1L,
-            Collections.emptyList(), false, Collections.emptyList(), null);
+            Collections.emptyList(), false, Collections.emptyList(), null, null);
       final String databaseName = dis.readUTF();
 
       try {
@@ -811,14 +914,14 @@ public final class RaftLogEntryCodec {
       case INSTALL_DATABASE_ENTRY -> decodeInstallDatabaseEntry(dis, databaseName);
       case DROP_DATABASE_ENTRY -> new DecodedEntry(RaftLogEntryType.DROP_DATABASE_ENTRY, databaseName,
           null, null, null, null, null, null, null, null, false, null, -1L, Collections.emptyList(), false,
-          Collections.emptyList(), null);
+          Collections.emptyList(), null, null);
       case SECURITY_USERS_ENTRY, SECURITY_GROUPS_ENTRY, SECURITY_API_TOKENS_ENTRY -> decodeSecurityEntry(dis, type);
       case BOOTSTRAP_FINGERPRINT_ENTRY -> decodeBootstrapFingerprintEntry(dis, databaseName);
     };
 
-    skipTrailingExtensionSections(dis, type);
+    final SecurityCas cas = readTrailingExtensionSections(dis, type);
 
-    return result;
+    return cas == null ? result : result.withSecurityCas(cas);
   }
 
   /**
@@ -835,11 +938,12 @@ public final class RaftLogEntryCodec {
    * of those sections, so there is nothing left here to frame. It extends through its own mechanism instead; see
    * {@link #EXTENSION_MAGIC}.
    */
-  private static void skipTrailingExtensionSections(final DataInputStream dis, final RaftLogEntryType type)
+  private static SecurityCas readTrailingExtensionSections(final DataInputStream dis, final RaftLogEntryType type)
       throws IOException {
     if (type == RaftLogEntryType.SCHEMA_ENTRY)
-      return;
+      return null;
 
+    SecurityCas cas = null;
     while (dis.available() > 0) {
       if (dis.available() < EXTENSION_HEADER_BYTES)
         throw new IllegalStateException("Corrupted Raft log entry: " + dis.available()
@@ -853,8 +957,32 @@ public final class RaftLogEntryCodec {
 
       final int length = dis.readInt();
       checkByteLength(length, dis.available(), type + " extension section");
-      dis.skipNBytes(length);
+      final byte[] payload = new byte[length];
+      dis.readFully(payload);
+
+      final SecurityCas decoded = decodeSecurityCasSection(payload);
+      if (decoded != null)
+        // Last one wins, deliberately: repeating a section is not a shape any producer emits, and picking the
+        // last is what a reader appending a corrected value would mean. Unknown sections are still skipped.
+        cas = decoded;
     }
+    return cas;
+  }
+
+  /**
+   * Reads a {@link #SECURITY_CAS_SECTION_ID} section, or returns null when the payload is some other extension
+   * section this version does not know - which is the whole point of the framing and must stay a skip, not a
+   * failure (issue #7138).
+   */
+  private static SecurityCas decodeSecurityCasSection(final byte[] payload) throws IOException {
+    if (payload.length != SECURITY_CAS_SECTION_BYTES)
+      return null;
+
+    final DataInputStream dis = new DataInputStream(new ByteArrayInputStream(payload));
+    if (dis.readInt() != SECURITY_CAS_SECTION_ID)
+      return null;
+
+    return new SecurityCas(dis.readLong(), dis.readLong());
   }
 
   private static DecodedEntry decodeTxEntry(final DataInputStream dis, final String databaseName) throws IOException {
@@ -877,7 +1005,7 @@ public final class RaftLogEntryCodec {
 
     return new DecodedEntry(RaftLogEntryType.TX_ENTRY, databaseName, walData, bucketRecordDelta,
         null, null, null, null, null, null, false, null, -1L, Collections.emptyList(), false, Collections.emptyList(),
-        null);
+        null, null);
   }
 
   private static DecodedEntry decodeSchemaEntry(final DataInputStream dis, final String databaseName) throws IOException {
@@ -1032,7 +1160,7 @@ public final class RaftLogEntryCodec {
 
     return new DecodedEntry(RaftLogEntryType.SCHEMA_ENTRY, databaseName, null, null,
         schemaJson, filesToAdd, filesToRemove, walEntries, bucketDeltas, null, false, null, -1L, sealedFileBlobs,
-        moreChunksFollow, sealedFileChunks, schemaDelta);
+        moreChunksFollow, sealedFileChunks, schemaDelta, null);
   }
 
   private static DecodedEntry decodeInstallDatabaseEntry(final DataInputStream dis, final String databaseName) throws IOException {
@@ -1044,7 +1172,7 @@ public final class RaftLogEntryCodec {
     }
     return new DecodedEntry(RaftLogEntryType.INSTALL_DATABASE_ENTRY, databaseName,
         null, null, null, null, null, null, null, null, forceSnapshot, null, -1L, Collections.emptyList(), false,
-        Collections.emptyList(), null);
+        Collections.emptyList(), null, null);
   }
 
   private static DecodedEntry decodeBootstrapFingerprintEntry(final DataInputStream dis, final String databaseName)
@@ -1057,7 +1185,7 @@ public final class RaftLogEntryCodec {
     final long lastTxId = dis.readLong();
     return new DecodedEntry(RaftLogEntryType.BOOTSTRAP_FINGERPRINT_ENTRY, databaseName,
         null, null, null, null, null, null, null, null, false, fingerprint, lastTxId, Collections.emptyList(), false,
-        Collections.emptyList(), null);
+        Collections.emptyList(), null, null);
   }
 
   /**
@@ -1074,7 +1202,7 @@ public final class RaftLogEntryCodec {
     final String json = new String(bytes, StandardCharsets.UTF_8);
     return new DecodedEntry(type, "",
         null, null, null, null, null, null, null, json, false, null, -1L, Collections.emptyList(), false,
-        Collections.emptyList(), null);
+        Collections.emptyList(), null, null);
   }
 
   private static void writeFileMap(final DataOutputStream dos, final Map<Integer, String> fileMap) throws IOException {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftTransactionBroker.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftTransactionBroker.java
@@ -20,6 +20,7 @@ package com.arcadedb.server.ha.raft;
 
 import com.arcadedb.log.LogManager;
 import com.arcadedb.network.binary.ReplicatedEntryTooLargeException;
+import com.arcadedb.server.security.SecurityDocumentVersions;
 import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 
@@ -439,7 +440,15 @@ public class RaftTransactionBroker {
    * Replicates a security users entry so all nodes update their user files.
    */
   public void replicateSecurityUsers(final String usersJson) {
-    final ByteString entry = RaftLogEntryCodec.encodeSecurityUsersEntry(usersJson);
+    replicateSecurityUsers(usersJson, SecurityDocumentVersions.UNCONDITIONAL, SecurityDocumentVersions.NO_VERSION);
+  }
+
+  /**
+   * Replicates a security users entry that carries the compare-and-set versions of issue #7509, so a node whose
+   * user list has moved on refuses the entry instead of installing a document built without its change in it.
+   */
+  public void replicateSecurityUsers(final String usersJson, final long expectedVersion, final long newVersion) {
+    final ByteString entry = RaftLogEntryCodec.encodeSecurityUsersEntry(usersJson, expectedVersion, newVersion);
     groupCommitter.submitAndWait(entry.toByteArray());
   }
 
@@ -447,7 +456,12 @@ public class RaftTransactionBroker {
    * Replicates a security-groups entry so all nodes update their group document (issue #7373).
    */
   public void replicateSecurityGroups(final String groupsJson) {
-    final ByteString entry = RaftLogEntryCodec.encodeSecurityGroupsEntry(groupsJson);
+    replicateSecurityGroups(groupsJson, SecurityDocumentVersions.UNCONDITIONAL, SecurityDocumentVersions.NO_VERSION);
+  }
+
+  /** {@link #replicateSecurityUsers(String, long, long)} for the group document (issue #7509). */
+  public void replicateSecurityGroups(final String groupsJson, final long expectedVersion, final long newVersion) {
+    final ByteString entry = RaftLogEntryCodec.encodeSecurityGroupsEntry(groupsJson, expectedVersion, newVersion);
     groupCommitter.submitAndWait(entry.toByteArray());
   }
 
@@ -455,7 +469,14 @@ public class RaftTransactionBroker {
    * Replicates a security API-tokens entry so all nodes update their token store (issue #7373).
    */
   public void replicateSecurityApiTokens(final String apiTokensJson) {
-    final ByteString entry = RaftLogEntryCodec.encodeSecurityApiTokensEntry(apiTokensJson);
+    replicateSecurityApiTokens(apiTokensJson, SecurityDocumentVersions.UNCONDITIONAL,
+        SecurityDocumentVersions.NO_VERSION);
+  }
+
+  /** {@link #replicateSecurityUsers(String, long, long)} for the API-token document (issue #7509). */
+  public void replicateSecurityApiTokens(final String apiTokensJson, final long expectedVersion,
+      final long newVersion) {
+    final ByteString entry = RaftLogEntryCodec.encodeSecurityApiTokensEntry(apiTokensJson, expectedVersion, newVersion);
     groupCommitter.submitAndWait(entry.toByteArray());
   }
 

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7509SecurityEntryCasCodecTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7509SecurityEntryCasCodecTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.server.security.SecurityDocumentVersions;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The wire half of issue #7509: a node-scoped security entry now carries the version of the document its
+ * submitter read and the version it establishes, so the apply can refuse an entry built from a document that
+ * has since changed on another node.
+ * <p>
+ * The two versions ride in a {@link RaftLogEntryCodec#EXTENSION_MAGIC} extension section (the #7138 frame)
+ * rather than in the entry body, and the tests below pin both directions of that choice: a new entry round
+ * trips its versions, and an entry produced by a node that predates the fix - which carries no section at all -
+ * still decodes, with no versions, which the applier reads as "apply unconditionally".
+ */
+class Issue7509SecurityEntryCasCodecTest {
+
+  @Test
+  void aSecurityUsersEntryRoundTripsItsCompareAndSetVersions() {
+    final String payload = "[{\"name\":\"root\"}]";
+
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(
+        RaftLogEntryCodec.encodeSecurityUsersEntry(payload, 7L, 8L));
+
+    assertThat(decoded.type()).isEqualTo(RaftLogEntryType.SECURITY_USERS_ENTRY);
+    assertThat(decoded.usersJson()).isEqualTo(payload);
+    assertThat(decoded.securityCas()).isNotNull();
+    assertThat(decoded.securityCas().expectedVersion()).isEqualTo(7L);
+    assertThat(decoded.securityCas().newVersion()).isEqualTo(8L);
+  }
+
+  @Test
+  void aSecurityGroupsEntryRoundTripsItsCompareAndSetVersions() {
+    final String payload = "{\"version\":2,\"databases\":{}}";
+
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(
+        RaftLogEntryCodec.encodeSecurityGroupsEntry(payload, 0L, 1L));
+
+    assertThat(decoded.type()).isEqualTo(RaftLogEntryType.SECURITY_GROUPS_ENTRY);
+    assertThat(decoded.usersJson()).isEqualTo(payload);
+    assertThat(decoded.securityCas().expectedVersion()).isZero();
+    assertThat(decoded.securityCas().newVersion()).isEqualTo(1L);
+  }
+
+  @Test
+  void aSecurityApiTokensEntryRoundTripsItsCompareAndSetVersions() {
+    final String payload = "{\"version\":1,\"tokens\":[]}";
+
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(
+        RaftLogEntryCodec.encodeSecurityApiTokensEntry(payload, 3L, 4L));
+
+    assertThat(decoded.type()).isEqualTo(RaftLogEntryType.SECURITY_API_TOKENS_ENTRY);
+    assertThat(decoded.usersJson()).isEqualTo(payload);
+    assertThat(decoded.securityCas().expectedVersion()).isEqualTo(3L);
+    assertThat(decoded.securityCas().newVersion()).isEqualTo(4L);
+  }
+
+  /** A peer seed: applied whatever the receiving node holds, but still stamping the version it establishes. */
+  @Test
+  void anUnconditionalSeedCarriesTheSentinelAndTheVersionItEstablishes() {
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(
+        RaftLogEntryCodec.encodeSecurityUsersEntry("[]", SecurityDocumentVersions.UNCONDITIONAL, 12L));
+
+    assertThat(decoded.securityCas().expectedVersion()).isEqualTo(SecurityDocumentVersions.UNCONDITIONAL);
+    assertThat(decoded.securityCas().newVersion()).isEqualTo(12L);
+  }
+
+  /**
+   * The rolling-upgrade half: an entry a node that predates #7509 wrote carries no section at all. It must still
+   * decode - halting on it would take down every not-yet-upgraded peer - and it must decode with NO versions, so
+   * the applier installs it unconditionally exactly as it does today.
+   */
+  @Test
+  void anEntryFromANodeThatPredatesTheFixDecodesWithNoVersions() throws IOException {
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(
+        legacySecurityEntry(RaftLogEntryType.SECURITY_USERS_ENTRY, "[{\"name\":\"root\"}]"));
+
+    assertThat(decoded.type()).isEqualTo(RaftLogEntryType.SECURITY_USERS_ENTRY);
+    assertThat(decoded.usersJson()).isEqualTo("[{\"name\":\"root\"}]");
+    assertThat(decoded.securityCas())
+        .as("no section means no compare-and-set, which the applier reads as 'apply regardless'")
+        .isNull();
+  }
+
+  /** Every other entry type is unaffected: it carries no security section and decodes with none. */
+  @Test
+  void anEntryOfAnotherTypeCarriesNoCompareAndSetVersions() {
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(
+        RaftLogEntryCodec.encodeDropDatabaseEntry("graph"));
+
+    assertThat(decoded.type()).isEqualTo(RaftLogEntryType.DROP_DATABASE_ENTRY);
+    assertThat(decoded.securityCas()).isNull();
+  }
+
+  /**
+   * A section this version does not know is still skipped rather than mistaken for the compare-and-set one -
+   * the forward compatibility #7138 exists for has to keep working now that something actually reads a section.
+   */
+  @Test
+  void anUnknownExtensionSectionIsSkippedAndDoesNotBecomeTheVersions() {
+    final ByteString withForeignSection = RaftLogEntryCodec.appendExtensionSection(
+        RaftLogEntryCodec.encodeSecurityUsersEntry("[]", 5L, 6L), new byte[] { 1, 2, 3 });
+
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(withForeignSection);
+
+    assertThat(decoded.usersJson()).isEqualTo("[]");
+    assertThat(decoded.securityCas().expectedVersion()).isEqualTo(5L);
+    assertThat(decoded.securityCas().newVersion()).isEqualTo(6L);
+  }
+
+  /** The entry shape a node that predates #7509 produces: no trailing extension section. */
+  private static ByteString legacySecurityEntry(final RaftLogEntryType type, final String json) throws IOException {
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    final DataOutputStream dos = new DataOutputStream(baos);
+    dos.writeByte(type.getId());
+    dos.writeUTF("");
+    final byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+    dos.writeInt(bytes.length);
+    dos.write(bytes);
+    dos.flush();
+    return ByteString.copyFrom(baos.toByteArray());
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
+++ b/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
@@ -18,6 +18,8 @@
  */
 package com.arcadedb.server;
 
+import com.arcadedb.server.security.SecurityDocumentVersions;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -310,6 +312,25 @@ public interface HAServerPlugin extends ServerPlugin {
   }
 
   /**
+   * Conditional form of {@link #replicateSecurityUsers(String)} (issue #7509): the entry carries the version of
+   * the user list the submitter read, and every node installs it only while its own copy is still at that
+   * version. A concurrent change made on another node therefore refuses this entry instead of being silently
+   * reverted by it.
+   * <p>
+   * The default delegates to the unconditional form, which is what an HA implementation that predates the
+   * compare-and-set does: it replicates exactly as before rather than failing to replicate at all.
+   *
+   * @param expectedVersion the users version the payload was built from, or
+   *                        {@link SecurityDocumentVersions#UNCONDITIONAL} to apply whatever the node holds
+   *                        (peer seeding, which must never be refused)
+   * @param newVersion      the version the payload establishes, or {@link SecurityDocumentVersions#NO_VERSION}
+   *                        to leave the counter alone
+   */
+  default void replicateSecurityUsers(final String usersJsonArray, final long expectedVersion, final long newVersion) {
+    replicateSecurityUsers(usersJsonArray);
+  }
+
+  /**
    * Replicates the full {@code server-groups.json} document across the cluster (issue #7373). Called by
    * {@code ServerSecurity.saveGroupClusterWide} / {@code deleteGroupClusterWide}, and by
    * {@code PostAddPeerHandler} to seed newly-joined peers. Default is a no-op for non-HA setups; the Raft
@@ -325,6 +346,15 @@ public interface HAServerPlugin extends ServerPlugin {
   }
 
   /**
+   * Conditional form of {@link #replicateSecurityGroups(String)} (issue #7509). See
+   * {@link #replicateSecurityUsers(String, long, long)} for what the two versions mean and why the default
+   * still replicates.
+   */
+  default void replicateSecurityGroups(final String groupsJson, final long expectedVersion, final long newVersion) {
+    replicateSecurityGroups(groupsJson);
+  }
+
+  /**
    * Replicates the full {@code server-api-tokens.json} document across the cluster (issue #7373). Called by
    * {@code ServerSecurity.createApiTokenClusterWide} / {@code deleteApiTokenClusterWide}, and by
    * {@code PostAddPeerHandler} to seed newly-joined peers. Default is a no-op for non-HA setups; the Raft
@@ -337,5 +367,14 @@ public interface HAServerPlugin extends ServerPlugin {
    */
   default void replicateSecurityApiTokens(final String apiTokensJson) {
     // No-op by default; Raft implementation overrides.
+  }
+
+  /**
+   * Conditional form of {@link #replicateSecurityApiTokens(String)} (issue #7509). See
+   * {@link #replicateSecurityUsers(String, long, long)} for what the two versions mean and why the default
+   * still replicates.
+   */
+  default void replicateSecurityApiTokens(final String apiTokensJson, final long expectedVersion, final long newVersion) {
+    replicateSecurityApiTokens(apiTokensJson);
   }
 }

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -217,17 +217,24 @@ public class ServerControlPlane {
           "Cannot connect '" + serverAddress + "' to the cluster: " + e.getMessage());
     }
 
-    // Seed the newly joined peer with the current users file, exactly as PostAddPeerHandler does after
-    // its own addPeer: server-users.jsonl lives under <server-root>/config/, outside the database
-    // directory, so snapshot install does not cover it and the new peer would run with a stale user set
-    // until the next cluster-wide user mutation. Best-effort, as it is there: the peer is already a
-    // committed member and a failure here does not - and must not - roll that back.
-    try {
-      ha.replicateSecurityUsers(server.getSecurity().getUsersJsonPayload());
-    } catch (final Exception e) {
+    // Seed the newly joined peer with the current security state, exactly as PostAddPeerHandler does after
+    // its own addPeer: server-users.jsonl, server-groups.json and server-api-tokens.json live under
+    // <server-root>/config/, outside the database directory, so snapshot install does not cover any of them and
+    // the new peer would run with a stale security state until the next cluster-wide mutation.
+    //
+    // Through seedSecurityStateClusterWide() rather than a bare replicateSecurityUsers(getUsersJsonPayload()),
+    // which is what this used to be and which was wrong twice over (issue #7509): it read the payload OUTSIDE
+    // the security monitor, so a revocation committing between the read and the submit was undone by the seed
+    // on every node in the cluster, and it seeded the users only - the group and API-token documents #7373
+    // added were left for the next change to carry.
+    //
+    // Best-effort, as it was: the peer is already a committed member and a failure here does not - and must not
+    // - roll that back.
+    final List<String> failedSeeds = server.getSecurity().seedSecurityStateClusterWide();
+    if (!failedSeeds.isEmpty())
       LogManager.instance().log(this, Level.WARNING,
-          "Users seed to '%s' after connect cluster failed (best-effort): %s", serverAddress, e.getMessage());
-    }
+          "Security seed to '%s' after connect cluster did not fully succeed (best-effort); documents not seeded: %s",
+          serverAddress, String.join(", ", failedSeeds));
   }
 
   // ---------------------------------------------------------------------------------------------

--- a/server/src/main/java/com/arcadedb/server/security/SecurityDocumentConflictException.java
+++ b/server/src/main/java/com/arcadedb/server/security/SecurityDocumentConflictException.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import com.arcadedb.server.security.SecurityDocumentVersions.Document;
+
+/**
+ * A replicated security document entry was built from a version of the document that is no longer current
+ * (issue #7509): somebody changed the same document on another node between this submitter's read and the
+ * apply.
+ * <p>
+ * Nothing is installed. The point is that the outcome is REPORTED: before this existed the stale document was
+ * installed on every node, so the concurrent change was reverted and neither request failed.
+ * <p>
+ * A {@link ServerSecurityException} so the HTTP layer already classifies it as a security failure rather than
+ * as an internal error; the message names the document and both versions, because what the caller has to do
+ * about it is re-read and reissue.
+ */
+public class SecurityDocumentConflictException extends ServerSecurityException {
+  private final Document document;
+  private final long     expectedVersion;
+  private final long     currentVersion;
+
+  public SecurityDocumentConflictException(final Document document, final long expectedVersion, final long currentVersion) {
+    super("The replicated " + document.getDocumentFileName() + " document changed on another node while this change "
+        + "was being submitted (it was built from version " + expectedVersion + ", the cluster is now at version "
+        + currentVersion + "), so it was refused rather than applied over that change. Re-read the document and "
+        + "reissue the change");
+    this.document = document;
+    this.expectedVersion = expectedVersion;
+    this.currentVersion = currentVersion;
+  }
+
+  public Document getDocument() {
+    return document;
+  }
+
+  public long getExpectedVersion() {
+    return expectedVersion;
+  }
+
+  public long getCurrentVersion() {
+    return currentVersion;
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/security/SecurityDocumentVersions.java
+++ b/server/src/main/java/com/arcadedb/server/security/SecurityDocumentVersions.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.serializer.json.JSONObject;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.logging.Level;
+
+/**
+ * The compare-and-set counter of each replicated security document (issue #7509).
+ * <p>
+ * All three security documents are replicated as the WHOLE document: the submitter reads the current one,
+ * mutates a copy and submits the result. Nothing serialised that sequence ACROSS nodes - the
+ * {@code synchronized} block in {@code ServerSecurity.createUserClusterWide} and its siblings is a per-node
+ * monitor - so two operators changing two different users on two nodes in the same second produced two entries
+ * each built without the other in it. Raft linearises them, the second one wins, and the first change is
+ * reverted on every node including the one that answered 200.
+ * <p>
+ * Each submitted entry now carries the version the submitter read plus the version it produces, and the apply
+ * installs it only when the node's current version still matches. The counter is therefore what makes a
+ * concurrent change detectable at all.
+ * <p>
+ * <b>Why a counter and not a hash of the document.</b> The check has to reach the SAME verdict on every node,
+ * or a committed entry is installed on some nodes and refused on others - which is divergence, the failure
+ * #6808 and #7373 exist to prevent, and strictly worse than the lost update being fixed here. A digest of the
+ * local document does not have that property: nodes can legitimately hold different documents (each node
+ * creates its own {@code root} with its own salt before the first seed, a group file can be hand-edited, the
+ * {@code SecurityGroupFileRepository} watcher re-reads it on its own interval). A counter that is only ever
+ * advanced by an apply does: every node that has applied the same prefix of the Raft log holds the same value.
+ * <p>
+ * <b>Why it is persisted.</b> An in-memory-only counter resets on restart, and a restarted node would then
+ * disagree with its peers about the very next entry - accepting what they refuse, or refusing what they
+ * accept. The file is written on every apply, and its absence means 0 on every node, which is what a cluster
+ * upgrading into this fix converges on without any migration step.
+ * <p>
+ * Writes are atomic (temp file, fsync, rename) and owner-only, the same shape
+ * {@link SecurityUserFileRepository#save} uses, so a crash mid-write can only damage the throwaway temp file.
+ */
+public class SecurityDocumentVersions {
+  public static final String FILE_NAME = "server-security-versions.json";
+
+  /**
+   * {@code expectedVersion} of an entry that must be applied whatever the node's current version is: what peer
+   * seeding submits, because a joining peer holds nothing to compare against and a refused seed would leave it
+   * running on its own stale documents. Also what an entry from a peer that predates this fix decodes to.
+   */
+  public static final long UNCONDITIONAL = -1L;
+
+  /**
+   * {@code newVersion} of an entry that must leave the counter alone: an entry produced by a node that predates
+   * this fix, which carries no version at all. Deliberately the same value as {@link #UNCONDITIONAL} and
+   * deliberately a separate name - the two say different things about different fields, and a reader who has
+   * to work out which meaning applies from the value alone is one refactor away from swapping them.
+   */
+  public static final long NO_VERSION = -1L;
+
+  /** The replicated security documents, each with its own independent counter. */
+  public enum Document {
+    USERS("users", SecurityUserFileRepository.FILE_NAME),
+    GROUPS("groups", SecurityGroupFileRepository.FILE_NAME),
+    API_TOKENS("apiTokens", ApiTokenConfiguration.FILE_NAME);
+
+    private final String key;
+    private final String documentFileName;
+
+    Document(final String key, final String documentFileName) {
+      this.key = key;
+      this.documentFileName = documentFileName;
+    }
+
+    /** The JSON key this document's counter is stored under. */
+    public String getKey() {
+      return key;
+    }
+
+    /** The file this counter tracks, for messages an operator has to act on. */
+    public String getDocumentFileName() {
+      return documentFileName;
+    }
+  }
+
+  private static final Document[]     DOCUMENTS = Document.values();
+  private final        String         filePath;
+  private final        AtomicLongArray versions = new AtomicLongArray(DOCUMENTS.length);
+  // Serialises writers exactly as SecurityUserFileRepository does, so two saves never interleave.
+  private final        Object         saveLock  = new Object();
+
+  public SecurityDocumentVersions(final String configPath) {
+    this.filePath = new File(configPath, FILE_NAME).getPath();
+  }
+
+  /**
+   * Reads the persisted counters, leaving every one of them at 0 when the file is absent or unreadable.
+   * <p>
+   * 0 rather than "unknown" on purpose: every node of a cluster upgrading into this fix starts from the same
+   * value, so the first conditional entry is agreed on by all of them. An "unknown" state would have to be
+   * resolved by accepting unconditionally, which is the lost update this class exists to stop.
+   */
+  public void load() {
+    final File file = new File(filePath);
+    if (!file.exists()) {
+      for (int i = 0; i < DOCUMENTS.length; i++)
+        versions.set(i, 0L);
+      return;
+    }
+
+    try {
+      final JSONObject json = new JSONObject(Files.readString(file.toPath(), DatabaseFactory.getDefaultCharset()));
+      for (int i = 0; i < DOCUMENTS.length; i++)
+        versions.set(i, Math.max(0L, json.getLong(DOCUMENTS[i].getKey(), 0L)));
+    } catch (final Exception e) {
+      // An unreadable counter file is reported and read as 0, not as a reason to refuse to start: the
+      // documents themselves are still loadable and the node is still able to authenticate. What it costs is
+      // that this node can disagree with its peers about the next security entry until one is applied.
+      LogManager.instance().log(this, Level.WARNING,
+          "Could not read the replicated security document versions from '%s'; starting from 0. Until the next "
+              + "security change is applied this node may refuse one its peers accept", e, FILE_NAME);
+      for (int i = 0; i < DOCUMENTS.length; i++)
+        versions.set(i, 0L);
+    }
+  }
+
+  /** The version of {@code document} this node currently holds. */
+  public long get(final Document document) {
+    return versions.get(document.ordinal());
+  }
+
+  /**
+   * Whether an entry built from {@code expectedVersion} may be applied to {@code document} on this node.
+   * {@link #UNCONDITIONAL} always may.
+   */
+  public boolean accepts(final Document document, final long expectedVersion) {
+    return expectedVersion == UNCONDITIONAL || expectedVersion == get(document);
+  }
+
+  /**
+   * Records that {@code document} is now at {@code newVersion} and persists every counter.
+   * <p>
+   * Returns the persistence failure instead of throwing it, the shape
+   * {@code ServerSecurity.applyReplicatedUsers} already uses for the document itself (issue #7137): the
+   * document is in force in memory by the time this is called, so the counter has to follow it in memory
+   * whatever the disk does. {@link #NO_VERSION} leaves the counter alone and writes nothing.
+   *
+   * @return the failure, or null when the counters reached disk
+   */
+  public Exception record(final Document document, final long newVersion) {
+    if (newVersion == NO_VERSION)
+      return null;
+
+    versions.set(document.ordinal(), newVersion);
+    return trySave();
+  }
+
+  private Exception trySave() {
+    final JSONObject json = new JSONObject();
+    for (int i = 0; i < DOCUMENTS.length; i++)
+      json.put(DOCUMENTS[i].getKey(), versions.get(i));
+
+    try {
+      save(json);
+      return null;
+    } catch (final Exception e) {
+      return e;
+    }
+  }
+
+  private void save(final JSONObject json) throws IOException {
+    final byte[] bytes = json.toString().getBytes(DatabaseFactory.getDefaultCharset());
+
+    synchronized (saveLock) {
+      final Path target = new File(filePath).toPath();
+      final File dir = target.getParent() != null ? target.getParent().toFile() : null;
+      if (dir != null && !dir.exists())
+        dir.mkdirs();
+
+      final Path tmp = Files.createTempFile(target.getParent(), FILE_NAME, ".tmp");
+      try {
+        try (final FileChannel channel = FileChannel.open(tmp, StandardOpenOption.WRITE)) {
+          channel.write(ByteBuffer.wrap(bytes));
+          channel.force(true);
+        }
+        applyOwnerOnlyPermissions(tmp);
+        try {
+          Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (final AtomicMoveNotSupportedException e) {
+          Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+      } finally {
+        Files.deleteIfExists(tmp);
+      }
+    }
+  }
+
+  private static void applyOwnerOnlyPermissions(final Path path) {
+    try {
+      final PosixFileAttributeView posixView = Files.getFileAttributeView(path, PosixFileAttributeView.class);
+      if (posixView != null)
+        posixView.setPermissions(Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
+    } catch (final IOException | UnsupportedOperationException e) {
+      // Non-POSIX system (e.g. Windows): skip
+    }
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -31,6 +31,7 @@ import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.DefaultConsoleReader;
 import com.arcadedb.server.HAServerPlugin;
 import com.arcadedb.server.ServerException;
+import com.arcadedb.server.security.SecurityDocumentVersions.Document;
 import com.arcadedb.server.ServerPlugin;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.security.credential.CredentialsValidator;
@@ -87,6 +88,12 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
   });
   private              Timer                           reloadConfigurationTimer;
   private final        ApiTokenConfiguration           apiTokenConfig;
+  /**
+   * The compare-and-set counter of each replicated security document (issue #7509). Read under this monitor
+   * when a mutation is submitted, advanced by the apply, and persisted so a restarted node does not disagree
+   * with its peers about the next entry.
+   */
+  private final        SecurityDocumentVersions        documentVersions;
   private static final int                                MAX_TOKEN_FAILURES   = 5;
   private static final long                               TOKEN_LOCKOUT_MS     = 30_000;
   private final        ConcurrentHashMap<String, long[]>  tokenFailures        = new ConcurrentHashMap<>();
@@ -115,6 +122,9 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     });
 
     apiTokenConfig = new ApiTokenConfiguration(configPath);
+
+    documentVersions = new SecurityDocumentVersions(configPath);
+    documentVersions.load();
 
     try {
       secretKeyFactory = SecretKeyFactory.getInstance(algorithm);
@@ -419,7 +429,8 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
       if (users.containsKey(name))
         throw new ServerSecurityException("User '" + name + "' already exists");
 
-      ha.replicateSecurityUsers(replicationPayloadWith(name, userConfiguration));
+      final long expectedVersion = documentVersions.get(Document.USERS);
+      ha.replicateSecurityUsers(replicationPayloadWith(name, userConfiguration), expectedVersion, expectedVersion + 1);
     }
   }
 
@@ -445,7 +456,8 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
 
       passwordChanged = !Objects.equals(previous.getPassword(), userConfiguration.getString("password", null));
 
-      ha.replicateSecurityUsers(replicationPayloadWith(name, userConfiguration));
+      final long expectedVersion = documentVersions.get(Document.USERS);
+      ha.replicateSecurityUsers(replicationPayloadWith(name, userConfiguration), expectedVersion, expectedVersion + 1);
     }
 
     // Applying the replicated list already dropped this principal's LOGIN sessions on every node, this one
@@ -472,7 +484,8 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
       if (!users.containsKey(userName))
         return false;
 
-      ha.replicateSecurityUsers(replicationPayloadWith(userName, null));
+      final long expectedVersion = documentVersions.get(Document.USERS);
+      ha.replicateSecurityUsers(replicationPayloadWith(userName, null), expectedVersion, expectedVersion + 1);
     }
 
     // Same rationale (and the same OUTSIDE-the-monitor placement) as dropUser(): a recreated same-name
@@ -802,6 +815,71 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
   }
 
   /**
+   * Refuses a replicated security document entry that was built from a version of {@code document} this node no
+   * longer holds (issue #7509) - somebody changed the same document on another node between the submitter's read
+   * and this apply. Called by {@code ArcadeStateMachine} BEFORE the matching {@code applyReplicated*}, so a
+   * refused entry installs nothing at all.
+   * <p>
+   * The check is what stops the read-modify-write from losing a change. Two nodes that each read version 5,
+   * mutate their own copy and submit both produce an entry that claims to turn 5 into 6. Raft linearises them;
+   * the first is applied everywhere and moves every node to 6; the second no longer matches on ANY node, so it
+   * is refused everywhere rather than installed over the first one, and its submitter is told.
+   * <p>
+   * <b>The verdict is the same on every node by construction</b>, which is what makes refusing an entry safe at
+   * all - a verdict that differed between nodes would be divergence, which is worse than the lost update. The
+   * counter is advanced only by an apply and never derived from the node's own documents, which CAN legitimately
+   * differ between nodes; see {@link SecurityDocumentVersions} for why a digest of the document would not have
+   * that property.
+   * <p>
+   * Runs on the Raft state-machine apply thread, so, like {@link #applyReplicatedUsers(String)}, it must never
+   * take this monitor and never block. It does neither: it reads one {@code AtomicLongArray} slot.
+   *
+   * @param expectedVersion the version the payload was built from, or {@link SecurityDocumentVersions#UNCONDITIONAL}
+   *                        for a peer seed and for an entry from a node that predates this fix
+   *
+   * @throws SecurityDocumentConflictException when the document moved on
+   */
+  public void checkReplicatedSecurityVersion(final Document document, final long expectedVersion) {
+    if (!documentVersions.accepts(document, expectedVersion))
+      throw new SecurityDocumentConflictException(document, expectedVersion, documentVersions.get(document));
+  }
+
+  /**
+   * Records that {@code document} is now at {@code newVersion} (issue #7509). Called by
+   * {@code ArcadeStateMachine} AFTER the matching {@code applyReplicated*} - including when that reported a
+   * PERSISTENCE failure, because the document is in force in memory by then (issue #7137) and a counter left
+   * behind would make this node refuse the next entry its peers accept.
+   * <p>
+   * <b>After, not before, and that ordering is the safe direction.</b> A submitter reads the document and the
+   * counter without this monitor, so it can observe them a moment apart. Recording last means the window it can
+   * land in is "document already new, counter still old", which makes it stamp a version the apply then refuses:
+   * a spurious refusal, which costs a retry. Recording first would open the opposite window - "counter already
+   * new, document still old" - in which a submitter builds its payload from the PREVIOUS document and stamps a
+   * version that matches, so the entry is accepted and the change it was built without is reverted. That is the
+   * bug this whole mechanism exists to close, reintroduced through the ordering.
+   * {@link SecurityDocumentVersions#NO_VERSION} leaves the counter alone, which is what an entry from a node
+   * that predates this fix carries.
+   * <p>
+   * A failure to write the counter down is logged and NOT thrown: the document it tracks is already in force, so
+   * adding a second exception would not undo anything. What it costs is in the message, because it is the same
+   * outstanding-durability condition #7137 describes for the document itself.
+   */
+  public void recordReplicatedSecurityVersion(final Document document, final long newVersion) {
+    final Exception failure = documentVersions.record(document, newVersion);
+    if (failure != null)
+      LogManager.instance().log(this, Level.SEVERE,
+          "Could not write the replicated security document versions to '%s'. The new %s IS in effect on this node; "
+              + "what failed is recording which version it is, so a restart before this is fixed can make this node "
+              + "refuse a security change its peers accept (or the reverse) until the next one is applied",
+          failure, SecurityDocumentVersions.FILE_NAME, document.getDocumentFileName());
+  }
+
+  /** The version of a replicated security document this node currently holds (issue #7509). */
+  public long getSecurityDocumentVersion(final Document document) {
+    return documentVersions.get(document);
+  }
+
+  /**
    * Applies a replicated users payload: writes it to {@code server-users.jsonl}
    * and populates the in-memory users map directly from the payload.
    * Called from the Raft state machine on every peer when a SECURITY_USERS_ENTRY
@@ -1021,7 +1099,9 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     }
 
     synchronized (this) {
-      ha.replicateSecurityGroups(groupsDocumentWith(database, name, groupConfig).toString());
+      final long expectedVersion = documentVersions.get(Document.GROUPS);
+      ha.replicateSecurityGroups(groupsDocumentWith(database, name, groupConfig).toString(), expectedVersion,
+          expectedVersion + 1);
     }
   }
 
@@ -1040,7 +1120,8 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
       if (root == null)
         return false;
 
-      ha.replicateSecurityGroups(root.toString());
+      final long expectedVersion = documentVersions.get(Document.GROUPS);
+      ha.replicateSecurityGroups(root.toString(), expectedVersion, expectedVersion + 1);
     }
     return true;
   }
@@ -1145,24 +1226,35 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     }
   }
 
-  /** Reads and submits the user list under this monitor. See {@link #seedSecurityStateClusterWide}. */
+  /**
+   * Reads and submits the user list under this monitor. See {@link #seedSecurityStateClusterWide}.
+   * <p>
+   * Submitted UNCONDITIONALLY (issue #7509): a seed exists precisely because the joining peer holds nothing
+   * comparable, so refusing it on a version mismatch would leave that peer authenticating against whatever its
+   * own configuration directory happened to contain. It still carries the version it establishes, so every node
+   * - the joiner included - ends the seed on the same counter and the next ordinary change is conditional
+   * again.
+   */
   private void seedUsersClusterWide(final HAServerPlugin ha) {
     synchronized (this) {
-      ha.replicateSecurityUsers(getUsersJsonPayload());
+      ha.replicateSecurityUsers(getUsersJsonPayload(), SecurityDocumentVersions.UNCONDITIONAL,
+          documentVersions.get(Document.USERS) + 1);
     }
   }
 
-  /** Reads and submits the group document under this monitor. See {@link #seedSecurityStateClusterWide}. */
+  /** Reads and submits the group document under this monitor. See {@link #seedUsersClusterWide}. */
   private void seedGroupsClusterWide(final HAServerPlugin ha) {
     synchronized (this) {
-      ha.replicateSecurityGroups(getGroupsJsonPayload());
+      ha.replicateSecurityGroups(getGroupsJsonPayload(), SecurityDocumentVersions.UNCONDITIONAL,
+          documentVersions.get(Document.GROUPS) + 1);
     }
   }
 
-  /** Reads and submits the API-token document under this monitor. See {@link #seedSecurityStateClusterWide}. */
+  /** Reads and submits the API-token document under this monitor. See {@link #seedUsersClusterWide}. */
   private void seedApiTokensClusterWide(final HAServerPlugin ha) {
     synchronized (this) {
-      ha.replicateSecurityApiTokens(getApiTokensJsonPayload());
+      ha.replicateSecurityApiTokens(getApiTokensJsonPayload(), SecurityDocumentVersions.UNCONDITIONAL,
+          documentVersions.get(Document.API_TOKENS) + 1);
     }
   }
 
@@ -1184,7 +1276,8 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
 
     synchronized (this) {
       final ApiTokenConfiguration.MintedToken minted = apiTokenConfig.mintToken(name, database, expiresAt, permissions);
-      ha.replicateSecurityApiTokens(minted.documentJson());
+      final long expectedVersion = documentVersions.get(Document.API_TOKENS);
+      ha.replicateSecurityApiTokens(minted.documentJson(), expectedVersion, expectedVersion + 1);
       return minted.response();
     }
   }
@@ -1205,7 +1298,8 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
       if (document == null)
         return false;
 
-      ha.replicateSecurityApiTokens(document);
+      final long expectedVersion = documentVersions.get(Document.API_TOKENS);
+      ha.replicateSecurityApiTokens(document, expectedVersion, expectedVersion + 1);
     }
     return true;
   }

--- a/server/src/test/java/com/arcadedb/server/security/Issue7509ReplicatedSecurityDocumentCasTest.java
+++ b/server/src/test/java/com/arcadedb/server/security/Issue7509ReplicatedSecurityDocumentCasTest.java
@@ -1,0 +1,567 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.HAServerPlugin;
+import com.arcadedb.server.security.SecurityDocumentVersions.Document;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #7509: a replicated security document was read-modify-write, so a concurrent admin
+ * change on another node was lost.
+ * <p>
+ * All three documents - the user list, the group document and the API-token document - are replicated as the
+ * WHOLE document: the submitter reads the current one, mutates a copy and submits the result. The
+ * {@code synchronized} block that serialises that sequence is a PER-NODE monitor, so node B doing the same
+ * thing at the same time built its payload from its own view. Raft linearised the two entries and the second
+ * one carried a document that had been built without the first one in it: the first change was reverted on
+ * every node, including the one that accepted it and answered 200.
+ * <p>
+ * Every test here drives the same shape - <b>the race, deterministically</b>. Node A's entry is captured on its
+ * way to the log but not applied; node B's change is applied to the whole cluster; then A's stale entry is
+ * released. The assertions are that it is refused on EVERY node (a verdict that differs between nodes would be
+ * divergence, which is worse than the lost update) and that B's change is still in force.
+ * <p>
+ * The cluster is two {@link ServerSecurity} instances with their own configuration directories, driven through
+ * the same {@code applyReplicated*} methods the Raft state machine calls.
+ */
+class Issue7509ReplicatedSecurityDocumentCasTest {
+
+  private static final String CONFIG_PATH = "target/test-security-7509";
+
+  private FixtureServer   server;
+  private ServerSecurity  nodeA;
+  private ServerSecurity  nodeB;
+  private CapturingCluster cluster;
+
+  @BeforeEach
+  void setUp() {
+    GlobalConfiguration.SERVER_SECURITY_SALT_ITERATIONS.setValue(1000);
+    final File dir = new File(CONFIG_PATH);
+    if (dir.exists())
+      FileUtils.deleteRecursively(dir);
+    assertThat(new File(CONFIG_PATH, "nodeA").mkdirs()).isTrue();
+    assertThat(new File(CONFIG_PATH, "nodeB").mkdirs()).isTrue();
+
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.SERVER_ROOT_PATH, "./target");
+
+    server = new FixtureServer(configuration);
+    nodeA = new ServerSecurity(server, configuration, new File(CONFIG_PATH, "nodeA").getPath());
+    nodeB = new ServerSecurity(null, new ContextConfiguration(), new File(CONFIG_PATH, "nodeB").getPath());
+    server.setSecurity(nodeA);
+
+    cluster = new CapturingCluster(List.of(nodeA, nodeB));
+    server.setHA(cluster);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (nodeA != null)
+      nodeA.stopService();
+    if (nodeB != null)
+      nodeB.stopService();
+    GlobalConfiguration.SERVER_SECURITY_SALT_ITERATIONS.reset();
+    FileUtils.deleteRecursively(new File(CONFIG_PATH));
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // The user list - the path the issue was reported on
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  void aUserCreatedOnAnotherNodeIsNotRevertedByAConcurrentCreate() {
+    // Node A reads the list and submits "add alice". Its entry reaches the log but is not applied yet.
+    cluster.captureNext();
+    nodeA.createUserClusterWide(user("alice"));
+    final SubmittedEntry stale = cluster.releaseCaptured();
+
+    // Meanwhile node B adds bob, built from the same starting list, and that entry is applied everywhere.
+    cluster.apply(new SubmittedEntry(Document.USERS, usersDocumentWith("bob"), 0L, 1L));
+    assertThat(nodeA.existsUser("bob")).isTrue();
+
+    // A's entry now carries a list with alice and WITHOUT bob. Before the fix it was installed and bob vanished.
+    assertThatThrownBy(() -> cluster.apply(stale)).isInstanceOf(SecurityDocumentConflictException.class);
+
+    assertThat(nodeA.existsUser("bob")).as("bob must survive a stale entry from another node").isTrue();
+    assertThat(nodeB.existsUser("bob")).isTrue();
+    assertThat(nodeA.existsUser("alice")).as("and the refused change must not be half-applied").isFalse();
+    assertThat(nodeB.existsUser("alice")).isFalse();
+  }
+
+  @Test
+  void aUserUpdateBuiltFromAStaleListIsRefused() {
+    nodeA.createUserClusterWide(user("alice"));
+
+    cluster.captureNext();
+    nodeA.updateUserClusterWide(user("alice", "rotated-password"));
+    final SubmittedEntry stale = cluster.releaseCaptured();
+
+    cluster.apply(new SubmittedEntry(Document.USERS, usersDocumentWith("bob"), 1L, 2L));
+
+    assertThatThrownBy(() -> cluster.apply(stale)).isInstanceOf(SecurityDocumentConflictException.class);
+    assertThat(nodeA.existsUser("bob")).isTrue();
+    assertThat(nodeB.existsUser("bob")).isTrue();
+  }
+
+  /**
+   * The revocation direction, which is the worse one: a DROP submitted on node A undone by an unrelated change
+   * on node B means an account the operator removed - and was told had been removed - is still able to log in.
+   */
+  @Test
+  void aUserDropIsNotUndoneByAConcurrentUnrelatedChange() {
+    nodeA.createUserClusterWide(user("alice"));
+
+    cluster.captureNext();
+    assertThat(nodeA.dropUserClusterWide("alice")).isTrue();
+    final SubmittedEntry staleDrop = cluster.releaseCaptured();
+
+    // Node B adds bob. Its document still contains alice, because alice's drop has not been applied yet.
+    cluster.apply(new SubmittedEntry(Document.USERS, usersDocumentWith("bob", "alice"), 1L, 2L));
+
+    assertThatThrownBy(() -> cluster.apply(staleDrop)).isInstanceOf(SecurityDocumentConflictException.class);
+    assertThat(nodeA.existsUser("bob")).as("bob is not reverted").isTrue();
+  }
+
+  /** The happy path still works, and moves every node's counter by exactly one. */
+  @Test
+  void anUncontendedUserChangeAppliesEverywhereAndAdvancesTheVersion() {
+    assertThat(nodeA.getSecurityDocumentVersion(Document.USERS)).isZero();
+
+    nodeA.createUserClusterWide(user("alice"));
+
+    assertThat(nodeA.existsUser("alice")).isTrue();
+    assertThat(nodeB.existsUser("alice")).isTrue();
+    assertThat(nodeA.getSecurityDocumentVersion(Document.USERS)).isEqualTo(1L);
+    assertThat(nodeB.getSecurityDocumentVersion(Document.USERS)).isEqualTo(1L);
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // The group document (#7373 gave it the same shape deliberately)
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  void aGroupSavedOnAnotherNodeIsNotRevertedByAConcurrentSave() {
+    cluster.captureNext();
+    nodeA.saveGroupClusterWide("*", "reader", group());
+    final SubmittedEntry stale = cluster.releaseCaptured();
+
+    cluster.apply(new SubmittedEntry(Document.GROUPS, groupsDocumentWith("writer"), 0L, 1L));
+    assertThat(groupsOf(nodeA).has("writer")).isTrue();
+
+    assertThatThrownBy(() -> cluster.apply(stale)).isInstanceOf(SecurityDocumentConflictException.class);
+
+    assertThat(groupsOf(nodeA).has("writer")).as("the group added on the other node survives").isTrue();
+    assertThat(groupsOf(nodeB).has("writer")).isTrue();
+    assertThat(groupsOf(nodeA).has("reader")).as("and the refused save installed nothing").isFalse();
+  }
+
+  @Test
+  void aGroupDeleteBuiltFromAStaleDocumentIsRefused() {
+    nodeA.saveGroupClusterWide("*", "reader", group());
+
+    cluster.captureNext();
+    assertThat(nodeA.deleteGroupClusterWide("*", "reader")).isTrue();
+    final SubmittedEntry staleDelete = cluster.releaseCaptured();
+
+    cluster.apply(new SubmittedEntry(Document.GROUPS, groupsDocumentWith("writer", "reader"), 1L, 2L));
+
+    assertThatThrownBy(() -> cluster.apply(staleDelete)).isInstanceOf(SecurityDocumentConflictException.class);
+    assertThat(groupsOf(nodeA).has("writer")).isTrue();
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // The API-token document
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  void anApiTokenMintedOnAnotherNodeIsNotRevertedByAConcurrentMint() {
+    cluster.captureNext();
+    nodeA.createApiTokenClusterWide("ci", "*", 0L, new JSONObject());
+    final SubmittedEntry stale = cluster.releaseCaptured();
+
+    // Another node mints its own token from the same empty starting document.
+    final JSONObject otherToken = mintedElsewhere("deploy");
+    cluster.apply(new SubmittedEntry(Document.API_TOKENS, tokensDocumentWith(otherToken), 0L, 1L));
+    assertThat(nodeA.getApiTokenConfiguration().listTokens()).hasSize(1);
+
+    assertThatThrownBy(() -> cluster.apply(stale)).isInstanceOf(SecurityDocumentConflictException.class);
+
+    assertThat(nodeA.getApiTokenConfiguration().listTokens())
+        .as("the token minted on the other node is still there").hasSize(1);
+    assertThat(nodeB.getApiTokenConfiguration().listTokens()).hasSize(1);
+  }
+
+  /**
+   * The revocation direction for tokens. A token the operator revoked coming back because somebody minted an
+   * unrelated one on another node in the same second is a security failure, not a consistency one.
+   */
+  @Test
+  void anApiTokenRevocationIsNotUndoneByAConcurrentMint() {
+    final JSONObject created = nodeA.createApiTokenClusterWide("ci", "*", 0L, new JSONObject());
+    final String hash = created.getString("tokenHash");
+
+    cluster.captureNext();
+    assertThat(nodeA.deleteApiTokenClusterWide(hash)).isTrue();
+    final SubmittedEntry staleRevocation = cluster.releaseCaptured();
+
+    // Node B mints a second token from a document that still contains the revoked one.
+    final JSONObject existing = nodeA.getApiTokenConfiguration().listTokens().getFirst();
+    cluster.apply(new SubmittedEntry(Document.API_TOKENS,
+        tokensDocumentWith(existing, mintedElsewhere("deploy")), 1L, 2L));
+
+    assertThatThrownBy(() -> cluster.apply(staleRevocation)).isInstanceOf(SecurityDocumentConflictException.class);
+    assertThat(nodeA.getApiTokenConfiguration().listTokens())
+        .as("nothing was installed, so the mint on the other node stands")
+        .hasSize(2);
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Peer seeding stays unconditional
+  // -------------------------------------------------------------------------------------------
+
+  /**
+   * A seed must never be refused: the joining peer holds nothing to compare against, and a refused seed leaves
+   * it authenticating against whatever its own configuration directory happened to contain. It still stamps the
+   * version it establishes, so the next ordinary change is conditional again on every node.
+   */
+  @Test
+  void seedingAPeerIsUnconditionalAndStillStampsTheVersion() {
+    nodeA.createUserClusterWide(user("alice"));
+    // Move the cluster's counters out from under the seed, the way a change on another node would.
+    cluster.apply(new SubmittedEntry(Document.USERS, usersDocumentWith("alice", "bob"), 1L, 5L));
+
+    assertThatCode(() -> assertThat(nodeA.seedSecurityStateClusterWide()).isEmpty()).doesNotThrowAnyException();
+
+    assertThat(nodeA.getSecurityDocumentVersion(Document.USERS)).isEqualTo(6L);
+    assertThat(nodeB.getSecurityDocumentVersion(Document.USERS))
+        .as("every node ends the seed on the same counter").isEqualTo(6L);
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Durability of the counter
+  // -------------------------------------------------------------------------------------------
+
+  /**
+   * The counter has to survive a restart, or a restarted node would disagree with its peers about the very next
+   * entry - accepting what they refuse, or refusing what they accept, which is divergence rather than a lost
+   * update.
+   */
+  @Test
+  void theVersionSurvivesARestart() {
+    nodeA.createUserClusterWide(user("alice"));
+    nodeA.saveGroupClusterWide("*", "reader", group());
+    assertThat(new File(CONFIG_PATH + "/nodeA", SecurityDocumentVersions.FILE_NAME)).isFile();
+
+    final ServerSecurity restarted = new ServerSecurity(null, new ContextConfiguration(),
+        new File(CONFIG_PATH, "nodeA").getPath());
+    try {
+      assertThat(restarted.getSecurityDocumentVersion(Document.USERS)).isEqualTo(1L);
+      assertThat(restarted.getSecurityDocumentVersion(Document.GROUPS)).isEqualTo(1L);
+      assertThat(restarted.getSecurityDocumentVersion(Document.API_TOKENS)).isZero();
+    } finally {
+      restarted.stopService();
+    }
+  }
+
+  /**
+   * A cluster upgrading into this fix has no counter file anywhere, and every node reads that as 0 - so the
+   * first conditional entry is agreed on by all of them rather than needing a migration step.
+   */
+  @Test
+  void aNodeWithNoCounterFileStartsFromZero() {
+    assertThat(new File(CONFIG_PATH + "/nodeB", SecurityDocumentVersions.FILE_NAME)).doesNotExist();
+    assertThat(nodeB.getSecurityDocumentVersion(Document.USERS)).isZero();
+    assertThat(nodeB.getSecurityDocumentVersion(Document.GROUPS)).isZero();
+    assertThat(nodeB.getSecurityDocumentVersion(Document.API_TOKENS)).isZero();
+  }
+
+  /**
+   * An entry from a node that predates the fix carries no versions at all, which the applier reads as "apply
+   * regardless and touch no counter" - so a mixed-version cluster keeps behaving exactly as it did rather than
+   * refusing entries no node can satisfy.
+   */
+  @Test
+  void anEntryWithNoVersionsAppliesUnconditionallyAndLeavesTheCounterAlone() {
+    nodeA.createUserClusterWide(user("alice"));
+    assertThat(nodeA.getSecurityDocumentVersion(Document.USERS)).isEqualTo(1L);
+
+    cluster.apply(new SubmittedEntry(Document.USERS, usersDocumentWith("alice", "legacy"),
+        SecurityDocumentVersions.UNCONDITIONAL, SecurityDocumentVersions.NO_VERSION));
+
+    assertThat(nodeA.existsUser("legacy")).isTrue();
+    assertThat(nodeA.getSecurityDocumentVersion(Document.USERS)).isEqualTo(1L);
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Fixture
+  // -------------------------------------------------------------------------------------------
+
+  private static JSONObject user(final String name) {
+    return user(name, "hashed-password");
+  }
+
+  private static JSONObject user(final String name, final String password) {
+    return new JSONObject().put("name", name).put("password", password).put("databases", new JSONObject());
+  }
+
+  /** The user list as a peer that has not seen this node's in-flight change would build it. */
+  private static String usersDocumentWith(final String... names) {
+    final JSONArray array = new JSONArray();
+    array.put(new JSONObject().put("name", "root").put("databases", new JSONObject()));
+    for (final String name : names)
+      array.put(user(name));
+    return array.toString();
+  }
+
+  private static JSONObject group() {
+    return new JSONObject()
+        .put("resultSetLimit", -1L)
+        .put("readTimeout", -1L)
+        .put("access", new JSONArray())
+        .put("types", new JSONObject());
+  }
+
+  private static String groupsDocumentWith(final String... groupNames) {
+    final JSONObject groups = new JSONObject();
+    for (final String name : groupNames)
+      groups.put(name, group());
+    return new JSONObject()
+        .put("version", ServerSecurity.LATEST_VERSION)
+        .put("databases", new JSONObject().put("*", new JSONObject().put("groups", groups)))
+        .toString();
+  }
+
+  private static JSONObject groupsOf(final ServerSecurity security) {
+    return security.groupsToJSON().getJSONObject("databases").getJSONObject("*").getJSONObject("groups");
+  }
+
+  /** A token document entry as another node would have produced it, carrying a hash and no token material. */
+  private static JSONObject mintedElsewhere(final String name) {
+    return new JSONObject()
+        .put("name", name)
+        .put("tokenHash", ApiTokenConfiguration.hashToken("at-" + name + "-elsewhere"))
+        .put("database", "*")
+        .put("createdAt", System.currentTimeMillis())
+        .put("expiresAt", 0L)
+        .put("permissions", new JSONObject());
+  }
+
+  private static String tokensDocumentWith(final JSONObject... tokens) {
+    final JSONArray array = new JSONArray();
+    for (final JSONObject token : tokens)
+      array.put(token);
+    return new JSONObject().put("version", 1).put("tokens", array).toString();
+  }
+
+  /** One entry on its way through the Raft log: the document, and the versions it compares and establishes. */
+  private record SubmittedEntry(Document document, String payload, long expectedVersion, long newVersion) {
+  }
+
+  /**
+   * Stands in for the Raft round trip across a two-node cluster, with one addition the ordinary fixture does not
+   * need: an entry can be CAPTURED - accepted into the log but not applied - so a second entry can be applied
+   * ahead of it. That is the race of issue #7509 made deterministic; nothing else about the ordering matters.
+   * <p>
+   * An apply that fails on a node rethrows to the submitter, which is what Ratis does with a state-machine
+   * failure, and every node is applied to so the test can assert the verdict is the same on all of them.
+   */
+  private static final class CapturingCluster implements HAServerPlugin {
+    private final List<ServerSecurity>  nodes;
+    private final Deque<SubmittedEntry> captured = new ArrayDeque<>();
+    private       boolean               capturing;
+
+    private CapturingCluster(final List<ServerSecurity> nodes) {
+      this.nodes = nodes;
+    }
+
+    /** The next submitted entry reaches the log but is not applied until {@link #releaseCaptured()}. */
+    void captureNext() {
+      capturing = true;
+    }
+
+    SubmittedEntry releaseCaptured() {
+      return captured.removeFirst();
+    }
+
+    void apply(final SubmittedEntry entry) {
+      RuntimeException failure = null;
+      for (final ServerSecurity node : nodes) {
+        try {
+          applyOn(node, entry);
+        } catch (final RuntimeException e) {
+          // Collected rather than thrown immediately, so a refusal is proved to happen on EVERY node and not
+          // only on the first one the loop reaches.
+          if (failure == null)
+            failure = e;
+        }
+      }
+      if (failure != null)
+        throw failure;
+    }
+
+    /**
+     * The three steps {@code ArcadeStateMachine.applySecurity*Entry} performs on every node, in that order:
+     * refuse an entry built from a version this node no longer holds, install the document, record the version
+     * it establishes. Kept in this order deliberately - a check after the install would install a stale
+     * document first, and a record before it would move the counter for a document that never arrived.
+     */
+    private static void applyOn(final ServerSecurity node, final SubmittedEntry entry) {
+      node.checkReplicatedSecurityVersion(entry.document(), entry.expectedVersion());
+      switch (entry.document()) {
+      case USERS -> node.applyReplicatedUsers(entry.payload());
+      case GROUPS -> node.applyReplicatedGroups(entry.payload());
+      case API_TOKENS -> node.applyReplicatedApiTokens(entry.payload());
+      }
+      node.recordReplicatedSecurityVersion(entry.document(), entry.newVersion());
+    }
+
+    private void submit(final Document document, final String payload, final long expectedVersion,
+        final long newVersion) {
+      final SubmittedEntry entry = new SubmittedEntry(document, payload, expectedVersion, newVersion);
+      if (capturing) {
+        capturing = false;
+        captured.addLast(entry);
+        return;
+      }
+      apply(entry);
+    }
+
+    @Override
+    public void replicateSecurityUsers(final String usersJsonArray) {
+      submit(Document.USERS, usersJsonArray, SecurityDocumentVersions.UNCONDITIONAL,
+          SecurityDocumentVersions.NO_VERSION);
+    }
+
+    @Override
+    public void replicateSecurityUsers(final String usersJsonArray, final long expectedVersion, final long newVersion) {
+      submit(Document.USERS, usersJsonArray, expectedVersion, newVersion);
+    }
+
+    @Override
+    public void replicateSecurityGroups(final String groupsJson) {
+      submit(Document.GROUPS, groupsJson, SecurityDocumentVersions.UNCONDITIONAL, SecurityDocumentVersions.NO_VERSION);
+    }
+
+    @Override
+    public void replicateSecurityGroups(final String groupsJson, final long expectedVersion, final long newVersion) {
+      submit(Document.GROUPS, groupsJson, expectedVersion, newVersion);
+    }
+
+    @Override
+    public void replicateSecurityApiTokens(final String apiTokensJson) {
+      submit(Document.API_TOKENS, apiTokensJson, SecurityDocumentVersions.UNCONDITIONAL,
+          SecurityDocumentVersions.NO_VERSION);
+    }
+
+    @Override
+    public void replicateSecurityApiTokens(final String apiTokensJson, final long expectedVersion,
+        final long newVersion) {
+      submit(Document.API_TOKENS, apiTokensJson, expectedVersion, newVersion);
+    }
+
+    @Override
+    public ELECTION_STATUS getElectionStatus() {
+      return ELECTION_STATUS.DONE;
+    }
+
+    @Override
+    public void startService() {
+    }
+
+    @Override
+    public boolean isLeader() {
+      return true;
+    }
+
+    @Override
+    public String getLeaderName() {
+      return "leader";
+    }
+
+    @Override
+    public String getClusterName() {
+      return "test";
+    }
+
+    @Override
+    public Map<String, Object> getStats() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public int getConfiguredServers() {
+      return 2;
+    }
+
+    @Override
+    public String getLeaderAddress() {
+      return null;
+    }
+
+    @Override
+    public String getReplicaAddresses() {
+      return "";
+    }
+
+    @Override
+    public void disconnectCluster() {
+    }
+
+    @Override
+    public void shutdownRemoteServer(final String serverName) {
+    }
+  }
+
+  private static final class FixtureServer extends ArcadeDBServer {
+    private ServerSecurity security;
+
+    private FixtureServer(final ContextConfiguration configuration) {
+      super(configuration);
+    }
+
+    private void setSecurity(final ServerSecurity security) {
+      this.security = security;
+    }
+
+    @Override
+    public ServerSecurity getSecurity() {
+      return security;
+    }
+  }
+}


### PR DESCRIPTION
Closes #7509

## Summary

All three replicated security documents - the user list (`SECURITY_USERS_ENTRY`), the group document and the
API-token document (`SECURITY_GROUPS_ENTRY` / `SECURITY_API_TOKENS_ENTRY`) - are replicated as the **whole
document**: the submitter reads the current one, mutates a copy and submits the result. The `synchronized` block
that serialises that read-compute-submit sequence is a **per-node** monitor, so a second node doing the same
thing at the same time built its payload from its own view; Raft linearised the two entries and the second one
carried a document built without the first one in it. The first change was reverted on every node, including the
one that accepted it and answered 200 - and for a `DELETE` that means a revocation the operator was told had
succeeded. Every entry now carries the version of the document its submitter read plus the version it
establishes, and each node installs it only while its own copy is still at that version, so a stale entry is
refused everywhere and reported instead of being installed over the change it was built without.

## Why a counter, and why it is persisted

The safety of refusing an entry rests entirely on **every node reaching the same verdict on it**; a verdict that
differed between nodes would install a committed entry on some and refuse it on others, which is divergence -
the failure #6808 and #7373 exist to prevent, and worse than the lost update being fixed.

- The counter is advanced **only by an apply** and never derived from the node's own documents. Deriving the
  check from a digest of the local document would not be safe: nodes can legitimately hold different documents
  (each creates its own `root` with its own salt before the first seed, a group file can be hand-edited, the
  `SecurityGroupFileRepository` watcher re-reads it on its own interval).
- It is persisted in `server-security-versions.json`, because an in-memory-only counter resets on restart and a
  restarted node would then disagree with its peers about the very next entry. Absent means 0 on every node, so
  a cluster upgrading into this needs no migration step.
- The apply records the counter **after** installing the document. That ordering is the safe direction and is
  written into the javadoc: the reverse opens a window in which a submitter builds its payload from the previous
  document, stamps a version that matches, and has the entry accepted - the bug this mechanism exists to close,
  reintroduced through the ordering.

The two versions ride in a `RaftLogEntryCodec` **extension section** (the #7138 frame) rather than in the entry
body, so a peer that predates the fix skips them and applies unconditionally - today's behaviour - instead of
halting on an unknown field, which for a node-scoped entry is the permanent node-wide halt #7138 exists to
prevent.

This also reroutes `ServerControlPlane.connectCluster`'s peer seed through `seedSecurityStateClusterWide()`. It
used to read the user list **outside** the security monitor - so a revocation committing in that window was
undone by the seed on every node - and seeded only that one document, leaving the group and API-token documents
#7373 added to the next change.

## Test plan

- [ ] `mvn -o -pl server -am -Dtest='com.arcadedb.server.security.*Test,Issue7401ServerControlPlaneConnectClusterTest,ServerControlPlane*Test' test` - 105 tests, green.
- [ ] `mvn -o -pl ha-raft -am -Dtest='RaftLogEntryCodecTest,Issue7509SecurityEntryCasCodecTest,Issue7138EntryExtensionSectionTest,Issue7137SecurityEntryWriteFailureTest,Issue7227SecurityEntryAppliedPositionMovesPastFailureTest,Issue7252SecurityEntryReplayAfterRestartTest,Issue7373SecurityConfigBrokerEntryTest,Issue7373SecurityConfigEntryCodecTest,RaftTransactionBrokerTest,ArcadeStateMachineApplyRetryTest' test` - 96 tests, green.
- [ ] The new tests are proved able to fail: with the compare-and-set disabled, **7 of the 12** tests in `Issue7509ReplicatedSecurityDocumentCasTest` fail - exactly one per submitting entry point.
- [ ] Manually, on a 3-node cluster: create a user on the leader and issue an openCypher `DROP USER` against a follower in the same second; the loser now gets an error naming both versions, and the winner's change is still in force on all three nodes.

## Coverage

Each row has a test that drives the invariant through **that** entry point, by capturing the entry on its way to
the log and releasing it after another node's change has been applied - the race, made deterministic.

| Entry point | Covered by fix? | Covered by a test? |
|---|---|---|
| `ServerSecurity.createUserClusterWide` | yes | yes |
| `ServerSecurity.updateUserClusterWide` | yes | yes |
| `ServerSecurity.dropUserClusterWide` (also the `SecurityManager.dropUser` / openCypher `DROP USER` door) | yes | yes |
| `ServerSecurity.saveGroupClusterWide` | yes | yes |
| `ServerSecurity.deleteGroupClusterWide` | yes | yes |
| `ServerSecurity.createApiTokenClusterWide` | yes | yes |
| `ServerSecurity.deleteApiTokenClusterWide` | yes | yes |
| `seedUsers`/`seedGroups`/`seedApiTokensClusterWide` | deliberately UNCONDITIONAL - a joining peer holds nothing to compare against - but stamps the version it establishes | yes |
| `ServerControlPlane.connectCluster` peer seed | yes, rerouted to `seedSecurityStateClusterWide()` | yes |
| A `SECURITY_*_ENTRY` from a peer that predates the fix | applies unconditionally and touches no counter, exactly as today | yes (codec + apply) |

### Known gaps

Each filed before this PR opened:

- **#7540** - during a **rolling upgrade**, a peer with #7138 but not this fix skips the compare-and-set section
  and applies an entry the upgraded nodes refuse. Narrow (it takes a concurrent security change inside the
  upgrade window) but the outcome is divergence, not a lost update. Closing it needs a cluster-wide capability
  signal the HA layer does not have; the issue carries the interim mitigation.
- **#7536** - the counter is written to its own file, not atomically with the document it tracks, so a node whose
  config volume is full or read-only (the #7137 condition) reloads a stale counter after a restart and then
  disagrees with its peers. Closing it means a format change per document, `server-users.jsonl` included.
- **#7537** - a refused change is reported to the caller but not automatically re-read and retried. The reported
  defect is that the lost update was *silent*, and it no longer is; the retry needs its own design because a
  state-machine failure reaching a non-leader submitter arrives as a message, not as an exception type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEJXCdUGW61QSXqyurphpt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added version-aware replication for users, groups, and API tokens to prevent stale concurrent updates from overwriting newer security changes.
  - Replicated security updates now detect version conflicts and reject outdated changes while preserving current data.
  - Cluster joining now seeds users, groups, and API tokens consistently across peers.
  - Security document versions persist across restarts.

- **Bug Fixes**
  - Prevented lost updates during concurrent security-document modifications.
  - Preserved compatibility with existing unconditional and legacy replicated entries.

- **Tests**
  - Added coverage for conflicts, persistence, peer seeding, and legacy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->