### PR TITLE
fix(#7508): forward to the leader over HTTPS when the cluster has an endpoint for it

### DIFF
--- a/docs/7508-ha-leader-forward-https-scheme.md
+++ b/docs/7508-ha-leader-forward-https-scheme.md
@@ -133,8 +133,9 @@ The other three entry points are reachable: `LeaderCommandForwarder` from four H
 ### Residual risk
 
 - No integration test starts a genuine HTTPS HA cluster: the scheme decision is proved by unit tests
-  per entry point, not by an end-to-end TLS forward. The issue reporter did not reproduce on one
-  either.
+  per entry point, not by an end-to-end TLS forward, so hostname verification, SNI and real
+  truststore loading on this path stay uncovered. The issue reporter did not reproduce on one
+  either. **Filed as #7563.**
 - Truststore rotation rebuilds the forward's HTTPS client from the truststore's path, password,
   mtime and size - the same fingerprint `TrustedHttpClientCache` uses - but the two implementations
   are separate.
@@ -242,6 +243,14 @@ is a weaker pass and is recorded as such. Four findings, all fixed before the PR
    cross-node HTTP round trip the call is about to make. If the forward ever needs more, the fix is a
    time-bounded revalidation inside that cache, which would serve the capability probe too.
 
+---
+
+# Appendix: review log
+
+Everything above is the durable record - the invariant, the enumeration, the coverage table, the
+design and the residual risk. What follows is dated correspondence with the PR reviewers, kept so a
+later reader can see why a given branch behaves as it does rather than having to reopen the PR.
+
 ## Review cycle 1 - `7198db162a`
 
 ### CodeRabbit, inline on `HAServerPlugin.java:120` - "Fail closed when TLS is required" (Major, CWE-319) - APPLIED, in part
@@ -291,3 +300,36 @@ uncovered `RaftReplicatedDatabase` send - restate gaps this PR already declares 
 
 Counts every function in the 10 touched files, not the ones this diff adds; the added members carry Javadoc.
 Writing docstrings for untouched methods to clear a bot threshold is not in scope for a bug fix.
+
+## Review cycle 2 - `33a9d64128`
+
+CodeRabbit re-verified its own finding against the new code and accepted the split: "`LeaderDial.resolve`
+now refuses the forward when `getLeaderHttpsAddress()` returns an endpoint but `getPeerHttpsClient()` is
+unavailable or throws ... The remaining HTTP fallback occurs only when no HTTPS endpoint resolves. This
+preserves compatibility for clusters that never declared HTTPS endpoints." Thread answered by the bot
+itself; no code change.
+
+The `claude` review found no bugs and said nothing blocks the merge. Its five points:
+
+1. **Lock contention on the new hot path.** `forwardHttpsClients.clientFor()` is `synchronized` and is now
+   called by every HTTP worker thread forwarding on an SSL cluster, where the existing
+   `capabilityHttpsClients` had one scheduled caller. During a truststore rotation the thread that observes
+   the change holds the monitor across `previous.close()`, which waits for in-flight sends. **No change**:
+   this is the tradeoff the field's Javadoc already states, it is bounded by the forwards' own request
+   timeouts, and it happens only when an operator rotates a certificate. Replacing it would mean a
+   revalidation window inside `TrustedHttpClientCache`, which is a change to the capability probe's
+   behaviour too and does not belong in this fix.
+2. **Per-forward cost** of the two `stat`s and the password digest - already reasoned about above. No change.
+3. **No live-TLS integration test.** Agreed, and it is the one gap unit tests structurally cannot close on
+   a path that decides whether credentials are encrypted. **Filed as #7563**, with the fixture shape and the
+   other peer-to-peer dials the same fixture would cover.
+4. **This document mixes a durable design record with an ephemeral review log.** Fair. Split with the
+   appendix heading above rather than dropped: the orchestrating workflow requires the review history to be
+   recorded here, so it is now labelled as correspondence instead of reading as design.
+5. **`LeaderProxy` is dead code.** Already declared, tracked as #7547. No change.
+
+## Final state
+
+`clean-approval` - the latest review from each bot says nothing blocks the merge, the one CodeRabbit
+thread was re-verified and answered by CodeRabbit itself, and the three known gaps carry issue numbers
+(#7546, #7547, #7563).

--- a/docs/7508-ha-leader-forward-https-scheme.md
+++ b/docs/7508-ha-leader-forward-https-scheme.md
@@ -356,9 +356,28 @@ The `claude` review found no bugs and nothing blocking. Three minor findings, al
 `ArcadeStateMachinePerDatabaseHaltTest`, a WAL-entry-parsing assertion that touches nothing in this change.
 Reproduced identically on base commit `99b6692780`.
 
+## Review cycle 4 - `358563ce76`
+
+One real bug, applied. `RaftReplicatedDatabase.forwardCommandToLeaderViaRaft` still named
+`leaderHttpAddress` in both `TransactionException` messages on the failure paths, while the request had
+been sent to `leaderHttpsAddress` whenever one was resolved - so a TLS handshake failure, the one error an
+operator would take straight to a truststore, reported the plain-HTTP address it was never sent to. The two
+server-module entry points already reported the dialled URL; this third site was the oversight. The URL is
+now built once and used for the request and both messages.
+
+The review's other points restate tradeoffs already recorded above (the `synchronized` cache on the forward
+path) or scope boundaries already filed (#7547, #7563). The reviewer notes it could not run Maven, so its
+pass was static.
+
+This was the last cycle the run was budgeted for, so the loop stopped here rather than polling for a
+verification pass on the fix above. It is a two-line message change with both regression suites green
+(14 in `server`, 5 in `ha-raft`).
+
 ## Final state
 
-`clean-approval` - the latest review from each bot says nothing blocks the merge, the one CodeRabbit
-thread was re-verified and answered by CodeRabbit itself, and the three known gaps carry issue numbers
-(#7546, #7547, #7563). Every review finding across the three cycles is either applied or answered with
-evidence; none is deferred.
+`max-cycles-reached` - four cycles ran, the budget. No finding is outstanding: the latest review from each
+bot says nothing blocks the merge, the one CodeRabbit thread was re-verified and answered by CodeRabbit
+itself, and the three known gaps carry issue numbers (#7546, #7547, #7563). Every review finding across the
+four cycles is either applied or answered with evidence; none is deferred, and no
+`review-deferred-*.md` file was produced. What the label marks is that the final commit did not itself get
+a verification pass, not that anything was left unaddressed.

--- a/docs/7508-ha-leader-forward-https-scheme.md
+++ b/docs/7508-ha-leader-forward-https-scheme.md
@@ -241,3 +241,53 @@ is a weaker pass and is recorded as such. Four findings, all fixed before the PR
    HTTPS (a non-SSL cluster never calls it), and it is two `stat`s and one short digest against a
    cross-node HTTP round trip the call is about to make. If the forward ever needs more, the fix is a
    time-bounded revalidation inside that cache, which would serve the capability probe too.
+
+## Review cycle 1 - `7198db162a`
+
+### CodeRabbit, inline on `HAServerPlugin.java:120` - "Fail closed when TLS is required" (Major, CWE-319) - APPLIED, in part
+
+Correct for one of the two fallback branches, and the distinction matters enough to state:
+
+- **No HTTPS endpoint resolves for the leader.** That is what every SSL cluster answers when it left the optional
+  5th field of `arcadedb.ha.serverList` out, and dialling the plain listener is what it did before this PR. Failing
+  closed here would turn a working cluster into a broken one on upgrade, and it is the case `PeerDialAddress`,
+  `LeaderDatabaseQuery`, `PeerCapabilityQuery` and `SnapshotInstaller` all deliberately fall back on (#6221). Left
+  falling back.
+- **An HTTPS endpoint IS named and no client can be built for it.** Here the operator has said where the forward
+  belongs and this PR's new code path silently downgraded it. `SnapshotInstaller.buildSSLContext` already falls
+  back to the JVM default truststore when none is configured, so a null-or-throwing client means the trust
+  material itself could not be loaded - a misconfiguration, not an "undeclared" state. **Now refused.**
+
+`LeaderDial` gained `refusal` / `refused()`, the shape `PeerDialAddress` already uses, and each caller turns it
+into its own error: `ServerIsNotTheLeaderException` for `LeaderCommandForwarder` and `RaftReplicatedDatabase`, a
+503 for `PostBatchHandler`, `false` for `LeaderProxy`. Three tests added - the refusal at the decision, and at each
+of the two reachable entry points - and the two that asserted the old downgrade now assert the refusal. A fourth
+new test pins the branch that must NOT be refused, so a later "make it stricter" cannot quietly break every
+cluster that never declared its `https` ports.
+
+### claude - `LeaderDial.HTTPS_CLIENT_FALLBACK_WARNED` is static, not per-server - NOT APPLIED, with evidence
+
+The premise does not hold. A static one-time latch is the established pattern for exactly this notice:
+
+```
+$ grep -rn "static final AtomicBoolean" --include='*.java' ha-raft/src/main server/src/main
+ha-raft/.../SnapshotHttpHandler.java:104:  private static final AtomicBoolean WARNED_MISCONFIGURED_LIMIT = ...
+ha-raft/.../LeaderDatabaseQuery.java:73:   private static final AtomicBoolean PLAIN_HTTP_FALLBACK_WARNED = ...
+ha-raft/.../SnapshotInstaller.java:158:    private static final AtomicBoolean PLAIN_HTTP_FALLBACK_WARNED = ...
+ha-raft/.../PeerCapabilityQuery.java:81:   private static final AtomicBoolean PLAIN_HTTP_FALLBACK_WARNED = ...
+```
+
+Three of those carry the same "SSL is on but this dial fell back to plain HTTP" notice this one carries.
+`TrustedHttpClientCache` is per-server because it owns a *resource* - an `HttpClient` with a selector thread and a
+connection pool - whose lifetime must match the server's, which is a different question from how often a log line
+repeats. Taking the reviewer's own stated alternative ("or explicitly deciding to leave as-is, since it's
+log-only"): the latch is kept and its Javadoc now names the three precedents and the JVM-wide scope, so the
+decision is on the page rather than implied. The message already says "logged only once".
+
+The reviewer's other points - the per-forward `TrustedHttpClientCache` cost, the `LeaderProxy` dead code, the
+uncovered `RaftReplicatedDatabase` send - restate gaps this PR already declares (#7546, #7547); no change.
+
+### CodeRabbit pre-merge check - "Docstring Coverage 26.92%" - NOT APPLIED
+
+Counts every function in the 10 touched files, not the ones this diff adds; the added members carry Javadoc.
+Writing docstrings for untouched methods to clear a bot threshold is not in scope for a bug fix.

--- a/docs/7508-ha-leader-forward-https-scheme.md
+++ b/docs/7508-ha-leader-forward-https-scheme.md
@@ -1,0 +1,243 @@
+# #7508 - the follower-to-leader forward always dials `http://`
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/7508
+Branch: `fix/7508-ha-leader-forward-https-scheme`
+Type: bug (labels `bug`, `server`, `ha`, milestone 26.10.1)
+
+## Report
+
+Every follower-to-leader forward builds an `http://` URL from `HAServerPlugin.getLeaderAddress()`,
+which is the only leader endpoint the interface exposes. On an SSL cluster the forward therefore
+dials the plaintext listener, while every other peer-to-peer RPC in the cluster already prefers the
+peer's HTTPS endpoint.
+
+## Analysis
+
+### What the report gets right
+
+`LeaderCommandForwarder` and `LeaderProxy` both hardcode the scheme, and `HAServerPlugin` exposes
+only one address:
+
+```
+$ grep -rn '"http://"' --include='*.java' . | grep -v '/test/'
+ha-raft/.../LeaderDatabaseQuery.java:136:      return new Endpoint("http://" + httpAddr + "/api/v1/cluster/bootstrap-state", false);
+ha-raft/.../RaftHAServer.java:936:    final String url = (https ? "https://" : "http://") + followerAddr + "/api/v1/cluster/resync/"
+ha-raft/.../BootstrapElection.java:453:        .uri(URI.create("http://" + httpAddr + "/api/v1/cluster/bootstrap-state"))
+ha-raft/.../PeerAuthSessionQuery.java:144:        : "http://" + dial.httpAddress() + ROUTE;
+ha-raft/.../RaftHAPlugin.java:427:          new URL("http://" + targetAddr + "/api/v1/server").openConnection();
+ha-raft/.../RaftReplicatedDatabase.java:3522:        .uri(URI.create("http://" + leaderHttpAddress + "/api/v1/command/" + getName()))
+ha-raft/.../SnapshotInstaller.java:977:      final String snapshotUrl = (https ? "https://" : "http://") + endpoint + "/api/v1/ha/snapshot/" + databaseName;
+ha-raft/.../PeerCapabilityQuery.java:170:      return "http://" + httpAddr + "/api/v1/cluster/capabilities";
+server/.../LeaderProxy.java:106:    final String urlString = "http://" + leaderAddress + path + ...
+server/.../LeaderCommandForwarder.java:144:      leaderUri = URI.create("http://" + leaderHttpAddress + targetPath);
+server/.../PostBatchHandler.java:1586:    String url = "http://" + leaderAddress + "/api/v1/batch/" + databaseName;
+(non-HA hits in integration/, network/, engine/ omitted - they parse user-supplied URLs)
+```
+
+`SnapshotInstaller`, `RaftHAServer.forceResyncStalledReplica`, `LeaderDatabaseQuery.chooseEndpoint`,
+`PeerCapabilityQuery.chooseUrl` and `PeerAuthSessionQuery` all already select the scheme with the
+same rule: `useSSL && httpsAddress != null`. Only the *forward* path does not.
+
+### What the report gets wrong, and the impact that is actually real
+
+The report frames the failure as "a cluster that listens on HTTPS only - the plain HTTP listener
+disabled". **ArcadeDB has no such mode.** `HttpServer.buildUndertowServer` binds the plain listener
+unconditionally and adds the HTTPS one on top:
+
+```
+$ sed -n '354,372p' server/src/main/java/com/arcadedb/server/http/HttpServer.java
+  private Undertow buildUndertowServer(...) {
+    final Undertow.Builder builder = Undertow.builder()
+        ...
+        .addHttpListener(httpPortListening, host)      <- unconditional
+        ...
+    if (configuration.getValueAsBoolean(GlobalConfiguration.NETWORK_USE_SSL)) {
+      final SSLContext sslContext = createSSLContext();
+      builder.addHttpsListener(httpsPortListening, host, sslContext)
+```
+
+So the connection error the issue describes needs the plain port to be blocked from outside the
+process (a firewall, a NetworkPolicy, a service mesh that only exposes the TLS port) rather than
+simply unconfigured. Two consequences are real without any of that, though, and they are what this
+fix is actually for:
+
+1. **The forward silently downgrades inter-node traffic to cleartext on an SSL cluster.** The
+   forwarded request carries either the client's own `Authorization` header (Basic credentials or an
+   API token, relayed verbatim) or the cluster token in `X-ArcadeDB-Cluster-Token`, plus the whole
+   request body. An operator who set `arcadedb.ssl.enabled` gets every other peer-to-peer RPC
+   encrypted and this one in the clear.
+2. **On a cluster that declares `https` ports but not `http` ones, the forward is refused outright.**
+   The HTTP address is then *derived* as the peer's Raft host plus **this** node's HTTP port
+   (`RaftHAServer.resolveHttpAddress`), so `isOwnHttpAddress(leaderAddress)` answers true and the
+   forwarder throws `ServerIsNotTheLeaderException` - while the correctly declared HTTPS endpoint sits
+   unused in `httpsAddresses`.
+
+## Completeness
+
+### Invariant
+
+> A node forwarding a request to the cluster leader dials the leader's HTTPS endpoint whenever SSL is
+> enabled and one resolves for it, and plain HTTP only when it does not - the same rule every other
+> peer-to-peer dial in the cluster already follows.
+
+### Enumeration
+
+Writers/readers of the leader endpoint:
+
+```
+$ grep -rn "getLeaderAddress\|getLeaderHttpAddress" --include='*.java' . | grep -v '/test/' | grep -v '/remote/'
+server/.../HAServerPlugin.java:109:  String getLeaderAddress();                         <- the only endpoint on the interface
+server/.../GetServerHandler.java:121:      final String leaderServer = ha.getLeaderAddress();      <- reports it, never dials
+server/.../PostBatchHandler.java:1562:    final String leaderAddress = ha.getLeaderAddress();     <- DIALS
+server/.../LeaderCommandForwarder.java:125:    final String leaderHttpAddress = ha.getLeaderAddress(); <- DIALS
+server/.../AbstractServerHttpHandler.java:715/717                                     <- error text only
+ha-raft/.../RaftHAPlugin.java:390:  public String getLeaderAddress()                   <- delegates to RaftHAServer
+ha-raft/.../RaftHAServer.java:1851:  public String getLeaderHttpAddress()
+ha-raft/.../ArcadeStateMachine.java:3382,4369                                         <- snapshot source, already HTTPS-aware
+ha-raft/.../RaftReplicatedDatabase.java:3489/3522                                     <- DIALS
+grpcw/.../GrpcErrorMapper.java:201, ArcadeDbGrpcAdminService.java:1180                <- error text only (gRPC refuses, never forwards)
+```
+
+Same-shape siblings - every unattended peer dial, whether or not it is a leader forward - are the
+`"http://"` grep above.
+
+### Coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| `LeaderCommandForwarder.forwardIfReplica` - `POST /api/v1/server`, `POST`/`PUT`/`DELETE /api/v1/server/users` | yes | yes |
+| `PostBatchHandler.forwardBatchToLeader` - `POST /api/v1/batch/{db}` | yes | yes |
+| `RaftReplicatedDatabase.forwardCommandToLeaderViaRaft` - SQL write on a follower | yes | yes |
+| `LeaderProxy.tryProxy` | yes, but **nothing constructs LeaderProxy** - see Reachability (#7547) | yes (scheme choice only) |
+| `RaftHAPlugin.shutdownRemoteServer` - peer dial, not a leader forward | no - filed as #7546 | no |
+| `BootstrapElection.bootstrapStateRequest` - peer dial before any leader exists | no - filed as #7546 | no |
+| `LeaderDatabaseQuery`, `PeerCapabilityQuery`, `PeerAuthSessionQuery`, `SnapshotInstaller`, `RaftHAServer.forceResyncStalledReplica`, `PostVerifyDatabaseHandler` | argued: already select the scheme with the same rule | n/a |
+
+### Reachability
+
+`LeaderProxy` is **not on any live path**:
+
+```
+$ grep -rn "new LeaderProxy" --include='*.java' .
+(no output)
+```
+
+`HttpServer` constructs `LeaderCommandForwarder` (line 153) but never a `LeaderProxy`, so the three
+`arcadedb.ha.proxy*` settings it reads configure nothing today. Its scheme is fixed here for
+consistency, and the fix is a no-op at runtime until something wires the proxy up. Filed as #7547.
+
+The other three entry points are reachable: `LeaderCommandForwarder` from four HTTP routes,
+`PostBatchHandler.forwardBatchToLeader` from `POST /api/v1/batch/{db}`, and
+`RaftReplicatedDatabase.forwardCommandToLeaderViaRaft` from every write submitted on a follower.
+
+### Residual risk
+
+- No integration test starts a genuine HTTPS HA cluster: the scheme decision is proved by unit tests
+  per entry point, not by an end-to-end TLS forward. The issue reporter did not reproduce on one
+  either.
+- Truststore rotation rebuilds the forward's HTTPS client from the truststore's path, password,
+  mtime and size - the same fingerprint `TrustedHttpClientCache` uses - but the two implementations
+  are separate.
+
+## The fix
+
+One decision point, `server/src/main/java/com/arcadedb/server/http/handler/LeaderDial.java`, which every
+forward now asks instead of concatenating a scheme of its own:
+
+```java
+public record LeaderDial(String address, boolean https, HttpClient client) {
+  public static LeaderDial resolve(final HAServerPlugin ha, final HttpClient plainClient) { ... }
+  public String url(final String pathWithQuery) { ... }
+}
+```
+
+It reads two new methods on `HAServerPlugin`, both defaulting to "there is no HTTPS endpoint", so every
+implementation but `RaftHAPlugin` is left exactly where it was:
+
+- `getLeaderHttpsAddress()` - the endpoint to prefer, or `null`;
+- `getPeerHttpsClient()` - a client that validates the peer certificate against this node's truststore.
+
+`RaftHAPlugin` serves the first from `RaftHAServer.getLeaderHttpsAddress()` and the second from a
+`TrustedHttpClientCache` of its own (`forwardHttpsClients`), closed with the server. The address is
+withheld - never refused - in the three cases the pure `RaftHAServer.preferredLeaderHttpsAddress` covers:
+SSL off, no HTTPS endpoint resolved, or the endpoint resolved is this node's own.
+
+The self-address guard each caller already ran moved onto the address actually dialled, and is asked only
+of the plain-HTTP branch: `isOwnHttpAddress` compares against this node's *HTTP* listener and cannot speak
+for an HTTPS endpoint, which is why the plugin owns that check for the HTTPS one. That is what closes the
+second failure mode above - a cluster that declares `https` ports and not `http` ones now forwards over
+TLS instead of refusing itself.
+
+Files changed:
+
+| File | Change |
+|---|---|
+| `server/.../HAServerPlugin.java` | two default methods: `getLeaderHttpsAddress()`, `getPeerHttpsClient()` |
+| `server/.../http/handler/LeaderDial.java` | new - the shared decision |
+| `server/.../http/handler/LeaderCommandForwarder.java` | dials `LeaderDial`, self-check on the plain branch only |
+| `server/.../http/handler/PostBatchHandler.java` | same; `forwardBatchToLeader` relaxed to package-private for the test |
+| `server/.../http/handler/LeaderProxy.java` | same (see Reachability - #7547) |
+| `ha-raft/.../RaftHAServer.java` | `getLeaderHttpsAddress()` + pure `preferredLeaderHttpsAddress`, `forwardHttpsClients` cache closed in `stop()` |
+| `ha-raft/.../RaftHAPlugin.java` | implements both new plugin methods |
+| `ha-raft/.../RaftReplicatedDatabase.java` | the SQL write forward dials `LeaderDial` |
+
+## Tests
+
+- `server/src/test/java/com/arcadedb/server/http/handler/Issue7508LeaderForwardSchemeTest.java` - 10 tests.
+  Five drive `LeaderDial.resolve` (HTTPS wins; no HTTPS endpoint; an HTTPS endpoint with no client; trust
+  material unreadable; no leader at all). Five drive the two reachable server-module entry points through a
+  recording `HttpClient`, asserting the exact URI dialled, including the case where the HTTP self-address
+  check used to refuse a forward that now travels over TLS.
+- `ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7508LeaderHttpsEndpointTest.java` - 5 tests on the
+  withhold policy, loopback equivalence included.
+
+Proved able to fail: with `getLeaderHttpsAddress()` forced to `null` (the pre-fix behaviour), 4 of the 10
+server tests and 2 of the 5 ha-raft tests go red; restoring the fix returns all 15 to green.
+
+`RaftReplicatedDatabase`'s forward is covered at the decision it makes (`LeaderDial.resolve` plus
+`RaftHAServer.preferredLeaderHttpsAddress`), not at its HTTP send: driving that needs a live TLS cluster.
+
+### Regression runs
+
+| Suite | Result |
+|---|---|
+| `mvn -o -pl server test -DexcludedGroups=benchmark,vector,slow` | 1105 tests, 10 failures + 5 errors |
+| `mvn -o -pl ha-raft test -DexcludedGroups=benchmark,vector,slow` | 449 tests, 0 failures; `LeaveClusterTest` crashes its fork |
+
+Both sets of failures are pre-existing on this machine and were reproduced on the base commit
+(`99b6692780`) in a throwaway worktree:
+
+- the `server` failures are the fixed-port trap `CLAUDE.md` documents. `lsof -nP -iTCP:2480 -sTCP:LISTEN`
+  shows two foreign JVMs holding 2480/2481, and the failing classes - `AutoCommitParameterTest`,
+  `HttpBodySizeLimitTest`, `Issue6220TruncateHttpDefaultTest`, `ClusterInternalAuthTest`,
+  `PostClusterAuthSessionHandlerTest` - are exactly the ones that bind them. At base they fail the same way
+  (11 failures + 5 errors of the same 24 tests). None of them reaches a leader forward: a single-node test
+  server has no HA plugin, so `forwardIfReplica` returns before `LeaderDial` is consulted.
+- `LeaveClusterTest` (a 3-node `BaseRaftHATest` cluster on fixed ports) crashes its surefire fork
+  identically at base.
+
+## Adversarial pass
+
+The orchestrator's isolated subagent could not be spawned - no `Task` tool is exposed in this environment -
+so the pass was run by re-reading the diff against the issue rather than by an uncontaminated reader. That
+is a weaker pass and is recorded as such. Four findings, all fixed before the PR opened:
+
+1. **`RaftReplicatedDatabase` vetted one address and dialled another.** It awaits the leader's HTTP address
+   through `awaitLeaderAddress(raft::getLeaderHttpAddress, ...)` and runs `isOwnHttpAddress` on *that*
+   string, but the first version of the change built its URL from `LeaderDial.resolve`, which re-reads
+   `getLeaderAddress()`. A leadership change between the two reads would have dialled an address the
+   self-check never saw. Fixed: only the encrypted half is taken from the dial; the plain-HTTP address stays
+   the awaited one. `LeaderProxy` got the same treatment, since its plain address is the caller's parameter.
+2. **A comment described code six lines below it.** The new dial resolution had been inserted between the
+   #6191 self-address comment and the `if` it explains. Fixed by moving the resolution above that block.
+3. **`LeaderDial`'s Javadoc claimed "every other peer-to-peer dial in the cluster" already selects its
+   scheme.** The `"http://"` grep in the Enumeration section disproves that: `BootstrapElection` and
+   `RaftHAPlugin.shutdownRemoteServer` do not. Reworded to name the five that do and to point at #7546 for
+   the two that do not.
+4. **A per-forward cost on the HTTPS branch.** `getPeerHttpsClient()` goes through
+   `TrustedHttpClientCache.clientFor`, which stats the truststore twice and SHA-256s its password on every
+   call to decide whether to rebuild - sized in #7301 for a probe every few seconds, not for a request. Kept
+   as is, with the reasoning stated rather than assumed: the cost is paid only when the dial is actually
+   HTTPS (a non-SSL cluster never calls it), and it is two `stat`s and one short digest against a
+   cross-node HTTP round trip the call is about to make. If the forward ever needs more, the fix is a
+   time-bounded revalidation inside that cache, which would serve the capability probe too.

--- a/docs/7508-ha-leader-forward-https-scheme.md
+++ b/docs/7508-ha-leader-forward-https-scheme.md
@@ -108,7 +108,7 @@ Same-shape siblings - every unattended peer dial, whether or not it is a leader 
 | `LeaderCommandForwarder.forwardIfReplica` - `POST /api/v1/server`, `POST`/`PUT`/`DELETE /api/v1/server/users` | yes | yes |
 | `PostBatchHandler.forwardBatchToLeader` - `POST /api/v1/batch/{db}` | yes | yes |
 | `RaftReplicatedDatabase.forwardCommandToLeaderViaRaft` - SQL write on a follower | yes | yes |
-| `LeaderProxy.tryProxy` | yes, but **nothing constructs LeaderProxy** - see Reachability (#7547) | yes (scheme choice only) |
+| `LeaderProxy.tryProxy` | yes, but **nothing constructs LeaderProxy** - see Reachability (#7547) | the refusal branch only; its HTTPS dial reads the body through `exchange.startBlocking()`, which a detached exchange cannot serve |
 | `RaftHAPlugin.shutdownRemoteServer` - peer dial, not a leader forward | no - filed as #7546 | no |
 | `BootstrapElection.bootstrapStateRequest` - peer dial before any leader exists | no - filed as #7546 | no |
 | `LeaderDatabaseQuery`, `PeerCapabilityQuery`, `PeerAuthSessionQuery`, `SnapshotInstaller`, `RaftHAServer.forceResyncStalledReplica`, `PostVerifyDatabaseHandler` | argued: already select the scheme with the same rule | n/a |
@@ -328,8 +328,37 @@ The `claude` review found no bugs and said nothing blocks the merge. Its five po
    recorded here, so it is now labelled as correspondence instead of reading as design.
 5. **`LeaderProxy` is dead code.** Already declared, tracked as #7547. No change.
 
+## Review cycle 3 - `8bae0665e1`
+
+The `claude` review found no bugs and nothing blocking. Three minor findings, all applied:
+
+1. **Fully-qualified names in the new test fixtures.** `CLAUDE.md` asks for imports. Mechanical; the
+   `RecordingHttpClient`/`CannedResponse` members now use `SSLContext`, `SSLParameters`, `SSLSession`,
+   `CookieHandler`, `ProxySelector`, `Authenticator`, `Duration`, `CompletableFuture` and `Executor` by name.
+2. **The coverage table overclaimed `LeaderProxy`.** It said "yes (scheme choice only)" while nothing
+   exercised the branch at all - `LeaderProxyTest` is a placeholder that never calls `tryProxy`. Corrected,
+   and a test was added for the half that can be driven: the refusal short-circuit.
+   **That test found a real ordering flaw.** The refusal was checked *after* `readBodyCapped`, so a request
+   that was never going to be relayed still buffered an upload of up to `arcadedb.ha.proxyMaxBodySize`,
+   holding a request thread and that much heap. The dial resolution and its refusal now sit before the body
+   read, next to the loop-prevention refusal that is there for the same reason.
+3. **A theoretical "just became leader" window** in `RaftReplicatedDatabase`, where the refusal is checked
+   before the `raft.isLeader()` branch. It cannot produce a false positive, and the reasoning is now a
+   comment rather than an assumption: a refusal needs `getLeaderHttpsAddress()` to have named an endpoint,
+   and on a node that has just become the leader `getLeaderId()` and `localPeerId` are the same id, so that
+   method compares one `resolveHttpsAddress()` against itself and withholds. The existing
+   `nothingIsOfferedWhenTheResolvedHttpsEndpointIsThisNodesOwn` pins exactly that input.
+
+### Regression re-run after cycle 3
+
+`mvn -o -pl ha-raft test -DexcludedGroups=benchmark,vector,slow` reached 1409 tests this time - the earlier
+449 was cut short by `LeaveClusterTest` crashing its fork - with 2 failures in
+`ArcadeStateMachinePerDatabaseHaltTest`, a WAL-entry-parsing assertion that touches nothing in this change.
+Reproduced identically on base commit `99b6692780`.
+
 ## Final state
 
 `clean-approval` - the latest review from each bot says nothing blocks the merge, the one CodeRabbit
 thread was re-verified and answered by CodeRabbit itself, and the three known gaps carry issue numbers
-(#7546, #7547, #7563).
+(#7546, #7547, #7563). Every review finding across the three cycles is either applied or answered with
+evidence; none is deferred.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -36,6 +36,7 @@ import com.arcadedb.database.DatabaseInternal;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
@@ -389,6 +390,27 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
   @Override
   public String getLeaderAddress() {
     return raftHAServer != null ? raftHAServer.getLeaderHttpAddress() : null;
+  }
+
+  /**
+   * The HTTPS endpoint a forward to the leader should prefer, or {@code null} when the plain-HTTP one is what
+   * there is (issue #7508). The policy - SSL on, an HTTPS endpoint that resolves, and not this node's own - lives
+   * in {@link RaftHAServer#getLeaderHttpsAddress()}, next to the resolver it reads.
+   */
+  @Override
+  public String getLeaderHttpsAddress() {
+    return raftHAServer != null ? raftHAServer.getLeaderHttpsAddress() : null;
+  }
+
+  /**
+   * The HTTPS client a forward to {@link #getLeaderHttpsAddress()} is sent on: this node's truststore, so the
+   * leader's certificate is validated against the cluster's trust anchors and not against this node's own key
+   * material - the same context {@code SnapshotInstaller}, the capability probe and the bootstrap-state query
+   * already use (issue #4470).
+   */
+  @Override
+  public HttpClient getPeerHttpsClient() throws IOException {
+    return raftHAServer != null ? raftHAServer.getForwardHttpsClient() : null;
   }
 
   @Override

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -71,6 +71,7 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.URI;
+import java.net.http.HttpClient;
 import java.net.URLEncoder;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
@@ -236,6 +237,15 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   // Per server and not static: several ArcadeDBServer instances share a JVM in every HA test, and a shared cache
   // would rebuild on each probe and could close a client another server was still sending on.
   private final    TrustedHttpClientCache    capabilityHttpsClients = new TrustedHttpClientCache();
+  /**
+   * The HTTPS client that requests forwarded to the leader are sent on (issue #7508). A second cache rather than
+   * a share of {@link #capabilityHttpsClients}: that one is asked by a single scheduled thread, sequentially, and
+   * its rebuild path is documented against exactly that. This one is asked by HTTP worker threads, concurrently,
+   * so a truststore rotation makes one of them close the previous client - an orderly shutdown that waits for the
+   * forwards still in flight on it - while the others wait on the cache's monitor. That is bounded by their own
+   * request timeouts and happens only when the operator rotates a certificate.
+   */
+  private final    TrustedHttpClientCache    forwardHttpsClients    = new TrustedHttpClientCache();
   // Runs leader-driven stalled-replica resyncs off the lag-monitor thread (issue #4728). One worker is
   // enough since at most one resync fires per replica per stall streak; a small bounded queue with a
   // caller-runs policy degrades to running on the lag-monitor thread under the (unlikely) burst.
@@ -1005,6 +1015,15 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   }
 
   /**
+   * The HTTPS client a forward to the leader is sent on, built from this node's truststore and rebuilt only when
+   * that truststore changes (issue #7508). Owned here, so it is closed with the server rather than held for the
+   * life of the JVM.
+   */
+  HttpClient getForwardHttpsClient() throws IOException {
+    return forwardHttpsClients.clientFor(arcadeServer);
+  }
+
+  /**
    * Returns a human-readable display name for a peer, e.g. "arcadedb-0 (localhost:2480)".
    * Falls back to the raw peer ID string if the peer is unknown.
    */
@@ -1708,6 +1727,9 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     // been told to stand down. Making the close asynchronous to avoid that wait would hand the shutdown path a
     // client that outlives the server it belongs to, which is the leak this call exists to prevent.
     capabilityHttpsClients.close();
+    // Same reasoning for the forward client: a forward still in flight holds this close() until it unwinds,
+    // bounded by that request's own timeout, and leaving it open would leak a selector thread per server.
+    forwardHttpsClients.close();
     stalledResyncExecutor.shutdownNow();
     channelRecoveryExecutor.shutdownNow();
     if (transactionBroker != null) {
@@ -1850,6 +1872,42 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    */
   public String getLeaderHttpAddress() {
     return resolveHttpAddress(getLeaderId());
+  }
+
+  /**
+   * The HTTPS endpoint (host:port) of the current Raft leader, for a caller that would otherwise dial its
+   * plain-HTTP one; {@code null} when there is nothing better to dial than that (issue #7508).
+   * <p>
+   * Three ways to answer {@code null}, and none of them is a failure - the caller falls back to
+   * {@link #getLeaderHttpAddress()}, the listener that is always bound:
+   * <ul>
+   * <li>SSL is off, so there is no HTTPS listener anywhere in the cluster to dial;</li>
+   * <li>no HTTPS endpoint resolves for the leader ({@link #resolveHttpsAddress} answers {@code null} when the
+   * 5th field of {@code arcadedb.ha.serverList} is absent and this node has no HTTPS port to derive one from);</li>
+   * <li>the one that resolves is this node's own. The HTTP twin leaves that check to its callers, which run
+   * {@link #isOwnHttpAddress}; that method speaks for the HTTP listener and cannot answer for an HTTPS endpoint,
+   * so this one makes the check itself rather than handing out an address no caller can vet.</li>
+   * </ul>
+   * Resolved through the plain {@link #resolveHttpsAddress} rather than through
+   * {@link #getUnambiguousPeerHttpsAddress}, mirroring the HTTP twin exactly: an address that names the wrong
+   * node is caught by the receiving node's one-hop refusal, since the forward carries
+   * {@code LeaderForwardContext.FORWARDED_TO_LEADER_HEADER} whichever scheme it travelled on (issue #6191).
+   */
+  public String getLeaderHttpsAddress() {
+    return preferredLeaderHttpsAddress(configuration.getValueAsBoolean(GlobalConfiguration.NETWORK_USE_SSL),
+        resolveHttpsAddress(getLeaderId()), getLocalHttpsAddress());
+  }
+
+  /**
+   * The decision {@link #getLeaderHttpsAddress()} makes, without the resolver behind it. Package-private and pure
+   * so the three ways it answers {@code null} are unit-testable without a Raft group (issue #7508).
+   */
+  static String preferredLeaderHttpsAddress(final boolean useSSL, final String leaderHttpsAddress,
+      final String localHttpsAddress) {
+    if (!useSSL || leaderHttpsAddress == null)
+      return null;
+    return localHttpsAddress != null && isSameHttpEndpoint(localHttpsAddress, leaderHttpsAddress)
+        ? null : leaderHttpsAddress;
   }
 
   public RaftClient getClient() {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -3492,6 +3492,11 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     // The cluster named an HTTPS endpoint for the leader and this node cannot reach it. Posting the write to the
     // plain listener instead would put it, and the cluster token below, on the wire in clear; refuse with the
     // typed error the caller already retries on (issue #7508).
+    //
+    // Ahead of the "this node became the leader while waiting" branch below, and it cannot steal a write from it:
+    // a refusal needs getLeaderHttpsAddress() to have named an endpoint, and that method resolves the LEADER's
+    // HTTPS address and withholds it when it is this node's own. On a node that has just become the leader those
+    // are the same resolve() of the same peer id, so it answers null and no refusal can be raised (PR #7554 review).
     if (dial != null && dial.refused())
       throw new ServerIsNotTheLeaderException("Cannot forward the command: " + dial.refusal(), raft.getLeaderName());
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -3488,6 +3488,13 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     // further down cannot vet one address and dial another across a leadership change in between.
     final HAServerPlugin haPlugin = server.getHA();
     final LeaderDial dial = haPlugin != null ? LeaderDial.resolve(haPlugin, HTTP_CLIENT) : null;
+
+    // The cluster named an HTTPS endpoint for the leader and this node cannot reach it. Posting the write to the
+    // plain listener instead would put it, and the cluster token below, on the wire in clear; refuse with the
+    // typed error the caller already retries on (issue #7508).
+    if (dial != null && dial.refused())
+      throw new ServerIsNotTheLeaderException("Cannot forward the command: " + dial.refusal(), raft.getLeaderName());
+
     final String leaderHttpsAddress = dial != null && dial.https() ? dial.address() : null;
 
     // The address resolved for the leader is this node's own, and this node is not the leader: the POST would

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -3544,10 +3544,15 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       body.put("params", ordinalParams);
     }
 
+    // Built once and used for both the request and the failure messages below: a TLS handshake error reported
+    // against the plain-HTTP address the request was never sent to is the message an operator would take to a
+    // truststore problem (PR #7554 review).
+    final String leaderUrl = (leaderHttpsAddress != null
+        ? "https://" + leaderHttpsAddress
+        : "http://" + leaderHttpAddress) + "/api/v1/command/" + getName();
+
     final HttpRequest.Builder builder = HttpRequest.newBuilder()
-        .uri(URI.create((leaderHttpsAddress != null
-            ? "https://" + leaderHttpsAddress
-            : "http://" + leaderHttpAddress) + "/api/v1/command/" + getName()))
+        .uri(URI.create(leaderUrl))
         .header("Content-Type", "application/json")
         .POST(HttpRequest.BodyPublishers.ofString(body.toString()));
 
@@ -3591,9 +3596,9 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       throw e;
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new TransactionException("Interrupted while forwarding command to leader at " + leaderHttpAddress, e);
+      throw new TransactionException("Interrupted while forwarding command to leader at " + leaderUrl, e);
     } catch (final Exception e) {
-      throw new TransactionException("Error forwarding command to leader at " + leaderHttpAddress, e);
+      throw new TransactionException("Error forwarding command to leader at " + leaderUrl, e);
     }
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -97,6 +97,7 @@ import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.HAReplicatedDatabase;
 import com.arcadedb.server.HAServerPlugin;
 import com.arcadedb.server.LeaderForwardContext;
+import com.arcadedb.server.http.handler.LeaderDial;
 
 import java.io.IOException;
 import java.net.URI;
@@ -3480,13 +3481,26 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       throw new TransactionException("Cannot forward command to leader: leader HTTP address is not available "
           + "(no leader elected within " + leaderWaitMs + "ms; tune " + GlobalConfiguration.HA_FORWARD_LEADER_WAIT_TIMEOUT_MS.getKey() + ")");
 
+    // The scheme the write travels on: the leader's HTTPS endpoint when the cluster has one for it, the
+    // plain-HTTP address awaited above otherwise (issue #7508). On an SSL cluster the plain branch puts the
+    // cluster token and the whole write on the wire in cleartext. Only the encrypted half is taken from the
+    // dial - the plain address stays the one awaited above, so the self-address check below and the URL built
+    // further down cannot vet one address and dial another across a leadership change in between.
+    final HAServerPlugin haPlugin = server.getHA();
+    final LeaderDial dial = haPlugin != null ? LeaderDial.resolve(haPlugin, HTTP_CLIENT) : null;
+    final String leaderHttpsAddress = dial != null && dial.https() ? dial.address() : null;
+
     // The address resolved for the leader is this node's own, and this node is not the leader: the POST would
     // come back here, be forwarded again, and consume one more HTTP worker thread per hop. This is what the
     // derive fallback produces when the peers share a host and no 'http' port is declared - it pairs the
     // leader's Raft host with THIS node's HTTP port. Refuse with the typed error the HTTP and gRPC layers
     // already know how to report (issue #6191). The one case where the self-address is right - this node
     // became the leader while waiting above - is left alone: that POST executes locally and terminates.
-    if (!raft.isLeader() && raft.isOwnHttpAddress(leaderHttpAddress)) {
+    //
+    // Asked only when the write is about to travel on that plain-HTTP address: isOwnHttpAddress answers for this
+    // node's HTTP listener and cannot speak for an HTTPS endpoint, which getLeaderHttpsAddress() withholds when
+    // it is this node's own.
+    if (!raft.isLeader() && leaderHttpsAddress == null && raft.isOwnHttpAddress(leaderHttpAddress)) {
       if (selfForwardWarned.compareAndSet(false, true))
         LogManager.instance().log(this, Level.WARNING,
             "The HTTP address resolved for the leader (%s) is this node's own, so a write forwarded to it would come "
@@ -3519,7 +3533,9 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     }
 
     final HttpRequest.Builder builder = HttpRequest.newBuilder()
-        .uri(URI.create("http://" + leaderHttpAddress + "/api/v1/command/" + getName()))
+        .uri(URI.create((leaderHttpsAddress != null
+            ? "https://" + leaderHttpsAddress
+            : "http://" + leaderHttpAddress) + "/api/v1/command/" + getName()))
         .header("Content-Type", "application/json")
         .POST(HttpRequest.BodyPublishers.ofString(body.toString()));
 
@@ -3553,7 +3569,8 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     builder.header("X-ArcadeDB-Forwarded-User", proxiedUser);
 
     try {
-      final HttpResponse<String> response = HTTP_CLIENT.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+      final HttpResponse<String> response = (leaderHttpsAddress != null ? dial.client() : HTTP_CLIENT)
+          .send(builder.build(), HttpResponse.BodyHandlers.ofString());
       if (response.statusCode() != 200)
         throw reconstructLeaderException(response.statusCode(), response.body());
 

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7508LeaderHttpsEndpointTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7508LeaderHttpsEndpointTest.java
@@ -59,6 +59,11 @@ class Issue7508LeaderHttpsEndpointTest {
     // What the derive fallback produces on a cluster whose peers share a host and declare no 'https' port: every
     // peer's HTTPS endpoint collapses onto this node's own, and dialling it comes straight back here. The caller
     // cannot catch this itself - isOwnHttpAddress compares against the HTTP listener, not the HTTPS one.
+    //
+    // It is also the state a node that has JUST BECOME the leader is in: getLeaderHttpsAddress() then resolves
+    // getLeaderId() and localPeerId to the same peer, so both arguments are one resolve() of one id. That is why a
+    // write arriving during that window cannot be refused for "the cluster requires TLS and I cannot reach it" -
+    // there is no endpoint to require (PR #7554 review).
     assertThat(RaftHAServer.preferredLeaderHttpsAddress(true, LOCAL_HTTPS, LOCAL_HTTPS)).isNull();
 
     // Loopback spelled two ways on one port is one socket, which isSameHttpEndpoint already knows (issue #6204).

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7508LeaderHttpsEndpointTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7508LeaderHttpsEndpointTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression for issue #7508: the endpoint a forward to the leader is dialled on.
+ * <p>
+ * {@code RaftHAServer.getLeaderHttpsAddress()} is what tells the shared {@code LeaderDial} decision that the cluster
+ * has an encrypted endpoint for the leader. It has to withhold one in three cases, each of which sends the caller
+ * back to the plain-HTTP address - the listener {@code HttpServer.buildUndertowServer} always binds - rather than
+ * refusing the forward outright. That is the same withhold-rather-than-refuse rule
+ * {@link PeerDialAddress#encryptedEndpointOf} applies to every other peer-to-peer dial (issue #6221).
+ */
+class Issue7508LeaderHttpsEndpointTest {
+
+  private static final String LEADER_HTTPS = "leader.example.com:2490";
+  private static final String LOCAL_HTTPS  = "follower.example.com:2490";
+
+  @Test
+  void theLeaderHttpsEndpointIsOfferedOnAnSslClusterThatResolvesOne() {
+    assertThat(RaftHAServer.preferredLeaderHttpsAddress(true, LEADER_HTTPS, LOCAL_HTTPS))
+        .isEqualTo(LEADER_HTTPS);
+  }
+
+  @Test
+  void nothingIsOfferedWhenSslIsOff() {
+    // The 5th field of arcadedb.ha.serverList can name an https port on a cluster that never enabled SSL, so the
+    // address resolving is not on its own a reason to dial it.
+    assertThat(RaftHAServer.preferredLeaderHttpsAddress(false, LEADER_HTTPS, LOCAL_HTTPS)).isNull();
+  }
+
+  @Test
+  void nothingIsOfferedWhenNoHttpsEndpointResolvesForTheLeader() {
+    assertThat(RaftHAServer.preferredLeaderHttpsAddress(true, null, LOCAL_HTTPS)).isNull();
+  }
+
+  @Test
+  void nothingIsOfferedWhenTheResolvedHttpsEndpointIsThisNodesOwn() {
+    // What the derive fallback produces on a cluster whose peers share a host and declare no 'https' port: every
+    // peer's HTTPS endpoint collapses onto this node's own, and dialling it comes straight back here. The caller
+    // cannot catch this itself - isOwnHttpAddress compares against the HTTP listener, not the HTTPS one.
+    assertThat(RaftHAServer.preferredLeaderHttpsAddress(true, LOCAL_HTTPS, LOCAL_HTTPS)).isNull();
+
+    // Loopback spelled two ways on one port is one socket, which isSameHttpEndpoint already knows (issue #6204).
+    assertThat(RaftHAServer.preferredLeaderHttpsAddress(true, "127.0.0.1:2490", "localhost:2490")).isNull();
+  }
+
+  @Test
+  void theEndpointIsStillOfferedWhenThisNodeHasNoHttpsAddressToCompareAgainst() {
+    // getLocalHttpsAddress() degrades to null while the local HTTPS listener is coming up. The self-check is then
+    // inactive, exactly as PeerDialAddress.resolve leaves the HTTP one, rather than withholding every endpoint.
+    assertThat(RaftHAServer.preferredLeaderHttpsAddress(true, LEADER_HTTPS, null)).isEqualTo(LEADER_HTTPS);
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
+++ b/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
@@ -19,6 +19,7 @@
 package com.arcadedb.server;
 
 import java.io.IOException;
+import java.net.http.HttpClient;
 import java.util.List;
 import java.util.Map;
 
@@ -107,6 +108,42 @@ public interface HAServerPlugin extends ServerPlugin {
    * Returns the HTTP address (host:port) of the current leader, or null if unknown.
    */
   String getLeaderAddress();
+
+  /**
+   * The HTTPS endpoint (host:port) a forward to the leader should be dialled on in preference to
+   * {@link #getLeaderAddress()}, or {@code null} when there is none to prefer.
+   * <p>
+   * Answering {@code null} is the ordinary case, not a failure: it is what an implementation says when SSL is off,
+   * when no HTTPS endpoint resolves for the leader, or when the one that does is this node's own. A caller reads
+   * {@code null} as "dial the plain-HTTP address", which is the listener that is always bound
+   * ({@code HttpServer.buildUndertowServer} adds it unconditionally and the HTTPS one only on top). That is the
+   * same withhold-rather-than-refuse rule {@code PeerDialAddress.encryptedEndpointOf} applies to every other
+   * peer-to-peer dial in the cluster (issue #6221).
+   * <p>
+   * <b>An implementation that answers non-null owns the self-address check for that address.</b> Callers apply
+   * {@link #isOwnHttpAddress} to the plain-HTTP address they were handed, and it cannot speak for an HTTPS
+   * endpoint: the two are read from independent fields of {@code arcadedb.ha.serverList} with independent derive
+   * fallbacks, so one can be this node's own while the other is not.
+   *
+   * @see #getPeerHttpsClient()
+   */
+  default String getLeaderHttpsAddress() {
+    return null;
+  }
+
+  /**
+   * An {@link HttpClient} that validates a cluster peer's certificate against this node's truststore, for dialling
+   * the endpoint {@link #getLeaderHttpsAddress()} named. {@code null} when this implementation has none, in which
+   * case the caller falls back to the plain-HTTP address.
+   * <p>
+   * The client is owned by the plugin and must not be closed by the caller: it carries a connection pool and a
+   * selector thread that are shared by every forward and released when the plugin stops.
+   *
+   * @throws IOException when the trust material cannot be read - the caller falls back to plain HTTP.
+   */
+  default HttpClient getPeerHttpsClient() throws IOException {
+    return null;
+  }
 
   /**
    * Returns a comma-separated list of replica HTTP addresses, or empty string if none.

--- a/server/src/main/java/com/arcadedb/server/http/handler/LeaderCommandForwarder.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/LeaderCommandForwarder.java
@@ -122,16 +122,21 @@ public final class LeaderCommandForwarder {
               + " prevents", ha.getLeaderName());
     }
 
-    final String leaderHttpAddress = ha.getLeaderAddress();
-    if (leaderHttpAddress == null)
+    // Where to dial the leader and on which scheme: the HTTPS endpoint when the cluster has one for it,
+    // the plain-HTTP one otherwise (issue #7508). On an SSL cluster the plain branch would relay the
+    // credentials below in cleartext.
+    final LeaderDial dial = LeaderDial.resolve(ha, HTTP_CLIENT);
+    if (dial == null)
       throw new ServerIsNotTheLeaderException("Leader address is unknown", ha.getLeaderName());
 
     // Dialing an address that resolves to this node comes straight back here, and this node is not the
     // leader. That is what the derive fallback produces when the peers share a host and no HTTP port is
-    // declared: it pairs the leader's Raft host with THIS node's HTTP port (issue #6191).
-    if (ha.isOwnHttpAddress(leaderHttpAddress))
+    // declared: it pairs the leader's Raft host with THIS node's HTTP port (issue #6191). Asked only of the
+    // plain-HTTP branch: isOwnHttpAddress compares against this node's HTTP listener and cannot answer for an
+    // HTTPS endpoint, which the plugin withholds when it is this node's own instead.
+    if (!dial.https() && ha.isOwnHttpAddress(dial.address()))
       throw new ServerIsNotTheLeaderException(
-          "Cannot forward the server command: the HTTP address resolved for the leader (" + leaderHttpAddress
+          "Cannot forward the server command: the HTTP address resolved for the leader (" + dial.address()
               + ") is this node's own, and this node is not the leader. Declare every node's HTTP port explicitly with "
               + "the 'host:raftPort:httpPort' syntax in " + GlobalConfiguration.HA_SERVER_LIST.getKey(),
           ha.getLeaderName());
@@ -141,7 +146,7 @@ public final class LeaderCommandForwarder {
 
     final URI leaderUri;
     try {
-      leaderUri = URI.create("http://" + leaderHttpAddress + targetPath);
+      leaderUri = URI.create(dial.url(targetPath));
     } catch (final IllegalArgumentException e) {
       // URI.create is the one call on this path that throws an UNCHECKED exception, so without this it
       // would leave as a 500 - a server fault - for a request target that is simply not a URI.
@@ -188,11 +193,11 @@ public final class LeaderCommandForwarder {
     }
 
     try {
-      final HttpResponse<String> response = HTTP_CLIENT.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+      final HttpResponse<String> response = dial.client().send(builder.build(), HttpResponse.BodyHandlers.ofString());
       return new ExecutionResponse(response.statusCode(), response.body());
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new IOException("Interrupted while forwarding server command to leader at " + leaderHttpAddress, e);
+      throw new IOException("Interrupted while forwarding server command to leader at " + dial.url(targetPath), e);
     }
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/LeaderCommandForwarder.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/LeaderCommandForwarder.java
@@ -129,6 +129,13 @@ public final class LeaderCommandForwarder {
     if (dial == null)
       throw new ServerIsNotTheLeaderException("Leader address is unknown", ha.getLeaderName());
 
+    // The cluster named an HTTPS endpoint for the leader and this node cannot reach it. Downgrading to the plain
+    // listener would put the Authorization header relayed below on the wire in clear, which is the failure this
+    // whole change exists to end - so the command is refused instead (issue #7508).
+    if (dial.refused())
+      throw new ServerIsNotTheLeaderException("Cannot forward the server command: " + dial.refusal(),
+          ha.getLeaderName());
+
     // Dialing an address that resolves to this node comes straight back here, and this node is not the
     // leader. That is what the derive fallback produces when the peers share a host and no HTTP port is
     // declared: it pairs the leader's Raft host with THIS node's HTTP port (issue #6191). Asked only of the

--- a/server/src/main/java/com/arcadedb/server/http/handler/LeaderDial.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/LeaderDial.java
@@ -51,17 +51,34 @@ import java.util.logging.Level;
  * endpoint sitting unused.</li>
  * </ul>
  *
- * @param address the {@code host:port} to dial
+ * <b>Falling back is not the same as failing open.</b> A cluster that never declared its {@code https} ports
+ * resolves no HTTPS endpoint, and dialling its plain listener is what it did before this class existed - refusing
+ * there would break every SSL cluster that left the optional 5th field of {@code arcadedb.ha.serverList} out. But
+ * a cluster that HAS named an HTTPS endpoint for the leader has said where this forward belongs, and if no client
+ * can be built to reach it the forward is <b>refused</b> rather than sent in the clear:
+ * {@code SnapshotInstaller.buildSSLContext} already falls back to the JVM default truststore when none is
+ * configured, so failing to produce a client means the trust material itself could not be loaded.
+ *
+ * @param address the {@code host:port} to dial, or {@code null} on a refusal
  * @param https   whether {@link #address} speaks TLS
  * @param client  the client to send on - the caller's own for plain HTTP, the plugin's trust-carrying one for HTTPS
+ * @param refusal why this forward may not be sent at all, or {@code null} when it may
  */
-public record LeaderDial(String address, boolean https, HttpClient client) {
+public record LeaderDial(String address, boolean https, HttpClient client, String refusal) {
 
   /**
-   * Said once per JVM: a plugin that advertises an HTTPS leader endpoint but cannot hand out a client for it has
-   * a configuration fault worth naming, and the forward that fell back to cleartext would otherwise be silent.
+   * Said once per JVM: a cluster that names an HTTPS leader endpoint but cannot hand out a client for it has a
+   * configuration fault worth naming in the log of the node that found it, not only in the answer its client gets.
+   * One latch per JVM rather than per server, matching {@code PLAIN_HTTP_FALLBACK_WARNED} in
+   * {@code SnapshotInstaller}, {@code PeerCapabilityQuery} and {@code LeaderDatabaseQuery} - the three other
+   * one-time notices about an SSL cluster's peer transport.
    */
-  private static final AtomicBoolean HTTPS_CLIENT_FALLBACK_WARNED = new AtomicBoolean(false);
+  private static final AtomicBoolean HTTPS_CLIENT_UNAVAILABLE_WARNED = new AtomicBoolean(false);
+
+  /** True when the cluster requires TLS for this forward and it cannot be established; {@link #refusal} says why. */
+  public boolean refused() {
+    return refusal != null;
+  }
 
   /** The URL this dial targets. {@code pathWithQuery} starts with {@code /} and may carry a query string. */
   public String url(final String pathWithQuery) {
@@ -69,13 +86,15 @@ public record LeaderDial(String address, boolean https, HttpClient client) {
   }
 
   /**
-   * Where to dial the current leader, or {@code null} when no leader address is known at all - which the caller
-   * reports as "the leader address is unknown", exactly as it did when it read {@code getLeaderAddress()} itself.
+   * Where to dial the current leader; {@code null} when no leader address is known at all - which the caller
+   * reports as "the leader address is unknown", exactly as it did when it read {@code getLeaderAddress()} itself -
+   * and a {@link #refused()} dial when the cluster requires TLS for this forward and it cannot be established.
    * <p>
-   * The HTTPS endpoint wins when the plugin offers one AND can hand out a client that trusts the cluster's
-   * certificates; anything else falls back to the plain-HTTP address, because that listener is the one that is
-   * always bound. A plugin that offers no HTTPS endpoint - the interface default, and what {@code RaftHAPlugin}
-   * answers whenever SSL is off - therefore leaves the dial exactly where it was.
+   * The HTTPS endpoint wins when the plugin names one AND can hand out a client that trusts the cluster's
+   * certificates. A plugin that names no HTTPS endpoint - the interface default, and what {@code RaftHAPlugin}
+   * answers whenever SSL is off or none resolves - leaves the dial on the plain-HTTP address, the listener that is
+   * always bound, exactly where it was. A plugin that names one and cannot serve a client for it gets a refusal
+   * rather than a downgrade; see the class note on why those two are not the same case.
    * <p>
    * <b>The caller still owns the self-address check, and only on the plain-HTTP branch.</b>
    * {@link HAServerPlugin#isOwnHttpAddress} compares against this node's HTTP listener and cannot speak for an
@@ -92,23 +111,32 @@ public record LeaderDial(String address, boolean https, HttpClient client) {
       try {
         final HttpClient httpsClient = ha.getPeerHttpsClient();
         if (httpsClient != null)
-          return new LeaderDial(httpsAddress, true, httpsClient);
-        warnHttpsFallback("it offers no HTTPS client to dial it with");
+          return new LeaderDial(httpsAddress, true, httpsClient, null);
+        return refuse(httpsAddress, "no HTTPS client is available to dial it with");
       } catch (final IOException e) {
-        warnHttpsFallback("its trust material cannot be read (" + e.getMessage() + ")");
+        return refuse(httpsAddress, "its trust material cannot be read (" + e.getMessage() + ")");
       }
     }
 
     final String httpAddress = ha.getLeaderAddress();
-    return httpAddress == null || httpAddress.isBlank() ? null : new LeaderDial(httpAddress, false, plainClient);
+    return httpAddress == null || httpAddress.isBlank() ? null : new LeaderDial(httpAddress, false, plainClient, null);
   }
 
-  private static void warnHttpsFallback(final String reason) {
-    if (HTTPS_CLIENT_FALLBACK_WARNED.compareAndSet(false, true))
+  /**
+   * A refusal naming the endpoint the cluster asked for and why it could not be reached, phrased to be appended to
+   * a caller's own "cannot forward ..." message. The same shape {@code PeerDialAddress.refuse} uses.
+   */
+  private static LeaderDial refuse(final String httpsAddress, final String reason) {
+    if (HTTPS_CLIENT_UNAVAILABLE_WARNED.compareAndSet(false, true))
       LogManager.instance().log(LeaderDial.class, Level.WARNING,
-          "The HA plugin names an HTTPS endpoint for the cluster leader but %s, so requests forwarded to the leader "
-              + "fall back to the plain-HTTP endpoint and travel in cleartext together with the credentials they "
-              + "relay. Check the truststore named by '%s'. This notice is logged only once.",
-          reason, GlobalConfiguration.NETWORK_SSL_TRUSTSTORE.getKey());
+          "The cluster names an HTTPS endpoint for the leader (%s) but %s, so requests that have to run on the leader "
+              + "are refused rather than forwarded over the plain-HTTP endpoint, which would put what they relay on "
+              + "the wire in cleartext. Check the truststore named by '%s'. This notice is logged only once.",
+          httpsAddress, reason, GlobalConfiguration.NETWORK_SSL_TRUSTSTORE.getKey());
+
+    return new LeaderDial(null, false, null,
+        "the cluster requires the leader to be reached over TLS at " + httpsAddress + ", but " + reason
+            + "; the request is refused rather than forwarded in cleartext. Check the truststore named by '"
+            + GlobalConfiguration.NETWORK_SSL_TRUSTSTORE.getKey() + "'");
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/LeaderDial.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/LeaderDial.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.server.HAServerPlugin;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+
+/**
+ * Where a forward to the cluster leader is dialled, on which scheme, and with which client (issue #7508).
+ * <p>
+ * Every follower-to-leader forward used to build its URL as {@code "http://" + ha.getLeaderAddress() + path},
+ * because that address is the only leader endpoint {@link HAServerPlugin} exposed. Meanwhile five peer-to-peer
+ * dials in the cluster - snapshot download ({@code SnapshotInstaller}), the capability probe
+ * ({@code PeerCapabilityQuery}), the bootstrap-state query ({@code LeaderDatabaseQuery}), the auth-session RPC
+ * ({@code PeerAuthSessionQuery}) and the stalled-replica resync ({@code RaftHAServer.forceResyncStalledReplica})
+ * - already pick their scheme with one rule: prefer the peer's HTTPS endpoint when SSL is enabled and one
+ * resolves. This puts the forward on that same rule, in one place rather than once per call site. Two dials that
+ * are neither forwards nor on that rule are tracked separately in issue #7546.
+ * <p>
+ * Two things go wrong without it on a cluster with {@code arcadedb.ssl.enabled} set, and neither needs the plain
+ * listener to be switched off (it cannot be - {@code HttpServer.buildUndertowServer} binds it unconditionally):
+ * <ul>
+ * <li><b>the forward travels in cleartext.</b> It relays either the client's own {@code Authorization} header or
+ * the cluster token, plus the request body, so an operator who enabled SSL gets every peer-to-peer RPC encrypted
+ * except this one;</li>
+ * <li><b>on a cluster that declares {@code https} ports and not {@code http} ones the forward is refused
+ * outright.</b> The HTTP address is then derived as the leader's Raft host plus THIS node's HTTP port, so
+ * {@link HAServerPlugin#isOwnHttpAddress} answers true and the caller refuses - with a correctly declared HTTPS
+ * endpoint sitting unused.</li>
+ * </ul>
+ *
+ * @param address the {@code host:port} to dial
+ * @param https   whether {@link #address} speaks TLS
+ * @param client  the client to send on - the caller's own for plain HTTP, the plugin's trust-carrying one for HTTPS
+ */
+public record LeaderDial(String address, boolean https, HttpClient client) {
+
+  /**
+   * Said once per JVM: a plugin that advertises an HTTPS leader endpoint but cannot hand out a client for it has
+   * a configuration fault worth naming, and the forward that fell back to cleartext would otherwise be silent.
+   */
+  private static final AtomicBoolean HTTPS_CLIENT_FALLBACK_WARNED = new AtomicBoolean(false);
+
+  /** The URL this dial targets. {@code pathWithQuery} starts with {@code /} and may carry a query string. */
+  public String url(final String pathWithQuery) {
+    return (https ? "https://" : "http://") + address + pathWithQuery;
+  }
+
+  /**
+   * Where to dial the current leader, or {@code null} when no leader address is known at all - which the caller
+   * reports as "the leader address is unknown", exactly as it did when it read {@code getLeaderAddress()} itself.
+   * <p>
+   * The HTTPS endpoint wins when the plugin offers one AND can hand out a client that trusts the cluster's
+   * certificates; anything else falls back to the plain-HTTP address, because that listener is the one that is
+   * always bound. A plugin that offers no HTTPS endpoint - the interface default, and what {@code RaftHAPlugin}
+   * answers whenever SSL is off - therefore leaves the dial exactly where it was.
+   * <p>
+   * <b>The caller still owns the self-address check, and only on the plain-HTTP branch.</b>
+   * {@link HAServerPlugin#isOwnHttpAddress} compares against this node's HTTP listener and cannot speak for an
+   * HTTPS endpoint; the plugin withholds an HTTPS address that is this node's own instead (see
+   * {@link HAServerPlugin#getLeaderHttpsAddress()}).
+   *
+   * @param ha          the HA plugin, which must not be {@code null} - the caller has already established that
+   *                    this node is an HA replica
+   * @param plainClient the client to use when the dial resolves to plain HTTP
+   */
+  public static LeaderDial resolve(final HAServerPlugin ha, final HttpClient plainClient) {
+    final String httpsAddress = ha.getLeaderHttpsAddress();
+    if (httpsAddress != null) {
+      try {
+        final HttpClient httpsClient = ha.getPeerHttpsClient();
+        if (httpsClient != null)
+          return new LeaderDial(httpsAddress, true, httpsClient);
+        warnHttpsFallback("it offers no HTTPS client to dial it with");
+      } catch (final IOException e) {
+        warnHttpsFallback("its trust material cannot be read (" + e.getMessage() + ")");
+      }
+    }
+
+    final String httpAddress = ha.getLeaderAddress();
+    return httpAddress == null || httpAddress.isBlank() ? null : new LeaderDial(httpAddress, false, plainClient);
+  }
+
+  private static void warnHttpsFallback(final String reason) {
+    if (HTTPS_CLIENT_FALLBACK_WARNED.compareAndSet(false, true))
+      LogManager.instance().log(LeaderDial.class, Level.WARNING,
+          "The HA plugin names an HTTPS endpoint for the cluster leader but %s, so requests forwarded to the leader "
+              + "fall back to the plain-HTTP endpoint and travel in cleartext together with the credentials they "
+              + "relay. Check the truststore named by '%s'. This notice is logged only once.",
+          reason, GlobalConfiguration.NETWORK_SSL_TRUSTSTORE.getKey());
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/handler/LeaderProxy.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/LeaderProxy.java
@@ -108,6 +108,15 @@ public final class LeaderProxy {
     // the encrypted half is taken from the dial, so the address the caller vetted is the one dialled otherwise.
     final HAServerPlugin ha = httpServer.getServer().getHA();
     final LeaderDial dial = ha != null ? LeaderDial.resolve(ha, client) : null;
+
+    // The cluster named an HTTPS endpoint for the leader and this node cannot reach it. Proxying the request over
+    // the plain listener would put its body and the cluster token injected below in the clear, so the proxy stands
+    // down and the caller answers with its own error instead (issue #7508).
+    if (dial != null && dial.refused()) {
+      LogManager.instance().log(this, Level.WARNING, "Leader proxy refused: %s", dial.refusal());
+      return false;
+    }
+
     final boolean https = dial != null && dial.https();
     final String targetAddress = https ? dial.address() : leaderAddress;
     final HttpClient targetClient = https ? dial.client() : client;

--- a/server/src/main/java/com/arcadedb/server/http/handler/LeaderProxy.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/LeaderProxy.java
@@ -20,6 +20,7 @@ package com.arcadedb.server.http.handler;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.server.HAServerPlugin;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.server.HttpServerExchange;
@@ -101,9 +102,20 @@ public final class LeaderProxy {
       return false;
     }
 
+    // Which scheme the leader is dialled on. The caller passes the plain-HTTP address it read from the HA
+    // plugin; when the cluster has an HTTPS endpoint for the leader, that one is preferred and the proxied
+    // request - which carries the cluster token and the client's whole body - is encrypted (issue #7508). Only
+    // the encrypted half is taken from the dial, so the address the caller vetted is the one dialled otherwise.
+    final HAServerPlugin ha = httpServer.getServer().getHA();
+    final LeaderDial dial = ha != null ? LeaderDial.resolve(ha, client) : null;
+    final boolean https = dial != null && dial.https();
+    final String targetAddress = https ? dial.address() : leaderAddress;
+    final HttpClient targetClient = https ? dial.client() : client;
+
     final String path = exchange.getRequestPath();
     final String query = exchange.getQueryString();
-    final String urlString = "http://" + leaderAddress + path + (query == null || query.isEmpty() ? "" : "?" + query);
+    final String urlString = (https ? "https://" : "http://") + targetAddress + path
+        + (query == null || query.isEmpty() ? "" : "?" + query);
 
     final HttpRequest.Builder builder;
     try {
@@ -138,22 +150,22 @@ public final class LeaderProxy {
 
     final HttpResponse<byte[]> response;
     try {
-      response = client.send(builder.build(), HttpResponse.BodyHandlers.ofByteArray());
+      response = targetClient.send(builder.build(), HttpResponse.BodyHandlers.ofByteArray());
     } catch (final HttpTimeoutException e) {
-      LogManager.instance().log(this, Level.WARNING, "Leader proxy timeout to %s: %s", leaderAddress, e.getMessage());
+      LogManager.instance().log(this, Level.WARNING, "Leader proxy timeout to %s: %s", targetAddress, e.getMessage());
       return false;
     } catch (final ConnectException e) {
-      LogManager.instance().log(this, Level.WARNING, "Leader proxy cannot connect to %s: %s", leaderAddress, e.getMessage());
+      LogManager.instance().log(this, Level.WARNING, "Leader proxy cannot connect to %s: %s", targetAddress, e.getMessage());
       return false;
     } catch (final IOException e) {
-      LogManager.instance().log(this, Level.WARNING, "Leader proxy IO error to %s: %s", leaderAddress, e.getMessage());
+      LogManager.instance().log(this, Level.WARNING, "Leader proxy IO error to %s: %s", targetAddress, e.getMessage());
       return false;
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
-      LogManager.instance().log(this, Level.WARNING, "Leader proxy interrupted to %s", leaderAddress);
+      LogManager.instance().log(this, Level.WARNING, "Leader proxy interrupted to %s", targetAddress);
       return false;
     } catch (final Throwable t) {
-      LogManager.instance().log(this, Level.SEVERE, "Leader proxy unexpected error to %s: %s", t, leaderAddress, t.getMessage());
+      LogManager.instance().log(this, Level.SEVERE, "Leader proxy unexpected error to %s: %s", t, targetAddress, t.getMessage());
       return false;
     }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/LeaderProxy.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/LeaderProxy.java
@@ -90,6 +90,29 @@ public final class LeaderProxy {
       return false;
     }
 
+    // Which scheme the leader is dialled on. The caller passes the plain-HTTP address it read from the HA
+    // plugin; when the cluster has an HTTPS endpoint for the leader, that one is preferred and the proxied
+    // request - which carries the cluster token and the client's whole body - is encrypted (issue #7508). Only
+    // the encrypted half is taken from the dial, so the address the caller vetted is the one dialled otherwise.
+    final HAServerPlugin ha = httpServer.getServer().getHA();
+    final LeaderDial dial = ha != null ? LeaderDial.resolve(ha, client) : null;
+
+    // The cluster named an HTTPS endpoint for the leader and this node cannot reach it. Proxying the request over
+    // the plain listener would put its body and the cluster token injected below in the clear, so the proxy stands
+    // down and the caller answers with its own error instead (issue #7508).
+    //
+    // Decided BEFORE the body is read, like the loop-prevention refusal above and for the same reason: buffering
+    // an upload up to 'arcadedb.ha.proxyMaxBodySize' for a request that was never going to be relayed costs a held
+    // request thread and that much heap per attempt.
+    if (dial != null && dial.refused()) {
+      LogManager.instance().log(this, Level.WARNING, "Leader proxy refused: %s", dial.refusal());
+      return false;
+    }
+
+    final boolean https = dial != null && dial.https();
+    final String targetAddress = https ? dial.address() : leaderAddress;
+    final HttpClient targetClient = https ? dial.client() : client;
+
     final byte[] body;
     try {
       body = readBodyCapped(exchange);
@@ -101,25 +124,6 @@ public final class LeaderProxy {
           "Leader proxy refused to forward request: body too large (> %d bytes)", maxBodySize);
       return false;
     }
-
-    // Which scheme the leader is dialled on. The caller passes the plain-HTTP address it read from the HA
-    // plugin; when the cluster has an HTTPS endpoint for the leader, that one is preferred and the proxied
-    // request - which carries the cluster token and the client's whole body - is encrypted (issue #7508). Only
-    // the encrypted half is taken from the dial, so the address the caller vetted is the one dialled otherwise.
-    final HAServerPlugin ha = httpServer.getServer().getHA();
-    final LeaderDial dial = ha != null ? LeaderDial.resolve(ha, client) : null;
-
-    // The cluster named an HTTPS endpoint for the leader and this node cannot reach it. Proxying the request over
-    // the plain listener would put its body and the cluster token injected below in the clear, so the proxy stands
-    // down and the caller answers with its own error instead (issue #7508).
-    if (dial != null && dial.refused()) {
-      LogManager.instance().log(this, Level.WARNING, "Leader proxy refused: %s", dial.refusal());
-      return false;
-    }
-
-    final boolean https = dial != null && dial.https();
-    final String targetAddress = https ? dial.address() : leaderAddress;
-    final HttpClient targetClient = https ? dial.client() : client;
 
     final String path = exchange.getRequestPath();
     final String query = exchange.getQueryString();

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
@@ -1569,6 +1569,13 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
       return new ExecutionResponse(503,
           "{ \"error\" : \"Cannot forward batch to leader: leader address is not available\"}");
 
+    // The cluster named an HTTPS endpoint for the leader and this node cannot reach it. Relaying the load over
+    // the plain listener would put it, and the cluster token below, on the wire in clear (issue #7508).
+    if (dial.refused())
+      return new ExecutionResponse(503, new JSONObject()
+          .put("error", "Cannot forward batch to leader: " + dial.refusal())
+          .toString());
+
     // The address resolved for the leader is this node's own: dialing it would come straight back here. The
     // derive fallback produces exactly this on a cluster whose peers share a host and declare no HTTP port,
     // because it pairs the leader's Raft host with THIS node's HTTP port (issue #6191). Asked only of the

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
@@ -1533,7 +1533,9 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
    *
    * @param streaming whether the client negotiated {@code Accept: application/x-ndjson}
    */
-  private ExecutionResponse forwardBatchToLeader(final HttpServerExchange exchange, final HAServerPlugin ha,
+  // Package-private rather than private so the scheme it dials the leader on is testable without a live
+  // cluster (issue #7508). The only production caller is execute() above.
+  ExecutionResponse forwardBatchToLeader(final HttpServerExchange exchange, final HAServerPlugin ha,
       final String databaseName, final ServerSecurityUser user, final String contentType,
       final CountingInputStream body, final boolean streaming) throws Exception {
 
@@ -1559,17 +1561,22 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
           .toString());
     }
 
-    final String leaderAddress = ha.getLeaderAddress();
-    if (leaderAddress == null || leaderAddress.isBlank())
+    // Where to dial the leader and on which scheme: its HTTPS endpoint when the cluster has one for it, the
+    // plain-HTTP one otherwise (issue #7508). The relayed payload and the cluster token below would otherwise
+    // cross an SSL cluster in cleartext.
+    final LeaderDial dial = LeaderDial.resolve(ha, HTTP_CLIENT);
+    if (dial == null)
       return new ExecutionResponse(503,
           "{ \"error\" : \"Cannot forward batch to leader: leader address is not available\"}");
 
     // The address resolved for the leader is this node's own: dialing it would come straight back here. The
     // derive fallback produces exactly this on a cluster whose peers share a host and declare no HTTP port,
-    // because it pairs the leader's Raft host with THIS node's HTTP port (issue #6191).
-    if (ha.isOwnHttpAddress(leaderAddress))
+    // because it pairs the leader's Raft host with THIS node's HTTP port (issue #6191). Asked only of the
+    // plain-HTTP branch: isOwnHttpAddress speaks for this node's HTTP listener and not for an HTTPS endpoint,
+    // which the plugin withholds when it is this node's own instead.
+    if (!dial.https() && ha.isOwnHttpAddress(dial.address()))
       return new ExecutionResponse(400, new JSONObject()
-          .put("error", "Cannot forward batch to leader: the HTTP address resolved for the leader (" + leaderAddress
+          .put("error", "Cannot forward batch to leader: the HTTP address resolved for the leader (" + dial.address()
               + ") is this node's own, and this node is not the leader. Declare every node's HTTP port explicitly "
               + "with the 'host:raftPort:httpPort' syntax in " + GlobalConfiguration.HA_SERVER_LIST.getKey())
           .toString());
@@ -1583,10 +1590,11 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
       return new ExecutionResponse(401,
           "{ \"error\" : \"Cannot forward batch to leader: no authenticated user in the current security context\"}");
 
-    String url = "http://" + leaderAddress + "/api/v1/batch/" + databaseName;
+    String path = "/api/v1/batch/" + databaseName;
     final String queryString = exchange.getQueryString();
     if (queryString != null && !queryString.isEmpty())
-      url += "?" + queryString;
+      path += "?" + queryString;
+    final String url = dial.url(path);
 
     // The body travels through the same guarded stream the leader-side load would use, so a cut upload cannot
     // relay a replay of its own bytes on to the leader either (issue #6180).
@@ -1599,9 +1607,9 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
         // the leader's first progress line - while the JDK client's own executor thread is still publishing the
         // relayed upload. That is what keeps the acknowledgements incremental across the hop.
         return relayNdJsonFromLeader(exchange, databaseName,
-            HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofInputStream()));
+            dial.client().send(request, HttpResponse.BodyHandlers.ofInputStream()));
 
-      final HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+      final HttpResponse<String> response = dial.client().send(request, HttpResponse.BodyHandlers.ofString());
 
       // ExecutionResponse carries only status + body, so the leader's X-ArcadeDB-Commit-Index bookmark
       // (issue #5862) has to be copied onto this exchange explicitly, or a READ_YOUR_WRITES client that
@@ -1612,11 +1620,11 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
       return new ExecutionResponse(response.statusCode(), response.body());
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
-      LogManager.instance().log(this, Level.WARNING, "Interrupted while forwarding /batch to leader at %s", leaderAddress);
+      LogManager.instance().log(this, Level.WARNING, "Interrupted while forwarding /batch to leader at %s", url);
       return new ExecutionResponse(503,
           "{ \"error\" : \"Interrupted while forwarding batch to leader\"}");
     } catch (final Exception e) {
-      LogManager.instance().log(this, Level.WARNING, "Error forwarding /batch to leader at %s: %s", leaderAddress, e.getMessage());
+      LogManager.instance().log(this, Level.WARNING, "Error forwarding /batch to leader at %s: %s", url, e.getMessage());
       return new ExecutionResponse(503,
           "{ \"error\" : \"Error forwarding batch to leader: " + e.getMessage().replace("\"", "'") + "\"}");
     }

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue7508LeaderForwardSchemeTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue7508LeaderForwardSchemeTest.java
@@ -100,20 +100,22 @@ class Issue7508LeaderForwardSchemeTest {
   }
 
   @Test
-  void theDialFallsBackToPlainHttpWhenThePluginNamesAnHttpsEndpointButOffersNoClientForIt() {
+  void theDialIsRefusedWhenTheClusterNamesAnHttpsEndpointButNoClientCanDialIt() {
     final HttpClient plain = HttpClient.newHttpClient();
 
     final LeaderDial dial = LeaderDial.resolve(new StubHA(LEADER_HTTP, LEADER_HTTPS, null), plain);
 
-    // Falling back beats refusing: the plain listener is the one that is always bound.
-    assertThat(dial).isNotNull();
-    assertThat(dial.https()).isFalse();
-    assertThat(dial.address()).isEqualTo(LEADER_HTTP);
-    assertThat(dial.client()).isSameAs(plain);
+    // Fail closed, not open. A cluster that named an HTTPS endpoint for the leader has said where this forward
+    // belongs; sending it to the plain listener instead would put the relayed Authorization header, the cluster
+    // token and the body on the wire in clear, which is the very failure this class exists to end.
+    assertThat(dial.refused()).isTrue();
+    assertThat(dial.refusal()).contains(LEADER_HTTPS).contains("refused rather than forwarded in cleartext");
+    assertThat(dial.address()).isNull();
+    assertThat(dial.client()).isNull();
   }
 
   @Test
-  void theDialFallsBackToPlainHttpWhenTheTrustMaterialCannotBeRead() {
+  void theDialIsRefusedWhenTheTrustMaterialCannotBeRead() {
     final HttpClient plain = HttpClient.newHttpClient();
 
     final LeaderDial dial = LeaderDial.resolve(new StubHA(LEADER_HTTP, LEADER_HTTPS, null) {
@@ -123,7 +125,21 @@ class Issue7508LeaderForwardSchemeTest {
       }
     }, plain);
 
-    assertThat(dial).isNotNull();
+    // Not a reason to downgrade either: buildSSLContext already falls back to the JVM default truststore when none
+    // is configured, so a failure here means the trust material itself could not be loaded.
+    assertThat(dial.refused()).isTrue();
+    assertThat(dial.refusal()).contains("truststore.jks");
+  }
+
+  @Test
+  void aClusterThatNeverDeclaredItsHttpsPortsIsNotRefused() {
+    // The other half of the rule: no HTTPS endpoint resolves at all, which is what every SSL cluster that left the
+    // optional 5th field of arcadedb.ha.serverList out answers. Refusing there would break a cluster that works.
+    final HttpClient plain = HttpClient.newHttpClient();
+
+    final LeaderDial dial = LeaderDial.resolve(new StubHA(LEADER_HTTP, null, null), plain);
+
+    assertThat(dial.refused()).isFalse();
     assertThat(dial.https()).isFalse();
     assertThat(dial.address()).isEqualTo(LEADER_HTTP);
   }
@@ -192,6 +208,21 @@ class Issue7508LeaderForwardSchemeTest {
     assertThat(tls.lastUri.get()).hasToString("https://" + LEADER_HTTPS + "/api/v1/server");
   }
 
+  @Test
+  void theServerCommandForwardIsRefusedRatherThanDowngradedWhenTheHttpsEndpointCannotBeReached() {
+    // The cluster named an HTTPS endpoint and no client can dial it. The forward relays the caller's own
+    // Authorization header, so the plain listener is not an acceptable second choice.
+    final StubHA ha = new StubHA(LEADER_HTTP, LEADER_HTTPS, null);
+
+    final LeaderCommandForwarder forwarder = new LeaderCommandForwarder(httpServerWith(ha));
+    final HttpServerExchange exchange = exchangeFor("/api/v1/server", null);
+
+    assertThatThrownBy(() -> forwarder.forwardIfReplica(exchange, user("root"),
+        LeaderCommandForwarder.currentPathWithQuery(exchange), "{}"))
+        .isInstanceOf(ServerIsNotTheLeaderException.class)
+        .hasMessageContaining("refused rather than forwarded in cleartext");
+  }
+
   // ---------------------------------------------------------------------------------------------------------------
   // Entry point 2: PostBatchHandler - POST /api/v1/batch/{database}
   // ---------------------------------------------------------------------------------------------------------------
@@ -226,6 +257,20 @@ class Issue7508LeaderForwardSchemeTest {
     // Same evidence as above: the plain branch is the only one the HTTP self-address check can refuse.
     assertThat(response.getCode()).isEqualTo(400);
     assertThat(response.getResponse()).contains("is this node's own");
+  }
+
+  @Test
+  void theBatchForwardIsRefusedRatherThanDowngradedWhenTheHttpsEndpointCannotBeReached() throws Exception {
+    final StubHA ha = new StubHA(LEADER_HTTP, LEADER_HTTPS, null);
+
+    final PostBatchHandler handler = new PostBatchHandler(httpServerWith(ha));
+    final HttpServerExchange exchange = exchangeFor("/api/v1/batch/graph", null);
+
+    final ExecutionResponse response = handler.forwardBatchToLeader(exchange, ha, "graph", user("root"),
+        "application/json", body("{\"@type\":\"vertex\"}\n"), false);
+
+    assertThat(response.getCode()).isEqualTo(503);
+    assertThat(response.getResponse()).contains("refused rather than forwarded in cleartext");
   }
 
   // ---------------------------------------------------------------------------------------------------------------

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue7508LeaderForwardSchemeTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue7508LeaderForwardSchemeTest.java
@@ -1,0 +1,476 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.HAServerPlugin;
+import com.arcadedb.server.http.HttpServer;
+import com.arcadedb.server.http.handler.PostBatchHandler.CountingInputStream;
+import com.arcadedb.server.security.ServerSecurityUser;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiPredicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression for issue #7508: a forward to the cluster leader used to build {@code "http://" + leaderAddress + path}
+ * unconditionally, while every other peer-to-peer dial in the cluster already prefers the peer's HTTPS endpoint when
+ * SSL is enabled. On an SSL cluster that put the relayed credentials - the client's own {@code Authorization} header,
+ * or the cluster token - on the wire in cleartext, and on a cluster that declares {@code https} ports but no
+ * {@code http} ones it made the forward refuse itself, because the derived HTTP address is then this node's own.
+ * <p>
+ * The dial decision is {@link LeaderDial}; these tests drive it directly and then through the two entry points in
+ * this module that make it - {@link LeaderCommandForwarder} (the four {@code /api/v1/server*} routes) and
+ * {@link PostBatchHandler#forwardBatchToLeader} ({@code POST /api/v1/batch/{database}}).
+ */
+class Issue7508LeaderForwardSchemeTest {
+
+  private static final String LEADER_HTTP  = "leader.example.com:2480";
+  private static final String LEADER_HTTPS = "leader.example.com:2490";
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // The decision itself
+  // ---------------------------------------------------------------------------------------------------------------
+
+  @Test
+  void theHttpsEndpointWinsWhenTheClusterHasOneForTheLeader() {
+    final HttpClient plain = HttpClient.newHttpClient();
+    final RecordingHttpClient tls = new RecordingHttpClient(200, "{}");
+
+    final LeaderDial dial = LeaderDial.resolve(new StubHA(LEADER_HTTP, LEADER_HTTPS, tls), plain);
+
+    assertThat(dial).isNotNull();
+    assertThat(dial.https()).isTrue();
+    assertThat(dial.address()).isEqualTo(LEADER_HTTPS);
+    assertThat(dial.client()).isSameAs(tls);
+    assertThat(dial.url("/api/v1/server")).isEqualTo("https://" + LEADER_HTTPS + "/api/v1/server");
+  }
+
+  @Test
+  void theDialStaysOnPlainHttpWhenNoHttpsEndpointResolvesForTheLeader() {
+    final HttpClient plain = HttpClient.newHttpClient();
+
+    // What every non-SSL cluster answers, and what the HAServerPlugin interface defaults to.
+    final LeaderDial dial = LeaderDial.resolve(new StubHA(LEADER_HTTP, null, null), plain);
+
+    assertThat(dial).isNotNull();
+    assertThat(dial.https()).isFalse();
+    assertThat(dial.address()).isEqualTo(LEADER_HTTP);
+    assertThat(dial.client()).isSameAs(plain);
+    assertThat(dial.url("/api/v1/server/users?name=bob"))
+        .isEqualTo("http://" + LEADER_HTTP + "/api/v1/server/users?name=bob");
+  }
+
+  @Test
+  void theDialFallsBackToPlainHttpWhenThePluginNamesAnHttpsEndpointButOffersNoClientForIt() {
+    final HttpClient plain = HttpClient.newHttpClient();
+
+    final LeaderDial dial = LeaderDial.resolve(new StubHA(LEADER_HTTP, LEADER_HTTPS, null), plain);
+
+    // Falling back beats refusing: the plain listener is the one that is always bound.
+    assertThat(dial).isNotNull();
+    assertThat(dial.https()).isFalse();
+    assertThat(dial.address()).isEqualTo(LEADER_HTTP);
+    assertThat(dial.client()).isSameAs(plain);
+  }
+
+  @Test
+  void theDialFallsBackToPlainHttpWhenTheTrustMaterialCannotBeRead() {
+    final HttpClient plain = HttpClient.newHttpClient();
+
+    final LeaderDial dial = LeaderDial.resolve(new StubHA(LEADER_HTTP, LEADER_HTTPS, null) {
+      @Override
+      public HttpClient getPeerHttpsClient() throws IOException {
+        throw new IOException("truststore.jks (No such file or directory)");
+      }
+    }, plain);
+
+    assertThat(dial).isNotNull();
+    assertThat(dial.https()).isFalse();
+    assertThat(dial.address()).isEqualTo(LEADER_HTTP);
+  }
+
+  @Test
+  void thereIsNoDialWhenNoLeaderAddressIsKnownAtAll() {
+    assertThat(LeaderDial.resolve(new StubHA(null, null, null), HttpClient.newHttpClient())).isNull();
+    assertThat(LeaderDial.resolve(new StubHA("  ", null, null), HttpClient.newHttpClient())).isNull();
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // Entry point 1: LeaderCommandForwarder - POST /api/v1/server and POST/PUT/DELETE /api/v1/server/users
+  // ---------------------------------------------------------------------------------------------------------------
+
+  @Test
+  void theServerCommandForwardDialsTheLeaderOverHttps() throws Exception {
+    final RecordingHttpClient tls = new RecordingHttpClient(200, "{\"result\":\"ok\"}");
+    final StubHA ha = new StubHA(LEADER_HTTP, LEADER_HTTPS, tls);
+
+    final LeaderCommandForwarder forwarder = new LeaderCommandForwarder(httpServerWith(ha));
+    final HttpServerExchange exchange = exchangeFor("/api/v1/server/users", "name=bob");
+
+    final ExecutionResponse response = forwarder.forwardIfReplica(exchange, user("root"),
+        LeaderCommandForwarder.currentPathWithQuery(exchange), "{\"name\":\"bob\"}");
+
+    assertThat(response).isNotNull();
+    assertThat(response.getCode()).isEqualTo(200);
+    assertThat(tls.lastUri.get())
+        .as("the forward has to reach the leader's HTTPS listener, not its plaintext one")
+        .hasToString("https://" + LEADER_HTTPS + "/api/v1/server/users?name=bob");
+  }
+
+  @Test
+  void theServerCommandForwardKeepsDialingPlainHttpWhenTheClusterHasNoHttpsEndpoint() {
+    // No HTTPS endpoint and the resolved HTTP address is this node's own: the self-address refusal (#6191) is
+    // what proves the plain-HTTP branch was taken, without this test opening a socket.
+    final StubHA ha = new StubHA(LEADER_HTTP, null, null);
+    ha.ownHttpAddress = LEADER_HTTP;
+
+    final LeaderCommandForwarder forwarder = new LeaderCommandForwarder(httpServerWith(ha));
+    final HttpServerExchange exchange = exchangeFor("/api/v1/server", null);
+
+    assertThatThrownBy(() -> forwarder.forwardIfReplica(exchange, user("root"),
+        LeaderCommandForwarder.currentPathWithQuery(exchange), "{}"))
+        .isInstanceOf(ServerIsNotTheLeaderException.class)
+        .hasMessageContaining("is this node's own");
+  }
+
+  @Test
+  void theHttpSelfAddressCheckNoLongerRefusesAForwardThatTravelsOverHttps() throws Exception {
+    // The second failure mode of #7508: a cluster that declares its 'https' ports and not its 'http' ones derives
+    // every peer's HTTP address as THIS node's, so isOwnHttpAddress answers true for the leader and the forward
+    // used to refuse itself - with a perfectly good HTTPS endpoint sitting unused.
+    final RecordingHttpClient tls = new RecordingHttpClient(200, "{}");
+    final StubHA ha = new StubHA(LEADER_HTTP, LEADER_HTTPS, tls);
+    ha.ownHttpAddress = LEADER_HTTP;
+
+    final LeaderCommandForwarder forwarder = new LeaderCommandForwarder(httpServerWith(ha));
+    final HttpServerExchange exchange = exchangeFor("/api/v1/server", null);
+
+    final ExecutionResponse response = forwarder.forwardIfReplica(exchange, user("root"),
+        LeaderCommandForwarder.currentPathWithQuery(exchange), "{}");
+
+    assertThat(response).isNotNull();
+    assertThat(response.getCode()).isEqualTo(200);
+    assertThat(tls.lastUri.get()).hasToString("https://" + LEADER_HTTPS + "/api/v1/server");
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // Entry point 2: PostBatchHandler - POST /api/v1/batch/{database}
+  // ---------------------------------------------------------------------------------------------------------------
+
+  @Test
+  void theBatchForwardDialsTheLeaderOverHttps() throws Exception {
+    final RecordingHttpClient tls = new RecordingHttpClient(200, "{\"records\":1}");
+    final StubHA ha = new StubHA(LEADER_HTTP, LEADER_HTTPS, tls);
+
+    final PostBatchHandler handler = new PostBatchHandler(httpServerWith(ha));
+    final HttpServerExchange exchange = exchangeFor("/api/v1/batch/graph", "async=false");
+
+    final ExecutionResponse response = handler.forwardBatchToLeader(exchange, ha, "graph", user("root"),
+        "application/json", body("{\"@type\":\"vertex\"}\n"), false);
+
+    assertThat(response.getCode()).isEqualTo(200);
+    assertThat(tls.lastUri.get())
+        .hasToString("https://" + LEADER_HTTPS + "/api/v1/batch/graph?async=false");
+  }
+
+  @Test
+  void theBatchForwardKeepsDialingPlainHttpWhenTheClusterHasNoHttpsEndpoint() throws Exception {
+    final StubHA ha = new StubHA(LEADER_HTTP, null, null);
+    ha.ownHttpAddress = LEADER_HTTP;
+
+    final PostBatchHandler handler = new PostBatchHandler(httpServerWith(ha));
+    final HttpServerExchange exchange = exchangeFor("/api/v1/batch/graph", null);
+
+    final ExecutionResponse response = handler.forwardBatchToLeader(exchange, ha, "graph", user("root"),
+        "application/json", body("{\"@type\":\"vertex\"}\n"), false);
+
+    // Same evidence as above: the plain branch is the only one the HTTP self-address check can refuse.
+    assertThat(response.getCode()).isEqualTo(400);
+    assertThat(response.getResponse()).contains("is this node's own");
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // Fixtures
+  // ---------------------------------------------------------------------------------------------------------------
+
+  private static HttpServer httpServerWith(final HAServerPlugin ha) {
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.getHA()).thenReturn(ha);
+    when(server.getConfiguration()).thenReturn(new ContextConfiguration());
+    final HttpServer httpServer = mock(HttpServer.class);
+    when(httpServer.getServer()).thenReturn(server);
+    return httpServer;
+  }
+
+  private static HttpServerExchange exchangeFor(final String path, final String query) {
+    final HttpServerExchange exchange = new HttpServerExchange(null);
+    exchange.setRequestPath(path);
+    exchange.setRequestURI(path);
+    exchange.setRequestMethod(Methods.POST);
+    if (query != null)
+      exchange.setQueryString(query);
+    exchange.getRequestHeaders().put(new HttpString("Authorization"), "Basic cm9vdDpwbGF5d2l0aGRhdGE=");
+    return exchange;
+  }
+
+  private static CountingInputStream body(final String payload) {
+    return new CountingInputStream(new HttpServerExchange(null),
+        new ByteArrayInputStream(payload.getBytes(StandardCharsets.UTF_8)));
+  }
+
+  private static ServerSecurityUser user(final String name) {
+    final ServerSecurityUser user = mock(ServerSecurityUser.class);
+    when(user.getName()).thenReturn(name);
+    return user;
+  }
+
+  /** An {@link HAServerPlugin} that answers only what the forward asks it. */
+  private static class StubHA implements HAServerPlugin {
+    private final String     httpAddress;
+    private final String     httpsAddress;
+    private final HttpClient httpsClient;
+    private       String     ownHttpAddress;
+
+    private StubHA(final String httpAddress, final String httpsAddress, final HttpClient httpsClient) {
+      this.httpAddress = httpAddress;
+      this.httpsAddress = httpsAddress;
+      this.httpsClient = httpsClient;
+    }
+
+    @Override
+    public String getLeaderAddress() {
+      return httpAddress;
+    }
+
+    @Override
+    public String getLeaderHttpsAddress() {
+      return httpsAddress;
+    }
+
+    @Override
+    public HttpClient getPeerHttpsClient() throws IOException {
+      return httpsClient;
+    }
+
+    @Override
+    public boolean isOwnHttpAddress(final String address) {
+      return ownHttpAddress != null && ownHttpAddress.equals(address);
+    }
+
+    @Override
+    public String getClusterToken() {
+      return "cluster-token";
+    }
+
+    @Override
+    public boolean isLeader() {
+      return false;
+    }
+
+    @Override
+    public ELECTION_STATUS getElectionStatus() {
+      return ELECTION_STATUS.DONE;
+    }
+
+    @Override
+    public String getLeaderName() {
+      return "leader";
+    }
+
+    @Override
+    public String getClusterName() {
+      return "test";
+    }
+
+    @Override
+    public Map<String, Object> getStats() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public int getConfiguredServers() {
+      return 3;
+    }
+
+    @Override
+    public String getReplicaAddresses() {
+      return "";
+    }
+
+    @Override
+    public void shutdownRemoteServer(final String serverName) {
+    }
+
+    @Override
+    public void disconnectCluster() {
+    }
+
+    @Override
+    public void startService() {
+    }
+  }
+
+  /** Records the URI the forward dialled and answers a canned response, so no socket is opened. */
+  private static final class RecordingHttpClient extends HttpClient {
+    private final AtomicReference<URI> lastUri = new AtomicReference<>();
+    private final int                  status;
+    private final String               payload;
+
+    private RecordingHttpClient(final int status, final String payload) {
+      this.status = status;
+      this.payload = payload;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> HttpResponse<T> send(final HttpRequest request, final HttpResponse.BodyHandler<T> responseBodyHandler) {
+      lastUri.set(request.uri());
+      return (HttpResponse<T>) new CannedResponse(request, status, payload);
+    }
+
+    @Override
+    public <T> java.util.concurrent.CompletableFuture<HttpResponse<T>> sendAsync(final HttpRequest request,
+        final HttpResponse.BodyHandler<T> responseBodyHandler) {
+      return java.util.concurrent.CompletableFuture.completedFuture(send(request, responseBodyHandler));
+    }
+
+    @Override
+    public <T> java.util.concurrent.CompletableFuture<HttpResponse<T>> sendAsync(final HttpRequest request,
+        final HttpResponse.BodyHandler<T> responseBodyHandler, final HttpResponse.PushPromiseHandler<T> pushHandler) {
+      return sendAsync(request, responseBodyHandler);
+    }
+
+    @Override
+    public Optional<java.net.CookieHandler> cookieHandler() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<java.time.Duration> connectTimeout() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Redirect followRedirects() {
+      return Redirect.NEVER;
+    }
+
+    @Override
+    public Optional<java.net.ProxySelector> proxy() {
+      return Optional.empty();
+    }
+
+    @Override
+    public javax.net.ssl.SSLContext sslContext() {
+      try {
+        return javax.net.ssl.SSLContext.getDefault();
+      } catch (final Exception e) {
+        throw new IllegalStateException(e);
+      }
+    }
+
+    @Override
+    public javax.net.ssl.SSLParameters sslParameters() {
+      return new javax.net.ssl.SSLParameters();
+    }
+
+    @Override
+    public Optional<java.net.Authenticator> authenticator() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Version version() {
+      return Version.HTTP_1_1;
+    }
+
+    @Override
+    public Optional<java.util.concurrent.Executor> executor() {
+      return Optional.empty();
+    }
+  }
+
+  /** The smallest {@link HttpResponse} the forward paths read: a status code and a body. */
+  private record CannedResponse(HttpRequest request, int status, String payload) implements HttpResponse<Object> {
+    private static final BiPredicate<String, String> ALL = (name, value) -> true;
+
+    @Override
+    public int statusCode() {
+      return status;
+    }
+
+    @Override
+    public HttpRequest request() {
+      return request;
+    }
+
+    @Override
+    public Optional<HttpResponse<Object>> previousResponse() {
+      return Optional.empty();
+    }
+
+    @Override
+    public HttpHeaders headers() {
+      return HttpHeaders.of(Map.of("Content-Type", List.of("application/json")), ALL);
+    }
+
+    @Override
+    public Object body() {
+      return payload;
+    }
+
+    @Override
+    public Optional<javax.net.ssl.SSLSession> sslSession() {
+      return Optional.empty();
+    }
+
+    @Override
+    public URI uri() {
+      return request.uri();
+    }
+
+    @Override
+    public HttpClient.Version version() {
+      return HttpClient.Version.HTTP_1_1;
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue7508LeaderForwardSchemeTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue7508LeaderForwardSchemeTest.java
@@ -30,18 +30,27 @@ import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import org.junit.jupiter.api.Test;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSession;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiPredicate;
 
@@ -274,6 +283,24 @@ class Issue7508LeaderForwardSchemeTest {
   }
 
   // ---------------------------------------------------------------------------------------------------------------
+  // Entry point 3: LeaderProxy - unreachable in production today (nothing constructs it, issue #7547), so only the
+  // branch that needs no request body is driven here. The HTTPS dial itself reads the body through
+  // exchange.startBlocking(), which a detached HttpServerExchange cannot serve.
+  // ---------------------------------------------------------------------------------------------------------------
+
+  @Test
+  void theProxyStandsDownRatherThanRelayingInClearWhenTheHttpsEndpointCannotBeReached() {
+    final StubHA ha = new StubHA(LEADER_HTTP, LEADER_HTTPS, null);
+
+    final LeaderProxy proxy = new LeaderProxy(httpServerWith(ha));
+
+    // Returning false hands the request back to the caller's own error path, which is what the proxy already did
+    // for an unusable leader address - and it happens before the body is read, so no upload is buffered for a
+    // request that was never going to be relayed.
+    assertThat(proxy.tryProxy(new HttpServerExchange(null), LEADER_HTTP, user("root"))).isFalse();
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
   // Fixtures
   // ---------------------------------------------------------------------------------------------------------------
 
@@ -413,24 +440,24 @@ class Issue7508LeaderForwardSchemeTest {
     }
 
     @Override
-    public <T> java.util.concurrent.CompletableFuture<HttpResponse<T>> sendAsync(final HttpRequest request,
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(final HttpRequest request,
         final HttpResponse.BodyHandler<T> responseBodyHandler) {
-      return java.util.concurrent.CompletableFuture.completedFuture(send(request, responseBodyHandler));
+      return CompletableFuture.completedFuture(send(request, responseBodyHandler));
     }
 
     @Override
-    public <T> java.util.concurrent.CompletableFuture<HttpResponse<T>> sendAsync(final HttpRequest request,
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(final HttpRequest request,
         final HttpResponse.BodyHandler<T> responseBodyHandler, final HttpResponse.PushPromiseHandler<T> pushHandler) {
       return sendAsync(request, responseBodyHandler);
     }
 
     @Override
-    public Optional<java.net.CookieHandler> cookieHandler() {
+    public Optional<CookieHandler> cookieHandler() {
       return Optional.empty();
     }
 
     @Override
-    public Optional<java.time.Duration> connectTimeout() {
+    public Optional<Duration> connectTimeout() {
       return Optional.empty();
     }
 
@@ -440,26 +467,26 @@ class Issue7508LeaderForwardSchemeTest {
     }
 
     @Override
-    public Optional<java.net.ProxySelector> proxy() {
+    public Optional<ProxySelector> proxy() {
       return Optional.empty();
     }
 
     @Override
-    public javax.net.ssl.SSLContext sslContext() {
+    public SSLContext sslContext() {
       try {
-        return javax.net.ssl.SSLContext.getDefault();
+        return SSLContext.getDefault();
       } catch (final Exception e) {
         throw new IllegalStateException(e);
       }
     }
 
     @Override
-    public javax.net.ssl.SSLParameters sslParameters() {
-      return new javax.net.ssl.SSLParameters();
+    public SSLParameters sslParameters() {
+      return new SSLParameters();
     }
 
     @Override
-    public Optional<java.net.Authenticator> authenticator() {
+    public Optional<Authenticator> authenticator() {
       return Optional.empty();
     }
 
@@ -469,7 +496,7 @@ class Issue7508LeaderForwardSchemeTest {
     }
 
     @Override
-    public Optional<java.util.concurrent.Executor> executor() {
+    public Optional<Executor> executor() {
       return Optional.empty();
     }
   }
@@ -504,7 +531,7 @@ class Issue7508LeaderForwardSchemeTest {
     }
 
     @Override
-    public Optional<javax.net.ssl.SSLSession> sslSession() {
+    public Optional<SSLSession> sslSession() {
       return Optional.empty();
     }
 


### PR DESCRIPTION
Closes #7508

Every follower-to-leader forward built its URL as `"http://" + ha.getLeaderAddress() + path`, because that address is the only leader endpoint `HAServerPlugin` exposed. Five other peer-to-peer dials in the cluster - snapshot download, the capability probe, the bootstrap-state query, the auth-session RPC and the stalled-replica resync - already pick their scheme with one rule, `useSSL && httpsAddress != null`; only the forward did not. This puts the forward on that same rule through a single new decision point, `LeaderDial`, which reads two new `HAServerPlugin` default methods (`getLeaderHttpsAddress()` and `getPeerHttpsClient()`) that both answer "there is none" unless the implementation is `RaftHAPlugin`. `RaftHAServer` withholds rather than refuses - SSL off, no HTTPS endpoint resolved, or the endpoint resolved is this node's own each send the caller back to the plain-HTTP address, the listener that is always bound - and the self-address guard each caller already ran moved onto the address actually dialled, asked only of the plain branch, since `isOwnHttpAddress` compares against this node's *HTTP* listener and cannot speak for an HTTPS endpoint.

### What the impact actually is

The issue frames the failure as "a cluster that listens on HTTPS only - the plain HTTP listener disabled". **ArcadeDB has no such mode**: `HttpServer.buildUndertowServer` calls `addHttpListener` unconditionally and adds the HTTPS one on top, so the connection error described needs the plain port blocked from outside the process. Two consequences are real without that, and they are what this fixes:

1. **The forward downgrades inter-node traffic to cleartext on an SSL cluster.** It relays either the client's own `Authorization` header (Basic credentials or an API token, verbatim) or the cluster token, plus the whole request body. An operator who set `arcadedb.ssl.enabled` gets every other peer-to-peer RPC encrypted and this one in the clear.
2. **On a cluster that declares `https` ports but not `http` ones, the forward refuses itself.** The HTTP address is then *derived* as the leader's Raft host plus **this** node's HTTP port, so `isOwnHttpAddress` answers true and the forwarder throws `ServerIsNotTheLeaderException` - with a correctly declared HTTPS endpoint sitting unused in `httpsAddresses`.

## Test plan

- [ ] `mvn -o -pl server test -Dtest=Issue7508LeaderForwardSchemeTest` - 13 tests: six on `LeaderDial.resolve` (HTTPS wins; no HTTPS endpoint; an endpoint that cannot be dialled is *refused*; unreadable trust material is *refused*; a cluster that never declared `https` ports is *not* refused; no leader at all) and seven driving the two reachable server-module entry points through a recording `HttpClient` that asserts the exact URI dialled, or the refusal.
- [ ] `mvn -o -pl ha-raft test -Dtest=Issue7508LeaderHttpsEndpointTest` - 5 tests on the withhold policy, loopback equivalence included.
- [ ] `mvn -o -pl server test -DexcludedGroups=benchmark,vector,slow` and the same for `ha-raft`. On a machine with nothing else holding port 2480, both should be green; see below for what fails when something is.
- [ ] Proved able to fail: with `getLeaderHttpsAddress()` forced to `null` (the pre-fix behaviour), 4 of the then-10 server tests and 2 of the 5 ha-raft tests went red; restoring the fix returned them to green. The suite is 18 tests after the fail-closed branch was added in review.

Local regression runs: `server` 1105 tests, 10 failures + 5 errors; `ha-raft` 449 tests, 0 failures with `LeaveClusterTest` crashing its fork. **Both sets were reproduced unchanged on the base commit `99b6692780`** in a throwaway worktree. They are the fixed-port trap `CLAUDE.md` documents - `lsof -nP -iTCP:2480 -sTCP:LISTEN` showed two foreign JVMs holding 2480/2481, and the failing classes (`AutoCommitParameterTest`, `HttpBodySizeLimitTest`, `Issue6220TruncateHttpDefaultTest`, `ClusterInternalAuthTest`, `PostClusterAuthSessionHandlerTest`, `LeaveClusterTest`) are exactly the ones that bind them. None of them reaches a leader forward: a single-node test server has no HA plugin, so `forwardIfReplica` returns before `LeaderDial` is consulted.

## Coverage

| Entry point | Fixed | Test |
|---|---|---|
| `LeaderCommandForwarder.forwardIfReplica` - `POST /api/v1/server`, `POST`/`PUT`/`DELETE /api/v1/server/users` | yes | yes, URI asserted |
| `PostBatchHandler.forwardBatchToLeader` - `POST /api/v1/batch/{database}` | yes | yes, URI asserted |
| `RaftReplicatedDatabase.forwardCommandToLeaderViaRaft` - every SQL write submitted on a follower | yes | at the decision it makes (`LeaderDial.resolve` + `RaftHAServer.preferredLeaderHttpsAddress`), not at its HTTP send - that needs a live TLS cluster (#7563) |
| `LeaderProxy.tryProxy` | yes | scheme choice only - see Known gaps |
| `LeaderDatabaseQuery`, `PeerCapabilityQuery`, `PeerAuthSessionQuery`, `SnapshotInstaller`, `RaftHAServer.forceResyncStalledReplica`, `PostVerifyDatabaseHandler` | n/a - already select the scheme with this rule | n/a |

**Known gaps**

- **#7546** - `RaftHAPlugin.shutdownRemoteServer` and `BootstrapElection.bootstrapStateRequest` still dial `http://`, both carrying the cluster token. Neither is a leader forward (the bootstrap probe runs before any leader exists) and `shutdownRemoteServer` needs to move onto `PeerDialAddress` first, so neither can use the leader accessor this PR adds.
- **#7563** - **no integration test forwards to the leader over a real TLS socket.** The 18 tests here prove the *decision* (which address, which scheme, which client) through a recording `HttpClient`; hostname verification, SNI and truststore loading in anger only appear against a real handshake, and this path decides whether relayed credentials go out encrypted. The ticket carries the fixture shape and the other peer-to-peer TLS dials the same fixture would cover.
- **#7547** - **nothing constructs `LeaderProxy`.** `grep -rn "new LeaderProxy" --include='*.java' .` returns nothing; `HttpServer` builds a `LeaderCommandForwarder` and no proxy. Its scheme is fixed here for consistency, but **that fix cannot run today**, and the three `arcadedb.ha.proxy*` settings it reads configure nothing. Wire it up or delete it.

## Fail-closed boundary (added in review)

CodeRabbit flagged the first version as failing open (CWE-319). It was right about one of the two fallback branches, and the split is deliberate:

- **No HTTPS endpoint resolves for the leader** - what every SSL cluster answers when it left the optional 5th field of `arcadedb.ha.serverList` out. Still falls back to the plain listener: that is what it did before this PR, and refusing would turn a working cluster into a broken one on upgrade with no operator change. It is also the branch `PeerDialAddress.encryptedEndpointOf`, `LeaderDatabaseQuery`, `PeerCapabilityQuery` and `SnapshotInstaller` all deliberately fall back on (#6221).
- **An HTTPS endpoint IS named and no client can be built for it** - the operator has said where the forward belongs, and `SnapshotInstaller.buildSSLContext` already falls back to the JVM default truststore when none is configured, so a null-or-throwing client means the trust material itself could not be loaded. **Now refused**, via `LeaderDial.refused()/refusal()` (the shape `PeerDialAddress` uses), which each caller turns into its own error: `ServerIsNotTheLeaderException`, a 503, or `false`.

`aClusterThatNeverDeclaredItsHttpsPortsIsNotRefused` pins the first branch so a later "make it stricter" cannot quietly break those clusters. CodeRabbit re-verified and accepted the split on the thread.

## Adversarial pass

Run by re-reading the diff rather than by an isolated subagent (no `Task` tool was available in this environment), which is a weaker pass. Four findings, all fixed before this PR opened: `RaftReplicatedDatabase` vetted one leader address and dialled another across a possible leadership change (now only the encrypted half comes from the dial, the plain address stays the awaited one; `LeaderProxy` got the same treatment); a comment had been separated from the `if` it explains; `LeaderDial`'s Javadoc claimed an exhaustive "every other peer-to-peer dial" that the `"http://"` grep disproves (reworded, pointing at #7546); and the per-forward cost of `TrustedHttpClientCache.clientFor` (two `stat`s and a SHA-256 of the truststore password) was kept with the reasoning stated - it is paid only when the dial is actually HTTPS, against a cross-node round trip the call is about to make. Full detail in `docs/7508-ha-leader-forward-https-scheme.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEJXCdUGW61QSXqyurphpt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Leader-bound requests now use HTTPS when a secure leader endpoint is available.
  - Requests are no longer downgraded to plain HTTP when the leader’s HTTPS connection cannot be established.
  - Improved forwarding behavior for API commands, batch operations, and proxied requests.
  - Added clearer error handling when secure forwarding is unavailable.

- **Documentation**
  - Added documentation covering the fix, testing, verification results, and remaining integration-test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->