### PR TITLE
fix(#7510): refresh a peer's cached permissions when a group entry applies, not on the reload tick

### DIFF
--- a/.claude/skills/engine-concurrency/SKILL.md
+++ b/.claude/skills/engine-concurrency/SKILL.md
@@ -30,6 +30,7 @@ download, i.e. the longest-running thing the HA layer does, and it no longer par
 | `MaterializedViewScheduler` | `server` | Cron-style MV refresh | scheduled executor | n/a |
 | Raft HA pools | `ha-raft` | Leader election, log replication | configurable in Raft conf | n/a |
 | `ArcadeStateMachine.snapshotInstallExecutor` | `ha-raft` | Leader-initiated follower snapshot install, off the Ratis state-machine thread | 1 worker, 16-deep queue (Ratis serialises installs per division) | Abort, turned into a failed future so Ratis retries - never caller-runs, which would put the download back on the Ratis thread |
+| `ServerSecurity.permissionsRefreshExecutor` | `server` | Re-deriving the cached per-database permissions after a group document arrives over HA replication, off the Raft state-machine apply thread (issue #7510) | core 0 (an idle server carries no thread) / max 1, 30 s keep-alive, 1-deep queue | **Drop**, logged at `FINE` - and that is coalescing, not loss: the task reads the group document when it RUNS, and the new document is published before the submit, so the one already queued covers every change dropped behind it |
 | Undertow IO + worker | `server` | HTTP request handling | hardcoded 500 worker threads | Undertow built-in |
 | `ServerMonitor` | `server` | Periodic metric collection | scheduled executor | n/a |
 

--- a/docs/7510-ha-replicated-group-permission-refresh.md
+++ b/docs/7510-ha-replicated-group-permission-refresh.md
@@ -1,0 +1,271 @@
+# Issue #7510 - a replicated group change reaches a peer's cached permissions only on the security reload tick
+
+- Issue: https://github.com/ArcadeData/arcadedb/issues/7510
+- Type: bug (labels already on the issue: `bug`, `server`, `ha`, `concurrency`, `security`, `in progress`; assignee `robfrank`)
+- Branch: `fix/7510-ha-replicated-group-permission-refresh`
+- Refs: #7373 (the PR that made group changes replicate at all)
+
+## Root cause
+
+`server-groups.json` is the durable state, but the *enforcement* state is derived: every
+`ServerSecurityUser` keeps a `ConcurrentHashMap<String, ServerSecurityDatabaseUser> databaseCache`
+(`ServerSecurityUser:38`) built the first time that principal touches a database, and only
+`ServerSecurity.updateSchema(DatabaseInternal)` re-derives it.
+
+- On the node that served the request, `ServerControlPlane.saveGroup`/`deleteGroup` call
+  `refreshPermissionsOf(database)` (`ServerControlPlane:644`, `:666`, `:673`) right after the
+  cluster-wide mutation, so the caches follow the document immediately.
+- On a **peer**, the entry arrives as `SECURITY_GROUPS_ENTRY` and lands in
+  `ServerSecurity.applyReplicatedGroups` (`ArcadeStateMachine:3692`). That method installs the
+  document and deliberately does nothing else: it runs on the Raft state-machine apply thread,
+  which must never block, and `updateSchema` walks every open database.
+- The peer therefore converged only through `SecurityGroupFileRepository`'s own file watcher
+  (`SecurityGroupFileRepository:174-195`), which polls `file.lastModified()` every
+  `arcadedb.server.reloadEvery` ms (`GlobalConfiguration:1629`, default **5000**) and then fires
+  `reloadCallback` -> `ServerSecurity`'s constructor lambda (`ServerSecurity:110-115`) ->
+  `updateSchema` per database.
+
+So for up to one reload interval a peer keeps granting the **old, wider** access to any principal
+that was already connected, while `GET /server/groups` on that same peer already returns the new
+definition and the operator's request has already returned 200. Nothing an operator can query
+shows the gap.
+
+### The lag is real, not a never
+
+`persist()` writes the file without touching `fileLastUpdated` (which only `load()` sets), so the
+watcher does eventually see the replicated write and fire. The defect is latency, not a permanent
+miss - which matches the issue report.
+
+## Invariant the fix establishes
+
+> Once a replicated group document has been installed on a node, that node re-derives the cached
+> per-database permissions of every database it has open **without waiting for the
+> `arcadedb.server.reloadEvery` file-watcher tick**, and without doing that work on the Raft
+> state-machine apply thread.
+
+## Completeness
+
+### Sweep commands and output
+
+```
+$ grep -rn "applyReplicatedGroups" --include='*.java' server/src/main ha-raft/src/main grpcw/src/main engine/src/main
+server/src/main/java/com/arcadedb/server/security/ServerSecurity.java:1067:  public void applyReplicatedGroups(final String groupsJson) {
+ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java:3692:      server.getSecurity().applyReplicatedGroups(payload);
+(the remaining 5 hits are javadoc references)
+```
+
+```
+$ grep -rn "\.updateSchema(" --include='*.java' . | grep -v '/src/test/'
+server/src/main/java/com/arcadedb/server/ServerControlPlane.java:677:        security.updateSchema((DatabaseInternal) server.getDatabase(databaseName));
+engine/src/main/java/com/arcadedb/database/LocalDatabase.java:2966:          security.updateSchema(this);
+engine/src/main/java/com/arcadedb/schema/LocalSchema.java:3146:      security.updateSchema(database);
+```
+
+```
+$ grep -rn "groupRepository\.\(save\|applyReplicated\)\|replicateSecurityGroups(" --include='*.java' . | grep -v '/src/test/'
+ha-raft/.../RaftTransactionBroker.java:449:  public void replicateSecurityGroups(final String groupsJson) {
+ha-raft/.../RaftHAPlugin.java:219, :224
+server/.../HAServerPlugin.java:323:  default void replicateSecurityGroups(final String groupsJson) {
+server/.../ServerSecurity.java:146  (saveInError)
+server/.../ServerSecurity.java:917  (saveGroups() - no production caller)
+server/.../ServerSecurity.java:992  (persistGroups, from local saveGroup/deleteGroup)
+server/.../ServerSecurity.java:1024 (saveGroupClusterWide)
+server/.../ServerSecurity.java:1043 (deleteGroupClusterWide)
+server/.../ServerSecurity.java:1087 (applyReplicatedGroups)
+server/.../ServerSecurity.java:1158 (seedGroupsClusterWide)
+```
+
+```
+$ grep -rn "controlPlane\.\(saveGroup\|deleteGroup\)" --include='*.java' . | grep -v '/src/test/'
+server/.../http/handler/DeleteGroupHandler.java:50
+server/.../http/handler/PostGroupHandler.java:53
+grpcw/.../ArcadeDbGrpcAdminService.java:441, :453
+```
+
+```
+$ grep -rn "onReload\|reloadCallback" --include='*.java' . | grep -v '/src/test/'
+server/.../SecurityGroupFileRepository.java:51, :188, :189, :300, :301
+server/.../ServerSecurity.java:110
+```
+
+### Entry-point coverage table
+
+| # | Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|---|
+| 1 | Peer: `ArcadeStateMachine.applySecurityGroupsEntry` -> `ServerSecurity.applyReplicatedGroups` (grant narrowed) | **yes** - schedules the refresh on a dedicated single worker | yes - `aReplicatedRevocationReachesTheCachedPrincipalWithoutTheReloadTick` |
+| 2 | Same, grant **widened** (so the test cannot pass by denying everything) | **yes** - same call | yes - `aReplicatedGrantReachesTheCachedPrincipalWithoutTheReloadTick` |
+| 3 | Same, but the local file write FAILED: the document is in force in memory and `ReplicatedSecurityConfigPersistenceException` is thrown | **yes** - the refresh is scheduled *before* the throw | yes - `aRefreshIsStillScheduledWhenTheReplicatedWriteFails` |
+| 4 | Joining peer seed: `PostAddPeerHandler` -> `seedGroupsClusterWide` -> `replicateSecurityGroups` -> apply | **yes** | argued: byte-for-byte the same `applyReplicatedGroups` call as rows 1-3; no separate test |
+| 5 | Serving node: `ServerControlPlane.saveGroup`/`deleteGroup` (HTTP `PostGroupHandler`/`DeleteGroupHandler`, gRPC `ArcadeDbGrpcAdminService`) | pre-existing `refreshPermissionsOf`, unchanged | existing `Issue7373*` / control-plane tests |
+| 6 | Non-HA single node: `saveGroupClusterWide`/`deleteGroupClusterWide` fall back to local `saveGroup`/`deleteGroup`, refreshed by row 5's caller | pre-existing, unchanged | existing tests |
+| 7 | Hand-edited `server-groups.json` -> watcher -> `reloadCallback` | pre-existing; now calls the same extracted `refreshAllDatabasePermissions()` | yes - `theReloadWatcherBodyRefreshesEveryOpenDatabase` |
+| 8 | Peer: `applyReplicatedUsers` | argued: it builds **new** `ServerSecurityUser` instances and swaps the map, and `databaseCache` is a `private final` per-instance field (`ServerSecurityUser:38`), so no derived state survives the swap |
+| 9 | Peer: `applyReplicatedApiTokens` | argued: a token principal carries a `syntheticGroupConfig`, and `ServerSecurityUser:156` / `:213` take that branch *instead of* the file group configuration, so a group document cannot change its answer |
+| 10 | `ServerSecurity.saveGroups()` (public, writes the whole document with no refresh) | argued: sweep C shows the definition and **no** production call site |
+| 11 | The refresh sweep itself, when one database in it cannot be handed over (dropped under the iteration, or refused with `DatabaseNotAvailableException` because its directory still carries the interrupted-snapshot marker) | **yes** - guarded per database rather than once around the loop | yes - `oneUnavailableDatabaseDoesNotStopTheOthersFromBeingRefreshed` (added by the adversarial pass) |
+
+### Residual risk
+
+1. **Coalescing drops a refresh by design.** The worker has a one-deep queue: while one refresh is
+   queued, a second submission is dropped, because the queued one has not read the group document
+   yet and will therefore see the newest one. A drop while a refresh is *running* cannot happen -
+   that slot is free. This is correct but it is a queue, not a proof, and it is the thing to look
+   at first if convergence ever looks slow under a burst of group edits.
+2. **The refresh is still asynchronous.** The window shrinks from up to `reloadEvery` (5 s by
+   default) to the scheduling latency of a single idle worker - microseconds to milliseconds - but
+   it is not zero, and it cannot be: the apply thread may not block. A caller that needs a
+   synchronous guarantee has to use the control plane on the node it is talking to, which already
+   refreshes inline.
+3. **The file watcher remains the safety net** and is deliberately not removed: if the executor is
+   saturated, shut down, or the task throws, the peer still converges on the reload tick exactly as
+   it did before this change.
+4. **The sweep can reopen a closed database**, because it resolves names with `allowLoad = true`. Pre-existing
+   on the watcher path this method was extracted from; see finding 2 of the adversarial pass below.
+5. **Not covered, and pre-existing:** `SecurityGroupFileRepository`'s watcher timer is only started
+   inside `load()`. `applyReplicated()` publishes the document without going through `load()`, so
+   on a node whose *first ever* group access is a replicated apply, `getGroups()` never falls into
+   the lazy-init branch and the watcher is never scheduled at all. Filed as a follow-up (see
+   below) - it is a different defect (the safety net not existing) from the one this PR fixes
+   (the safety net being the only mechanism). Filed as **#7545**.
+
+## Change
+
+`server/src/main/java/com/arcadedb/server/security/ServerSecurity.java`
+
+1. **`refreshAllDatabasePermissions()`** - the loop that was inlined in the group file's `onReload` lambda,
+   extracted as a public method so the replicated path runs the same body rather than a second hand-written
+   copy of it. It reads the *current* document rather than a snapshot handed to it, which is what lets a
+   queued refresh stand in for the ones coalesced behind it.
+2. **`permissionsRefreshExecutor`** - one daemon worker, `core 0 / max 1 / 30 s keep-alive`, one-deep
+   `ArrayBlockingQueue`, shaped after `ArcadeStateMachine`'s `snapshotInstallExecutor` (and, per the
+   `engine-concurrency` rule, explicitly not the JDK common `ForkJoinPool`). Its rejection handler **drops**
+   the task and logs at `FINE`, which is coalescing rather than loss: a drop can only happen while another
+   refresh is queued and has not started, and the new document is published before the submit, so the queued
+   task reads a document at least as new as the dropped one's.
+3. **`applyReplicatedGroups`** now calls `scheduleDatabasePermissionsRefresh()` immediately after
+   `groupRepository.applyReplicated(root)` and **before** the persistence failure is reported. That ordering is
+   the point of row 3: `applyReplicated` publishes in memory first, so the node authorizes against the new
+   document whether or not the write succeeded, and the case that needs the refresh most - a narrowed
+   permission on a node whose config volume is full - must not be the one that skips it.
+4. `stopService()` shuts the worker down.
+
+`server/src/test/java/com/arcadedb/server/security/Issue7373ReplicatedGroupAuthorizationTest.java` - **comments
+only**, no assertion or logic changed. Its javadoc described the reload-tick lag as the current behaviour and
+named #7510 as the issue that would close it; that text is now false. The two assertions it makes still hold and
+still mean something: the apply itself stays non-blocking, and the mocked server there reports no open database,
+so the new asynchronous refresh has nothing to walk and cannot race them.
+
+## Finding ledger
+
+- [x] 1. A replicated group change reaches a peer's cached permissions only on the security reload tick -
+      **fixed**, off-thread refresh scheduled from `applyReplicatedGroups` (coverage rows 1-4).
+
+## Test results
+
+New: `server/src/test/java/com/arcadedb/server/security/Issue7510ReplicatedGroupRefreshTest.java`, 4 tests.
+
+Before the fix (only the extraction in place, no scheduling):
+
+```
+Tests run: 4, Failures: 3, Errors: 0, Skipped: 0
+  aRefreshIsStillScheduledWhenTheReplicatedWriteFails:169 [the revocation is enforced on the peer even though persisting it failed]
+  aReplicatedGrantReachesTheCachedPrincipalWithoutTheReloadTick:137 [the widened grant reaches the cached principal without waiting for the reload tick]
+  aReplicatedRevocationReachesTheCachedPrincipalWithoutTheReloadTick:121 [the principal already connected to the peer is denied without waiting for the reload tick]
+```
+
+Each of the three failed by exhausting the full 10 s outcome wait (30.99 s for the class), i.e. by the peer not
+converging - which is the defect, reproduced through the entry point the Raft state machine actually uses.
+
+After the fix: `Tests run: 4, Failures: 0, Errors: 0` in 0.958 s - the class is now faster than one reload
+interval, which is the change stated as a number.
+
+Regression runs (all with `-Dmaven.repo.local=$WORKTREE/.m2repo`, isolated from the parallel agents):
+
+| Command | Result |
+|---|---|
+| `mvn -o -pl server -am install -DskipTests` | BUILD SUCCESS |
+| `mvn -o -pl ha-raft -am install -DskipTests` | BUILD SUCCESS |
+| `mvn -o -pl server test -Dtest='Issue7373*,ServerSecurity*,SecurityGroup*,ServerControlPlane*,*Group*Test'` | 66 tests, 0 failures |
+| `mvn -o -pl ha-raft test -Dtest='Issue7137…,Issue7227…,Issue7252…,Issue7373SecurityConfig*'` | 15 tests, 0 failures |
+| `mvn -o -pl server test -DexcludedGroups=benchmark,vector,slow` | 1099 tests, 13 failures + 6 errors - **all environmental, see below** |
+
+### The 19 failures in the full server run are a port collision, not this change
+
+`lsof -nP -iTCP:2480 -sTCP:LISTEN` reports two foreign `java` processes holding 2480 (other agents' servers
+running concurrently on this machine). The failing classes are `ClusterInternalAuthTest`,
+`PostClusterAuthSessionHandlerTest`, `AutoCommitParameterTest`, `PostCommandHandlerDecodeTest`,
+`HttpBodySizeLimitTest`, `Issue6220TruncateHttpDefaultTest`, `Issue5675CreateIndexIfNotExistsHttpTest` - every one
+of them an HTTP test against `127.0.0.1:2480`, failing with `401` where it expected `200`/`204`/`400`/`404`, or
+with `Schema Type with name 'TestDoc' was not found`. That is the signature `CLAUDE.md` documents for this exact
+situation. None of them replicate a group, reload the group file, or construct a Raft entry, and the whole
+`com.arcadedb.server.security` package - including the four new tests and every pre-existing group test - is green
+in that same run:
+
+```
+Issue7510ReplicatedGroupRefreshTest        Tests run: 4,  Failures: 0, Errors: 0
+Issue7373ReplicatedGroupAuthorizationTest  Tests run: 2,  Failures: 0, Errors: 0
+Issue7373ClusterWideGroupsAndTokensTest    Tests run: 24, Failures: 0, Errors: 0
+Issue6806GroupPermissionRefreshTest        Tests run: 7,  Failures: 0, Errors: 0
+SecurityGroupFileRepositoryTest            Tests run: 3,  Failures: 0, Errors: 0
+ServerSecurityIT                           Tests run: 6,  Failures: 0, Errors: 0
+```
+
+## Reachability
+
+- `applyReplicatedGroups` is called on a live path: `ArcadeStateMachine.applySecurityGroupsEntry:3692`, the
+  `SECURITY_GROUPS_ENTRY` arm of the Raft apply switch (`:933`).
+- `ServerSecurity` is constructed by the server itself - `ArcadeDBServer.java:399`,
+  `security = new ServerSecurity(this, configuration, serverRootPath + "/config")` - the only production
+  construction site, so the executor field exists on every running node.
+- No configuration flag gates the refresh: it is unconditional on the apply path. `arcadedb.server.reloadEvery`
+  now only sizes the safety net behind it.
+- Cost when nothing replicates: zero threads. The pool has `corePoolSize` 0, so a server that never applies a
+  group entry never starts the worker.
+
+## Impact
+
+- A peer now enforces a replicated group change within the scheduling latency of an idle worker instead of up to
+  `arcadedb.server.reloadEvery` ms (default 5000).
+- No change to the node that served the request (`ServerControlPlane.refreshPermissionsOf`, still inline), to the
+  non-HA path, or to the hand-edited-file path beyond both now calling the same extracted method.
+- The Raft apply thread does strictly less work than a blocking refresh would have cost it, and exactly one queue
+  offer more than before.
+
+## Recommendations
+
+- Watch for the `FINE` "coalesced into it" line if convergence ever looks slow under a burst of group edits; a
+  sustained stream of them is the only way to keep the one-deep queue occupied.
+- #7545 is the remaining gap in the same area: on a node whose first group access is a replicated apply, the file
+  watcher is never scheduled at all, so the safety net this change deliberately keeps does not exist there.
+
+## Adversarial pass
+
+The orchestrator's Phase 1.5 spawns a subagent that has not seen the author's reasoning. **The `Task` tool is
+disabled in this session**, so no such subagent could be spawned; the pass was run by the author against the diff
+instead, which is weaker - it is the same head that wrote the patch - and is recorded as such. Three findings,
+each verified against the tree:
+
+1. **Real, in scope - fixed here.** `refreshAllDatabasePermissions()` had no per-database guard, so one database
+   that `ArcadeDBServer.getDatabase()` refuses aborted the sweep and left every database after it in the
+   iteration waiting for the reload tick - this issue, reintroduced for those databases by the very method that
+   removes it. The refusal is not hypothetical:
+   `ArcadeDBServer.java:1422-1426` throws `DatabaseNotAvailableException` for a directory still carrying the
+   interrupted-snapshot marker, and a peer mid-snapshot-install is exactly a node that also receives replicated
+   group entries. Fixed by moving the guard inside the loop, and pinned by
+   `oneUnavailableDatabaseDoesNotStopTheOthersFromBeingRefreshed`, which iterates the broken name FIRST and fails
+   (verified by reverting the guard: `Tests run: 5, Failures: 1`) without it.
+
+2. **Real, pre-existing, not worsened in kind - argued, not filed.** The sweep resolves each name with
+   `server.getDatabase(name)`, i.e. `allowLoad = true`, so an entry that is present in the map but closed is
+   **reopened** as a side effect of a permission refresh (`ArcadeDBServer.java:1411-1475`). That is undesirable,
+   but it is not introduced here: `applyReplicated()` writes the group file, the watcher's `lastModified` check
+   therefore fires, and the watcher has always run this same loop. The patch makes it happen sooner, not for the
+   first time. Changing `allowLoad` would alter the hand-edited-file path too and is a different change;
+   recorded in residual risk instead of silently altered.
+
+3. **Not real.** Suspected deadlock: the refresh worker taking the `ServerSecurity` monitor while
+   `saveGroupClusterWide` holds it across the Raft round trip. It cannot. The worker's path is
+   `refreshAllDatabasePermissions` -> `updateSchema` -> `getDatabaseGroupsConfiguration`, and
+   `ServerSecurity.java:1549` declares that method `protected JSONObject getDatabaseGroupsConfiguration(...)` -
+   not `synchronized` - while `updateSchema` (`:587`) is not synchronized either. The worker never contends for
+   that monitor, and the apply thread never waits for the worker.

--- a/docs/7510-ha-replicated-group-permission-refresh.md
+++ b/docs/7510-ha-replicated-group-permission-refresh.md
@@ -323,12 +323,26 @@ https://github.com/ArcadeData/arcadedb/pull/7553
 | 1 | `7d03762b` | the fix as opened | `claude`: "Nothing here blocks merging" - three polish items: register the pool in the `engine-concurrency` inventory, tighten `refreshAllDatabasePermissions` to package-private, prefer `shutdown()` over `shutdownNow()`. CodeRabbit posted nothing on this head |
 | 2 | `977998b2` | pool inventory row added; method package-private; `stopService()` drains the queue then `shutdown()`s (neither plain option was right: `shutdownNow()` interrupts a walk that may be inside `ArcadeDBServer.getDatabase()`, plain `shutdown()` lets a still-QUEUED task start after the service stopped) | `claude`: non-blocking notes - nothing waits for an in-flight refresh before `stopInternal()` closes the databases; say out loud why `Exception` and not `Throwable`; the doc said 4 tests and the class had 5 |
 | 3 | `2c771d22` | bounded `awaitTermination(2s)`; the `Exception`-not-`Throwable` choice stated in the comment; doc count corrected | `claude`: non-blocking. **CodeRabbit's first review**, 4 inline findings, one of them Major (CWE-863) and correct |
-| 4 | `e479a7ac` | `updateSchema`'s read and publish serialised under one dedicated monitor; the persistence-failure test made deterministic and made to assert the exception; coverage-table cells | - |
+| 4 | `e479a7ac` -> `89737649` | `updateSchema`'s read and publish serialised under one dedicated monitor; the persistence-failure test made deterministic and made to assert the exception; coverage-table cells; this tracking doc | `claude`: "Nothing found here blocks merging" - one observation, that `permissionsPublishLock` is server-wide rather than per database, explicitly "not a requested change". CodeRabbit re-reviewed and **resolved all four of its threads** |
+| 5 | `eed3fd1d` | comment only: the lock's javadoc now says why the granularity is server-wide and not per database, which was the half the surrounding note left out | `claude`: **"Bugs: None found"**; repeats the per-database-lock idea as "a 'watch this if it ever becomes hot' note, not something I'd hold the PR on" |
 
 ### Deferred items
 
-None. Every review comment across the four cycles was either applied or answered in the thread with
-evidence - there is no `review-deferred-*.md` file in this branch.
+None. Every review comment across the five cycles was either applied or answered in the thread with evidence -
+there is no `review-deferred-*.md` file in this branch, and all four CodeRabbit inline threads are resolved.
+
+### Skipped with rationale
+
+- **A per-database-name lock instead of the one server-wide monitor** (raised in cycles 4 and 5, both times as
+  explicitly non-blocking). Not taken. A refresh is a walk of cached maps with no I/O, and every trigger for one -
+  a group edit, a schema change, a database open - is rare, so the parallelism it would buy back is not something
+  a workload here would measure. The cost is real: a map of locks keyed by database name is a second lifetime to
+  manage for every name the server has ever seen. The trade is now stated in the lock's javadoc rather than left
+  for the next reader to rediscover.
+- **Two tests build their own `ServerSecurity` instead of reusing the `@BeforeEach` fixture** (cycle 4, "harmless,
+  just a little redundant setup"). Deliberate: both need a *different* server mock - one with two database names
+  where the first throws, one with a subclass that instruments the configuration read - so reusing the fixture
+  would mean making the fixture conditional, which is the more confusing of the two shapes.
 
 The one review suggestion **not** taken as written is CodeRabbit's "add a latch-based regression test for this
 ordering". The reply on that thread says why: the lost update depends on which of two racing threads the
@@ -338,5 +352,5 @@ and was proved able to fail by removing the lock.
 
 ### Final state
 
-`clean-approval` - the last substantive review says nothing blocks the merge, no major issue is open, and every
-CodeRabbit thread has a reply. **The merge is the developer's.**
+`clean-approval` - the last review on `eed3fd1d` reports **"Bugs: None found"**, no major issue is open, and all
+four CodeRabbit threads are resolved. **The merge is the developer's; this workflow does not merge PRs.**

--- a/docs/7510-ha-replicated-group-permission-refresh.md
+++ b/docs/7510-ha-replicated-group-permission-refresh.md
@@ -99,10 +99,11 @@ server/.../ServerSecurity.java:110
 | 5 | Serving node: `ServerControlPlane.saveGroup`/`deleteGroup` (HTTP `PostGroupHandler`/`DeleteGroupHandler`, gRPC `ArcadeDbGrpcAdminService`) | pre-existing `refreshPermissionsOf`, unchanged | existing `Issue7373*` / control-plane tests |
 | 6 | Non-HA single node: `saveGroupClusterWide`/`deleteGroupClusterWide` fall back to local `saveGroup`/`deleteGroup`, refreshed by row 5's caller | pre-existing, unchanged | existing tests |
 | 7 | Hand-edited `server-groups.json` -> watcher -> `reloadCallback` | pre-existing; now calls the same extracted `refreshAllDatabasePermissions()` | yes - `theReloadWatcherBodyRefreshesEveryOpenDatabase` |
-| 8 | Peer: `applyReplicatedUsers` | argued: it builds **new** `ServerSecurityUser` instances and swaps the map, and `databaseCache` is a `private final` per-instance field (`ServerSecurityUser:38`), so no derived state survives the swap |
-| 9 | Peer: `applyReplicatedApiTokens` | argued: a token principal carries a `syntheticGroupConfig`, and `ServerSecurityUser:156` / `:213` take that branch *instead of* the file group configuration, so a group document cannot change its answer |
-| 10 | `ServerSecurity.saveGroups()` (public, writes the whole document with no refresh) | argued: sweep C shows the definition and **no** production call site |
+| 8 | Peer: `applyReplicatedUsers` | argued: it builds **new** `ServerSecurityUser` instances and swaps the map, and `databaseCache` is a `private final` per-instance field (`ServerSecurityUser:38`), so no derived state survives the swap | n/a - nothing to refresh |
+| 9 | Peer: `applyReplicatedApiTokens` | argued: a token principal carries a `syntheticGroupConfig`, and `ServerSecurityUser:156` / `:213` take that branch *instead of* the file group configuration, so a group document cannot change its answer | n/a - a group document cannot reach it |
+| 10 | `ServerSecurity.saveGroups()` (public, writes the whole document with no refresh) | argued: sweep C shows the definition and **no** production call site | n/a - unreachable in production |
 | 11 | The refresh sweep itself, when one database in it cannot be handed over (dropped under the iteration, or refused with `DatabaseNotAvailableException` because its directory still carries the interrupted-snapshot marker) | **yes** - guarded per database rather than once around the loop | yes - `oneUnavailableDatabaseDoesNotStopTheOthersFromBeingRefreshed` (added by the adversarial pass) |
+| 12 | Concurrent refreshers publishing out of order (watcher timer vs `ServerControlPlane` vs `LocalDatabase.open()` vs the new worker) | **yes** - `updateSchema` reads the document and publishes it under one dedicated monitor | yes - `concurrentRefreshesNeverOverlapTheirReadAndPublish` |
 
 ### Residual risk
 
@@ -273,3 +274,38 @@ each verified against the tree:
    `ServerSecurity.java:1549` declares that method `protected JSONObject getDatabaseGroupsConfiguration(...)` -
    not `synchronized` - while `updateSchema` (`:587`) is not synchronized either. The worker never contends for
    that monitor, and the apply thread never waits for the worker.
+
+## Review cycle 3 - the lost update CodeRabbit found
+
+CodeRabbit flagged `updateSchema` as CWE-863, and it was right. The method read the group document and then
+published it to every cached `ServerSecurityDatabaseUser` with nothing serialising the two halves, while several
+threads refresh independently: the group file's watcher timer, `ServerControlPlane` on an HTTP or gRPC admin
+request, `LocalDatabase.open()`, `LocalSchema` after a schema change - and, as of this PR, the replicated-apply
+worker. The slower of two refreshes could therefore publish the OLDER document last, writing a widened grant back
+over a permission another thread had just narrowed, where it would stand until the next refresh.
+
+The comment that used to sit on that read said *"the configuration cannot change under a single refresh"*, which
+is precisely the thing the code did not guarantee - the shape `CLAUDE.md` warns about, a comment asserting an
+invariant the code does not hold.
+
+Fixed by taking one dedicated monitor across the read and the publish. Two deliberate choices:
+
+- **Per database, not around a whole sweep**, so the lock never spans `server.getDatabase()`, which can open a
+  database.
+- **A dedicated monitor, not this object's.** `saveGroupClusterWide` holds the `ServerSecurity` monitor across a
+  Raft round trip; putting a database open behind that round trip is exactly the coupling
+  `applyReplicatedGroups`' non-blocking invariant exists to prevent.
+
+Lock-order safety was checked rather than assumed: `SecurityGroupFileRepository`'s timer calls `load()` (which is
+`synchronized`) and then invokes `reloadCallback` **outside** it, so no thread holds the repository monitor while
+entering `updateSchema`; and `ServerSecurityDatabaseUser.refresh` is a `synchronized` leaf that calls nothing back.
+
+The regression test asserts **mutual exclusion** rather than trying to lose the race on purpose: the overlap is
+what the lock forbids, and the lost update is only its consequence, so the overlap is the thing that can be
+asserted deterministically. Proved able to fail by replacing the `synchronized` block with `if (true)`:
+`Tests run: 6, Failures: 1 - concurrentRefreshesNeverOverlapTheirReadAndPublish`.
+
+The persistence-failure test was also made deterministic in this cycle: it now replaces the configuration
+directory with a regular **file**, so `Files.createTempFile()` cannot succeed whatever the process's privileges
+are, and it asserts the `ReplicatedSecurityConfigPersistenceException` instead of tolerating its absence. Under
+the previous `setWritable(false)` a privileged run would have passed the test down the ordinary success path.

--- a/docs/7510-ha-replicated-group-permission-refresh.md
+++ b/docs/7510-ha-replicated-group-permission-refresh.md
@@ -163,9 +163,11 @@ so the new asynchronous refresh has nothing to walk and cannot race them.
 
 ## Test results
 
-New: `server/src/test/java/com/arcadedb/server/security/Issue7510ReplicatedGroupRefreshTest.java`, **5 tests** -
-four written against the coverage table before the fix, plus the per-database-guard test added afterwards by the
-adversarial pass (finding 1 below).
+New: `server/src/test/java/com/arcadedb/server/security/Issue7510ReplicatedGroupRefreshTest.java`, **6 tests** -
+four written against the coverage table before the fix, the per-database-guard test added afterwards by the
+adversarial pass (finding 1 below), and `concurrentRefreshesNeverOverlapTheirReadAndPublish` added in review
+cycle 3 (last section). The `Tests run: 4` figures below are historical and are deliberately left as they were
+run: they are the before/after of the original four, made when the other two did not exist.
 
 Before the fix (only the extraction in place, no scheduling):
 
@@ -309,3 +311,32 @@ The persistence-failure test was also made deterministic in this cycle: it now r
 directory with a regular **file**, so `Files.createTempFile()` cannot succeed whatever the process's privileges
 are, and it asserts the `ReplicatedSecurityConfigPersistenceException` instead of tolerating its absence. Under
 the previous `setWritable(false)` a privileged run would have passed the test down the ordinary success path.
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/7553
+
+### Review cycles
+
+| # | Head | What changed | Reviewer outcome |
+|---|---|---|---|
+| 1 | `7d03762b` | the fix as opened | `claude`: "Nothing here blocks merging" - three polish items: register the pool in the `engine-concurrency` inventory, tighten `refreshAllDatabasePermissions` to package-private, prefer `shutdown()` over `shutdownNow()`. CodeRabbit posted nothing on this head |
+| 2 | `977998b2` | pool inventory row added; method package-private; `stopService()` drains the queue then `shutdown()`s (neither plain option was right: `shutdownNow()` interrupts a walk that may be inside `ArcadeDBServer.getDatabase()`, plain `shutdown()` lets a still-QUEUED task start after the service stopped) | `claude`: non-blocking notes - nothing waits for an in-flight refresh before `stopInternal()` closes the databases; say out loud why `Exception` and not `Throwable`; the doc said 4 tests and the class had 5 |
+| 3 | `2c771d22` | bounded `awaitTermination(2s)`; the `Exception`-not-`Throwable` choice stated in the comment; doc count corrected | `claude`: non-blocking. **CodeRabbit's first review**, 4 inline findings, one of them Major (CWE-863) and correct |
+| 4 | `e479a7ac` | `updateSchema`'s read and publish serialised under one dedicated monitor; the persistence-failure test made deterministic and made to assert the exception; coverage-table cells | - |
+
+### Deferred items
+
+None. Every review comment across the four cycles was either applied or answered in the thread with
+evidence - there is no `review-deferred-*.md` file in this branch.
+
+The one review suggestion **not** taken as written is CodeRabbit's "add a latch-based regression test for this
+ordering". The reply on that thread says why: the lost update depends on which of two racing threads the
+scheduler picks, whereas the overlap the lock forbids can be asserted deterministically, so
+`concurrentRefreshesNeverOverlapTheirReadAndPublish` asserts the peak occupancy of the critical section instead -
+and was proved able to fail by removing the lock.
+
+### Final state
+
+`clean-approval` - the last substantive review says nothing blocks the merge, no major issue is open, and every
+CodeRabbit thread has a reply. **The merge is the developer's.**

--- a/docs/7510-ha-replicated-group-permission-refresh.md
+++ b/docs/7510-ha-replicated-group-permission-refresh.md
@@ -162,7 +162,9 @@ so the new asynchronous refresh has nothing to walk and cannot race them.
 
 ## Test results
 
-New: `server/src/test/java/com/arcadedb/server/security/Issue7510ReplicatedGroupRefreshTest.java`, 4 tests.
+New: `server/src/test/java/com/arcadedb/server/security/Issue7510ReplicatedGroupRefreshTest.java`, **5 tests** -
+four written against the coverage table before the fix, plus the per-database-guard test added afterwards by the
+adversarial pass (finding 1 below).
 
 Before the fix (only the extraction in place, no scheduling):
 
@@ -177,7 +179,9 @@ Each of the three failed by exhausting the full 10 s outcome wait (30.99 s for t
 converging - which is the defect, reproduced through the entry point the Raft state machine actually uses.
 
 After the fix: `Tests run: 4, Failures: 0, Errors: 0` in 0.958 s - the class is now faster than one reload
-interval, which is the change stated as a number.
+interval, which is the change stated as a number. With the fifth test added it is `Tests run: 5, Failures: 0` in
+0.577 s, and that fifth test was separately proved able to fail by reverting its guard
+(`Tests run: 5, Failures: 1`).
 
 Regression runs (all with `-Dmaven.repo.local=$WORKTREE/.m2repo`, isolated from the parallel agents):
 

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -242,7 +242,14 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     if (groupRepository != null)
       groupRepository.stop();
 
-    permissionsRefreshExecutor.shutdownNow();
+    // shutdown() rather than shutdownNow(), with the queue drained by hand, because neither one alone is right
+    // here. shutdownNow() interrupts a walk that may be inside ArcadeDBServer.getDatabase(), turning a normal
+    // shutdown into a spurious SEVERE/WARNING from an interrupted channel; plain shutdown() lets a task that is
+    // still QUEUED start afterwards, and a refresh that begins after the security service has stopped can ask
+    // for a database the server is in the middle of closing. Draining first and then refusing new work leaves
+    // exactly one behaviour: an already-running walk finishes, nothing else starts.
+    permissionsRefreshExecutor.shutdown();
+    permissionsRefreshExecutor.getQueue().clear();
   }
 
   public ServerSecurityUser authenticate(final String userName, final String userPassword, final String databaseName) {
@@ -678,8 +685,12 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
    * Blocking, by nature: {@link #updateSchema} walks every user that has cached a
    * {@link ServerSecurityDatabaseUser} for each open database. Callers on a thread that may not block - the Raft
    * state-machine apply thread above all - must go through {@link #scheduleDatabasePermissionsRefresh()}.
+   * <p>
+   * Package-private: the two production callers are in this class and the only other caller is the test beside
+   * it. The per-database refresh other packages need is {@link #updateSchema}, which is the {@code SecurityManager}
+   * interface method.
    */
-  public void refreshAllDatabasePermissions() {
+  void refreshAllDatabasePermissions() {
     if (server == null)
       return;
 

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -50,7 +50,10 @@ import java.security.SecureRandom;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.util.*;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 import static com.arcadedb.GlobalConfiguration.SERVER_SECURITY_ALGORITHM;
@@ -95,6 +98,36 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
   private static final long                               PASSWORD_LOCKOUT_MS   = 30_000;
   private final        ConcurrentHashMap<String, long[]>  passwordFailures      = new ConcurrentHashMap<>();
 
+  /**
+   * Single daemon worker that re-derives the cached per-database permissions after a group document has arrived
+   * over HA replication, so a peer converges in milliseconds instead of on the security reload tick (#7510).
+   * <p>
+   * It exists because the install and the refresh cannot share a thread. {@link #applyReplicatedGroups} runs on
+   * the Raft state-machine apply thread, which must never block, while {@link #refreshAllDatabasePermissions}
+   * walks every open database. Until this executor, a peer's only route to the new permissions was
+   * {@link SecurityGroupFileRepository}'s file watcher, up to {@code arcadedb.server.reloadEvery} ms later - so a
+   * permission an operator had just narrowed kept being granted on that node for the length of the interval,
+   * while {@code GET /server/groups} on the very same node already returned the new definition.
+   * <p>
+   * Not one of the JVM-wide {@code DedicatedThreadPool}s and, per the rule those exist to enforce, not the JDK
+   * common {@code ForkJoinPool} either: this is per-server security state rather than engine parallelism, and it
+   * has to stay serialised so two refreshes cannot interleave their publishes. The shape is
+   * {@code ArcadeStateMachine}'s snapshot-install executor - core 0 so an idle server carries no thread, max 1,
+   * daemon - differing only in what happens to a task it will not take.
+   * <p>
+   * <b>A refused refresh is dropped on purpose, and that is coalescing rather than loss.</b> The queue holds one
+   * task, and a task reads the group document when it RUNS instead of being handed a snapshot. Reaching the
+   * rejection handler at all therefore means another refresh is queued and has not started yet - a refresh
+   * already running has released the slot - and {@link #scheduleDatabasePermissionsRefresh}'s only caller,
+   * {@link #applyReplicatedGroups}, submits only after the new document is published in
+   * {@link SecurityGroupFileRepository}'s {@code volatile} field. The queued task consequently reads a document
+   * at least as new as the one whose refresh was dropped.
+   * <p>
+   * The handler's other caller is shutdown: once {@code stopService()} has run, a refresh submitted by a late
+   * apply is dropped as well, which is what stopping means.
+   */
+  private final        ThreadPoolExecutor                 permissionsRefreshExecutor = createPermissionsRefreshExecutor();
+
   public ServerSecurity(final ArcadeDBServer server, final ContextConfiguration configuration, final String configPath) {
     this.server = server;
     this.algorithm = configuration.getValueAsString(SERVER_SECURITY_ALGORITHM);
@@ -108,9 +141,7 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
 
     usersRepository = new SecurityUserFileRepository(configPath);
     groupRepository = new SecurityGroupFileRepository(configPath, checkConfigReloadEveryMs).onReload(latestConfiguration -> {
-      for (final String databaseName : server.getDatabaseNames()) {
-        updateSchema(server.getDatabase(databaseName));
-      }
+      refreshAllDatabasePermissions();
       return null;
     });
 
@@ -210,6 +241,8 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     users = new ConcurrentHashMap<>();
     if (groupRepository != null)
       groupRepository.stop();
+
+    permissionsRefreshExecutor.shutdownNow();
   }
 
   public ServerSecurityUser authenticate(final String userName, final String userPassword, final String databaseName) {
@@ -594,6 +627,76 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
 
     for (final ServerSecurityUser user : users.values())
       user.refreshDatabaseConfiguration(database, groupConfiguration);
+  }
+
+  private static ThreadPoolExecutor createPermissionsRefreshExecutor() {
+    return new ThreadPoolExecutor(0, 1, 30L, TimeUnit.SECONDS, new ArrayBlockingQueue<>(1), r -> {
+      final Thread thread = new Thread(r, "arcadedb-security-permissions-refresh");
+      thread.setDaemon(true);
+      return thread;
+    }, (rejected, executor) -> LogManager.instance().log(ServerSecurity.class, Level.FINE,
+        "A cached-permission refresh is already queued or the server is stopping; this one is coalesced into it"));
+  }
+
+  /**
+   * Hands {@link #refreshAllDatabasePermissions} to {@link #permissionsRefreshExecutor}, for callers that may not
+   * block - the Raft state-machine apply thread above all (issue #7510).
+   * <p>
+   * Returns as soon as the task is queued. The group file's watcher is deliberately left in place as the safety
+   * net behind it: if the worker is saturated, stopped, or the refresh throws, the node still converges on the
+   * {@code arcadedb.server.reloadEvery} tick exactly as it did before.
+   */
+  private void scheduleDatabasePermissionsRefresh() {
+    if (server == null)
+      return;
+
+    permissionsRefreshExecutor.execute(this::runDatabasePermissionsRefresh);
+  }
+
+  /** The body run on {@link #permissionsRefreshExecutor}. */
+  private void runDatabasePermissionsRefresh() {
+    try {
+      refreshAllDatabasePermissions();
+    } catch (final Exception e) {
+      // Nothing may escape the worker: a throw here is swallowed by the executor, and the node would then quietly
+      // fall back to converging on the reload tick - the behaviour this executor exists to replace. It has to be
+      // visible rather than silently reverted to.
+      LogManager.instance().log(this, Level.SEVERE,
+          "Error while refreshing the cached database permissions after a replicated group change; this node now "
+              + "converges only on the '%s' reload tick", e, SecurityGroupFileRepository.FILE_NAME);
+    }
+  }
+
+  /**
+   * Re-derives the cached permissions of every database this server currently has open, from the group document
+   * in force right now.
+   * <p>
+   * The body the {@code server-groups.json} watcher has always run, extracted so the HA apply path can run the
+   * same thing instead of a second hand-written copy of it (issue #7510). It reads the current document rather
+   * than a snapshot handed to it, which is what lets a queued refresh stand in for the ones coalesced behind it.
+   * <p>
+   * Blocking, by nature: {@link #updateSchema} walks every user that has cached a
+   * {@link ServerSecurityDatabaseUser} for each open database. Callers on a thread that may not block - the Raft
+   * state-machine apply thread above all - must go through {@link #scheduleDatabasePermissionsRefresh()}.
+   */
+  public void refreshAllDatabasePermissions() {
+    if (server == null)
+      return;
+
+    for (final String databaseName : server.getDatabaseNames())
+      try {
+        updateSchema(server.getDatabase(databaseName));
+      } catch (final Exception e) {
+        // Guarded PER DATABASE, not once around the loop. server.getDatabase() can refuse a name this iteration
+        // has already seen - it is dropped meanwhile, or its directory still carries the interrupted-snapshot
+        // marker ArcadeDBServer.getDatabase() throws DatabaseNotAvailableException for - and a peer mid-snapshot
+        // install is precisely a node that also receives replicated group entries. One such refusal must cost
+        // that database's refresh only: aborting the sweep would leave every database after it in the iteration
+        // waiting for the reload tick, which is the lag this method exists to remove.
+        LogManager.instance().log(this, Level.WARNING,
+            "Could not refresh the cached permissions of database '%s'; it converges on the '%s' reload tick, or "
+                + "when it is next opened", e, databaseName, SecurityGroupFileRepository.FILE_NAME);
+      }
   }
 
   public String getEncodedHash(final String password, final String salt, final int iterations) {
@@ -1058,11 +1161,12 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
    * is in force, are the group half of issue #7137: see
    * {@link SecurityGroupFileRepository#applyReplicated}.
    * <p>
-   * The per-database permission caches are NOT refreshed from here: {@code ServerSecurity.updateSchema} opens
-   * and walks each database, which is blocking work this thread may not do. The peers pick the change up through
-   * {@code SecurityGroupFileRepository}'s file watcher, on the {@code arcadedb.server.security.reloadEvery}
-   * interval, which is the same mechanism a hand-edited group file has always gone through. The node that served
-   * the request refreshes immediately, in {@code ServerControlPlane}.
+   * The per-database permission caches are not refreshed ON this thread - {@code ServerSecurity.updateSchema}
+   * opens and walks each database, which is blocking work the apply thread may not do - but they are no longer
+   * left to the file watcher either: the refresh is handed to {@link #permissionsRefreshExecutor} before this
+   * method returns (issue #7510), so the peer converges in milliseconds rather than up to one
+   * {@code arcadedb.server.reloadEvery} interval later. The watcher stays as the safety net behind that, and the
+   * node that served the request still refreshes inline, in {@code ServerControlPlane}.
    */
   public void applyReplicatedGroups(final String groupsJson) {
     final JSONObject root = new JSONObject(groupsJson);
@@ -1085,6 +1189,13 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
               + "discard the versionless file and fall back to the DEFAULT group definitions");
 
     final Exception persistFailure = groupRepository.applyReplicated(root);
+
+    // Scheduled BEFORE the persistence failure is reported, and unconditionally: applyReplicated() publishes the
+    // document in memory first, so this node authorizes against it from now on whether or not the write
+    // succeeded. Scheduling after the throw below would leave the case that needs the refresh most - a narrowed
+    // permission on a node whose configuration volume is full or read-only - waiting for the reload tick.
+    scheduleDatabasePermissionsRefresh();
+
     if (persistFailure != null) {
       LogManager.instance().log(this, Level.SEVERE,
           "Could not write the replicated group document to '%s'. The new groups ARE in effect on this node from "

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -132,6 +132,12 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
    * Serialises {@link #updateSchema}, so the document a refresh read and the permissions it publishes cannot be
    * separated by another refresh. See that method for why an unsynchronised read-then-publish is a lost update on
    * an authorization decision rather than a benign one.
+   * <p>
+   * <b>Server-wide, not per database.</b> Two databases refreshing concurrently used to be able to run fully in
+   * parallel and now take turns, which is a deliberate trade and a cheap one: a refresh is a walk of cached maps
+   * with no I/O in it, and the things that trigger one - a group edit, a schema change, a database open - are all
+   * rare. A map of per-database locks would buy parallelism nothing measures back, at the price of a second
+   * lifetime to manage for every database name the server has ever seen.
    */
   private final        Object                             permissionsPublishLock     = new Object();
 

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -128,6 +128,13 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
    */
   private final        ThreadPoolExecutor                 permissionsRefreshExecutor = createPermissionsRefreshExecutor();
 
+  /**
+   * Serialises {@link #updateSchema}, so the document a refresh read and the permissions it publishes cannot be
+   * separated by another refresh. See that method for why an unsynchronised read-then-publish is a lost update on
+   * an authorization decision rather than a benign one.
+   */
+  private final        Object                             permissionsPublishLock     = new Object();
+
   public ServerSecurity(final ArcadeDBServer server, final ContextConfiguration configuration, final String configPath) {
     this.server = server;
     this.algorithm = configuration.getValueAsString(SERVER_SECURITY_ALGORITHM);
@@ -643,12 +650,29 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     if (database == null)
       return;
 
-    // Resolved once for the whole sweep instead of once per user: the lookup merges the wildcard and the
-    // per-database group objects, and the configuration cannot change under a single refresh.
-    final JSONObject groupConfiguration = getDatabaseGroupsConfiguration(database.getName());
+    // The read and the publish are ONE critical section, and that is the whole point of the lock.
+    //
+    // Several threads refresh independently - the group file's watcher timer, ServerControlPlane on an HTTP or
+    // gRPC admin request, LocalDatabase.open(), LocalSchema after a schema change, and now the replicated-apply
+    // worker this class added for issue #7510. Reading the document outside a lock let the slower of two
+    // refreshes publish the OLDER document last: a sweep that had read the previous definitions, preempted
+    // mid-walk, would finish by writing them over a narrowed permission another thread had already published, and
+    // the widened grant then stood until the next refresh. That is a lost update on an authorization decision
+    // (CWE-863), and the comment that used to sit here - "the configuration cannot change under a single refresh"
+    // - asserted the opposite of what the code did.
+    //
+    // Taken per DATABASE rather than around a whole sweep, so it never spans server.getDatabase(), which can open
+    // one. A dedicated monitor and emphatically not this object's: saveGroupClusterWide holds the ServerSecurity
+    // monitor across a Raft round trip, and putting a database open behind that round trip is exactly the kind of
+    // coupling applyReplicatedGroups' invariant exists to prevent.
+    synchronized (permissionsPublishLock) {
+      // Resolved once for the whole sweep instead of once per user: the lookup merges the wildcard and the
+      // per-database group objects, and under this lock it genuinely cannot change while the sweep publishes it.
+      final JSONObject groupConfiguration = getDatabaseGroupsConfiguration(database.getName());
 
-    for (final ServerSecurityUser user : users.values())
-      user.refreshDatabaseConfiguration(database, groupConfiguration);
+      for (final ServerSecurityUser user : users.values())
+        user.refreshDatabaseConfiguration(database, groupConfiguration);
+    }
   }
 
   private static ThreadPoolExecutor createPermissionsRefreshExecutor() {

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -250,6 +250,21 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     // exactly one behaviour: an already-running walk finishes, nothing else starts.
     permissionsRefreshExecutor.shutdown();
     permissionsRefreshExecutor.getQueue().clear();
+
+    // And then WAIT for the walk that was already running, briefly. ArcadeDBServer.stopInternal() calls this
+    // method immediately before the loop that closes every ServerDatabase, so without this the worker would still
+    // be resolving names out of server.getDatabaseNames() while the main thread closes those same databases. The
+    // bound is short and the timeout is not an error: a refresh is a traversal of cached maps, and if it somehow
+    // has not finished in two seconds, proceeding is what this method did before - the guards inside the worker
+    // turn whatever it then touches into a log line rather than a failure.
+    try {
+      if (!permissionsRefreshExecutor.awaitTermination(2, TimeUnit.SECONDS))
+        LogManager.instance().log(this, Level.FINE,
+            "A cached-permission refresh was still running when the security service stopped; the databases close "
+                + "under it");
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
   }
 
   public ServerSecurityUser authenticate(final String userName, final String userPassword, final String databaseName) {
@@ -668,6 +683,10 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
       // Nothing may escape the worker: a throw here is swallowed by the executor, and the node would then quietly
       // fall back to converging on the reload tick - the behaviour this executor exists to replace. It has to be
       // visible rather than silently reverted to.
+      //
+      // Exception and deliberately not Throwable: an Error is not a refresh that failed, it is a JVM that is no
+      // longer able to run one, and logging it here as though the node had merely lost its fast path would be a
+      // lie about the state of the process. Let it kill the worker and reach the default handler.
       LogManager.instance().log(this, Level.SEVERE,
           "Error while refreshing the cached database permissions after a replicated group change; this node now "
               + "converges only on the '%s' reload tick", e, SecurityGroupFileRepository.FILE_NAME);

--- a/server/src/test/java/com/arcadedb/server/security/Issue7373ReplicatedGroupAuthorizationTest.java
+++ b/server/src/test/java/com/arcadedb/server/security/Issue7373ReplicatedGroupAuthorizationTest.java
@@ -44,16 +44,17 @@ import static org.mockito.Mockito.when;
  * <b>authorization decision</b> on a peer, rather than to a file.
  * <p>
  * The two halves are deliberately separate in the fix, and this test is what makes that separation visible.
- * {@link ServerSecurity#applyReplicatedGroups} installs the document and nothing else - it runs on the Raft
- * state-machine apply thread, which may not block, and {@link ServerSecurity#updateSchema} opens and walks every
- * database. The cached {@code ServerSecurityDatabaseUser} of an already-connected principal therefore keeps
- * answering from the PREVIOUS document until the refresh runs: on the node that served the request
- * {@code ServerControlPlane} runs it immediately, and on a peer the group file's watcher does, on the
- * {@code arcadedb.server.security.reloadEvery} tick (issue #7510 is about closing that lag).
+ * {@link ServerSecurity#applyReplicatedGroups} installs the document; it does not walk the databases ON the
+ * calling thread, because that thread is the Raft state-machine apply thread and {@link ServerSecurity#updateSchema}
+ * opens and walks every database. The cached {@code ServerSecurityDatabaseUser} of an already-connected principal
+ * therefore keeps answering from the PREVIOUS document until a refresh runs, and the refresh is somebody else's
+ * call: {@code ServerControlPlane} makes it inline on the node that served the request, and on a peer issue #7510
+ * hands it to a dedicated worker (with the group file's watcher left behind it as the safety net).
  * <p>
- * So both assertions below matter, and the first one is not a bug being pinned as a feature - it is the reason
- * #7510 exists, stated in a form that will fail if someone makes the apply blocking by calling
- * {@code updateSchema} from it.
+ * So both assertions below matter, and the first one is not a bug being pinned as a feature - it is the statement
+ * that the apply itself stays non-blocking, and it will fail if someone calls {@code updateSchema} directly from
+ * it. The mocked server here reports no open database, so #7510's asynchronous refresh has nothing to walk and
+ * the assertion is not a race against it.
  */
 class Issue7373ReplicatedGroupAuthorizationTest {
 
@@ -109,16 +110,17 @@ class Issue7373ReplicatedGroupAuthorizationTest {
     assertThat(security.getDatabaseGroupsConfiguration(DATABASE).getJSONObject(GROUP).getJSONArray("access"))
         .as("the document itself is revoked immediately on the peer").isEmpty();
 
-    // ...but the apply does not walk the databases, so the principal that was already connected still answers
-    // from its cache. That is the lag issue #7510 tracks, and asserting it here is what would fail if someone
-    // "fixed" it by calling updateSchema() from the state-machine apply thread.
+    // ...but the apply itself does not walk the databases, so the principal that was already connected still
+    // answers from its cache. This is what would fail if someone called updateSchema() directly from the
+    // state-machine apply thread; #7510's off-thread refresh finds no open database on this mocked server.
     assertThat(alice.getDatabaseUser(database))
         .as("getDatabaseUser caches per database, and nothing in the apply clears it").isSameAs(cached);
     assertThat(cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA))
         .as("the cached principal has not been refreshed yet").isTrue();
 
-    // The refresh is the second half: ServerControlPlane runs it on the serving node, the group file's watcher
-    // runs it on a peer. Once it has run, the replicated revocation is enforced against the live principal.
+    // The refresh is the second half: ServerControlPlane runs it inline on the serving node, and on a peer the
+    // worker added by #7510 does. Once it has run, the replicated revocation is enforced against the live
+    // principal.
     security.updateSchema(database);
 
     assertThat(cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA))

--- a/server/src/test/java/com/arcadedb/server/security/Issue7510ReplicatedGroupRefreshTest.java
+++ b/server/src/test/java/com/arcadedb/server/security/Issue7510ReplicatedGroupRefreshTest.java
@@ -37,9 +37,13 @@ import java.io.File;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -145,32 +149,99 @@ class Issue7510ReplicatedGroupRefreshTest {
    * so the refresh has to have been scheduled before the throw, not after it.
    */
   @Test
-  void aRefreshIsStillScheduledWhenTheReplicatedWriteFails() {
+  void aRefreshIsStillScheduledWhenTheReplicatedWriteFails() throws Exception {
     security.applyReplicatedGroups(documentGranting(new JSONArray().put("updateSchema")));
 
     final ServerSecurityUser alice = createAlice();
     final ServerSecurityDatabaseUser cached = alice.getDatabaseUser(database);
     assertThat(cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA)).isTrue();
 
-    // Make the write fail the way a read-only or full volume does: put a DIRECTORY where the temp file and the
-    // target both have to go. Files.createTempFile() in that directory then fails and persist() throws.
+    // Make the write fail deterministically, on every platform and for root too: replace the configuration
+    // DIRECTORY with a regular file of the same name. SecurityGroupFileRepository.persist() then calls
+    // Files.createTempFile() with that file as the parent directory, which cannot succeed whatever the
+    // permissions say - where chmod 0555 is merely usually enough, and is not enough at all for a privileged
+    // process, which would let this test pass without ever reaching the branch it is named after.
     final File blocker = new File(CONFIG_PATH);
     FileUtils.deleteRecursively(blocker);
-    assertThat(blocker.mkdirs()).isTrue();
-    assertThat(blocker.setWritable(false)).isTrue();
-
     try {
-      try {
-        security.applyReplicatedGroups(documentGranting(new JSONArray()));
-      } catch (final ReplicatedSecurityConfigPersistenceException expected) {
-        // The durability half failed; the enforcement half must still happen. Asserted below either way, so a
-        // platform on which the write unexpectedly succeeds (running as root) still exercises the refresh.
-      }
+      assertThat(blocker.createNewFile()).isTrue();
+
+      // Asserted, not tolerated: the durability half MUST have failed, or the enforcement assertion below would
+      // be the ordinary success path wearing this test's name.
+      assertThatThrownBy(() -> security.applyReplicatedGroups(documentGranting(new JSONArray())))
+          .isInstanceOf(ReplicatedSecurityConfigPersistenceException.class);
 
       assertThat(await(() -> !cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA)))
           .as("the revocation is enforced on the peer even though persisting it failed").isTrue();
     } finally {
-      blocker.setWritable(true);
+      blocker.delete();
+    }
+  }
+
+  /**
+   * The refresh's read-and-publish must be one critical section. Several threads refresh independently - the group
+   * file's watcher, {@code ServerControlPlane} on an admin request, {@code LocalDatabase.open()}, and the worker
+   * this issue added - and an unsynchronised read let the slower of two publish the OLDER document last, writing a
+   * widened grant back over a narrowed one (CWE-863).
+   * <p>
+   * Asserted as mutual exclusion rather than by trying to lose a race on purpose: the overlap is what the lock
+   * forbids, and a lost update is only its consequence. The override sleeps inside the configuration read, so
+   * without the lock several sweeps are inside it at once and the peak count exceeds one.
+   */
+  @Test
+  void concurrentRefreshesNeverOverlapTheirReadAndPublish() throws Exception {
+    final String path = CONFIG_PATH + "-exclusion";
+    final File dir = new File(path);
+    FileUtils.deleteRecursively(dir);
+    assertThat(dir.mkdirs()).isTrue();
+
+    final AtomicInteger inside = new AtomicInteger();
+    final AtomicInteger peak = new AtomicInteger();
+
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.getDatabaseNames()).thenReturn(Set.of(DATABASE));
+    when(server.getDatabase(DATABASE)).thenReturn(database);
+
+    final ServerSecurity counting = new ServerSecurity(server, new ContextConfiguration(), path) {
+      @Override
+      protected JSONObject getDatabaseGroupsConfiguration(final String databaseName) {
+        peak.accumulateAndGet(inside.incrementAndGet(), Math::max);
+        try {
+          Thread.sleep(50);
+          return super.getDatabaseGroupsConfiguration(databaseName);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IllegalStateException(e);
+        } finally {
+          inside.decrementAndGet();
+        }
+      }
+    };
+    when(server.getSecurity()).thenReturn(counting);
+
+    final int threads = 4;
+    final CountDownLatch start = new CountDownLatch(1);
+    final CountDownLatch done = new CountDownLatch(threads);
+    try {
+      for (int i = 0; i < threads; i++)
+        new Thread(() -> {
+          try {
+            start.await();
+            counting.updateSchema(database);
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+          } finally {
+            done.countDown();
+          }
+        }, "refresh-" + i).start();
+
+      start.countDown();
+      assertThat(done.await(30, TimeUnit.SECONDS)).as("every refresh finished").isTrue();
+      assertThat(peak.get())
+          .as("no two refreshes were ever inside the read-and-publish section together").isEqualTo(1);
+    } finally {
+      counting.stopService();
+      FileUtils.deleteRecursively(dir);
     }
   }
 

--- a/server/src/test/java/com/arcadedb/server/security/Issue7510ReplicatedGroupRefreshTest.java
+++ b/server/src/test/java/com/arcadedb/server/security/Issue7510ReplicatedGroupRefreshTest.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.engine.FileManager;
+import com.arcadedb.exception.DatabaseNotAvailableException;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.security.SecurityDatabaseUser.DATABASE_ACCESS;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.ServerDatabase;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BooleanSupplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #7510: a group document that arrives over HA replication must reach the peer's <b>cached</b> permissions
+ * without waiting for the {@code arcadedb.server.reloadEvery} file-watcher tick.
+ * <p>
+ * The peer half of #7373 installed the document and stopped there - correctly, because
+ * {@link ServerSecurity#applyReplicatedGroups} runs on the Raft state-machine apply thread and
+ * {@link ServerSecurity#updateSchema} walks every open database. Convergence was then left to
+ * {@code SecurityGroupFileRepository}'s watcher, i.e. up to one reload interval (5 s by default) during which a
+ * principal already connected to that peer kept the permission the operator had just narrowed.
+ * <p>
+ * Every assertion below waits for an <i>outcome</i> rather than for the executor, so the test says nothing about
+ * how the refresh is scheduled: it fails by timing out if the peer converges only on the watcher tick, which the
+ * watcher cannot deliver here - {@link #RELOAD_EVERY_MS} is far longer than {@link #REFRESH_TIMEOUT_MS}.
+ */
+class Issue7510ReplicatedGroupRefreshTest {
+
+  private static final String CONFIG_PATH        = "target/test-security-7510-refresh";
+  private static final String DATABASE           = "graph";
+  private static final String GROUP              = "editors";
+  /** Long enough that a pass can only come from the replicated-apply refresh, never from the file watcher. */
+  private static final int    RELOAD_EVERY_MS    = 600_000;
+  private static final long   REFRESH_TIMEOUT_MS = 10_000;
+
+  private ServerSecurity security;
+  private ServerDatabase database;
+
+  @BeforeEach
+  void setUp() {
+    GlobalConfiguration.SERVER_SECURITY_SALT_ITERATIONS.setValue(1000);
+    final File dir = new File(CONFIG_PATH);
+    if (dir.exists())
+      FileUtils.deleteRecursively(dir);
+    assertThat(dir.mkdirs()).isTrue();
+
+    database = mockDatabase();
+
+    // A mocked server that reports the database as open, which is what makes this a peer with something to
+    // refresh: ServerSecurity resolves the principal's permissions through server.getSecurity(), and the refresh
+    // walks server.getDatabaseNames() / getDatabase(name). getHA() answers null, so this node is not itself
+    // submitting Raft entries - exactly the peer applying someone else's entry.
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.getDatabaseNames()).thenReturn(Set.of(DATABASE));
+    when(server.getDatabase(DATABASE)).thenReturn(database);
+
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.SERVER_SECURITY_RELOAD_EVERY, RELOAD_EVERY_MS);
+
+    security = new ServerSecurity(server, configuration, CONFIG_PATH);
+    when(server.getSecurity()).thenReturn(security);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (security != null)
+      security.stopService();
+    GlobalConfiguration.SERVER_SECURITY_SALT_ITERATIONS.reset();
+    FileUtils.deleteRecursively(new File(CONFIG_PATH));
+  }
+
+  /**
+   * Row 1 of the coverage table - the direction that matters. A narrowed permission must stop being granted on
+   * the peer without the reload tick.
+   */
+  @Test
+  void aReplicatedRevocationReachesTheCachedPrincipalWithoutTheReloadTick() {
+    security.applyReplicatedGroups(documentGranting(new JSONArray().put("updateSchema")));
+
+    final ServerSecurityUser alice = createAlice();
+    final ServerSecurityDatabaseUser cached = alice.getDatabaseUser(database);
+    assertThat(cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA))
+        .as("the grant is in force on the peer before the revocation").isTrue();
+
+    security.applyReplicatedGroups(documentGranting(new JSONArray()));
+
+    assertThat(security.getDatabaseGroupsConfiguration(DATABASE).getJSONObject(GROUP).getJSONArray("access"))
+        .as("the document itself is revoked immediately, as it always was").isEmpty();
+    assertThat(await(() -> !cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA)))
+        .as("the principal already connected to the peer is denied without waiting for the reload tick").isTrue();
+  }
+
+  /** Row 2 - the grant direction, so the test cannot pass by denying everything. */
+  @Test
+  void aReplicatedGrantReachesTheCachedPrincipalWithoutTheReloadTick() {
+    security.applyReplicatedGroups(documentGranting(new JSONArray()));
+
+    final ServerSecurityUser alice = createAlice();
+    final ServerSecurityDatabaseUser cached = alice.getDatabaseUser(database);
+    assertThat(cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA))
+        .as("the peer starts with no grant").isFalse();
+
+    security.applyReplicatedGroups(documentGranting(new JSONArray().put("updateSchema")));
+
+    assertThat(await(() -> cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA)))
+        .as("the widened grant reaches the cached principal without waiting for the reload tick").isTrue();
+  }
+
+  /**
+   * Row 3 - the peer could not write {@code server-groups.json}, so the apply reports the durability failure. The
+   * document is nonetheless in force in memory from that moment (see {@code SecurityGroupFileRepository#applyReplicated}),
+   * so the refresh has to have been scheduled before the throw, not after it.
+   */
+  @Test
+  void aRefreshIsStillScheduledWhenTheReplicatedWriteFails() {
+    security.applyReplicatedGroups(documentGranting(new JSONArray().put("updateSchema")));
+
+    final ServerSecurityUser alice = createAlice();
+    final ServerSecurityDatabaseUser cached = alice.getDatabaseUser(database);
+    assertThat(cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA)).isTrue();
+
+    // Make the write fail the way a read-only or full volume does: put a DIRECTORY where the temp file and the
+    // target both have to go. Files.createTempFile() in that directory then fails and persist() throws.
+    final File blocker = new File(CONFIG_PATH);
+    FileUtils.deleteRecursively(blocker);
+    assertThat(blocker.mkdirs()).isTrue();
+    assertThat(blocker.setWritable(false)).isTrue();
+
+    try {
+      try {
+        security.applyReplicatedGroups(documentGranting(new JSONArray()));
+      } catch (final ReplicatedSecurityConfigPersistenceException expected) {
+        // The durability half failed; the enforcement half must still happen. Asserted below either way, so a
+        // platform on which the write unexpectedly succeeds (running as root) still exercises the refresh.
+      }
+
+      assertThat(await(() -> !cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA)))
+          .as("the revocation is enforced on the peer even though persisting it failed").isTrue();
+    } finally {
+      blocker.setWritable(true);
+    }
+  }
+
+  /**
+   * Row 7 - the body the group file's reload watcher has always run is now shared with the replicated path, so
+   * assert it directly: it must walk every database the server has open.
+   */
+  @Test
+  void theReloadWatcherBodyRefreshesEveryOpenDatabase() {
+    security.applyReplicatedGroups(documentGranting(new JSONArray().put("updateSchema")));
+
+    final ServerSecurityUser alice = createAlice();
+    final ServerSecurityDatabaseUser cached = alice.getDatabaseUser(database);
+    assertThat(cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA)).isTrue();
+
+    security.saveGroup(DATABASE, GROUP, groupWith(new JSONArray()));
+    assertThat(cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA))
+        .as("a local save does not refresh the caches by itself - ServerControlPlane does that").isTrue();
+
+    security.refreshAllDatabasePermissions();
+
+    assertThat(cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA))
+        .as("the shared refresh body re-derives every open database from the current document").isFalse();
+  }
+
+  /**
+   * The sweep is guarded per database, not once around the loop: one database that cannot be handed over - dropped
+   * under the iteration, or still carrying the interrupted-snapshot marker {@code ArcadeDBServer.getDatabase()}
+   * refuses with {@code DatabaseNotAvailableException} - must cost only its own refresh. Aborting would leave
+   * every database after it in the iteration waiting for the reload tick, i.e. reintroduce this very issue for
+   * them.
+   */
+  @Test
+  void oneUnavailableDatabaseDoesNotStopTheOthersFromBeingRefreshed() {
+    final String healthyPath = CONFIG_PATH + "-mixed";
+    final File dir = new File(healthyPath);
+    FileUtils.deleteRecursively(dir);
+    assertThat(dir.mkdirs()).isTrue();
+
+    final ServerDatabase healthy = mockDatabase();
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    // A LinkedHashSet so the broken name is iterated FIRST: with the guard around the loop instead of inside it,
+    // the healthy database that follows would never be reached.
+    when(server.getDatabaseNames()).thenReturn(new LinkedHashSet<>(List.of("dropped-under-the-sweep", DATABASE)));
+    when(server.getDatabase("dropped-under-the-sweep"))
+        .thenThrow(new DatabaseNotAvailableException("Database 'dropped-under-the-sweep' is not available"));
+    when(server.getDatabase(DATABASE)).thenReturn(healthy);
+
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.SERVER_SECURITY_RELOAD_EVERY, RELOAD_EVERY_MS);
+
+    final ServerSecurity mixed = new ServerSecurity(server, configuration, healthyPath);
+    when(server.getSecurity()).thenReturn(mixed);
+    try {
+      mixed.applyReplicatedGroups(documentGranting(new JSONArray().put("updateSchema")));
+
+      final ServerSecurityUser alice = mixed.createUser(new JSONObject()
+          .put("name", "alice")
+          .put("password", mixed.encodePassword("alice-password"))
+          .put("databases", new JSONObject().put(DATABASE, new JSONArray().put(GROUP))));
+      final ServerSecurityDatabaseUser cached = alice.getDatabaseUser(healthy);
+      assertThat(cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA)).isTrue();
+
+      mixed.applyReplicatedGroups(documentGranting(new JSONArray()));
+
+      assertThat(await(() -> !cached.requestAccessOnDatabase(DATABASE_ACCESS.UPDATE_SCHEMA)))
+          .as("the database after the unavailable one is still refreshed").isTrue();
+    } finally {
+      mixed.stopService();
+      FileUtils.deleteRecursively(dir);
+    }
+  }
+
+  private ServerSecurityUser createAlice() {
+    return security.createUser(new JSONObject()
+        .put("name", "alice")
+        .put("password", security.encodePassword("alice-password"))
+        .put("databases", new JSONObject().put(DATABASE, new JSONArray().put(GROUP))));
+  }
+
+  /**
+   * Waits for an outcome rather than for a thread: the refresh is asynchronous by design, and a test that
+   * asserted on the executor would pin the mechanism instead of the guarantee.
+   */
+  private static boolean await(final BooleanSupplier condition) {
+    final long deadline = System.currentTimeMillis() + REFRESH_TIMEOUT_MS;
+    while (System.currentTimeMillis() < deadline) {
+      if (condition.getAsBoolean())
+        return true;
+      try {
+        Thread.sleep(10);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return false;
+      }
+    }
+    return condition.getAsBoolean();
+  }
+
+  private static JSONObject groupWith(final JSONArray databaseAccess) {
+    return new JSONObject()
+        .put("access", databaseAccess)
+        .put("resultSetLimit", -1L)
+        .put("readTimeout", -1L)
+        .put("types", new JSONObject().put("*", new JSONObject().put("access",
+            new JSONArray().put("createRecord").put("readRecord").put("updateRecord").put("deleteRecord"))));
+  }
+
+  /** A whole group document, in the shape a {@code SECURITY_GROUPS_ENTRY} carries. */
+  private static String documentGranting(final JSONArray databaseAccess) {
+    return new JSONObject()
+        .put("version", ServerSecurity.LATEST_VERSION)
+        .put("databases", new JSONObject().put(DATABASE,
+            new JSONObject().put("groups", new JSONObject().put(GROUP, groupWith(databaseAccess)))))
+        .toString();
+  }
+
+  private static ServerDatabase mockDatabase() {
+    final FileManager fileManager = mock(FileManager.class);
+    when(fileManager.getFiles()).thenReturn(List.of());
+
+    final Schema schema = mock(Schema.class);
+    when(schema.getTypes()).thenReturn(List.of());
+
+    final ServerDatabase db = mock(ServerDatabase.class);
+    when(db.getName()).thenReturn(DATABASE);
+    when(db.getFileManager()).thenReturn(fileManager);
+    when(db.getSchema()).thenReturn(schema);
+    return db;
+  }
+}


### PR DESCRIPTION
Closes #7510

#7373 made a group change replicate, so `server-groups.json` is identical on every node - but the *derived*
state is not. Each `ServerSecurityUser` caches a `ServerSecurityDatabaseUser` per database, and only
`ServerSecurity.updateSchema` re-derives it. The node that served the request refreshes inline
(`ServerControlPlane.refreshPermissionsOf`); a peer did not, because `applyReplicatedGroups` runs on the Raft
state-machine apply thread and may not do that blocking walk. Convergence was therefore left to
`SecurityGroupFileRepository`'s file watcher, up to `arcadedb.server.reloadEvery` ms (default 5000) later - so a
**narrowed** permission kept being granted on that peer for the length of the interval, while
`GET /server/groups` on the same peer already returned the new definition and the operator's request had already
returned 200. This hands the refresh to a dedicated single daemon worker instead of skipping it: the apply stays
non-blocking, the peer converges in milliseconds, and the watcher is deliberately kept as the safety net behind
it.

## What changed

`server/src/main/java/com/arcadedb/server/security/ServerSecurity.java`

- **`refreshAllDatabasePermissions()`** - the loop that was inlined in the group file's `onReload` lambda,
  extracted so the replicated path runs the same body rather than a second hand-written copy. It reads the
  *current* document rather than a snapshot handed to it, which is what lets a queued refresh stand in for the
  ones coalesced behind it. Guarded **per database**: one database `ArcadeDBServer.getDatabase()` refuses - it
  was dropped under the iteration, or its directory still carries the interrupted-snapshot marker that throws
  `DatabaseNotAvailableException` - must not leave every database after it in the sweep waiting for the tick.
- **`permissionsRefreshExecutor`** - one daemon worker, core 0 / max 1 / 30 s keep-alive, one-deep
  `ArrayBlockingQueue`, shaped after `ArcadeStateMachine`'s `snapshotInstallExecutor` and, per the
  `engine-concurrency` rule, explicitly not the JDK common `ForkJoinPool`. Its rejection handler **drops** and
  logs at `FINE`, which is coalescing rather than loss: reaching the handler means another refresh is queued and
  has not started, and the new document is published before the submit, so the queued task reads a document at
  least as new as the dropped one's. `corePoolSize` 0 means a server that never applies a group entry never
  starts the thread.
- **`applyReplicatedGroups`** schedules the refresh immediately after `groupRepository.applyReplicated(root)`
  and **before** the persistence failure is reported. That ordering is the point: `applyReplicated` publishes in
  memory first, so the node authorizes against the new document whether or not the write succeeded, and the case
  that needs the refresh most - a narrowed permission on a node whose config volume is full or read-only - must
  not be the one that skips it.
- `stopService()` shuts the worker down.

`Issue7373ReplicatedGroupAuthorizationTest` - **comments only**, no assertion or logic changed. Its javadoc
described the reload-tick lag as current behaviour and named #7510 as the issue that would close it; that text is
now false. Both assertions still hold and still mean something: the apply itself stays non-blocking, and the
mocked server there reports no open database, so the new asynchronous refresh has nothing to walk and cannot
race them.

## Test plan

- [x] New `server/src/test/java/com/arcadedb/server/security/Issue7510ReplicatedGroupRefreshTest.java`, 5 tests,
      each waiting on an **outcome** rather than on the executor, with the reload interval set to 600 s so a pass
      cannot come from the watcher.
- [x] Before the fix: `Tests run: 4, Failures: 3` - the three behavioural tests each exhausted the full 10 s
      outcome wait (30.99 s for the class), i.e. failed by the peer not converging.
- [x] After: `Tests run: 5, Failures: 0` in 0.577 s - the class is now faster than one reload interval.
- [x] The per-database guard test was proved able to fail: reverting the guard gives
      `Tests run: 5, Failures: 1 - oneUnavailableDatabaseDoesNotStopTheOthersFromBeingRefreshed`.
- [x] `mvn -o -pl server -am install -DskipTests` and `mvn -o -pl ha-raft -am install -DskipTests` - BUILD SUCCESS.
- [x] `mvn -o -pl server test -Dtest='Issue7510*,Issue7373*,Issue6806GroupPermissionRefreshTest,SecurityGroupFileRepositoryTest,ServerSecurity*'` - 60 tests, 0 failures.
- [x] `mvn -o -pl ha-raft test -Dtest='Issue7137…,Issue7227…,Issue7252…,Issue7373SecurityConfig*'` - 15 tests, 0 failures.
- [x] `mvn -o -pl server test -DexcludedGroups=benchmark,vector,slow` - 1099 tests, 19 failures, **all a port
      collision**: `lsof -nP -iTCP:2480 -sTCP:LISTEN` showed two foreign `java` processes holding 2480, and every
      failing class is an HTTP test against `127.0.0.1:2480` failing with `401` where it expected
      `200`/`204`/`400`/`404`, or `Schema Type with name 'TestDoc' was not found`. None replicates a group,
      reloads the group file, or builds a Raft entry, and the whole `com.arcadedb.server.security` package is
      green in that same run.

## Coverage

Entry points the fix covers:

| Entry point | Fixed | Test |
|---|---|---|
| Peer: `ArcadeStateMachine.applySecurityGroupsEntry` -> `applyReplicatedGroups`, permission **narrowed** | yes | `aReplicatedRevocationReachesTheCachedPrincipalWithoutTheReloadTick` |
| Same, permission **widened** | yes | `aReplicatedGrantReachesTheCachedPrincipalWithoutTheReloadTick` |
| Same, with the local file write FAILING (document in force, `ReplicatedSecurityConfigPersistenceException` thrown) | yes | `aRefreshIsStillScheduledWhenTheReplicatedWriteFails` |
| Joining-peer seed: `seedGroupsClusterWide` -> `replicateSecurityGroups` -> same apply | yes | argued - byte-for-byte the same call; no separate test |
| One database in the sweep unavailable | yes | `oneUnavailableDatabaseDoesNotStopTheOthersFromBeingRefreshed` |
| Hand-edited `server-groups.json` -> watcher -> `reloadCallback` | unchanged, now shares the extracted method | `theReloadWatcherBodyRefreshesEveryOpenDatabase` |
| Serving node (`ServerControlPlane.saveGroup`/`deleteGroup`, HTTP + gRPC) and the non-HA fallback | unchanged - already inline | existing tests |
| `applyReplicatedUsers` | argued - it builds **new** `ServerSecurityUser` instances, and `databaseCache` is a `private final` per-instance field, so no derived state survives the swap |
| `applyReplicatedApiTokens` | argued - a token principal carries a `syntheticGroupConfig` that is taken *instead of* the file group configuration |
| `ServerSecurity.saveGroups()` | argued - the grep finds the definition and no production call site |

**Known gaps**

- **#7545** - `SecurityGroupFileRepository`'s watcher timer is only scheduled from inside `load()`, and
  `applyReplicated()` publishes the document without going through it. On a node whose *first ever* group access
  is a replicated apply, the watcher is never scheduled at all - so on that node the safety net this PR
  deliberately keeps does not exist. Filed before this PR opened; a different defect from the one fixed here (the
  net not existing, versus the net being the only mechanism).
- The sweep still resolves names with `allowLoad = true`, so a database present-but-closed in the server's map is
  reopened as a side effect. Pre-existing on the watcher path this method was extracted from - `applyReplicated`
  writes the file, so the watcher has always run this same loop - and argued in the tracking doc rather than
  changed, because altering `allowLoad` would change the hand-edited-file path too.

Tracking doc: `docs/7510-ha-replicated-group-permission-refresh.md`, including the completeness sweep commands
and their output, and the adversarial pass (run by the author, because the `Task` tool was disabled in this
session - recorded as the weaker pass it is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEJXCdUGW61QSXqyurphpt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Replicated group permission changes now reach high-availability peers within milliseconds, without waiting for the periodic file-watcher refresh.
  - Permission updates continue to refresh even when persistence encounters an error.
  - A problem refreshing one database no longer prevents other databases from updating.
  - Multiple pending refresh requests are consolidated to improve efficiency.
  - Existing file-watcher fallback behavior remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->