### PR TITLE
fix(#7521): retry the security seed of a newly added peer and refuse to report a partial seed as success

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2026,6 +2026,14 @@ public enum GlobalConfiguration {
       "Base delay in milliseconds for exponential backoff between snapshot download retries. Actual delay is baseMs * 2^attempt.",
       Long.class, 5000L),
 
+  HA_SECURITY_SEED_RETRIES("arcadedb.ha.securitySeedRetries", SCOPE.SERVER,
+      "Attempts, in total, at seeding each security document (users, groups, API tokens) to a peer that has just been added to the cluster. The seed is submitted as a Raft entry, so its usual failure is a momentary loss of quorum - the same condition that makes adding a peer interesting - and only the documents that failed are retried. 1 disables the retry. When the budget is exhausted the caller is answered with a failure naming the documents that did not land, never a success.",
+      Integer.class, 3),
+
+  HA_SECURITY_SEED_RETRY_BASE_MS("arcadedb.ha.securitySeedRetryBaseMs", SCOPE.SERVER,
+      "Base delay in milliseconds for the exponential backoff between security-document seed retries. The delay before retry n (1-based) is baseMs * 2^(n-1).",
+      Long.class, 500L),
+
   HA_SNAPSHOT_INSTALL_BACKUP_WAIT_MS("arcadedb.ha.snapshotInstallBackupWaitMs", SCOPE.SERVER,
       "Milliseconds a snapshot install waits for a backup or an import of the same database, already running on this node, to finish before it replaces the database files anyway. An install applies a committed Raft entry, so the wait has to be bounded: when it expires the install proceeds and logs a warning. 0 refuses to wait at all.",
       Long.class, 60_000L),

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2027,11 +2027,11 @@ public enum GlobalConfiguration {
       Long.class, 5000L),
 
   HA_SECURITY_SEED_RETRIES("arcadedb.ha.securitySeedRetries", SCOPE.SERVER,
-      "Attempts, in total, at seeding each security document (users, groups, API tokens) to a peer that has just been added to the cluster. The seed is submitted as a Raft entry, so its usual failure is a momentary loss of quorum - the same condition that makes adding a peer interesting - and only the documents that failed are retried. 1 disables the retry. When the budget is exhausted the caller is answered with a failure naming the documents that did not land, never a success.",
+      "Attempts, in total, at seeding each security document (users, groups, API tokens) to a peer that has just been added to the cluster. The seed is submitted as a Raft entry, so its usual failure is a momentary loss of quorum - the same condition that makes adding a peer interesting - and only the documents that failed are retried. 1 disables the retry. The value is clamped into [1, 10], because the attempts are spent inside the request that added the peer. When the budget is exhausted the caller is answered with a failure naming the documents that did not land, never a success.",
       Integer.class, 3),
 
   HA_SECURITY_SEED_RETRY_BASE_MS("arcadedb.ha.securitySeedRetryBaseMs", SCOPE.SERVER,
-      "Base delay in milliseconds for the exponential backoff between security-document seed retries. The delay before retry n (1-based) is baseMs * 2^(n-1).",
+      "Base delay in milliseconds for the exponential backoff between security-document seed retries. The delay before retry n (1-based) is baseMs * 2^(n-1), saturating at 30000 so no single pause can exceed half a minute whatever is configured. 0 or less retries without pausing.",
       Long.class, 500L),
 
   HA_SNAPSHOT_INSTALL_BACKUP_WAIT_MS("arcadedb.ha.snapshotInstallBackupWaitMs", SCOPE.SERVER,

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostAddPeerHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostAddPeerHandler.java
@@ -103,8 +103,11 @@ public class PostAddPeerHandler extends AbstractServerHttpHandler {
     if (failedSeeds.isEmpty())
       return new ExecutionResponse(200, response.toString());
 
-    // 'error' short and 'detail' long, which is the shape AbstractServerHttpHandler.sendErrorResponse produces
-    // and which Studio's globalNotifyError renders as a notification title plus body.
+    // 'error' short and 'detail' long. Built here rather than through AbstractServerHttpHandler.sendErrorResponse,
+    // which serves exceptions and conceals 'detail' in production mode: this is a fixed operational sentence on a
+    // root-only route, not a cause chain, and concealing it would remove the only thing the operator can act on.
+    // The field NAMES match that method's, because Studio's globalNotifyError reads 'error' as the notification
+    // title and 'detail' as its body.
     final String documents = String.join(", ", failedSeeds);
     response.put("error", "Peer " + peerId + " added, but these security documents could NOT be seeded to it: "
         + documents);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostAddPeerHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostAddPeerHandler.java
@@ -71,23 +71,51 @@ public class PostAddPeerHandler extends AbstractServerHttpHandler {
     // here and submitting afterwards would leave a window in which a revocation commits in between, and the
     // seed - which carries a whole document - would then put the revoked token, or the deleted group, back on
     // every node. addPeer is exactly when an operator is also likely to be rotating credentials.
-    final List<String> failedSeeds = httpServer.getServer().getSecurity().seedSecurityStateClusterWide();
+    //
+    // With the configured retry budget (arcadedb.ha.securitySeedRetries), because the entries go through Raft
+    // and the usual failure is a momentary loss of quorum - the same condition that makes adding a peer
+    // interesting. Only the documents that failed are retried, and each retry re-reads under the monitor.
+    final List<String> failedSeeds = httpServer.getServer().getSecurity().seedSecurityStateClusterWideWithRetry();
 
-    // Still best-effort: a failed seed does not roll back the peer addition, because the peer is already a
-    // cluster member and removing it again is a second failure mode rather than a repair. But the response says
-    // so rather than reporting a flat success - the operator is the one who has to reissue the seed, and they
-    // cannot do that if the only record is a WARNING in this node's log (issue #7521).
+    return seedOutcomeResponse(peerId, failedSeeds);
+  }
+
+  /**
+   * The response for a peer that was admitted and a seed that may or may not have landed (issue #7521).
+   * <p>
+   * A failed seed still does not roll back the peer addition: the peer is already a cluster member, and removing
+   * it again is a second failure mode rather than a repair. What it does change is the <b>status</b>. Reporting a
+   * partial failure as HTTP 200 with a {@code warning} field meant operator automation read a success and moved
+   * on, while the peer kept authenticating and authorizing from its own copies of the three documents - for a
+   * node re-added after having been out of the cluster, a snapshot of the security state from whenever it left,
+   * so a user dropped since, a group narrowed since or a token revoked since is still in force there.
+   * <p>
+   * 503 rather than 500: the seed is submitted as a Raft entry and its usual failure is a momentary loss of
+   * quorum, so the condition is transient and re-issuing the very same request is the fix. That request is
+   * idempotent on the membership change - {@code RaftClusterManager.addPeer} treats an already-member peer as
+   * success - and reissues the seed.
+   * <p>
+   * Static and package-private so the status/body contract is unit-testable without an
+   * {@code HttpServerExchange}.
+   */
+  static ExecutionResponse seedOutcomeResponse(final String peerId, final List<String> failedSeeds) {
     final JSONObject response = new JSONObject().put("result", "Peer " + peerId + " added");
-    if (!failedSeeds.isEmpty()) {
-      response.put("warning", "Peer added, but the following security documents could NOT be seeded to it: "
-          + String.join(", ", failedSeeds)
-          + ". The new peer keeps its own copy of them until the next cluster-wide change of that kind; reissue "
-          + "the change, or re-run addPeer, before treating the peer as consistent");
-      LogManager.instance().log(this, Level.WARNING,
-          "Peer '%s' was added but these security documents could not be seeded to it: %s", peerId,
-          String.join(", ", failedSeeds));
-    }
+    if (failedSeeds.isEmpty())
+      return new ExecutionResponse(200, response.toString());
 
-    return new ExecutionResponse(200, response.toString());
+    // 'error' short and 'detail' long, which is the shape AbstractServerHttpHandler.sendErrorResponse produces
+    // and which Studio's globalNotifyError renders as a notification title plus body.
+    final String documents = String.join(", ", failedSeeds);
+    response.put("error", "Peer " + peerId + " added, but these security documents could NOT be seeded to it: "
+        + documents);
+    response.put("detail", "Until they are, peer " + peerId + " authenticates and authorizes from its own copies of "
+        + "them - a user deleted, a group narrowed or an API token revoked since it last held them is still in "
+        + "force there. Re-run this request: adding a peer that is already a member is a no-op and the seed is "
+        + "reissued. Remove the peer if it cannot be seeded");
+    LogManager.instance().log(PostAddPeerHandler.class, Level.SEVERE,
+        "Peer '%s' was added but these security documents could not be seeded to it: %s. It serves requests with "
+            + "its own copies of them until the seed is reissued", peerId, documents);
+
+    return new ExecutionResponse(503, response.toString());
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7521SeedOutcomeResponseTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7521SeedOutcomeResponseTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.http.handler.ExecutionResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #7521: {@code POST /api/v1/cluster/peer} reported a security seed that had not
+ * landed as an HTTP <b>200</b> carrying a {@code warning} field.
+ * <p>
+ * Operator automation reads the status, so a 200 meant the peer was treated as fully joined while it kept
+ * authenticating and authorizing from its own copies of {@code server-users.jsonl}, {@code server-groups.json}
+ * and {@code server-api-tokens.json}. For a node re-added after having been out of the cluster, those are the
+ * security state from whenever it left: a user dropped since, a group narrowed since or a token revoked since is
+ * still in force there.
+ * <p>
+ * The status/body contract is what this pins. The retry that produces the list, and the
+ * {@code connect cluster} sibling that reaches the same seed, are pinned by
+ * {@code Issue7521SecuritySeedRetryTest} in the server module.
+ */
+class Issue7521SeedOutcomeResponseTest {
+
+  @Test
+  void aFullySeededPeerIsAPlain200() {
+    final ExecutionResponse response = PostAddPeerHandler.seedOutcomeResponse("node2", List.of());
+
+    assertThat(response.getCode()).isEqualTo(200);
+
+    final JSONObject body = new JSONObject(response.getResponse());
+    assertThat(body.getString("result")).isEqualTo("Peer node2 added");
+    assertThat(body.has("error")).as("nothing failed, so nothing is reported").isFalse();
+    assertThat(body.has("detail")).isFalse();
+  }
+
+  /**
+   * 503 rather than 200: the caller has to see a failure. 503 rather than 500 because the seed goes through Raft
+   * and its usual failure is a momentary loss of quorum - the condition clears, and re-issuing the very same
+   * request is the fix.
+   */
+  @Test
+  void aPeerWhoseSeedDidNotLandIsA503NamingTheDocuments() {
+    final ExecutionResponse response = PostAddPeerHandler.seedOutcomeResponse("node2",
+        List.of("users", "API tokens"));
+
+    assertThat(response.getCode())
+        .as("a partial failure must not be reported as success")
+        .isEqualTo(503);
+
+    final JSONObject body = new JSONObject(response.getResponse());
+    assertThat(body.getString("result"))
+        .as("the peer IS a member - the membership change is not rolled back")
+        .isEqualTo("Peer node2 added");
+
+    assertThat(body.getString("error"))
+        .as("the short half names the documents the peer is stale on")
+        .contains("users").contains("API tokens");
+
+    final String detail = body.getString("detail");
+    assertThat(detail)
+        .as("the operator has to be told what the peer enforces in the meantime")
+        .contains("authenticates and authorizes from its own copies");
+    assertThat(detail)
+        .as("and what to do about it - re-running the request is idempotent and reissues the seed")
+        .contains("Re-run this request");
+  }
+
+  /** One failing document is named on its own, without the separator a joined list would leave dangling. */
+  @Test
+  void aSingleFailingDocumentIsNamedWithoutASeparator() {
+    final ExecutionResponse response = PostAddPeerHandler.seedOutcomeResponse("node3", List.of("groups"));
+
+    assertThat(response.getCode()).isEqualTo(503);
+    assertThat(new JSONObject(response.getResponse()).getString("error"))
+        .endsWith("seeded to it: groups");
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -162,9 +162,16 @@ public class ServerControlPlane {
    * the one it derives for itself from the same address, and an operator writes here what they would
    * have written in the configuration.
    * <p>
-   * Equivalent to {@code POST /api/v1/cluster/peer} and deliberately so: the same atomic Raft
-   * membership change, and the same users seed afterwards, because {@code server-users.jsonl} lives
-   * outside the database directory and a snapshot install does not carry it.
+   * The same atomic Raft membership change as {@code POST /api/v1/cluster/peer}, and deliberately so,
+   * followed by the same seed of the three security documents - {@code server-users.jsonl},
+   * {@code server-groups.json} and {@code server-api-tokens.json} - which live outside the database
+   * directory, so a snapshot install carries none of them.
+   * <p>
+   * The two verbs are <b>not</b> equivalent in what they do when that seed does not land. This one
+   * stays best-effort, which is what issue #7401 decided and what
+   * {@code Issue7401ServerControlPlaneConnectClusterTest} pins: the server is a committed member by
+   * the time the seed runs, so a failed seed is logged at SEVERE and the join still reports success.
+   * The route answers 503 in the same situation (issue #7521). Reconciling the two is issue #7550.
    * <p>
    * <b>Note the direction.</b> The address names the server being <em>added</em>; the cluster that
    * grows is the one this server belongs to. That is the opposite of the pre-Raft implementation this

--- a/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
+++ b/server/src/main/java/com/arcadedb/server/ServerControlPlane.java
@@ -217,17 +217,28 @@ public class ServerControlPlane {
           "Cannot connect '" + serverAddress + "' to the cluster: " + e.getMessage());
     }
 
-    // Seed the newly joined peer with the current users file, exactly as PostAddPeerHandler does after
-    // its own addPeer: server-users.jsonl lives under <server-root>/config/, outside the database
-    // directory, so snapshot install does not cover it and the new peer would run with a stale user set
-    // until the next cluster-wide user mutation. Best-effort, as it is there: the peer is already a
-    // committed member and a failure here does not - and must not - roll that back.
-    try {
-      ha.replicateSecurityUsers(server.getSecurity().getUsersJsonPayload());
-    } catch (final Exception e) {
-      LogManager.instance().log(this, Level.WARNING,
-          "Users seed to '%s' after connect cluster failed (best-effort): %s", serverAddress, e.getMessage());
-    }
+    // Seed the newly joined peer with the current security documents, through the same retrying,
+    // monitor-held helper PostAddPeerHandler uses after its own addPeer (issue #7521). All three of them:
+    // server-users.jsonl, server-groups.json and server-api-tokens.json all live under <server-root>/config/,
+    // outside the database directory, so snapshot install carries none of them, and seeding only the users -
+    // which is what this did - left a group narrowed or a token revoked while the peer was away in force on it
+    // until the next cluster-wide change of that kind.
+    final List<String> failedSeeds = server.getSecurity().seedSecurityStateClusterWideWithRetry();
+    if (!failedSeeds.isEmpty())
+      // Still best-effort on THIS verb: the join is a committed membership change by the time the seed runs, and
+      // issue #7401 deliberately decided a seed failure must not be reported as a failed join, because the caller
+      // would retry a join that already happened. The sibling POST /api/v1/cluster/peer route answers 503 in the
+      // same situation, so the two verbs disagree about how loudly this is reported - tracked by issue #7550,
+      // which is where that inconsistency gets resolved one way or the other rather than here.
+      //
+      // SEVERE, not WARNING: what has happened is that a cluster member enforces credentials the cluster has
+      // already changed.
+      LogManager.instance().log(this, Level.SEVERE,
+          "Server '%s' joined the cluster but these security documents could NOT be seeded to it: %s. It "
+              + "authenticates and authorizes from its own copies of them - a user deleted, a group narrowed or an "
+              + "API token revoked since it last held them is still in force there. Re-run connect cluster: joining "
+              + "a server that is already a member is a no-op and the seed is reissued", serverAddress,
+          String.join(", ", failedSeeds));
   }
 
   // ---------------------------------------------------------------------------------------------

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/PluginApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/PluginApiSpec.java
@@ -169,11 +169,25 @@ public class PluginApiSpec implements OpenApiContributor {
   private PathItem createAddPeerPath() {
     final Operation post = SpecBuilders.operation("addClusterPeer", "Cluster",
         "Add a peer to the cluster",
-        "Adds a peer to the Raft configuration. " + RAFT_REQUIRED);
+        """
+            Adds a peer to the Raft configuration, then seeds it with the current security documents \
+            (users, groups and API tokens), which live outside the database directory and are therefore \
+            not carried by a snapshot install.
+
+            The seed is retried within arcadedb.ha.securitySeedRetries. If a document still has not been \
+            submitted when the budget is spent, the answer is 503: the peer IS a member - the membership \
+            change is never rolled back - but until the seed lands it authenticates and authorizes from its \
+            own copies of those documents, so a credential the cluster has revoked can still be in force \
+            there. Re-issuing this request is the fix: adding a peer that is already a member is a no-op and \
+            the seed is reissued. """ + RAFT_REQUIRED);
     post.setRequestBody(SpecBuilders.jsonBody("Peer to add", "AddPeerRequest", true));
-    post.setResponses(SpecBuilders.standardResponses("200",
-        SpecBuilders.jsonResponse("Peer added", "ClusterActionResponse"),
-        "400", "401", "403", "500"));
+    final ApiResponses responses = SpecBuilders.standardResponses("200",
+        SpecBuilders.jsonResponse("Peer added and every security document seeded", "ClusterActionResponse"),
+        "400", "401", "403", "500");
+    responses.addApiResponse("503", SpecBuilders.jsonResponse(
+        "Peer added, but at least one security document could not be seeded to it. 'error' names them and "
+            + "'detail' says what the peer enforces until the seed is reissued.", "ClusterActionResponse"));
+    post.setResponses(responses);
 
     final PathItem pathItem = new PathItem();
     pathItem.setPost(post);
@@ -510,6 +524,11 @@ public class PluginApiSpec implements OpenApiContributor {
         "Database the action applied to. Present on resync."));
     schema.addProperty("localServer", SpecBuilders.string(
         "Server that performed the action. Present on resync."));
+    schema.addProperty("error", SpecBuilders.string(
+        "Short reason the action did not fully succeed. Present on the 503 of add-peer, naming the security "
+            + "documents that could not be seeded to the new peer."));
+    schema.addProperty("detail", SpecBuilders.string(
+        "Long form of 'error', including what to do about it. Present whenever 'error' is."));
     return schema;
   }
 

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -1182,7 +1182,8 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
    * failure {@link #seedSecurityStateClusterWide()}'s monitor exists to prevent, arriving through the retry.
    * <p>
    * An interrupt stops the retrying rather than swallowing the flag: the interrupt status is restored and what
-   * is still unseeded is returned, so the caller reports the honest partial result.
+   * is still unseeded is returned, so the caller reports the honest partial result. That holds whether or not a
+   * backoff is configured - the flag is checked before the pause as well as raised by it.
    *
    * @param maxAttempts  attempts in total per document, clamped into {@code [1, 10]}
    * @param retryBaseMs  base backoff in milliseconds; the pause before retry n (1-based) is
@@ -1244,6 +1245,14 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
    * stops the retrying - the interrupt flag is restored so the caller's thread keeps it.
    */
   private static boolean pauseBeforeRetry(final long retryBaseMs, final int retry) {
+    // Before the pause, not only inside it. A base delay of 0 or less is a documented configuration - "retries
+    // without pausing" - and with no sleep to throw, an interrupt raised while seedOnce was blocked in a Raft
+    // submit would never be observed: the loop would spin through the whole budget, which is the opposite of
+    // what this method's contract says. isInterrupted() rather than interrupted(), so the flag stays with the
+    // caller's thread exactly as the catch below restores it.
+    if (Thread.currentThread().isInterrupted())
+      return false;
+
     final long pause = backoffMs(retryBaseMs, retry);
     if (pause <= 0)
       return true;

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -65,6 +65,16 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
   private static final String                          SEED_USERS           = "users";
   private static final String                          SEED_GROUPS          = "groups";
   private static final String                          SEED_API_TOKENS      = "API tokens";
+  /**
+   * Ceilings on what {@code arcadedb.ha.securitySeedRetries} and {@code arcadedb.ha.securitySeedRetryBaseMs}
+   * can turn into. Both are operator-supplied and both are spent inside an HTTP request that has already made a
+   * Raft membership change, so neither may be taken at face value: a retry count of {@code Integer.MAX_VALUE}
+   * is an unbounded stream of Raft submissions on a request thread, and a base delay near {@code Long.MAX_VALUE}
+   * is a pause no operator meant. Clamped rather than refused, so a mistyped setting degrades instead of
+   * breaking the route.
+   */
+  private static final int                             MAX_SEED_ATTEMPTS       = 10;
+  private static final long                            MAX_SEED_RETRY_PAUSE_MS = 30_000L;
   private final        ArcadeDBServer                  server;
   private final        SecurityUserFileRepository      usersRepository;
   private final        SecurityGroupFileRepository     groupRepository;
@@ -1174,9 +1184,9 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
    * An interrupt stops the retrying rather than swallowing the flag: the interrupt status is restored and what
    * is still unseeded is returned, so the caller reports the honest partial result.
    *
-   * @param maxAttempts  attempts in total per document; anything below 1 is treated as 1
+   * @param maxAttempts  attempts in total per document, clamped into {@code [1, 10]}
    * @param retryBaseMs  base backoff in milliseconds; the pause before retry n (1-based) is
-   *                     {@code retryBaseMs * 2^(n-1)}. 0 retries without pausing
+   *                     {@code retryBaseMs * 2^(n-1)} saturated at 30 s. 0 or less retries without pausing
    *
    * @return the names of the documents that could not be seeded, empty when all three were submitted
    */
@@ -1185,7 +1195,12 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     if (ha == null)
       return List.of();
 
-    final int attempts = Math.max(1, maxAttempts);
+    final int attempts = Math.clamp(maxAttempts, 1, MAX_SEED_ATTEMPTS);
+    if (attempts != maxAttempts)
+      LogManager.instance().log(this, Level.WARNING,
+          "%s is %d, which is outside [1, %d]; seeding each security document at most %d times instead",
+          GlobalConfiguration.HA_SECURITY_SEED_RETRIES.getKey(), maxAttempts, MAX_SEED_ATTEMPTS, attempts);
+
     List<String> failed = seedOnce(ha, null);
 
     for (int retry = 1; retry < attempts && !failed.isEmpty(); retry++) {
@@ -1220,17 +1235,36 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
    * stops the retrying - the interrupt flag is restored so the caller's thread keeps it.
    */
   private static boolean pauseBeforeRetry(final long retryBaseMs, final int retry) {
-    if (retryBaseMs <= 0)
+    final long pause = backoffMs(retryBaseMs, retry);
+    if (pause <= 0)
       return true;
     try {
-      // Shift on the retry index, not on an unbounded counter: attempts are bounded by maxAttempts, which is
-      // configuration, so cap the exponent as well rather than trusting it to stay small.
-      Thread.sleep(retryBaseMs << Math.min(retry - 1, 16));
+      Thread.sleep(pause);
       return true;
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
       return false;
     }
+  }
+
+  /**
+   * {@code retryBaseMs} doubled once per retry already made, saturating at {@link #MAX_SEED_RETRY_PAUSE_MS}.
+   * <p>
+   * Saturating rather than shifting, because both inputs are configuration: {@code Long.MAX_VALUE << 1} is
+   * <i>negative</i>, and a negative argument makes {@code Thread.sleep} throw {@code IllegalArgumentException}
+   * out of a method whose contract is to return the documents that could not be seeded. The loop stops as soon
+   * as the value reaches the ceiling, so nothing is ever doubled past it and the overflow has no way in.
+   */
+  static long backoffMs(final long retryBaseMs, final int retry) {
+    if (retryBaseMs <= 0)
+      return 0L;
+    long pause = retryBaseMs;
+    for (int i = 1; i < retry; i++) {
+      if (pause >= MAX_SEED_RETRY_PAUSE_MS)
+        return MAX_SEED_RETRY_PAUSE_MS;
+      pause <<= 1;
+    }
+    return Math.min(pause, MAX_SEED_RETRY_PAUSE_MS);
   }
 
   private void seed(final List<String> failed, final String what, final Runnable seeding) {

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -1201,6 +1201,15 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
           "%s is %d, which is outside [1, %d]; seeding each security document at most %d times instead",
           GlobalConfiguration.HA_SECURITY_SEED_RETRIES.getKey(), maxAttempts, MAX_SEED_ATTEMPTS, attempts);
 
+    // Symmetric with the clamp above: a base delay the backoff is going to ignore is a misconfiguration, and
+    // saturating it silently leaves the operator believing a number that has no effect. Only worth saying when
+    // there will be a pause at all.
+    if (attempts > 1 && (retryBaseMs < 0 || retryBaseMs > MAX_SEED_RETRY_PAUSE_MS))
+      LogManager.instance().log(this, Level.WARNING,
+          "%s is %d, which is outside [0, %d]; pausing %s between attempts instead",
+          GlobalConfiguration.HA_SECURITY_SEED_RETRY_BASE_MS.getKey(), retryBaseMs, MAX_SEED_RETRY_PAUSE_MS,
+          retryBaseMs < 0 ? "not at all" : MAX_SEED_RETRY_PAUSE_MS + "ms");
+
     List<String> failed = seedOnce(ha, null);
 
     for (int retry = 1; retry < attempts && !failed.isEmpty(); retry++) {

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -61,6 +61,10 @@ import static com.arcadedb.GlobalConfiguration.SERVER_SECURITY_SALT_ITERATIONS;
 public class ServerSecurity implements ServerPlugin, SecurityManager {
 
   public static final  int                             LATEST_VERSION       = 2;
+  /** Document names {@link #seedSecurityStateClusterWide(int, long)} reports as failed, and retries by. */
+  private static final String                          SEED_USERS           = "users";
+  private static final String                          SEED_GROUPS          = "groups";
+  private static final String                          SEED_API_TOKENS      = "API tokens";
   private final        ArcadeDBServer                  server;
   private final        SecurityUserFileRepository      usersRepository;
   private final        SecurityGroupFileRepository     groupRepository;
@@ -1120,19 +1124,113 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
    * Each document is seeded under its own acquisition rather than all three under one, so an unrelated user
    * change is not blocked for three consecutive Raft round trips. Each is best-effort and independent: the
    * failures are collected and returned rather than thrown, so one failing seed does not skip the other two.
+   * <p>
+   * One attempt at each document. The cluster-admission paths call
+   * {@link #seedSecurityStateClusterWideWithRetry()} instead, which retries the ones that failed.
    *
    * @return the names of the documents that could not be seeded, empty when all three were submitted
    */
   public List<String> seedSecurityStateClusterWide() {
+    return seedSecurityStateClusterWide(1, 0L);
+  }
+
+  /**
+   * {@link #seedSecurityStateClusterWide()} with the retry budget the server is configured for
+   * ({@code arcadedb.ha.securitySeedRetries} and {@code arcadedb.ha.securitySeedRetryBaseMs}).
+   * <p>
+   * This is the overload every cluster-admission path uses, and the settings are read here - per call, through
+   * the server's configuration - rather than captured at construction, so a {@code SET SERVER SETTING} takes
+   * effect on the next admission without a restart.
+   *
+   * @return the names of the documents that could not be seeded, empty when all three were submitted
+   */
+  public List<String> seedSecurityStateClusterWideWithRetry() {
+    if (server == null)
+      return List.of();
+
+    final ContextConfiguration configuration = server.getConfiguration();
+    return seedSecurityStateClusterWide(
+        configuration.getValueAsInteger(GlobalConfiguration.HA_SECURITY_SEED_RETRIES),
+        configuration.getValueAsLong(GlobalConfiguration.HA_SECURITY_SEED_RETRY_BASE_MS));
+  }
+
+  /**
+   * {@link #seedSecurityStateClusterWide()} with a bounded retry over the documents that failed (issue #7521).
+   * <p>
+   * The seed is submitted as a Raft entry, so its usual failure is "no quorum right now" - which is the same
+   * condition that makes adding a peer interesting in the first place, and which clears on its own. A single
+   * attempt turned that transient condition into a peer running indefinitely on its own stale copies of the
+   * three documents, because nothing else converges them: they live under {@code <server-root>/config/},
+   * outside the database directory, so Raft snapshot install does not carry them.
+   * <p>
+   * Only the documents that failed are retried, so a document already submitted is not submitted again - a
+   * second entry would be harmless but not free, and the count is what the tests pin.
+   * <p>
+   * Every attempt re-reads the document under this monitor, exactly as the first one does. That is not an
+   * optimisation detail: a retry that replayed the payload read before the first attempt would carry a
+   * pre-revocation document and put the revoked token, or the deleted group, back on every node - the very
+   * failure {@link #seedSecurityStateClusterWide()}'s monitor exists to prevent, arriving through the retry.
+   * <p>
+   * An interrupt stops the retrying rather than swallowing the flag: the interrupt status is restored and what
+   * is still unseeded is returned, so the caller reports the honest partial result.
+   *
+   * @param maxAttempts  attempts in total per document; anything below 1 is treated as 1
+   * @param retryBaseMs  base backoff in milliseconds; the pause before retry n (1-based) is
+   *                     {@code retryBaseMs * 2^(n-1)}. 0 retries without pausing
+   *
+   * @return the names of the documents that could not be seeded, empty when all three were submitted
+   */
+  public List<String> seedSecurityStateClusterWide(final int maxAttempts, final long retryBaseMs) {
     final HAServerPlugin ha = server != null ? server.getHA() : null;
     if (ha == null)
       return List.of();
 
-    final List<String> failed = new ArrayList<>(3);
-    seed(failed, "users", () -> seedUsersClusterWide(ha));
-    seed(failed, "groups", () -> seedGroupsClusterWide(ha));
-    seed(failed, "API tokens", () -> seedApiTokensClusterWide(ha));
+    final int attempts = Math.max(1, maxAttempts);
+    List<String> failed = seedOnce(ha, null);
+
+    for (int retry = 1; retry < attempts && !failed.isEmpty(); retry++) {
+      LogManager.instance().log(this, Level.WARNING,
+          "Retrying the cluster-wide seed of these security documents (attempt %d of %d): %s", retry + 1, attempts,
+          String.join(", ", failed));
+      if (!pauseBeforeRetry(retryBaseMs, retry))
+        break;
+      failed = seedOnce(ha, failed);
+    }
+
     return failed;
+  }
+
+  /**
+   * One pass over the three documents, or over {@code only} when retrying. Each is independent: the failures
+   * are collected and returned rather than thrown, so one failing seed does not skip the others.
+   */
+  private List<String> seedOnce(final HAServerPlugin ha, final Collection<String> only) {
+    final List<String> failed = new ArrayList<>(3);
+    if (only == null || only.contains(SEED_USERS))
+      seed(failed, SEED_USERS, () -> seedUsersClusterWide(ha));
+    if (only == null || only.contains(SEED_GROUPS))
+      seed(failed, SEED_GROUPS, () -> seedGroupsClusterWide(ha));
+    if (only == null || only.contains(SEED_API_TOKENS))
+      seed(failed, SEED_API_TOKENS, () -> seedApiTokensClusterWide(ha));
+    return failed;
+  }
+
+  /**
+   * Sleeps the backoff for retry {@code retry} (1-based). Returns false when the wait was interrupted, which
+   * stops the retrying - the interrupt flag is restored so the caller's thread keeps it.
+   */
+  private static boolean pauseBeforeRetry(final long retryBaseMs, final int retry) {
+    if (retryBaseMs <= 0)
+      return true;
+    try {
+      // Shift on the retry index, not on an unbounded counter: attempts are bounded by maxAttempts, which is
+      // configuration, so cap the exponent as well rather than trusting it to stay small.
+      Thread.sleep(retryBaseMs << Math.min(retry - 1, 16));
+      return true;
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
   }
 
   private void seed(final List<String> failed, final String what, final Runnable seeding) {

--- a/server/src/test/java/com/arcadedb/server/security/Issue7521SecuritySeedRetryTest.java
+++ b/server/src/test/java/com/arcadedb/server/security/Issue7521SecuritySeedRetryTest.java
@@ -240,6 +240,39 @@ class Issue7521SecuritySeedRetryTest {
         .doesNotContain(hash);
   }
 
+  /**
+   * The interrupt contract the method's javadoc treats as load-bearing: a shutdown landing while a seed is in
+   * flight stops the retrying rather than being swallowed, and the caller's thread gets its flag back so
+   * whatever is unwinding above can still see it.
+   * <p>
+   * The interrupt is raised from inside the API-token seed - the last of the three - so the pause that follows
+   * is the next interruptible thing the loop does, and no file write sits between the two.
+   */
+  @Test
+  void anInterruptStopsTheRetryingAndGivesTheFlagBack() {
+    final SeedingHAPlugin ha = new SeedingHAPlugin(security) {
+      @Override
+      public void replicateSecurityApiTokens(final String apiTokensJson) {
+        Thread.currentThread().interrupt();
+        super.replicateSecurityApiTokens(apiTokensJson);
+      }
+    };
+    ha.failApiTokensTimes = Integer.MAX_VALUE;
+    server.setHA(ha);
+
+    // A base delay above zero, so the loop actually reaches Thread.sleep rather than retrying straight through.
+    final List<String> failed = security.seedSecurityStateClusterWide(5, 1L);
+
+    // Read AND clear the flag first, so an interrupt this test raised cannot leak into the teardown or the
+    // next test in this class.
+    assertThat(Thread.interrupted()).as("the interrupt is restored, not swallowed").isTrue();
+
+    assertThat(failed).containsExactly("API tokens");
+    assertThat(ha.apiTokenDocuments)
+        .as("the budget was 5, and the interrupt stopped it after the first attempt")
+        .hasSize(1);
+  }
+
   /** With no HA plugin at all there is no cluster to seed, and the retry loop must not turn that into work. */
   @Test
   void aStandaloneServerSeedsNothing() {

--- a/server/src/test/java/com/arcadedb/server/security/Issue7521SecuritySeedRetryTest.java
+++ b/server/src/test/java/com/arcadedb/server/security/Issue7521SecuritySeedRetryTest.java
@@ -1,0 +1,419 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.HAServerPlugin;
+import com.arcadedb.server.ServerControlPlane;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #7521: a peer whose security seed failed was admitted and served traffic with its
+ * own stale credentials.
+ * <p>
+ * The three security documents - {@code server-users.jsonl}, {@code server-groups.json} and
+ * {@code server-api-tokens.json} - live under {@code <server-root>/config/}, outside the database directory, so
+ * Raft snapshot install carries none of them. The seed an admission path issues is the only thing that converges
+ * them on a joining peer, and it is submitted as Raft entries, so its usual failure is "no quorum right now" -
+ * the same condition that makes adding a peer interesting in the first place.
+ * <p>
+ * Before the fix that seed was one attempt, and a failure was reported inside an HTTP 200. A peer re-added after
+ * having been out of the cluster then ran on the security state from whenever it left: a user dropped since, a
+ * group narrowed since or <b>a token revoked since</b> still authenticated and authorized there.
+ * <p>
+ * What is pinned here is the {@link ServerSecurity} half - the retry itself, that only the failing document is
+ * retried, and that every attempt re-reads under the security monitor - plus the {@code connect cluster} entry
+ * point, which seeded the users document alone and swallowed the failure. The HTTP status half of
+ * {@code POST /api/v1/cluster/peer} is pinned by {@code Issue7521SeedOutcomeResponseTest} in the ha-raft module,
+ * where that handler lives.
+ */
+class Issue7521SecuritySeedRetryTest {
+
+  private static final String CONFIG_PATH = "target/test-security-7521";
+
+  private FixtureServer      server;
+  private ServerSecurity     security;
+  private ServerControlPlane controlPlane;
+
+  @BeforeEach
+  void setUp() {
+    GlobalConfiguration.SERVER_SECURITY_SALT_ITERATIONS.setValue(1000);
+    final File dir = new File(CONFIG_PATH);
+    if (dir.exists())
+      FileUtils.deleteRecursively(dir);
+    assertThat(dir.mkdirs()).isTrue();
+
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.SERVER_ROOT_PATH, "./target");
+    // No pause between attempts: what these tests assert is the attempt count and the payload each attempt
+    // carries, never the elapsed time, so the backoff has nothing to contribute but seconds of test runtime.
+    configuration.setValue(GlobalConfiguration.HA_SECURITY_SEED_RETRY_BASE_MS, 0L);
+
+    server = new FixtureServer(configuration);
+    security = new ServerSecurity(server, configuration, CONFIG_PATH);
+    server.setSecurity(security);
+    controlPlane = new ServerControlPlane(server);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (security != null)
+      security.stopService();
+    GlobalConfiguration.SERVER_SECURITY_SALT_ITERATIONS.reset();
+    FileUtils.deleteRecursively(new File(CONFIG_PATH));
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // The retry itself
+  // -------------------------------------------------------------------------------------------
+
+  /**
+   * The condition this retry exists for: quorum is briefly unavailable, the first submission is rejected, and a
+   * moment later the same submission commits. One attempt reported that as a permanently unseeded peer.
+   */
+  @Test
+  void aSeedThatFailsOnceAndThenSucceedsIsReportedAsSeeded() {
+    final SeedingHAPlugin ha = new SeedingHAPlugin(security);
+    ha.failUsersTimes = 1;
+    server.setHA(ha);
+
+    assertThat(security.seedSecurityStateClusterWide(3, 0L))
+        .as("the second attempt landed, so nothing is left unseeded")
+        .isEmpty();
+
+    assertThat(ha.userDocuments).as("one rejected submission and one that committed").hasSize(2);
+    assertThat(ha.groupDocuments).as("the group document never failed, so it is submitted once").hasSize(1);
+    assertThat(ha.apiTokenDocuments).as("the token document never failed, so it is submitted once").hasSize(1);
+  }
+
+  /**
+   * A retry must re-send only what failed. Re-sending the documents that already committed costs a Raft round
+   * trip each and widens the window in which an unrelated admin change is overwritten by a document read before
+   * it.
+   */
+  @Test
+  void onlyTheDocumentThatFailedIsRetried() {
+    final SeedingHAPlugin ha = new SeedingHAPlugin(security);
+    ha.failApiTokensTimes = Integer.MAX_VALUE;
+    server.setHA(ha);
+
+    assertThat(security.seedSecurityStateClusterWide(3, 0L)).containsExactly("API tokens");
+
+    assertThat(ha.apiTokenDocuments).as("attempted once per attempt in the budget").hasSize(3);
+    assertThat(ha.userDocuments).as("committed on the first attempt, never re-sent").hasSize(1);
+    assertThat(ha.groupDocuments).as("committed on the first attempt, never re-sent").hasSize(1);
+  }
+
+  /** The budget is a bound: a document that never lands is reported, not retried forever. */
+  @Test
+  void aSeedThatNeverLandsIsReportedAfterTheBudgetIsSpent() {
+    final SeedingHAPlugin ha = new SeedingHAPlugin(security);
+    ha.failGroupsTimes = Integer.MAX_VALUE;
+    ha.failUsersTimes = Integer.MAX_VALUE;
+    server.setHA(ha);
+
+    assertThat(security.seedSecurityStateClusterWide(2, 0L))
+        .as("both are named, so the operator knows which documents the peer is stale on")
+        .containsExactly("users", "groups");
+
+    assertThat(ha.userDocuments).hasSize(2);
+    assertThat(ha.groupDocuments).hasSize(2);
+  }
+
+  /** A budget of one, or of nonsense, is one attempt - never zero, which would seed nothing at all. */
+  @Test
+  void aBudgetBelowOneStillMakesOneAttempt() {
+    final SeedingHAPlugin ha = new SeedingHAPlugin(security);
+    server.setHA(ha);
+
+    assertThat(security.seedSecurityStateClusterWide(0, 0L)).isEmpty();
+
+    assertThat(ha.userDocuments).hasSize(1);
+    assertThat(ha.groupDocuments).hasSize(1);
+    assertThat(ha.apiTokenDocuments).hasSize(1);
+  }
+
+  /**
+   * The point of the monitor, applied to the retry. A retry that replayed the payload read before the first
+   * attempt would carry a pre-revocation document and put the revoked token back on every node in the cluster -
+   * the exact failure the seed's monitor exists to prevent, arriving through the door added to fix a different
+   * one.
+   * <p>
+   * Driven by revoking the token locally from inside the failing first attempt, which stands in for a revocation
+   * committing in that window.
+   */
+  @Test
+  void everyAttemptRereadsTheDocumentInsteadOfReplayingTheFirstPayload() {
+    final JSONObject created = security.getApiTokenConfiguration().createToken("ci", "*", 0, new JSONObject());
+    final String hash = created.getString("tokenHash");
+
+    final SeedingHAPlugin ha = new SeedingHAPlugin(security) {
+      @Override
+      public void replicateSecurityApiTokens(final String apiTokensJson) {
+        if (apiTokenDocuments.isEmpty()) {
+          apiTokenDocuments.add(apiTokensJson);
+          // A revocation lands between attempt 1 and attempt 2. Applied straight to the store rather than
+          // through the control plane, so it does not re-enter this method.
+          assertThat(security.getApiTokenConfiguration().deleteToken(hash)).isTrue();
+          throw new IllegalStateException("consensus lost");
+        }
+        super.replicateSecurityApiTokens(apiTokensJson);
+      }
+    };
+    server.setHA(ha);
+
+    assertThat(security.seedSecurityStateClusterWide(2, 0L)).isEmpty();
+
+    assertThat(ha.apiTokenDocuments).hasSize(2);
+    assertThat(ha.apiTokenDocuments.getFirst())
+        .as("the first attempt read the document while the token was still live")
+        .contains(hash);
+    assertThat(ha.apiTokenDocuments.get(1))
+        .as("the retry must carry the post-revocation document, not a replay of the first payload")
+        .doesNotContain(hash);
+  }
+
+  /** With no HA plugin at all there is no cluster to seed, and the retry loop must not turn that into work. */
+  @Test
+  void aStandaloneServerSeedsNothing() {
+    assertThat(security.seedSecurityStateClusterWide(3, 0L)).isEmpty();
+    assertThat(security.seedSecurityStateClusterWideWithRetry()).isEmpty();
+  }
+
+  /** The configured budget is read per call, so a {@code SET SERVER SETTING} applies without a restart. */
+  @Test
+  void theConfiguredBudgetIsReadPerCall() {
+    final SeedingHAPlugin ha = new SeedingHAPlugin(security);
+    ha.failUsersTimes = Integer.MAX_VALUE;
+    server.setHA(ha);
+
+    server.getConfiguration().setValue(GlobalConfiguration.HA_SECURITY_SEED_RETRIES, 2);
+    assertThat(security.seedSecurityStateClusterWideWithRetry()).containsExactly("users");
+    assertThat(ha.userDocuments).hasSize(2);
+
+    ha.userDocuments.clear();
+    server.getConfiguration().setValue(GlobalConfiguration.HA_SECURITY_SEED_RETRIES, 4);
+    assertThat(security.seedSecurityStateClusterWideWithRetry()).containsExactly("users");
+    assertThat(ha.userDocuments).as("the new budget applies to the very next admission").hasSize(4);
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // connect cluster: the sibling admission path, which seeded the users document alone
+  // -------------------------------------------------------------------------------------------
+
+  /**
+   * {@code connect cluster} used to seed {@code server-users.jsonl} and nothing else, so a group narrowed or a
+   * token revoked while the joining server was away stayed in force on it.
+   */
+  @Test
+  void connectClusterSeedsAllThreeDocuments() {
+    final SeedingHAPlugin ha = new SeedingHAPlugin(security);
+    server.setHA(ha);
+
+    assertThatCode(() -> controlPlane.connectCluster("node2@localhost:2424")).doesNotThrowAnyException();
+
+    assertThat(ha.joined).containsExactly("node2@localhost:2424");
+    assertThat(ha.userDocuments).hasSize(1);
+    assertThat(ha.groupDocuments).as("the group document was never seeded by this path before").hasSize(1);
+    assertThat(ha.apiTokenDocuments).as("nor was the API-token document").hasSize(1);
+  }
+
+  /**
+   * The seed on this verb spends the configured budget and then gives up without failing the join.
+   * <p>
+   * Not failing it is the contract issue #7401 chose and {@code Issue7401ServerControlPlaneConnectClusterTest}
+   * pins: the server is a committed member by the time the seed runs, so reporting a failed join would send the
+   * caller to retry something that already happened. The sibling {@code POST /api/v1/cluster/peer} answers 503 in
+   * the same situation, and reconciling the two verbs is issue #7550 rather than this one. What this pins is that
+   * the budget IS spent on this path - a single attempt, which is what it used to make, is the defect - and that
+   * the other two documents still went out.
+   */
+  @Test
+  void connectClusterSpendsTheRetryBudgetAndDoesNotFailTheJoin() {
+    final SeedingHAPlugin ha = new SeedingHAPlugin(security);
+    ha.failGroupsTimes = Integer.MAX_VALUE;
+    server.setHA(ha);
+    server.getConfiguration().setValue(GlobalConfiguration.HA_SECURITY_SEED_RETRIES, 2);
+
+    assertThatCode(() -> controlPlane.connectCluster("node2@localhost:2424")).doesNotThrowAnyException();
+
+    assertThat(ha.joined)
+        .as("the membership change is NOT rolled back - removing a committed member is a second failure mode")
+        .containsExactly("node2@localhost:2424");
+    assertThat(ha.groupDocuments).as("the whole budget was spent on the document that failed").hasSize(2);
+    assertThat(ha.userDocuments).as("a failing group seed does not skip the others").hasSize(1);
+    assertThat(ha.apiTokenDocuments).hasSize(1);
+  }
+
+  /** A join that never happened must not be reported as a seed problem. */
+  @Test
+  void connectClusterStillRefusesABlankAddressBeforeSeedingAnything() {
+    final SeedingHAPlugin ha = new SeedingHAPlugin(security);
+    server.setHA(ha);
+
+    assertThatThrownBy(() -> controlPlane.connectCluster("  "))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    assertThat(ha.joined).isEmpty();
+    assertThat(ha.userDocuments).isEmpty();
+  }
+
+  // -------------------------------------------------------------------------------------------
+
+  /**
+   * Stands in for the Raft round trip: records each submitted document and applies it, which is what the state
+   * machine does on the leader before {@code submitAndWait} returns. Each document can be made to fail a given
+   * number of times first, which is what a momentary loss of quorum looks like from here.
+   */
+  private static class SeedingHAPlugin implements HAServerPlugin {
+    protected final ServerSecurity security;
+    final           List<String>   userDocuments     = new ArrayList<>();
+    final           List<String>   groupDocuments    = new ArrayList<>();
+    final           List<String>   apiTokenDocuments = new ArrayList<>();
+    final           List<String>   joined            = new ArrayList<>();
+    int failUsersTimes;
+    int failGroupsTimes;
+    int failApiTokensTimes;
+
+    private SeedingHAPlugin(final ServerSecurity security) {
+      this.security = security;
+    }
+
+    @Override
+    public void replicateSecurityUsers(final String usersJsonArray) {
+      userDocuments.add(usersJsonArray);
+      if (failUsersTimes > 0) {
+        --failUsersTimes;
+        throw new IllegalStateException("consensus lost");
+      }
+      security.applyReplicatedUsers(usersJsonArray);
+    }
+
+    @Override
+    public void replicateSecurityGroups(final String groupsJson) {
+      groupDocuments.add(groupsJson);
+      if (failGroupsTimes > 0) {
+        --failGroupsTimes;
+        throw new IllegalStateException("consensus lost");
+      }
+      security.applyReplicatedGroups(groupsJson);
+    }
+
+    @Override
+    public void replicateSecurityApiTokens(final String apiTokensJson) {
+      apiTokenDocuments.add(apiTokensJson);
+      if (failApiTokensTimes > 0) {
+        --failApiTokensTimes;
+        throw new IllegalStateException("consensus lost");
+      }
+      security.applyReplicatedApiTokens(apiTokensJson);
+    }
+
+    @Override
+    public void connectCluster(final String serverAddress) {
+      joined.add(serverAddress);
+    }
+
+    @Override
+    public ELECTION_STATUS getElectionStatus() {
+      return ELECTION_STATUS.DONE;
+    }
+
+    @Override
+    public void startService() {
+    }
+
+    @Override
+    public boolean isLeader() {
+      return true;
+    }
+
+    @Override
+    public String getLeaderName() {
+      return "leader";
+    }
+
+    @Override
+    public String getClusterName() {
+      return "test";
+    }
+
+    @Override
+    public Map<String, Object> getStats() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public int getConfiguredServers() {
+      return 3;
+    }
+
+    @Override
+    public String getLeaderAddress() {
+      return null;
+    }
+
+    @Override
+    public String getReplicaAddresses() {
+      return "";
+    }
+
+    @Override
+    public void shutdownRemoteServer(final String serverName) {
+    }
+
+    @Override
+    public void disconnectCluster() {
+    }
+  }
+
+  /** An {@link ArcadeDBServer} that is never started, so the security store can be supplied by the fixture. */
+  private static final class FixtureServer extends ArcadeDBServer {
+    private ServerSecurity security;
+
+    private FixtureServer(final ContextConfiguration configuration) {
+      super(configuration);
+    }
+
+    private void setSecurity(final ServerSecurity security) {
+      this.security = security;
+    }
+
+    @Override
+    public ServerSecurity getSecurity() {
+      return security;
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/security/Issue7521SecuritySeedRetryTest.java
+++ b/server/src/test/java/com/arcadedb/server/security/Issue7521SecuritySeedRetryTest.java
@@ -273,6 +273,31 @@ class Issue7521SecuritySeedRetryTest {
         .hasSize(1);
   }
 
+  /**
+   * The same contract with the backoff turned off, which is a documented configuration
+   * ({@code arcadedb.ha.securitySeedRetryBaseMs} of 0 "retries without pausing"). With no sleep to throw, an
+   * interrupt would be observed nowhere and the loop would spin through the whole budget - so the flag is
+   * checked before the pause as well.
+   */
+  @Test
+  void anInterruptStopsTheRetryingEvenWithNoBackoffConfigured() {
+    final SeedingHAPlugin ha = new SeedingHAPlugin(security) {
+      @Override
+      public void replicateSecurityApiTokens(final String apiTokensJson) {
+        Thread.currentThread().interrupt();
+        super.replicateSecurityApiTokens(apiTokensJson);
+      }
+    };
+    ha.failApiTokensTimes = Integer.MAX_VALUE;
+    server.setHA(ha);
+
+    final List<String> failed = security.seedSecurityStateClusterWide(5, 0L);
+
+    assertThat(Thread.interrupted()).as("the flag is left with the caller, not consumed by the check").isTrue();
+    assertThat(failed).containsExactly("API tokens");
+    assertThat(ha.apiTokenDocuments).as("one attempt of a budget of 5, with no pause to interrupt").hasSize(1);
+  }
+
   /** With no HA plugin at all there is no cluster to seed, and the retry loop must not turn that into work. */
   @Test
   void aStandaloneServerSeedsNothing() {

--- a/server/src/test/java/com/arcadedb/server/security/Issue7521SecuritySeedRetryTest.java
+++ b/server/src/test/java/com/arcadedb/server/security/Issue7521SecuritySeedRetryTest.java
@@ -166,6 +166,41 @@ class Issue7521SecuritySeedRetryTest {
   }
 
   /**
+   * The other end of the budget. Both settings are operator-supplied and both are spent inside the request that
+   * already made the membership change, so an unclamped {@code Integer.MAX_VALUE} would be an unbounded stream
+   * of Raft submissions on a request thread rather than a generous retry.
+   */
+  @Test
+  void anAbsurdBudgetIsClampedRatherThanHonoured() {
+    final SeedingHAPlugin ha = new SeedingHAPlugin(security);
+    ha.failUsersTimes = Integer.MAX_VALUE;
+    server.setHA(ha);
+
+    assertThat(security.seedSecurityStateClusterWide(Integer.MAX_VALUE, 0L)).containsExactly("users");
+
+    assertThat(ha.userDocuments).as("clamped to the 10-attempt ceiling").hasSize(10);
+  }
+
+  /**
+   * A base delay near {@code Long.MAX_VALUE} used to be shifted left, and {@code Long.MAX_VALUE << 1} is
+   * <b>negative</b> - which makes {@code Thread.sleep} throw {@code IllegalArgumentException} out of a method
+   * whose whole contract is to return the documents that could not be seeded. The backoff saturates instead.
+   */
+  @Test
+  void anAbsurdBackoffSaturatesInsteadOfOverflowingNegative() {
+    assertThat(ServerSecurity.backoffMs(Long.MAX_VALUE, 1)).isEqualTo(30_000L);
+    assertThat(ServerSecurity.backoffMs(Long.MAX_VALUE, 9)).isEqualTo(30_000L);
+    assertThat(ServerSecurity.backoffMs(500L, 1)).isEqualTo(500L);
+    assertThat(ServerSecurity.backoffMs(500L, 2)).isEqualTo(1_000L);
+    assertThat(ServerSecurity.backoffMs(500L, 3)).isEqualTo(2_000L);
+    assertThat(ServerSecurity.backoffMs(500L, 9)).as("saturates rather than growing to two minutes")
+        .isEqualTo(30_000L);
+    assertThat(ServerSecurity.backoffMs(0L, 4)).isZero();
+    assertThat(ServerSecurity.backoffMs(-1L, 4)).as("a negative setting is no pause, never a negative sleep")
+        .isZero();
+  }
+
+  /**
    * The point of the monitor, applied to the retry. A retry that replayed the payload read before the first
    * attempt would carry a pre-revocation document and put the revoked token back on every node in the cluster -
    * the exact failure the seed's monitor exists to prevent, arriving through the door added to fix a different
@@ -288,6 +323,8 @@ class Issue7521SecuritySeedRetryTest {
 
     assertThat(ha.joined).isEmpty();
     assertThat(ha.userDocuments).isEmpty();
+    assertThat(ha.groupDocuments).as("validation runs before any document is submitted").isEmpty();
+    assertThat(ha.apiTokenDocuments).isEmpty();
   }
 
   // -------------------------------------------------------------------------------------------

--- a/studio/src/main/resources/static/js/studio-cluster.js
+++ b/studio/src/main/resources/static/js/studio-cluster.js
@@ -679,9 +679,10 @@ function addPeerPrompt() {
     })
     .fail(function(jqXHR) {
       globalNotifyError(jqXHR.responseText);
-      // Refresh on failure too: a 503 from this route means the peer WAS added and only its security seed did
-      // not land (issue #7521), so the membership shown here has changed even though the call reports an error.
-      updateCluster();
+      // 503 only: that is the one failure from this route where the peer WAS added and just its security seed
+      // did not land (issue #7521), so the membership shown here has changed even though the call reports an
+      // error. A 400/401/403 never reached the membership change, and refreshing on those would say nothing.
+      if (jqXHR.status === 503) updateCluster();
     });
   });
 }

--- a/studio/src/main/resources/static/js/studio-cluster.js
+++ b/studio/src/main/resources/static/js/studio-cluster.js
@@ -677,7 +677,12 @@ function addPeerPrompt() {
       globalNotify("Success", "Peer " + peerId + " added", "success");
       updateCluster();
     })
-    .fail(function(jqXHR) { globalNotifyError(jqXHR.responseText); });
+    .fail(function(jqXHR) {
+      globalNotifyError(jqXHR.responseText);
+      // Refresh on failure too: a 503 from this route means the peer WAS added and only its security seed did
+      // not land (issue #7521), so the membership shown here has changed even though the call reports an error.
+      updateCluster();
+    });
   });
 }
 


### PR DESCRIPTION
Closes #7521

## Summary

`POST /api/v1/cluster/peer` admitted the peer and then seeded the three security documents -
`server-users.jsonl`, `server-groups.json`, `server-api-tokens.json` - with a **single** attempt,
reporting a failure as a `warning` field inside an **HTTP 200**. Those documents live under
`<server-root>/config/`, outside the database directory, so Raft snapshot install carries none of
them: the seed is the only thing that converges them on a joining peer. The seed is submitted as
Raft entries, so its usual failure is "no quorum right now" - the same condition that makes adding a
peer interesting in the first place - and operator automation reading a 200 moved on while the peer
kept authenticating and authorizing from its own copies. For a node re-added after having been out
of the cluster, those are the security state from whenever it left: a user dropped since, a group
narrowed since, or a token revoked since is still in force there, and behind a load balancer the
operator sees an intermittent success against a credential they believe is dead.

This takes the first of the two shapes the issue proposed - bounded retry before the handler
returns, and a hard failure when the seed does not land - and extends the same seed to the sibling
admission path.

## The invariant

> Every cluster-admission path submits all three security documents as Raft entries, retrying the
> ones that fail within a bounded budget and re-reading each under the security monitor on every
> attempt; and `POST /api/v1/cluster/peer` does not answer 2xx while any of them is still unseeded.

## Changes

| File | What changed |
|---|---|
| `GlobalConfiguration` | `arcadedb.ha.securitySeedRetries` (default 3) and `arcadedb.ha.securitySeedRetryBaseMs` (default 500) |
| `ServerSecurity` | `seedSecurityStateClusterWide(int, long)` - bounded retry over **only** the documents that failed, each attempt re-reading under the security monitor, interrupt-aware. `seedSecurityStateClusterWideWithRetry()` reads the configured budget per call, so a `SET SERVER SETTING` applies to the next admission. The existing no-arg method keeps its one-attempt meaning |
| `PostAddPeerHandler` | Uses the retrying seed and answers **503** with `error` + `detail` when documents remain unseeded, instead of 200 with a `warning`. The body is built by a static `seedOutcomeResponse`, so the status/body contract is unit-testable |
| `ServerControlPlane.connectCluster` | Seeded the **users document only**, read **outside** the security monitor, and swallowed the failure at WARNING. It now goes through the same retrying, monitor-held helper for all three documents; the failure log is SEVERE |
| `PluginApiSpec` | The add-peer operation declares the 503 and explains it; `ClusterActionResponse` gained `error` and `detail` |
| `studio-cluster.js` | The add-peer `fail` handler refreshes the cluster view, because a 503 there means the peer **was** added |

The membership change is never rolled back. That is deliberate and is what the issue itself says:
removing a committed member is a second failure mode, not a repair. What changes is that the caller
sees a failure status, and re-issuing the request is idempotent on the add (`RaftClusterManager.addPeer`
treats an already-member peer as success) and reissues the seed.

## Why not the readiness-gate shape

The issue's second option - "a peer whose security documents have not converged reports NOT_READY" -
is not implementable as described today, and the reason is not cost. The readiness probe is answered
**by the joining peer**, and the joining peer cannot distinguish "a seed was sent for me and never
arrived" from "the cluster's security state has not changed since I last wrote my files": there is no
committed cluster-wide version of the three documents to compare a local copy against (#7509 is the
issue that would have to introduce one). A gate built on "has this node applied a replicated security
entry since it started" would hold every node of a freshly bootstrapped cluster, and every node of a
rolling restart, at NOT_READY forever - an availability regression traded for a consistency one.

## Test plan

- [x] `Issue7521SecuritySeedRetryTest` (server, 10 tests): a seed that fails once and then succeeds is reported as seeded; only the failing document is retried; the budget is a bound; a budget below 1 still makes one attempt; **every attempt re-reads the document** (a revocation landing between attempt 1 and attempt 2 must not be resurrected by the retry); a standalone server seeds nothing; the configured budget is read per call; `connect cluster` seeds all three documents; `connect cluster` spends the budget without failing the join; a blank address still refuses before seeding anything
- [x] `Issue7521SeedOutcomeResponseTest` (ha-raft, 3 tests): a fully seeded peer is a plain 200 with no `error`/`detail`; an unseeded document is a 503 naming the documents in `error` and the consequence plus the remedy in `detail`; a single failing document is named without a dangling separator
- [x] The new tests were shown to be able to fail: forcing `seedOnce`'s `only` filter to `null` - the behaviour before the retry existed - turns two of them red, and the sabotage was reverted
- [x] `mvn -o -pl server -am -Dtest='Issue7373*,Issue7401*,Issue7521*,ServerControlPlane*,ServerSecurity*Test,PluginApiSpecTest,SecurityAdminApiSpecTest,...' test` -> 90 tests, 0 failures
- [x] `mvn -o -pl ha-raft -am -Dtest='Issue7521*,Issue7401Join*,Issue7373*,HAConfigDefaultsTest,ConfigValidationTest,RaftTransactionBrokerTest' test` -> 25/38 tests, 0 failures
- [x] `mvn -o -pl engine -Dtest='Issue7124*,Issue7163*,GlobalConfiguration*' test` -> 34 tests, 0 failures
- [ ] **Not run locally:** the multi-node HA ITs (`Issue7401ConnectClusterJoinsPeerIT`, `RaftUserSeedOnPeerAdd3NodesIT`). `BaseRaftHATest` binds fixed ports from 2480 up and 2480 was held by unrelated JVMs on the build machine for the whole session, so a local run would have failed for a reason unrelated to this change. CI runs them

## Coverage

Entry points this fix covers:

| Entry point | Covered |
|---|---|
| `POST /api/v1/cluster/peer` -> `PostAddPeerHandler` | Retry budget + 503 + `error`/`detail` |
| HTTP `connect cluster` and gRPC `ConnectCluster` -> `ServerControlPlane.connectCluster` | All three documents, monitor-held, retried (was: users only, outside the monitor) |
| Studio's add-peer form | Shows the 503 and refreshes the membership |

**Known gaps**

- **#7544** - Kubernetes StatefulSet scale-up auto-join (`KubernetesAutoJoin`) runs **no** seed at
  all: the pod adds itself and no member seeds it. Same failure mode as this issue and strictly
  worse. Out of scope because auto-join runs unattended on the joining pod, so there is no caller to
  report a hard failure to; a fix needs the leader to seed on a configuration change, or the joining
  node to request one.
- **#7550** - `connect cluster` still answers **success** when the seed did not land, where
  `POST /api/v1/cluster/peer` now answers 503. Reversing that turns
  `Issue7401ServerControlPlaneConnectClusterTest.aFailingUsersSeedDoesNotFailTheJoin` red, and that
  test states the contract in its own javadoc ("a seed failure must not be reported as a failed join
  - the caller would retry a join that already happened"). It is a deliberate decision from #7401,
  so this PR leaves it, makes the log SEVERE, and files the issue that reconciles the two verbs -
  which is also where the gRPC status question belongs, since a `NeedRetryException` maps to HTTP 503
  but reaches `ArcadeDbGrpcAdminService.toStatus` with no arm of its own.
- **#7524** (pre-existing, unchanged here) - no multi-node IT covers group / API-token seeding of a
  newly-added peer. The retry and the response contract here are covered by unit tests against a
  recording HA plugin, not against a real Raft quorum.
- A seed that exhausts the retry budget still leaves the peer a cluster member enforcing its own
  stale documents, and traffic to it is not gated. See "Why not the readiness-gate shape" above.

## Cost

Worst case on the add-peer route: `securitySeedRetries` attempts per document, each bounded by the
Raft submit's own timeout, plus 500 ms + 1 s of backoff at the defaults - on a worker thread
(`mustExecuteOnWorkerThread()`), on an operator-driven route that already carries the membership
change's own retry budget.

Refs #7373, #7513, #7401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEJXCdUGW61QSXqyurphpt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable retry limits and exponential backoff for cluster security-document seeding.
  * Newly added peers now seed users, groups, and API tokens with retries.
  * Cluster joins now seed all supported security documents.

* **Bug Fixes**
  * Incomplete security seeding now returns HTTP 503 with details while preserving the peer addition.
  * Cluster views refresh after peer-add errors, including partial-seeding failures.

* **Documentation**
  * Updated API documentation to describe security seeding, retry behavior, and partial-seed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->