### PR TITLE
fix(#7511): refuse a group or API-token change a cluster peer cannot decode

### DIFF
--- a/docs/7511-ha-rolling-upgrade-security-entry-capability-gate.md
+++ b/docs/7511-ha-rolling-upgrade-security-entry-capability-gate.md
@@ -343,3 +343,28 @@ claude's review said nothing blocks the merge. Its four notes:
    Residual risk and in `ha-raft/CLAUDE.md`'s "Negotiation governs what is written next" section. No change.
 
 No deferred items.
+
+### Cycle 3 - `eb5427e` - clean approval
+
+"Nothing here blocks merge." The review traced the source rather than the diff and independently confirmed the
+three things the design turns on:
+
+* `refreshPeerCapabilities()` already swallows a probe failure or interrupt and records it as unknown, so
+  `peersMissingCapabilityNow` cannot escape as an uncaught 500 in place of the intended 409 /
+  `FAILED_PRECONDITION`;
+* the 409 arm precedes the generic `OperationNotAvailableException` handling, with
+  `aPlainOperationNotAvailableRefusalIsNotSweptIntoTheSame409` pinning it;
+* the `exceptionArgs` / `detail` split is the correct one, mirroring `ResultSetTooLargeException`.
+
+Its one remaining note - that the exception extends `ServerControlPlane.OperationNotAvailableException` by outer
+qualification rather than importing the nested type - is marked stylistic with no precedent either way, and
+explicitly "not worth changing". No change made, and nothing deferred.
+
+CI on this head: `build-and-package`, CodeQL, Codacy, Meterian, lint and CodeRabbit all green. The one CodeRabbit
+review thread the PR ever had is resolved (by CodeRabbit itself, after re-verifying the fix).
+
+## Final state
+
+`clean-approval`. Three review cycles, three findings acted on (one CodeRabbit Major, two claude observations),
+nothing deferred, no unresolved feedback. Follow-ups #7548 and #7549 filed before the PR opened; #7521 already
+covers the addPeer-seed consequence. **The merge is the developer's.**

--- a/docs/7511-ha-rolling-upgrade-security-entry-capability-gate.md
+++ b/docs/7511-ha-rolling-upgrade-security-entry-capability-gate.md
@@ -318,3 +318,28 @@ a shared lock was rejected rather than forgotten, because this method runs on a 
 wait on both sides of a cycle.
 
 No deferred items.
+
+### Cycle 2 - `46b6c36` - CodeRabbit accepted and resolved; claude raised 4 notes, 1 acted on
+
+CodeRabbit re-reviewed the fix, agreed with the reasoning for putting the capability and peers - and not the
+free-form reasons - into `exceptionArgs`, and **resolved its own thread**. No new findings.
+
+claude's review said nothing blocks the merge. Its four notes:
+
+1. *The availability trade (an unreachable peer refuses a revocation) is by design* - flagged for visibility only.
+   No change; already documented in the setting, `ha-raft/CLAUDE.md`, the PR body and Residual risk.
+2. *"Might be worth a WARNING-level log line specifically when the round finds something missing, since that is
+   the case an operator most needs surfaced without cranking log verbosity."* **Acted on.** The FINE line added in
+   cycle 1 reports every round; this adds a WARNING carrying the whole refusal when the gate actually refuses,
+   throttled per capability at 60 s. The audience is the operator who is NOT the caller - a deployment script that
+   swallows the 409 leaves nobody else told - and the throttle is what stops that script's retry loop burying the
+   line. Per capability rather than globally, so a group refusal does not silence the token refusal behind it.
+   Pinned by `aRefusalIsReportedOnceAndThenThrottledPerCapability` against an injected clock.
+3. *"Worth confirming whatever consumes the returned failed list surfaces it somewhere an operator would actually
+   notice."* **Verified, already handled outside this diff.** `PostAddPeerHandler` (lines 74-89) puts the failed
+   documents in the `addPeer` HTTP response under `warning` - "Peer added, but the following security documents
+   could NOT be seeded to it: ..." - and logs a WARNING naming the peer. No change needed.
+4. *The downgrade path is a real residual gap for anyone who reads only the code.* Agreed and already recorded in
+   Residual risk and in `ha-raft/CLAUDE.md`'s "Negotiation governs what is written next" section. No change.
+
+No deferred items.

--- a/docs/7511-ha-rolling-upgrade-security-entry-capability-gate.md
+++ b/docs/7511-ha-rolling-upgrade-security-entry-capability-gate.md
@@ -1,0 +1,276 @@
+# #7511 - HA rolling upgrade: a group or API-token change halts every node older than #7373's entry types
+
+Branch: `fix/7511-ha-rolling-upgrade-entry-type-gate`
+
+## The defect
+
+#7373 added two Raft log entry types, `SECURITY_GROUPS_ENTRY` (id 7) and `SECURITY_API_TOKENS_ENTRY`
+(id 8). `ArcadeStateMachine.applyTransaction` refuses to skip a committed entry whose type byte it
+does not recognise and halts the node instead (`triggerCriticalHalt()`, the #4798 rule). That halt is
+correct: skipping the entry would diverge the cluster's security state silently.
+
+What was missing is anything that stops the entry being written in the first place. During a rolling
+upgrade the cluster is mixed by construction, so creating a group or minting an API token against an
+already-upgraded node committed an entry that halted every node still on the old build - a routine
+admin action turning a routine upgrade into a partial outage, with nothing in the API response saying
+the cluster was not ready for it.
+
+## The invariant the fix establishes
+
+> A Raft log entry whose type byte did not exist in every supported predecessor build is never
+> submitted while any peer of the current Raft configuration has failed to prove it can decode that
+> type.
+
+## Analysis
+
+The mechanism this needs already exists. Issue #7219 built a peer capability handshake for exactly
+this shape of problem (an optional trailing section of `SCHEMA_ENTRY` that an older peer silently
+ignored): `PostCapabilitiesHandler` answers what a node can decode, `PeerCapabilityQuery` asks,
+`PeerCapabilityRegistry` caches the answers with a TTL, and `RaftHAServer.peersMissingCapability`
+names the peers that have not proved they support a token. A node predating the route answers 404,
+which is the whole discriminator - no version parsing, and none would be safe.
+
+The difference between #7219's consumer and this one is what happens on a "no":
+
+* a schema delta has a **degraded mode** - ship the whole document - so #7219 withholds the delta and
+  logs;
+* an entry type has **no degraded mode**. The entry either is written, and halts the old peer, or it
+  is not written at all. So this gate must refuse the operation.
+
+## Completeness
+
+### Enumerating every way to violate the invariant
+
+Writers of the two entry types:
+
+```
+$ grep -rn "encodeSecurityGroupsEntry\|encodeSecurityApiTokensEntry" --include="*.java" . | grep /src/main/
+./ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftTransactionBroker.java:450:    final ByteString entry = RaftLogEntryCodec.encodeSecurityGroupsEntry(groupsJson);
+./ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftTransactionBroker.java:458:    final ByteString entry = RaftLogEntryCodec.encodeSecurityApiTokensEntry(apiTokensJson);
+./ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java:679:  public static ByteString encodeSecurityGroupsEntry(final String groupsJson) {
+./ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java:687:  public static ByteString encodeSecurityApiTokensEntry(final String apiTokensJson) {
+```
+
+Callers of the broker methods, and implementations of the plugin hook they sit behind:
+
+```
+$ grep -rn "getTransactionBroker().replicateSecurity" --include="*.java" .
+./ha-raft/.../RaftHAPlugin.java:209:      raftHAServer.getTransactionBroker().replicateSecurityUsers(usersJsonArray);
+./ha-raft/.../RaftHAPlugin.java:224:      raftHAServer.getTransactionBroker().replicateSecurityGroups(groupsJson);
+./ha-raft/.../RaftHAPlugin.java:239:      raftHAServer.getTransactionBroker().replicateSecurityApiTokens(apiTokensJson);
+
+$ grep -rn "implements HAServerPlugin" --include="*.java" . | grep /src/main/
+./ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java:52:public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider {
+```
+
+`RaftHAPlugin` is the only `HAServerPlugin` implementation in `src/main` and the only caller of the
+broker's two security-config methods, so its `replicateSecurityGroups` / `replicateSecurityApiTokens`
+are a single chokepoint for every submit of entry types 7 and 8. The `HAServerPlugin` defaults are
+no-ops for a non-HA server, which submits nothing.
+
+Callers of the plugin hooks - the operator-facing entry points:
+
+```
+$ grep -rn "replicateSecurityGroups\|replicateSecurityApiTokens" --include="*.java" . | grep /src/main/ | grep -v ha-raft
+server/.../ServerSecurity.java:1024:      ha.replicateSecurityGroups(groupsDocumentWith(database, name, groupConfig).toString());
+server/.../ServerSecurity.java:1043:      ha.replicateSecurityGroups(root.toString());
+server/.../ServerSecurity.java:1158:      ha.replicateSecurityGroups(getGroupsJsonPayload());
+server/.../ServerSecurity.java:1165:      ha.replicateSecurityApiTokens(getApiTokensJsonPayload());
+server/.../ServerSecurity.java:1187:      ha.replicateSecurityApiTokens(minted.documentJson());
+server/.../ServerSecurity.java:1208:      ha.replicateSecurityApiTokens(document);
+```
+
+Siblings - the same shape of bug elsewhere. Every `RaftLogEntryType` constant, and when its id first
+shipped:
+
+```
+$ grep -n "((byte)" ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryType.java
+22:  TX_ENTRY((byte) 1),
+23:  SCHEMA_ENTRY((byte) 2),
+24:  INSTALL_DATABASE_ENTRY((byte) 3),
+25:  DROP_DATABASE_ENTRY((byte) 4),
+26:  SECURITY_USERS_ENTRY((byte) 5),
+34:  BOOTSTRAP_FINGERPRINT_ENTRY((byte) 6),
+40:  SECURITY_GROUPS_ENTRY((byte) 7),
+45:  SECURITY_API_TOKENS_ENTRY((byte) 8);
+
+$ git tag --contains bbc64d81340ae1909263250b49656efba752dcc0 | head -5      # the id-6 commit
+26.5.1
+26.6.1
+26.7.1
+26.7.2
+26.7.3
+```
+
+Ids 1-5 came in with the Raft HA work itself (`f6afe41595`), id 6 shipped in 26.5.1, and ids 7 and 8
+are unreleased (`pom.xml` is `26.10.1-SNAPSHOT`). So ids 7 and 8 are the only ones a supported
+rolling upgrade can meet on a peer that cannot decode them.
+
+### Coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| `POST /api/v1/server/groups` -> `ServerControlPlane.saveGroup` -> `ServerSecurity.saveGroupClusterWide` -> `RaftHAPlugin.replicateSecurityGroups` | yes | yes |
+| `DELETE /api/v1/server/groups` -> `ServerControlPlane.deleteGroup` -> `deleteGroupClusterWide` -> same hook | yes | yes |
+| gRPC `SaveGroup` / `DeleteGroup` -> `ServerControlPlane` -> same hook | yes | yes (status mapping) |
+| `POST /api/v1/server/api-tokens` -> `createApiTokenClusterWide` -> `RaftHAPlugin.replicateSecurityApiTokens` | yes | yes |
+| `DELETE /api/v1/server/api-tokens` -> `deleteApiTokenClusterWide` -> same hook | yes | yes |
+| gRPC `CreateApiToken` / `DeleteApiToken` -> `ServerControlPlane` -> same hook | yes | yes (status mapping) |
+| `POST /api/v1/cluster/addPeer` -> `PostAddPeerHandler` -> `seedSecurityStateClusterWide` (groups + API-token halves) | yes | yes |
+| `SECURITY_USERS_ENTRY` (id 5) from `createUserClusterWide` / `dropUserClusterWide` / the users seed | **argued** | - |
+| `BOOTSTRAP_FINGERPRINT_ENTRY` (id 6) from `BootstrapElection` | **argued** | yes (the exhaustive switch) |
+| `SCHEMA_ENTRY` (id 2) trailing schema-delta section | **argued** | - |
+| Studio does not surface cluster readiness for these operations | **filed** | - |
+| `GET /api/v1/cluster` answers capabilities only from the leader | **filed** | - |
+
+Arguments, with evidence:
+
+* **`SECURITY_USERS_ENTRY` (id 5)** - introduced by `f6afe41595`, the commit that introduced Raft HA
+  itself, so no build that has ever spoken this protocol fails to decode it. The issue says the same.
+  Its optional `#7138` extension section is skip-tolerant by construction, not halt-on-unknown.
+* **`BOOTSTRAP_FINGERPRINT_ENTRY` (id 6)** - shipped in 26.5.1 (tag evidence above), and is written
+  only by `BootstrapElection` at first cluster formation with
+  `arcadedb.ha.bootstrapFromLocalDatabase=true`. It is deliberately NOT gated: refusing it would stop
+  the cluster forming rather than protect a peer, which is the opposite of what the gate is for. That
+  decision is not left to memory - `SecurityEntryCapabilityGate.capabilityFor` is an exhaustive
+  `switch` over `RaftLogEntryType` with no `default`, so adding a ninth constant fails to compile
+  until whoever adds it decides whether it needs a capability token.
+* **`SCHEMA_ENTRY` delta section** - already gated, by the mechanism this fix reuses
+  (`RaftReplicatedDatabase.schemaDeltaEnabled`, issue #7219). Its "no" degrades to the whole document
+  rather than refusing, because it has a degraded mode and an entry type does not.
+
+## The fix
+
+1. `PeerCapabilities` gains two tokens, `security-groups-entry` and `security-api-tokens-entry`, and
+   advertises both in `LOCAL`. They name what a receiver can DECODE, per that class's contract.
+2. `SecurityEntryCapabilityGate` maps a `RaftLogEntryType` to the token a peer must advertise before
+   the leader may write one, through an exhaustive switch, and refuses with a message that names the
+   lagging peers and the reason each is unknown (`PeerCapabilityRegistry.unknownReasonOf`).
+3. `RaftHAPlugin.replicateSecurityGroups` / `replicateSecurityApiTokens` run the gate before handing
+   the payload to the transaction broker, so nothing is submitted on a refusal.
+4. The refusal is `ClusterCapabilityNotReadyException`, a `ServerControlPlane.OperationNotAvailableException`
+   subtype: gRPC already maps that parent to `FAILED_PRECONDITION`, and a new arm in
+   `AbstractServerHttpHandler` answers HTTP `409 Conflict` - the two statuses the issue asks for.
+5. `RaftHAServer.peersMissingCapabilityNow` answers the gate. It reads the registry first and, only
+   when that says something is missing, runs ONE synchronous capability round and re-reads. The
+   background capability monitor runs on the leader only (#7219), so without the on-demand round a
+   group change served by a FOLLOWER - the REST routes do not forward, `PostGroupHandler` calls
+   `ServerControlPlane` directly - would see an empty registry and refuse every time.
+6. `arcadedb.ha.securityEntryCapabilityGate` (default `true`) turns the gate off for an operator who
+   knows every node understands the entries but cannot probe one of them.
+
+## Residual risk (first assessment, before the adversarial pass)
+
+* **A peer that cannot be probed blocks group and API-token changes, revocations included.** "Every
+  unknown is a no" is what makes the gate safe - an old build and an unreachable node are the same
+  404/timeout at the transport - but it means an admin operation is refused while any node is down,
+  not only while any node is old. The escape hatch is the setting in (6), and the refusal message
+  names it along with the peer and the reason. Deliberate: the alternative is halting that node when
+  it returns.
+* **The gate is a leader-and-follower check on the submitting node, not a cluster-wide handshake.**
+  It asks every peer of the current Raft configuration, which is the set that will apply the entry;
+  a node outside the configuration is not sent entries at all.
+* **Studio is untouched** - filed, see the follow-ups below.
+
+## Tests
+
+| Test | Module | What it drives |
+|---|---|---|
+| `Issue7511SecurityEntryCapabilityGateTest` (16) | `ha-raft` | the tokens, `capabilityFor`'s exhaustive mapping, the decision, the refusal text, and - through `RaftHAPlugin.replicateSecurityGroups` / `replicateSecurityApiTokens` with a mocked broker - that a refusal submits NOTHING |
+| `Issue7511SecurityEntryGateRefusalTest` (7) | `server` | every operator-facing entry point: save/delete group, mint/revoke token, and the `addPeer` seed, each asserting the refusal propagates AND that the node serving it kept no half-change |
+| `Issue7511ClusterNotReadyHttpStatusTest` (3) | `server` | the HTTP 409, wrapped and unwrapped, and that a plain `OperationNotAvailableException` is NOT swept into it (catch order) |
+| `Issue7511GrpcClusterNotReadyStatusTest` (2) | `grpcw` | the gRPC `FAILED_PRECONDITION` through `ArcadeDbGrpcAdminService.toStatus`, the mapper every admin RPC delegates to |
+| `Issue7511MixedVersionSecurityEntryIT` (1, `@Tag("slow")`) | `ha-raft` | a REAL 3-node cluster with one node advertising a pre-#7373 capability set: the leader refuses, an upgraded FOLLOWER refuses by asking the peers itself, the lagging node is still running, and the change goes through and converges on all three once it finishes upgrading |
+
+### Proving the tests can fail
+
+The gate call was removed from both `RaftHAPlugin` methods and the ha-raft suite re-run:
+
+```
+[ERROR] Tests run: 16, Failures: 2, Errors: 0
+[ERROR]   Issue7511SecurityEntryCapabilityGateTest.aRefusedApiTokenChangeSubmitsNothingToTheRaftLog:269
+[ERROR]   Issue7511SecurityEntryCapabilityGateTest.aRefusedGroupChangeSubmitsNothingToTheRaftLog:250
+```
+
+Exactly the two caller tests, and only those two. The same removal was then run against the integration test:
+
+```
+[ERROR] Tests run: 1, Failures: 1 -- Issue7511MixedVersionSecurityEntryIT
+Expecting code to raise a throwable.      (x2: the leader arm and the follower arm)
+```
+
+so the IT is not passing because something else refuses. The call was then restored (`git diff` back to +36 lines).
+
+### Regression runs
+
+```
+mvn -o -pl ha-raft -am test -Dtest='Issue7219CapabilityAdvertisementTest,Issue7219PeerCapabilityRegistryTest,
+  Issue7219SchemaEntryTrailingSectionTest,Issue7256SharedAddressCapabilityProbeTest,Issue7301PeerCapabilityReportingTest,
+  Issue7331CapabilityForgottenAtProbeFailureTest,Issue7332SharedEndpointPortOffsetTest,Issue7373SecurityConfigEntryCodecTest,
+  Issue7373SecurityConfigBrokerEntryTest,Issue7138EntryExtensionSectionTest,RaftLogEntryCodecTest,RaftTransactionBrokerTest,
+  HAConfigDefaultsTest,Issue7511SecurityEntryCapabilityGateTest'
+  -> Tests run: 144, Failures: 0, Errors: 0
+
+mvn -o -pl server -am test -Dtest='com.arcadedb.server.security.*Test'
+  -> Tests run: 89, Failures: 0, Errors: 0          (includes Issue7373ClusterWideGroupsAndTokensTest, 24)
+
+mvn -o -pl server -am test -Dtest='Issue7511ClusterNotReadyHttpStatusTest,Issue5064CommittedRemotelyHttpStatusTest'
+  -> Tests run: 8, Failures: 0, Errors: 0
+
+mvn -o -pl grpcw -am test -Dtest='Issue7511GrpcClusterNotReadyStatusTest,Issue7443GrpcMaintenanceSlotStatusTest'
+  -> Tests run: 4, Failures: 0, Errors: 0
+
+mvn -o -pl engine test -Dtest='ConfigurationTest,ContextConfigurationTest,GlobalConfigurationTest,
+  GlobalConfigurationReadinessHATest,Issue7124BooleanSettingStrictCoercionTest,Issue7163DatabaseScopeCallbackTest,Issue6875*'
+  -> Tests run: 79, Failures: 0, Errors: 0
+```
+
+## Reachability
+
+The changed code runs on a live path, not only under the new tests:
+
+* `RaftHAPlugin` is the only `HAServerPlugin` implementation in `src/main` (grep above) and is installed by the
+  server whenever HA is requested, so both gated methods are the real ones every entry point calls.
+* `PeerCapabilities.LOCAL` is what `RaftHAServer.advertisedCapabilities` is initialised from and what
+  `PostCapabilitiesHandler` answers with, so the two new tokens go out on the wire from this build with no further
+  wiring. That also means a peer running this build answers "yes" to both, which is what makes a fully upgraded
+  cluster pass the gate.
+* No new setting gates the mechanism off: `arcadedb.ha.securityEntryCapabilityGate` defaults to `true`, and the
+  gate additionally reads `true` when no server configuration can be reached at all.
+
+## Follow-ups filed before the PR
+
+* **#7548** - Studio does not surface that the cluster is not ready for group / API-token changes.
+* **#7549** - `GET /api/v1/cluster` reports peer capabilities only from the leader, so a readiness check has to
+  find the leader first.
+
+## Adversarial pass
+
+The orchestrator's Phase 1.5 spawns an independent subagent for this. The `Task` tool was **disabled in this
+session** ("No such tool available: Task"), so the pass was run by the author instead - which removes its main
+value, independence - and each finding below was checked against the tree rather than reasoned about. That
+limitation is recorded rather than papered over.
+
+| # | Finding | Disposition |
+|---|---|---|
+| 1 | The gate asks about peers and never about the local node (`RaftHAServer.peersMissingCapability`, `if (!peer.getId().equals(localPeerId))`), so a change issued ON a lagging node is not refused. | **Not a defect.** The gate ships with the decoder: a node old enough to halt has no gate to run, and a node that can decode the entry is not a peer that would halt on it. It is, however, why the IT needs three nodes rather than two - the follower arm has to be exercised from a follower that is not the lagging node. |
+| 2 | A declared-but-not-joined peer is not asked. | **Not a defect**, verified: `configuredPeers()` is `ClusterMembership.of(raftGroup.getPeers(), getLivePeers()).configuredPeers()`, the live configuration. A peer outside it is not sent entries, so it cannot halt on one. |
+| 3 | An unreachable peer is refused exactly like an old one, so a group change - or a token REVOCATION during an incident - is blocked while any node is down. | **Real, in scope, accepted.** Inherent to "every unknown is a no", which is what makes the gate safe. Mitigated by `arcadedb.ha.securityEntryCapabilityGate`, named in the refusal text, and documented in Residual risk and in `ha-raft/CLAUDE.md`. |
+| 4 | `POST /api/v1/cluster/addPeer` now reports `groups` / `API tokens` among its failed seeds whenever the just-added peer cannot be probed yet, where before the seed was submitted regardless. | **Real, in scope, accepted and reported rather than thrown** - `seedSecurityStateClusterWide` is best-effort per document by design, and `Issue7511SecurityEntryGateRefusalTest` pins that the users seed still goes through. The consequence of a failed seed is already tracked by **#7521**. |
+| 5 | The on-demand probe runs on the request thread while the `ServerSecurity` monitor is held, for up to `peers x PeerCapabilityRegistry.PROBE_TIMEOUT_MS` (2 s each). | **Bounded and checked.** `grep -n synchronized server/.../ServerSecurity.java` shows every monitor acquisition is on an admin-mutation path; `authenticate` (line 215) and `authenticateByApiToken` (line 1387) are NOT synchronized, so login is unaffected. What it delays is other security-admin mutations, which already block on a full Raft round trip. |
+| 6 | A rolling DOWNGRADE is still unprotected: an entry of type 7 or 8 already committed to the durable Raft log halts a node restarted onto a build that predates it. | **Real and out of reach of any gate**, for the reason `ha-raft/CLAUDE.md` already sets out for #7255: negotiation governs what is written next, never what is committed, and the node in trouble is the one without the check. Not filed as a new issue - it is the documented operational boundary of the whole mechanism ("a node being rolled back that far is rebuilt from a snapshot"), now covering entry types as well as sections. |
+| 7 | A follower's `GET /api/v1/cluster` still reports no peer capabilities, so readiness cannot be polled anywhere but the leader. | **Filed as #7549.** |
+| 8 | Studio offers the group and token controls unconditionally and renders the 409 as a generic error. | **Filed as #7548.** |
+
+## Residual risk
+
+Restated with what the adversarial pass added:
+
+* An unreachable peer blocks group and API-token changes, revocations included (finding 3). The escape hatch is
+  `arcadedb.ha.securityEntryCapabilityGate=false`, and the refusal names it.
+* `addPeer` reports a refused groups/API-token seed rather than silently submitting one (finding 4); #7521 tracks
+  what admitting such a peer means.
+* A rolling downgrade past this release is not protected and cannot be (finding 6) - the same boundary #7255
+  documents for schema deltas.
+* Studio and a follower's cluster payload still say nothing about readiness: #7548, #7549.
+* Nothing else. Every row of the coverage table is fixed here, filed, or argued with evidence above.

--- a/docs/7511-ha-rolling-upgrade-security-entry-capability-gate.md
+++ b/docs/7511-ha-rolling-upgrade-security-entry-capability-gate.md
@@ -274,3 +274,47 @@ Restated with what the adversarial pass added:
   documents for schema deltas.
 * Studio and a follower's cluster payload still say nothing about readiness: #7548, #7549.
 * Nothing else. Every row of the coverage table is fixed here, filed, or argued with evidence above.
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/7555
+
+## Review cycles
+
+### Cycle 1 - `771f11b` - 3 findings, all addressed, none deferred
+
+**CodeRabbit, `AbstractServerHttpHandler.java:761`, Major - "Preserve the cluster refusal details in production
+HTTP responses."** *Valid, and the most important finding of the review.* Verified against
+`buildErrorBody` (line 1628): `detail` is emitted only when `verbose`, i.e. not when
+`arcadedb.server.mode=production`, while `exceptionArgs` is emitted in every mode. The 409 arm passed `null` there,
+so in production the entire refusal reached the client as `{"error":"Cluster is not ready for this operation"}` -
+no peer, no capability. That is the silence this issue exists to end, reintroduced one mode over.
+
+Fixed, though **not** with the suggested `capabilityNotReady.getMessage()`. `exceptionArgs` is a wire contract
+(`RemoteHttpComponent.manageException`, `RaftReplicatedDatabase.reconstructLeaderException`) documented as carrying
+"bounded, non-sensitive values"; the message is neither. `ClusterCapabilityNotReadyException` now carries the
+capability and the missing peers as fields and renders `toExceptionArgs()` as
+`security-groups-entry|arcadedb2[,+N more]` - pipe-separated like `DuplicatedKeyException`'s, capped at five peers.
+The per-peer REASONS stay in the message: a reason is free-form probe-failure text that can carry a host, a port or
+a JDK exception message, which is the class of content `detail` is concealed for. Covered by
+`inProductionModeThePeerAndTheCapabilitySurviveInExceptionArgs` (production mode, asserts `detail` absent,
+`exceptionArgs` naming the peer and the capability, and the 404 reason NOT leaking into it) and
+`theExceptionArgsAreBoundedOnALargeCluster`. Falsified: reverting the arm to `null` fails the new test with
+`JSONObject[exceptionArgs] not found` and nothing else.
+
+**claude, observation 1 - the on-demand probe is held under a monitor shared with USER administration.** Valid
+refinement of finding 5 of the adversarial pass, which had only said "other security-admin mutations". Verified:
+`ServerSecurity.createUser` (line 301) is `synchronized` on the same monitor, so an unreachable peer delays the next
+`createUser` as much as the next group change. No behaviour change - the trade is deliberate - but claude's
+suggested "metric/log line" was worth taking: `peersMissingCapabilityNow` now logs the round at FINE with its
+elapsed time and what it concluded, so the stall is attributable, and both the gate's and the method's javadoc say
+the monitor is shared with user administration.
+
+**claude, observation 2 - a request-thread round can overlap the leader's background round.** Valid, harmless, and
+now written down rather than left for the next reader to re-derive. Documented on `peersMissingCapabilityNow`: the
+interleaving cannot produce a wrong CAPABLE (recording a capability requires a peer to have answered with it), and
+a shared lock was rejected rather than forgotten, because this method runs on a thread already holding the
+`ServerSecurity` monitor and making the capability-monitor thread wait on the same lock would put a monitor-held
+wait on both sides of a cycle.
+
+No deferred items.

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1980,6 +1980,31 @@ public enum GlobalConfiguration {
       costs one whole-document entry per database to re-prime the diff base.""",
       Boolean.class, true),
 
+  HA_SECURITY_ENTRY_CAPABILITY_GATE("arcadedb.ha.securityEntryCapabilityGate", SCOPE.SERVER,
+      """
+      Refuse a group or API-token change while any peer of the Raft configuration has not proved it can decode \
+      the log entry that change is replicated as (issue #7511). ON BY DEFAULT, and the default is the safe one. \
+      \
+      SECURITY_GROUPS_ENTRY and SECURITY_API_TOKENS_ENTRY are new in 26.10.1, and a node predating them cannot \
+      decode either. ArcadeStateMachine refuses to SKIP a committed entry whose type it does not recognise - \
+      skipping would diverge the cluster's security state silently - so it halts the node instead. During a \
+      rolling upgrade the cluster is mixed by construction, which made creating a group or minting a token on an \
+      already-upgraded node halt every node still on the old build: a routine admin action turning a routine \
+      upgrade into a partial outage. With this on, the operation is refused instead, with HTTP 409 / gRPC \
+      FAILED_PRECONDITION naming the peer that is holding the cluster back. Nothing is submitted, so nothing \
+      halts, and the change succeeds unchanged once the last node is up - no sequencing by hand. \
+      \
+      The peer is asked over POST /api/v1/cluster/capabilities, the #7219 handshake. Every unknown counts as a \
+      no: a peer that is unreachable, whose address identifies no single node, or that runs a build without that \
+      route all read the same way, because at the transport they ARE the same 404-or-timeout. That is what makes \
+      the gate safe and also what makes it strict - an admin change is refused while any node is DOWN, not only \
+      while any node is OLD, revocations included. \
+      \
+      Turn it off only to accept that trade knowingly: when a peer cannot be probed and you know from outside the \
+      cluster that every node runs a build that understands these entries. Turning it off does not make an old \
+      peer able to decode the entry - it makes the node halt again.""",
+      Boolean.class, true),
+
   HA_BOOTSTRAP_FROM_LOCAL_DATABASE("arcadedb.ha.bootstrapFromLocalDatabase", SCOPE.SERVER,
       """
       When true (the default) and every peer's Raft log is empty at first cluster formation, peers exchange a \

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
@@ -1065,8 +1065,12 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
    * Maps a handler failure to the status the client receives. A {@link StatusException} raised by the body (the
    * NOT_FOUND of {@code getDatabaseInfo}) is sent as it is; the authorization exception is checked before the
    * authentication one because it is the more specific outcome, not because of any inheritance between the two.
+   * <p>
+   * Package-private rather than private so the arms that answer a REFUSAL - where the status is the whole
+   * contract with the client, not a detail of it - can be pinned without standing up a gRPC server.
    */
-  private StatusException toStatus(final String operation, final Exception e) {
+  // @VisibleForTesting
+  StatusException toStatus(final String operation, final Exception e) {
     if (e instanceof StatusException se)
       return se;
     // A leader-only operation refused on a follower. Routed through the shared mapper so the answer carries the

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7511GrpcClusterNotReadyStatusTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7511GrpcClusterNotReadyStatusTest.java
@@ -26,6 +26,8 @@ import io.grpc.Status;
 import io.grpc.StatusException;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -51,7 +53,7 @@ class Issue7511GrpcClusterNotReadyStatusTest {
   void aClusterNotReadyRefusalIsAPreconditionFailureRatherThanAnInternalError() {
     final StatusException mapped = adminService().toStatus("saveGroup", new ClusterCapabilityNotReadyException(
         "Refusing to replicate the group document: peer(s) [arcadedb2] have not advertised the "
-            + "'security-groups-entry' capability"));
+            + "'security-groups-entry' capability", "security-groups-entry", List.of("arcadedb2")));
 
     assertThat(mapped.getStatus().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
     assertThat(mapped.getStatus().getDescription())
@@ -63,7 +65,7 @@ class Issue7511GrpcClusterNotReadyStatusTest {
   void theSameArmAnswersATokenRevocationRefusal() {
     final StatusException mapped = adminService().toStatus("deleteApiToken", new ClusterCapabilityNotReadyException(
         "Refusing to replicate the API-token document: peer(s) [arcadedb2] have not advertised the "
-            + "'security-api-tokens-entry' capability"));
+            + "'security-api-tokens-entry' capability", "security-api-tokens-entry", List.of("arcadedb2")));
 
     assertThat(mapped.getStatus().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
   }

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7511GrpcClusterNotReadyStatusTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue7511GrpcClusterNotReadyStatusTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.ClusterCapabilityNotReadyException;
+import com.arcadedb.server.security.credential.DefaultCredentialsValidator;
+import io.grpc.Status;
+import io.grpc.StatusException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #7511 on the gRPC transport: a group or API-token change refused because a peer cannot decode the entry it
+ * would be replicated as reaches the client as {@code FAILED_PRECONDITION}, not {@code INTERNAL}.
+ * <p>
+ * The distinction is the client's to act on. {@code INTERNAL} says the server broke and tells a generated client
+ * nothing about whether to retry; {@code FAILED_PRECONDITION} says the request was refused because the SYSTEM is
+ * not in a state where it can succeed, which is exactly true here and clears itself when the last node is
+ * upgraded. It is the status HTTP's {@code 409} is paired with everywhere else in this service.
+ * <p>
+ * Driven through {@code toStatus}, the mapper every admin RPC's {@code respond} wrapper delegates to, so
+ * {@code SaveGroup}, {@code DeleteGroup}, {@code CreateApiToken} and {@code DeleteApiToken} are all covered by the
+ * one arm rather than four tests of the same line.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue7511GrpcClusterNotReadyStatusTest {
+
+  @Test
+  void aClusterNotReadyRefusalIsAPreconditionFailureRatherThanAnInternalError() {
+    final StatusException mapped = adminService().toStatus("saveGroup", new ClusterCapabilityNotReadyException(
+        "Refusing to replicate the group document: peer(s) [arcadedb2] have not advertised the "
+            + "'security-groups-entry' capability"));
+
+    assertThat(mapped.getStatus().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
+    assertThat(mapped.getStatus().getDescription())
+        .as("the peer holding the cluster back is the only actionable half, so it must survive the mapping")
+        .contains("arcadedb2");
+  }
+
+  @Test
+  void theSameArmAnswersATokenRevocationRefusal() {
+    final StatusException mapped = adminService().toStatus("deleteApiToken", new ClusterCapabilityNotReadyException(
+        "Refusing to replicate the API-token document: peer(s) [arcadedb2] have not advertised the "
+            + "'security-api-tokens-entry' capability"));
+
+    assertThat(mapped.getStatus().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
+  }
+
+  private static ArcadeDbGrpcAdminService adminService() {
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.getConfiguration()).thenReturn(new ContextConfiguration());
+    return new ArcadeDbGrpcAdminService(server, new DefaultCredentialsValidator());
+  }
+}

--- a/ha-raft/CLAUDE.md
+++ b/ha-raft/CLAUDE.md
@@ -110,6 +110,34 @@ Three things about that mechanism that are easy to get wrong:
 
 The cost of getting it wrong is asymmetric and worth restating: withholding a section that a peer could actually have read costs one larger Raft entry. Writing one a peer cannot read costs a silent schema divergence. Every arm of `PeerCapabilityRegistry` is written to fail the cheap way.
 
+### A new entry TYPE needs a capability too, and its "no" is a refusal
+
+The three steps above describe an optional *section*. A new `RaftLogEntryType` is the same negotiation with one
+difference that changes what step 2 can do: an unknown section is invisible to an old peer, while an unknown type
+byte is a deliberate `triggerCriticalHalt()` (#4798). There is nothing to degrade to. `SCHEMA_ENTRY` can ship the
+whole document instead of a delta; a `SECURITY_GROUPS_ENTRY` either is written, and halts the peer, or is not
+written and the operation is refused.
+
+So #7511 gates the two types #7373 added - `SECURITY_GROUPS_ENTRY` (7) and `SECURITY_API_TOKENS_ENTRY` (8) - and
+refuses: `ClusterCapabilityNotReadyException`, HTTP 409 / gRPC `FAILED_PRECONDITION`, naming the peer and the
+reason its answer is missing. `SecurityEntryCapabilityGate.capabilityFor` is an exhaustive `switch` over
+`RaftLogEntryType` with no `default`, so **adding a ninth constant does not compile** until you decide whether it
+needs a token. That is the mechanism, not a reminder.
+
+Two things that are specific to a refusal and do not apply to a withheld section:
+
+- **It must not read a stale cache.** The background capability monitor runs on the LEADER only, because #7219's
+  only consumer was leader-side. A refusal is not: the group and API-token REST routes do not forward, so
+  `ServerSecurity.saveGroupClusterWide` runs on whichever node the client hit and submits through a Raft client
+  that routes to the leader. `peersMissingCapability` alone would therefore refuse every group change ever made on
+  a FOLLOWER, on a healthy single-version cluster. Gate on **`peersMissingCapabilityNow`**, which reads the cache
+  first and runs one synchronous round only when that is not already a full "yes".
+- **Strictness costs availability, so it needs an escape hatch.** "Every unknown is a no" turns an unreachable node
+  into a refusal, and for `SECURITY_API_TOKENS_ENTRY` that includes a REVOCATION during an incident.
+  `arcadedb.ha.securityEntryCapabilityGate` (default true) is how an operator who knows the unreachable node
+  understands the entry submits anyway; the refusal message names it. Do not remove it in the name of safety -
+  without it the only way past a down node is to remove it from the cluster.
+
 ### Negotiation governs what is written next, never what is already committed
 
 This is the boundary of the mechanism, and it is a **downgrade boundary rather than a code one** (#7255). The Raft log is durable: a delta entry committed while every peer was capable stays in it. A node restarted onto a build that predates #7211 replays it through the old `applySchemaEntry`, sees an empty `schemaJson`, applies nothing, logs nothing, and diverges - exactly the failure #6989 and #7219 exist to prevent, arriving from the one direction neither can reach. A node *joining* on an older build installs a snapshot rather than replaying the whole log, so its exposure is narrower: only the entries committed between that snapshot and the leader's next capability round.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerCapabilities.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerCapabilities.java
@@ -52,11 +52,29 @@ public final class PeerCapabilities {
   public static final String SCHEMA_DELTA = "schema-delta";
 
   /**
+   * This node decodes {@code SECURITY_GROUPS_ENTRY}, the Raft log entry type (id 7) that replicates the whole
+   * {@code server-groups.json} document (issue #7373).
+   * <p>
+   * Unlike {@link #SCHEMA_DELTA} this token does not guard an OPTIONAL section of an entry a peer can otherwise
+   * read - it guards the entry's type byte itself. A peer that lacks it does not misread the entry, it cannot read
+   * it at all, and {@code ArcadeStateMachine} halts rather than skip a committed entry (issue #4798). So the
+   * consumer of this token refuses the operation instead of degrading it: there is no whole-document fallback to
+   * degrade to. See {@link SecurityEntryCapabilityGate} and issue #7511.
+   */
+  public static final String SECURITY_GROUPS_ENTRY = "security-groups-entry";
+
+  /**
+   * This node decodes {@code SECURITY_API_TOKENS_ENTRY}, the Raft log entry type (id 8) that replicates the whole
+   * {@code server-api-tokens.json} document (issue #7373). Same contract as {@link #SECURITY_GROUPS_ENTRY}.
+   */
+  public static final String SECURITY_API_TOKENS_ENTRY = "security-api-tokens-entry";
+
+  /**
    * Everything this build can decode. Immutable, and deliberately a whitelist written out by hand rather than
    * derived from anything: a capability is a promise about the wire format, and the only thing that can make it
    * true is a human having checked that the decoder is present.
    */
-  public static final Set<String> LOCAL = Set.of(SCHEMA_DELTA);
+  public static final Set<String> LOCAL = Set.of(SCHEMA_DELTA, SECURITY_GROUPS_ENTRY, SECURITY_API_TOKENS_ENTRY);
 
   private PeerCapabilities() {
     // utility class

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -82,6 +82,21 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
     HALog.configure(configuration);
   }
 
+  /**
+   * Installs the Raft server this plugin delegates to, without going through {@code startService()} and a real
+   * Ratis cluster.
+   * <p>
+   * Package-private and test-only, the same seam {@code RaftHAServer.setCapabilityProber} is. It exists so the
+   * #7511 interlock can be driven through the method an operator's request actually reaches - the HTTP and gRPC
+   * control planes both end at {@code replicateSecurityGroups} / {@code replicateSecurityApiTokens} - rather than
+   * only through the gate helper those two call. A gate nothing calls is a gate that is not there, and only a test
+   * of the caller can tell the difference.
+   */
+  // @VisibleForTesting
+  void setRaftHAServer(final RaftHAServer raftHAServer) {
+    this.raftHAServer = raftHAServer;
+  }
+
   @Override
   public PluginInstallationPriority getInstallationPriority() {
     return PluginInstallationPriority.AFTER_HTTP_ON;
@@ -215,10 +230,21 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
     LogManager.instance().log(this, Level.INFO, "Security users entry committed via Raft");
   }
 
+  /**
+   * {@inheritDoc}
+   * <p>
+   * Gated on every peer having proved it can decode a {@code SECURITY_GROUPS_ENTRY} (issue #7511). The entry type
+   * is new in 26.10.1 and a peer that cannot decode it HALTS rather than skips it, so during a rolling upgrade an
+   * ungated group change turned a routine admin action into a partial outage. The gate runs before the broker is
+   * handed anything, so a refusal submits nothing.
+   */
   @Override
   public void replicateSecurityGroups(final String groupsJson) {
     if (raftHAServer == null)
       throw new TransactionException("Raft HA server not started");
+
+    SecurityEntryCapabilityGate.requireEveryPeerCanDecode(server, raftHAServer, RaftLogEntryType.SECURITY_GROUPS_ENTRY,
+        "group document");
 
     try {
       raftHAServer.getTransactionBroker().replicateSecurityGroups(groupsJson);
@@ -230,10 +256,20 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
     LogManager.instance().log(this, Level.INFO, "Security groups entry committed via Raft");
   }
 
+  /**
+   * {@inheritDoc}
+   * <p>
+   * Gated the same way {@link #replicateSecurityGroups} is, and for the same reason (issue #7511). Worth being
+   * explicit that this covers a REVOCATION as well as a mint: a revoked token is not revoked anywhere if the entry
+   * carrying it halts the nodes that were still serving it.
+   */
   @Override
   public void replicateSecurityApiTokens(final String apiTokensJson) {
     if (raftHAServer == null)
       throw new TransactionException("Raft HA server not started");
+
+    SecurityEntryCapabilityGate.requireEveryPeerCanDecode(server, raftHAServer,
+        RaftLogEntryType.SECURITY_API_TOKENS_ENTRY, "API-token document");
 
     try {
       raftHAServer.getTransactionBroker().replicateSecurityApiTokens(apiTokensJson);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -4391,6 +4391,38 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     return peerCapabilities.peersMissing(peerIds, capability);
   }
 
+  /**
+   * The peers that have NOT proved they can decode {@code capability}, asking them NOW when the cached answer
+   * does not already cover every one of them (issue #7511).
+   * <p>
+   * {@link #peersMissingCapability} alone is not enough for a caller that REFUSES on a "no". The background
+   * capability monitor runs on the leader only ({@link #startCapabilityMonitor}, called from
+   * {@link #startLagMonitor}), because #7219's only consumer was the leader-side schema-delta decision. The
+   * consumer this exists for is not leader-side: the group and API-token REST routes do not forward, so
+   * {@code ServerSecurity.saveGroupClusterWide} and friends run on whichever node the client or load balancer
+   * picked, and submit through a Raft client that routes to the leader. On a FOLLOWER the registry is empty by
+   * design, so a refusal built on the cached answer alone would refuse every group change ever made on a
+   * follower, on a perfectly healthy single-version cluster.
+   * <p>
+   * So the cached answer is consulted first and one synchronous round is run only when it is not already a full
+   * "yes". That keeps the leader's hot path free - a warm registry answers without dialling anything - and makes
+   * a follower's answer correct at the cost of one probe round on an operation that is rare by construction
+   * (group administration and token minting, both already serialised behind the {@code ServerSecurity} monitor
+   * across a full Raft round trip). The round is bounded: sequential, with
+   * {@link PeerCapabilityRegistry#PROBE_TIMEOUT_MS} per peer.
+   * <p>
+   * Re-reading after the round rather than returning what it observed is deliberate: the round records through
+   * the same generation-guarded registry the monitor writes to, so the re-read is the one answer both agree on.
+   */
+  public List<String> peersMissingCapabilityNow(final String capability) {
+    final List<String> cached = peersMissingCapability(capability);
+    if (cached.isEmpty())
+      return cached;
+
+    refreshPeerCapabilities();
+    return peersMissingCapability(capability);
+  }
+
   /** What this node tells its peers it can decode. */
   public Set<String> getAdvertisedCapabilities() {
     return advertisedCapabilities;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -4413,14 +4413,33 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * <p>
    * Re-reading after the round rather than returning what it observed is deliberate: the round records through
    * the same generation-guarded registry the monitor writes to, so the re-read is the one answer both agree on.
+   * <p>
+   * <b>Overlapping with the leader's background round is harmless, and deliberately not locked out</b> (PR #7555
+   * review). Two rounds can fan out at once on a leader, which costs a redundant probe and nothing else: every
+   * write goes through {@link PeerCapabilityRegistry}'s generation guard, and the one outcome that would matter -
+   * a peer wrongly read as CAPABLE - cannot be produced by an interleaving, because recording a capability
+   * requires a peer to have actually answered with it. A shared lock would remove the redundant probe at the cost
+   * of a lock-order hazard worth more than it: this method runs on a request thread that already holds the
+   * {@code ServerSecurity} monitor, so making the capability-monitor thread wait on the same lock would put a
+   * monitor-held wait on both sides of a cycle.
+   * <p>
+   * The round is logged at FINE with what it cost and what it concluded. It is the one place this feature can add
+   * latency an operator did not ask for - the {@code ServerSecurity} monitor is held across it, and that monitor is
+   * shared with user administration, so an unreachable peer delays the next {@code createUser} as well as the next
+   * group change - and a stall with nothing in the log to explain it is the thing that wastes an afternoon.
    */
   public List<String> peersMissingCapabilityNow(final String capability) {
     final List<String> cached = peersMissingCapability(capability);
     if (cached.isEmpty())
       return cached;
 
+    final long startedAt = System.currentTimeMillis();
     refreshPeerCapabilities();
-    return peersMissingCapability(capability);
+    final List<String> missing = peersMissingCapability(capability);
+    LogManager.instance().log(this, Level.FINE,
+        "Asked every peer about the '%s' capability before replicating an entry that needs it (%d ms); still "
+            + "missing: %s", capability, System.currentTimeMillis() - startedAt, missing);
+    return missing;
   }
 
   /** What this node tells its peers it can decode. */

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SecurityEntryCapabilityGate.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SecurityEntryCapabilityGate.java
@@ -24,6 +24,8 @@ import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.ClusterCapabilityNotReadyException;
 
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 
 /**
@@ -69,6 +71,22 @@ import java.util.logging.Level;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 final class SecurityEntryCapabilityGate {
+
+  /**
+   * How often a refusal is reported per capability. The refusal already travels to the caller as a 409, so this
+   * log line exists for the operator who is NOT the caller - the one watching the cluster during a rolling
+   * upgrade while somebody's deployment script quietly retries a group change (PR #7555 review). Throttled
+   * because such a script retries in a loop and a line per attempt would bury the one that matters; a minute is
+   * far shorter than the #7219 delta-withheld throttle because this event is an operator action rather than a
+   * per-DDL decision, and so is rare by construction.
+   */
+  private static final long REFUSAL_LOG_THROTTLE_MS = 60_000L;
+
+  /**
+   * When each capability's refusal was last reported. Bounded by construction: the keys can only ever be the
+   * tokens {@link #capabilityFor} returns, which is a closed set.
+   */
+  private static final Map<String, Long> LAST_REFUSAL_LOG = new ConcurrentHashMap<>();
 
   private SecurityEntryCapabilityGate() {
     // utility class
@@ -134,11 +152,17 @@ final class SecurityEntryCapabilityGate {
     if (missing.isEmpty())
       return;
 
+    final String message = refusal(what, type, capability, missing, raft.getPeerCapabilityRegistry());
+
+    // Also said in THIS node's log, not only to the caller. The caller may be a deployment script that swallows
+    // the 409; the operator watching the rolling upgrade is the one who has to act on it (PR #7555 review).
+    if (shouldLogRefusal(capability, System.currentTimeMillis()))
+      LogManager.instance().log(SecurityEntryCapabilityGate.class, Level.WARNING, "%s", message);
+
     // The peers and the token travel as FIELDS as well as in the message: production mode conceals the message
     // (AbstractServerHttpHandler.buildErrorBody drops 'detail'), and a refusal that could not name the lagging
     // node is the silence this issue exists to end (PR #7555 review).
-    throw new ClusterCapabilityNotReadyException(
-        refusal(what, type, capability, missing, raft.getPeerCapabilityRegistry()), capability, missing);
+    throw new ClusterCapabilityNotReadyException(message, capability, missing);
   }
 
   /**
@@ -171,6 +195,28 @@ final class SecurityEntryCapabilityGate {
         .append("=false only to submit it anyway, knowing that a peer which genuinely cannot decode it will halt.");
 
     return message.toString();
+  }
+
+  /**
+   * Whether this refusal of {@code capability} is the one to report, at wall-clock {@code now}.
+   * <p>
+   * Racy by design: two admin threads crossing the window at the same instant cost one duplicate line, which is a
+   * better trade than a lock on a path that is about to throw anyway. Package-private and taking the clock so the
+   * decision can be pinned without sleeping.
+   */
+  // @VisibleForTesting
+  static boolean shouldLogRefusal(final String capability, final long now) {
+    final Long last = LAST_REFUSAL_LOG.get(capability);
+    if (last != null && now - last < REFUSAL_LOG_THROTTLE_MS)
+      return false;
+    LAST_REFUSAL_LOG.put(capability, now);
+    return true;
+  }
+
+  /** Drops the throttle state, so one test's refusal cannot suppress the next test's log line. */
+  // @VisibleForTesting
+  static void resetRefusalLogThrottle() {
+    LAST_REFUSAL_LOG.clear();
   }
 
   /** Reads the interlock off the SERVER configuration, the scope the setting is declared in. */

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SecurityEntryCapabilityGate.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SecurityEntryCapabilityGate.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.ClusterCapabilityNotReadyException;
+
+import java.util.List;
+import java.util.logging.Level;
+
+/**
+ * Refuses to submit a Raft log entry whose TYPE BYTE a peer of the cluster cannot decode (issue #7511).
+ *
+ * <h2>Why a refusal and not a fallback</h2>
+ *
+ * {@link PeerCapabilities} was built for #7219, where the thing being negotiated is an optional trailing section
+ * of {@code SCHEMA_ENTRY}: a peer that cannot read it still reads the entry, so the leader has somewhere to
+ * degrade to - it ships the whole document and logs. An entry TYPE has no such fallback. Either the entry is
+ * written, and {@code ArcadeStateMachine} on the older peer halts the node rather than skip a committed entry it
+ * cannot decode (the #4798 rule, and the right rule: skipping would diverge the cluster's security state
+ * silently), or the entry is not written at all.
+ * <p>
+ * So this gate is the only place the choice can be made, and it makes it before anything is submitted: on a
+ * refusal nothing reaches the Raft log, nothing halts, and the caller's own state is untouched - the request is
+ * reissued unchanged once the last node is upgraded.
+ *
+ * <h2>Which types need a token</h2>
+ *
+ * {@link #capabilityFor} is an exhaustive {@code switch} over {@link RaftLogEntryType} with no {@code default},
+ * on purpose: adding a ninth constant does not compile until whoever adds it has decided whether a peer has to
+ * advertise something before the leader may write one. That is the half of #7511 that outlives #7373 - the issue
+ * asked for a mechanism that "would cover the next entry type too", and a switch that fails the build is a
+ * stronger guarantee than a sentence in a document.
+ *
+ * <h2>Every unknown is a no, and what that costs</h2>
+ *
+ * {@link RaftHAServer#peersMissingCapabilityNow} treats unreachable, never-probed, stale and explicitly-incapable
+ * as one answer, because at the transport an old build and an unreachable node ARE one answer: a 404 or a
+ * timeout. That is what makes the gate safe, and it is also what makes it strict - a group change or a token
+ * revocation is refused while any node is DOWN, not only while any node is OLD.
+ * {@code arcadedb.ha.securityEntryCapabilityGate} is the escape hatch for an operator who knows, from outside the
+ * cluster, that the node that cannot be probed does understand the entry; the refusal names it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+final class SecurityEntryCapabilityGate {
+
+  private SecurityEntryCapabilityGate() {
+    // utility class
+  }
+
+  /**
+   * The capability a peer must advertise before this cluster may write {@code type}, or {@code null} when the
+   * type needs none.
+   * <p>
+   * {@code null} is returned for the types that predate the mechanism, each for a reason that was checked rather
+   * than assumed:
+   * <ul>
+   *   <li>{@code TX_ENTRY}, {@code SCHEMA_ENTRY}, {@code INSTALL_DATABASE_ENTRY}, {@code DROP_DATABASE_ENTRY}
+   *       and {@code SECURITY_USERS_ENTRY} (ids 1-5) came in with the Raft HA work itself, so no build that has
+   *       ever spoken this protocol fails to decode them. {@code SCHEMA_ENTRY}'s optional delta section is
+   *       negotiated separately, by {@link PeerCapabilities#SCHEMA_DELTA}, and degrades rather than refuses.</li>
+   *   <li>{@code BOOTSTRAP_FINGERPRINT_ENTRY} (id 6) shipped in 26.5.1 and is written only at first cluster
+   *       formation, by {@code BootstrapElection}. It is deliberately NOT gated: refusing it would stop the
+   *       cluster forming rather than protect a peer, which is the opposite of what this gate is for.</li>
+   * </ul>
+   */
+  // @VisibleForTesting
+  static String capabilityFor(final RaftLogEntryType type) {
+    return switch (type) {
+      case SECURITY_GROUPS_ENTRY -> PeerCapabilities.SECURITY_GROUPS_ENTRY;
+      case SECURITY_API_TOKENS_ENTRY -> PeerCapabilities.SECURITY_API_TOKENS_ENTRY;
+      case TX_ENTRY, SCHEMA_ENTRY, INSTALL_DATABASE_ENTRY, DROP_DATABASE_ENTRY, SECURITY_USERS_ENTRY,
+          BOOTSTRAP_FINGERPRINT_ENTRY -> null;
+    };
+  }
+
+  /**
+   * Throws unless every peer of the current Raft configuration has proved it can decode {@code type}.
+   *
+   * @param server the local server, read for {@code arcadedb.ha.securityEntryCapabilityGate}. A {@code null}
+   *               server reads the setting's default, which is on: a gate that fails open because a field was
+   *               not wired is the failure this class exists to prevent.
+   * @param raft   the Raft server whose configuration is asked. Never {@code null} here - the caller has already
+   *               refused the submit without one.
+   * @param type   the entry type about to be written.
+   * @param what   what the caller is replicating, named the way an operator would name it ("group document"), for
+   *               the refusal message.
+   *
+   * @throws ClusterCapabilityNotReadyException when at least one peer has not advertised the capability
+   */
+  static void requireEveryPeerCanDecode(final ArcadeDBServer server, final RaftHAServer raft,
+      final RaftLogEntryType type, final String what) {
+    final String capability = capabilityFor(type);
+    if (capability == null)
+      return;
+
+    if (!gateEnabled(server)) {
+      // Throttling would be wrong here: this is not a periodic condition, it is one line per admin operation
+      // deliberately performed with the interlock off, and each one is a change that may halt a node.
+      LogManager.instance().log(SecurityEntryCapabilityGate.class, Level.WARNING,
+          "Replicating the %s with the cluster-capability interlock disabled (%s=false): any peer that cannot "
+              + "decode a %s HALTS when it applies this entry, and stays halted until it is upgraded (issue #7511)",
+          what, GlobalConfiguration.HA_SECURITY_ENTRY_CAPABILITY_GATE.getKey(), type);
+      return;
+    }
+
+    final List<String> missing = raft.peersMissingCapabilityNow(capability);
+    if (missing.isEmpty())
+      return;
+
+    throw new ClusterCapabilityNotReadyException(
+        refusal(what, type, capability, missing, raft.getPeerCapabilityRegistry()));
+  }
+
+  /**
+   * The refusal an operator reads, built from the peers that withheld the answer and the reason each is unknown.
+   * <p>
+   * Pure, and separated from the decision above, so the sentence an operator is left holding can be pinned by a
+   * test: it is the entire remedy this issue delivers, and a message that named neither the peer nor the setting
+   * would leave them exactly where the silent halt did.
+   */
+  // @VisibleForTesting
+  static String refusal(final String what, final RaftLogEntryType type, final String capability,
+      final List<String> missingPeers, final PeerCapabilityRegistry registry) {
+    final StringBuilder message = new StringBuilder(512);
+    message.append("Refusing to replicate the ").append(what)
+        .append(": peer(s) ").append(missingPeers)
+        .append(" have not advertised the '").append(capability)
+        .append("' capability, so they cannot decode a ").append(type)
+        .append(" and would HALT on applying it rather than skip a committed entry (issue #7511). Nothing was "
+            + "submitted, so nothing has changed anywhere in the cluster.");
+
+    for (final String peer : missingPeers) {
+      final String reason = registry != null ? registry.unknownReasonOf(peer) : null;
+      if (reason != null)
+        message.append(" Peer '").append(peer).append("': ").append(reason).append('.');
+    }
+
+    message.append(" Finish the rolling upgrade - or restore contact with those peers - and reissue this request; "
+            + "it succeeds unchanged once every node advertises the capability, with no sequencing by hand. "
+            + "Set ").append(GlobalConfiguration.HA_SECURITY_ENTRY_CAPABILITY_GATE.getKey())
+        .append("=false only to submit it anyway, knowing that a peer which genuinely cannot decode it will halt.");
+
+    return message.toString();
+  }
+
+  /** Reads the interlock off the SERVER configuration, the scope the setting is declared in. */
+  private static boolean gateEnabled(final ArcadeDBServer server) {
+    if (server == null || server.getConfiguration() == null)
+      return GlobalConfiguration.HA_SECURITY_ENTRY_CAPABILITY_GATE.getValueAsBoolean();
+    return server.getConfiguration().getValueAsBoolean(GlobalConfiguration.HA_SECURITY_ENTRY_CAPABILITY_GATE);
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SecurityEntryCapabilityGate.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SecurityEntryCapabilityGate.java
@@ -58,6 +58,13 @@ import java.util.logging.Level;
  * revocation is refused while any node is DOWN, not only while any node is OLD.
  * {@code arcadedb.ha.securityEntryCapabilityGate} is the escape hatch for an operator who knows, from outside the
  * cluster, that the node that cannot be probed does understand the entry; the refusal names it.
+ * <p>
+ * The second cost is latency, and it is wider than the gated operations. Every caller of this gate holds the
+ * {@code ServerSecurity} monitor across it, and that monitor is shared with USER administration - so an
+ * unreachable peer makes the probe round delay the next {@code createUser} as much as the next group change (PR
+ * #7555 review). Bounded by {@link PeerCapabilityRegistry#PROBE_TIMEOUT_MS} per peer, paid only when the cached
+ * answer is not already a full "yes", and logged at FINE by {@link RaftHAServer#peersMissingCapabilityNow} so the
+ * stall is attributable rather than mysterious.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -127,8 +134,11 @@ final class SecurityEntryCapabilityGate {
     if (missing.isEmpty())
       return;
 
+    // The peers and the token travel as FIELDS as well as in the message: production mode conceals the message
+    // (AbstractServerHttpHandler.buildErrorBody drops 'detail'), and a refusal that could not name the lagging
+    // node is the silence this issue exists to end (PR #7555 review).
     throw new ClusterCapabilityNotReadyException(
-        refusal(what, type, capability, missing, raft.getPeerCapabilityRegistry()));
+        refusal(what, type, capability, missing, raft.getPeerCapabilityRegistry()), capability, missing);
   }
 
   /**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7511MixedVersionSecurityEntryIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7511MixedVersionSecurityEntryIT.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ClusterCapabilityNotReadyException;
+import com.arcadedb.server.ServerControlPlane;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.function.Predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7511 against a real cluster: a group change or a token mint on a MIXED-VERSION cluster is refused rather
+ * than committed, and starts working by itself once the last node is upgraded.
+ * <p>
+ * This is the test the issue asks for. The unit tests pin the decision and the two transports' statuses; what only
+ * a cluster can show is that the gate reaches its answer through the actual capability RPC, over the wire, from a
+ * FOLLOWER as well as from the leader - the path that would otherwise refuse every group change ever made on a
+ * follower, because the background capability monitor runs on the leader alone.
+ *
+ * <h2>How an "old" node is built inside one JVM</h2>
+ *
+ * The same way {@code Issue7219MixedVersionSchemaDeltaIT} does it: {@link RaftHAServer#setAdvertisedCapabilities}
+ * makes a node answer the capability RPC exactly as a build without the two decoders would. It is a faithful
+ * stand-in because the decision consults nothing else - not a version string, not a build number, only what the
+ * peer said it can decode. The old node keeps advertising {@link PeerCapabilities#SCHEMA_DELTA}, so the cluster is
+ * mixed in the one dimension under test and unchanged in every other.
+ *
+ * <h2>Why three nodes</h2>
+ *
+ * The gate asks about the OTHER peers, never about the node running it - a node cannot fail to decode what its own
+ * build writes, and a genuinely old node has no gate at all, since the gate ships with the decoder. To exercise the
+ * follower arm there has to be a follower that is NOT the lagging node, which needs a third node.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+@Tag("slow")
+class Issue7511MixedVersionSecurityEntryIT extends BaseRaftHATest {
+
+  /** How long a node is given to observe a peer's advertisement change (a few refresh rounds). */
+  private static final long CAPABILITY_CONVERGENCE_TIMEOUT_MS = 30_000L;
+
+  /** What a build that predates #7373 advertises: it decodes schema deltas, and neither new entry type. */
+  private static final Set<String> PRE_7373_BUILD = Set.of(PeerCapabilities.SCHEMA_DELTA);
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    config.setValue(GlobalConfiguration.HA_QUORUM, "majority");
+    // arcadedb.ha.securityEntryCapabilityGate is deliberately NOT set: it defaults to on, and a test that turned
+    // it on by hand could not tell "the default protects an operator who did nothing" from "the test did it".
+  }
+
+  @Test
+  void aGroupOrTokenChangeIsRefusedWhileOneNodeCannotDecodeTheEntryAndResumesAfterTheUpgrade()
+      throws InterruptedException {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final int laggingIndex = (leaderIndex + 1) % getServerCount();
+    final int upgradedFollowerIndex = (leaderIndex + 2) % getServerCount();
+    final String laggingPeerId = peerIdForIndex(laggingIndex);
+
+    // One node is mid-rolling-upgrade: still on the build that predates #7373.
+    raftServerOf(laggingIndex).setAdvertisedCapabilities(PRE_7373_BUILD);
+    awaitObserved(leaderIndex, laggingPeerId, hasNeither(), "the leader must be told peer '" + laggingPeerId
+        + "' cannot decode either new entry type");
+
+    // ---- the leader refuses, and says which node is holding the cluster back -------------------------------
+    assertThatThrownBy(() -> controlPlaneOn(leaderIndex).saveGroup("*", "reader", readerGroup()))
+        .isInstanceOf(ClusterCapabilityNotReadyException.class)
+        .hasMessageContaining(laggingPeerId)
+        .hasMessageContaining(PeerCapabilities.SECURITY_GROUPS_ENTRY);
+
+    assertThatThrownBy(() -> controlPlaneOn(leaderIndex).createApiToken("ci", "*", 0, new JSONObject()))
+        .isInstanceOf(ClusterCapabilityNotReadyException.class)
+        .hasMessageContaining(PeerCapabilities.SECURITY_API_TOKENS_ENTRY);
+
+    // ---- and so does an UPGRADED FOLLOWER, which has no capability cache of its own ------------------------
+    // The REST routes for groups and API tokens do not forward to the leader, so this is not a hypothetical
+    // path: it is what happens whenever a load balancer sends the request to a node that is not the leader.
+    assertThatThrownBy(() -> controlPlaneOn(upgradedFollowerIndex).saveGroup("*", "reader", readerGroup()))
+        .as("a follower must reach the same answer, by asking the peers itself")
+        .isInstanceOf(ClusterCapabilityNotReadyException.class)
+        .hasMessageContaining(laggingPeerId);
+
+    // ---- nothing was submitted, so nothing halted ---------------------------------------------------------
+    assertThat(groupsOn(laggingIndex).has("reader"))
+        .as("the refused group must exist on no node at all")
+        .isFalse();
+    assertThat(groupsOn(leaderIndex).has("reader")).isFalse();
+    assertThat(getServer(laggingIndex).isStarted())
+        .as("the node the entry would have halted is still running, which is the whole point of #7511")
+        .isTrue();
+    assertThat(raftServerOf(laggingIndex).isLeader() || getRaftPlugin(laggingIndex) != null)
+        .as("and still a member of the cluster")
+        .isTrue();
+
+    // ---- finish the rolling upgrade; no setting change, no restart, no operator step ------------------------
+    raftServerOf(laggingIndex).setAdvertisedCapabilities(PeerCapabilities.LOCAL);
+    awaitObserved(leaderIndex, laggingPeerId, hasBoth(), "the leader must be told peer '" + laggingPeerId
+        + "' can now decode both entry types");
+
+    controlPlaneOn(leaderIndex).saveGroup("*", "reader", readerGroup());
+
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(groupsOn(i).has("reader"))
+          .as("once the cluster is uniform the change goes through and reaches node %d", i)
+          .isTrue();
+  }
+
+  // -----------------------------------------------------------------------------------------------------------
+
+  private static Predicate<Set<String>> hasNeither() {
+    return capabilities -> capabilities != null
+        && !capabilities.contains(PeerCapabilities.SECURITY_GROUPS_ENTRY)
+        && !capabilities.contains(PeerCapabilities.SECURITY_API_TOKENS_ENTRY);
+  }
+
+  private static Predicate<Set<String>> hasBoth() {
+    return capabilities -> capabilities != null
+        && capabilities.contains(PeerCapabilities.SECURITY_GROUPS_ENTRY)
+        && capabilities.contains(PeerCapabilities.SECURITY_API_TOKENS_ENTRY);
+  }
+
+  private ServerControlPlane controlPlaneOn(final int serverIndex) {
+    return new ServerControlPlane(getServer(serverIndex));
+  }
+
+  private JSONObject groupsOn(final int serverIndex) {
+    return getServer(serverIndex).getSecurity().groupsToJSON().getJSONObject("databases").getJSONObject("*")
+        .getJSONObject("groups");
+  }
+
+  private static JSONObject readerGroup() {
+    return new JSONObject()
+        .put("resultSetLimit", -1L)
+        .put("readTimeout", -1L)
+        .put("access", new JSONArray())
+        .put("types", new JSONObject());
+  }
+
+  private RaftHAServer raftServerOf(final int serverIndex) {
+    final RaftHAPlugin plugin = getRaftPlugin(serverIndex);
+    assertThat(plugin).as("server %d runs the Raft HA plugin", serverIndex).isNotNull();
+    assertThat(plugin.getRaftHAServer()).as("server %d has started its Raft server", serverIndex).isNotNull();
+    return plugin.getRaftHAServer();
+  }
+
+  /**
+   * Waits until {@code observerIndex} has actually PROBED {@code peerId} and recorded an advertisement satisfying
+   * {@code settled}.
+   * <p>
+   * Deliberately not "until the observer reports the peer as missing the capability": a peer that was never
+   * successfully probed reports exactly the same way, so a run in which the capability RPC was broken end to end
+   * would satisfy that weaker condition instantly - and the refusals below would then pass for the wrong reason,
+   * proving nothing about negotiation. Waiting for a RECORDED advertisement means the probe demonstrably worked
+   * and the answer it carried is the one the test planted.
+   */
+  private void awaitObserved(final int observerIndex, final String peerId, final Predicate<Set<String>> settled,
+      final String what) throws InterruptedException {
+    final RaftHAServer observer = raftServerOf(observerIndex);
+    final long deadline = System.currentTimeMillis() + CAPABILITY_CONVERGENCE_TIMEOUT_MS;
+    Set<String> observed = observedCapabilities(observer, peerId);
+    while (!settled.test(observed) && observer.isLeader() && System.currentTimeMillis() < deadline) {
+      Thread.sleep(200);
+      observed = observedCapabilities(observer, peerId);
+    }
+    // Only the leader runs the background refresh, so a node that lost leadership mid-test stops asking and its
+    // advertisements go stale - which would read here as "the negotiation is broken" and cost the next reader an
+    // hour. This test pins the leader it elected, so an election is a failed PRECONDITION and says so.
+    assertThat(observer.isLeader())
+        .as("this test pins the leader it elected at the start; %s lost leadership mid-test, so the capability "
+            + "refresh it drives stopped", observer.getLocalPeerId())
+        .isTrue();
+    // A wall-clock bound used as a hang detector, not as a latency assertion: the refresh runs every
+    // PeerCapabilityRegistry.REFRESH_PERIOD_MS, so a budget of several rounds only fires when it stopped asking.
+    assertThat(settled.test(observed))
+        .as(what + " (last observed advertisement: %s)", observed)
+        .isTrue();
+  }
+
+  private static Set<String> observedCapabilities(final RaftHAServer observer, final String peerId) {
+    final PeerCapabilityRegistry.Advertisement advertisement =
+        observer.getPeerCapabilityRegistry().freshAdvertisementOf(peerId);
+    return advertisement != null ? advertisement.capabilities() : null;
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7511SecurityEntryCapabilityGateTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7511SecurityEntryCapabilityGateTest.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.ClusterCapabilityNotReadyException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #7511: a group or API-token change committed on an already-upgraded node halted every node older than the
+ * two Raft log entry types #7373 added.
+ * <p>
+ * The halt itself is correct and stays - {@code ArcadeStateMachine} must not skip a committed entry it cannot
+ * decode (#4798), because skipping would diverge the cluster's security state silently. What was missing is
+ * anything that stops the entry being written while a peer in the configuration cannot read it, which during a
+ * rolling upgrade is the normal state of the cluster. The fix refuses the operation instead, so nothing is
+ * submitted and nothing halts.
+ * <p>
+ * The interesting half is the LAST test: a gate helper nothing calls is a gate that is not there, so
+ * {@code replicateSecurityGroups} and {@code replicateSecurityApiTokens} - the single chokepoint every HTTP and
+ * gRPC entry point funnels through - are driven directly, and the assertion is that the transaction broker was
+ * never handed anything.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7511SecurityEntryCapabilityGateTest {
+
+  private static final String LAGGING_PEER = "arcadedb2";
+
+  // -------------------------------------------------------------------------------------------------------
+  // 1. The vocabulary: the tokens exist, are advertised, and keep their exact spelling
+  // -------------------------------------------------------------------------------------------------------
+
+  /**
+   * The spellings are pinned deliberately. {@code PeerCapabilities} states that a token which has shipped keeps
+   * its exact spelling for as long as any supported version might advertise it: renaming one makes every older
+   * peer read as incapable, which for THIS consumer does not silently disable a feature - it refuses every group
+   * change and every token mint in the cluster.
+   */
+  @Test
+  void theTwoEntryTypesOfIssue7373HaveStableCapabilityTokens() {
+    assertThat(PeerCapabilities.SECURITY_GROUPS_ENTRY).isEqualTo("security-groups-entry");
+    assertThat(PeerCapabilities.SECURITY_API_TOKENS_ENTRY).isEqualTo("security-api-tokens-entry");
+  }
+
+  /**
+   * A capability names what THIS build can decode, and this build has both applies
+   * ({@code ArcadeStateMachine.applySecurityGroupsEntry} / {@code applySecurityApiTokensEntry}), so it must say
+   * so. A build that decoded the entries without advertising them would deadlock a cluster of its own peers:
+   * every node capable, none of them saying it, so no group could ever be created.
+   */
+  @Test
+  void thisBuildAdvertisesBothEntryTypesAlongsideTheSchemaDelta() {
+    assertThat(PeerCapabilities.LOCAL).containsExactlyInAnyOrder(PeerCapabilities.SCHEMA_DELTA,
+        PeerCapabilities.SECURITY_GROUPS_ENTRY, PeerCapabilities.SECURITY_API_TOKENS_ENTRY);
+  }
+
+  // -------------------------------------------------------------------------------------------------------
+  // 2. Which entry types need a token, and which deliberately do not
+  // -------------------------------------------------------------------------------------------------------
+
+  @Test
+  void onlyTheTwoEntryTypesIssue7373AddedRequireACapability() {
+    assertThat(SecurityEntryCapabilityGate.capabilityFor(RaftLogEntryType.SECURITY_GROUPS_ENTRY))
+        .isEqualTo(PeerCapabilities.SECURITY_GROUPS_ENTRY);
+    assertThat(SecurityEntryCapabilityGate.capabilityFor(RaftLogEntryType.SECURITY_API_TOKENS_ENTRY))
+        .isEqualTo(PeerCapabilities.SECURITY_API_TOKENS_ENTRY);
+  }
+
+  /**
+   * Ids 1-5 came in with the Raft HA work itself, so no build that has ever spoken this protocol fails to decode
+   * them. Id 6 shipped in 26.5.1 and is written only at first cluster formation, where refusing it would stop the
+   * cluster forming rather than protect a peer - the opposite of what the gate is for.
+   * <p>
+   * Asserted over {@code values()} rather than by listing six constants, so this test is the one that fails the
+   * day a ninth entry type is added without a decision about it - alongside the exhaustive switch in
+   * {@code capabilityFor}, which fails the compile.
+   */
+  @Test
+  void everyEntryTypeThatPredatesTheMechanismIsDeliberatelyUngated() {
+    for (final RaftLogEntryType type : RaftLogEntryType.values()) {
+      if (type == RaftLogEntryType.SECURITY_GROUPS_ENTRY || type == RaftLogEntryType.SECURITY_API_TOKENS_ENTRY)
+        continue;
+      assertThat(SecurityEntryCapabilityGate.capabilityFor(type))
+          .as("%s (id %d) predates the capability mechanism and must not be gated", type, type.getId())
+          .isNull();
+    }
+  }
+
+  /** An ungated type never asks the cluster anything, so it cannot be refused - or slowed down - by this gate. */
+  @Test
+  void anUngatedEntryTypeNeverQueriesThePeers() {
+    final RaftHAServer raft = mock(RaftHAServer.class);
+
+    SecurityEntryCapabilityGate.requireEveryPeerCanDecode(serverWithGate(true), raft,
+        RaftLogEntryType.BOOTSTRAP_FINGERPRINT_ENTRY, "bootstrap fingerprint");
+
+    verify(raft, never()).peersMissingCapabilityNow(anyString());
+  }
+
+  // -------------------------------------------------------------------------------------------------------
+  // 3. The decision
+  // -------------------------------------------------------------------------------------------------------
+
+  @Test
+  void aClusterWhereEveryPeerAdvertisesTheCapabilityIsNotRefused() {
+    final RaftHAServer raft = mock(RaftHAServer.class);
+    when(raft.peersMissingCapabilityNow(PeerCapabilities.SECURITY_GROUPS_ENTRY)).thenReturn(List.of());
+
+    assertThatCode(() -> SecurityEntryCapabilityGate.requireEveryPeerCanDecode(serverWithGate(true), raft,
+        RaftLogEntryType.SECURITY_GROUPS_ENTRY, "group document")).doesNotThrowAnyException();
+  }
+
+  @Test
+  void aPeerThatHasNotAdvertisedTheCapabilityRefusesTheGroupChange() {
+    final RaftHAServer raft = mock(RaftHAServer.class);
+    when(raft.peersMissingCapabilityNow(PeerCapabilities.SECURITY_GROUPS_ENTRY)).thenReturn(List.of(LAGGING_PEER));
+    when(raft.getPeerCapabilityRegistry()).thenReturn(registryWhereThePeerAnswered404());
+
+    assertThatThrownBy(() -> SecurityEntryCapabilityGate.requireEveryPeerCanDecode(serverWithGate(true), raft,
+        RaftLogEntryType.SECURITY_GROUPS_ENTRY, "group document"))
+        .isInstanceOf(ClusterCapabilityNotReadyException.class)
+        .hasMessageContaining(LAGGING_PEER)
+        .hasMessageContaining(PeerCapabilities.SECURITY_GROUPS_ENTRY);
+  }
+
+  @Test
+  void aPeerThatHasNotAdvertisedTheCapabilityRefusesTheTokenChangeToo() {
+    final RaftHAServer raft = mock(RaftHAServer.class);
+    when(raft.peersMissingCapabilityNow(PeerCapabilities.SECURITY_API_TOKENS_ENTRY)).thenReturn(List.of(LAGGING_PEER));
+
+    assertThatThrownBy(() -> SecurityEntryCapabilityGate.requireEveryPeerCanDecode(serverWithGate(true), raft,
+        RaftLogEntryType.SECURITY_API_TOKENS_ENTRY, "API-token document"))
+        .isInstanceOf(ClusterCapabilityNotReadyException.class)
+        .hasMessageContaining(PeerCapabilities.SECURITY_API_TOKENS_ENTRY);
+  }
+
+  /**
+   * The interlock is on by default and stays on when nothing was wired: a gate that fails open because a field
+   * was null is the failure this class exists to prevent.
+   */
+  @Test
+  void theGateIsOnWhenNoServerConfigurationCanBeRead() {
+    final RaftHAServer raft = mock(RaftHAServer.class);
+    when(raft.peersMissingCapabilityNow(PeerCapabilities.SECURITY_GROUPS_ENTRY)).thenReturn(List.of(LAGGING_PEER));
+
+    assertThatThrownBy(() -> SecurityEntryCapabilityGate.requireEveryPeerCanDecode(null, raft,
+        RaftLogEntryType.SECURITY_GROUPS_ENTRY, "group document"))
+        .isInstanceOf(ClusterCapabilityNotReadyException.class);
+  }
+
+  /** Turned off, the operation goes through as it did before #7511 - and the peers are not even asked. */
+  @Test
+  void theInterlockCanBeTurnedOffForAnOperatorWhoKnowsBetter() {
+    final RaftHAServer raft = mock(RaftHAServer.class);
+    when(raft.peersMissingCapabilityNow(PeerCapabilities.SECURITY_GROUPS_ENTRY)).thenReturn(List.of(LAGGING_PEER));
+
+    assertThatCode(() -> SecurityEntryCapabilityGate.requireEveryPeerCanDecode(serverWithGate(false), raft,
+        RaftLogEntryType.SECURITY_GROUPS_ENTRY, "group document")).doesNotThrowAnyException();
+
+    verify(raft, never()).peersMissingCapabilityNow(anyString());
+  }
+
+  // -------------------------------------------------------------------------------------------------------
+  // 4. The sentence an operator is left holding
+  // -------------------------------------------------------------------------------------------------------
+
+  /**
+   * The refusal is the entire remedy this issue delivers. "The cluster is not ready" sends an operator nowhere;
+   * the peer's name, the reason its answer is missing, and the knob that overrides the decision are the three
+   * things they can act on, so all three are pinned.
+   */
+  @Test
+  void theRefusalNamesThePeerTheReasonAndTheOverride() {
+    final String message = SecurityEntryCapabilityGate.refusal("group document",
+        RaftLogEntryType.SECURITY_GROUPS_ENTRY, PeerCapabilities.SECURITY_GROUPS_ENTRY, List.of(LAGGING_PEER),
+        registryWhereThePeerAnswered404());
+
+    assertThat(message).contains(LAGGING_PEER);
+    assertThat(message).contains(PeerCapabilities.SECURITY_GROUPS_ENTRY);
+    assertThat(message).contains("SECURITY_GROUPS_ENTRY");
+    assertThat(message)
+        .as("an operator must be told the reason the peer is unknown: an old build and an unreachable node have "
+            + "nothing in common as remedies")
+        .contains("404");
+    assertThat(message).contains(GlobalConfiguration.HA_SECURITY_ENTRY_CAPABILITY_GATE.getKey());
+    assertThat(message)
+        .as("nothing was submitted is the half that decides whether the operator has to clean anything up")
+        .containsIgnoringCase("nothing was submitted");
+  }
+
+  /** A peer with no recorded reason still has to be named; only the explanatory clause is dropped. */
+  @Test
+  void theRefusalStillNamesAPeerWhoseReasonWasNeverRecorded() {
+    final String message = SecurityEntryCapabilityGate.refusal("API-token document",
+        RaftLogEntryType.SECURITY_API_TOKENS_ENTRY, PeerCapabilities.SECURITY_API_TOKENS_ENTRY,
+        List.of(LAGGING_PEER), new PeerCapabilityRegistry());
+
+    assertThat(message).contains(LAGGING_PEER);
+    assertThat(message).contains(GlobalConfiguration.HA_SECURITY_ENTRY_CAPABILITY_GATE.getKey());
+  }
+
+  // -------------------------------------------------------------------------------------------------------
+  // 5. The caller: nothing is submitted on a refusal
+  // -------------------------------------------------------------------------------------------------------
+
+  /**
+   * The bug is not "the gate says no", it is "the entry reaches the Raft log". Driven through the plugin method
+   * every HTTP and gRPC entry point ends at, so the assertion is the one that matters: the broker - the only
+   * thing in {@code src/main} that encodes either entry type - was never handed the payload.
+   */
+  @Test
+  void aRefusedGroupChangeSubmitsNothingToTheRaftLog() {
+    final RaftTransactionBroker broker = mock(RaftTransactionBroker.class);
+    final RaftHAServer raft = mock(RaftHAServer.class);
+    when(raft.getTransactionBroker()).thenReturn(broker);
+    when(raft.peersMissingCapabilityNow(PeerCapabilities.SECURITY_GROUPS_ENTRY)).thenReturn(List.of(LAGGING_PEER));
+
+    final RaftHAPlugin plugin = pluginOn(raft, true);
+
+    assertThatThrownBy(() -> plugin.replicateSecurityGroups("{\"databases\":{}}"))
+        .isInstanceOf(ClusterCapabilityNotReadyException.class);
+
+    verify(broker, never()).replicateSecurityGroups(anyString());
+  }
+
+  /**
+   * The same for a token document, which is the case that matters most: a REVOCATION whose entry halts the nodes
+   * still serving the token has not revoked anything.
+   */
+  @Test
+  void aRefusedApiTokenChangeSubmitsNothingToTheRaftLog() {
+    final RaftTransactionBroker broker = mock(RaftTransactionBroker.class);
+    final RaftHAServer raft = mock(RaftHAServer.class);
+    when(raft.getTransactionBroker()).thenReturn(broker);
+    when(raft.peersMissingCapabilityNow(PeerCapabilities.SECURITY_API_TOKENS_ENTRY)).thenReturn(List.of(LAGGING_PEER));
+
+    final RaftHAPlugin plugin = pluginOn(raft, true);
+
+    assertThatThrownBy(() -> plugin.replicateSecurityApiTokens("{\"version\":1,\"tokens\":[]}"))
+        .isInstanceOf(ClusterCapabilityNotReadyException.class);
+
+    verify(broker, never()).replicateSecurityApiTokens(anyString());
+  }
+
+  /** The other direction, so the test above cannot pass because the plugin submits nothing under any condition. */
+  @Test
+  void aFullyUpgradedClusterStillReplicatesBothDocuments() {
+    final RaftTransactionBroker broker = mock(RaftTransactionBroker.class);
+    final RaftHAServer raft = mock(RaftHAServer.class);
+    when(raft.getTransactionBroker()).thenReturn(broker);
+    when(raft.peersMissingCapabilityNow(anyString())).thenReturn(List.of());
+
+    final RaftHAPlugin plugin = pluginOn(raft, true);
+
+    plugin.replicateSecurityGroups("{\"databases\":{}}");
+    plugin.replicateSecurityApiTokens("{\"version\":1,\"tokens\":[]}");
+
+    verify(broker).replicateSecurityGroups("{\"databases\":{}}");
+    verify(broker).replicateSecurityApiTokens("{\"version\":1,\"tokens\":[]}");
+  }
+
+  /**
+   * {@code SECURITY_USERS_ENTRY} predates every build this cluster can contain, so the users path must not have
+   * acquired a gate along with the other two - a rolling upgrade would otherwise stop being able to change a
+   * password, which is strictly worse than what #7511 set out to fix.
+   */
+  @Test
+  void theUsersEntryIsNotGatedAndStillReplicatesOnAMixedCluster() {
+    final RaftTransactionBroker broker = mock(RaftTransactionBroker.class);
+    final RaftHAServer raft = mock(RaftHAServer.class);
+    when(raft.getTransactionBroker()).thenReturn(broker);
+    when(raft.peersMissingCapabilityNow(anyString())).thenReturn(List.of(LAGGING_PEER));
+
+    final RaftHAPlugin plugin = pluginOn(raft, true);
+
+    plugin.replicateSecurityUsers("[{\"name\":\"root\"}]");
+
+    verify(broker).replicateSecurityUsers("[{\"name\":\"root\"}]");
+  }
+
+  // -------------------------------------------------------------------------------------------------------
+
+  private static RaftHAPlugin pluginOn(final RaftHAServer raft, final boolean gateEnabled) {
+    final RaftHAPlugin plugin = new RaftHAPlugin();
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.HA_SECURITY_ENTRY_CAPABILITY_GATE, gateEnabled);
+    plugin.configure(serverWith(configuration), configuration);
+    plugin.setRaftHAServer(raft);
+    return plugin;
+  }
+
+  private static ArcadeDBServer serverWithGate(final boolean enabled) {
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.HA_SECURITY_ENTRY_CAPABILITY_GATE, enabled);
+    return serverWith(configuration);
+  }
+
+  private static ArcadeDBServer serverWith(final ContextConfiguration configuration) {
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.getConfiguration()).thenReturn(configuration);
+    return server;
+  }
+
+  /** A registry holding the answer a node running a build without the capability route actually gives: a 404. */
+  private static PeerCapabilityRegistry registryWhereThePeerAnswered404() {
+    final PeerCapabilityRegistry registry = new PeerCapabilityRegistry();
+    registry.forget(registry.generation(), LAGGING_PEER, "the capability route answered HTTP 404");
+    return registry;
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7511SecurityEntryCapabilityGateTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7511SecurityEntryCapabilityGateTest.java
@@ -229,6 +229,27 @@ class Issue7511SecurityEntryCapabilityGateTest {
     assertThat(message).contains(GlobalConfiguration.HA_SECURITY_ENTRY_CAPABILITY_GATE.getKey());
   }
 
+  /**
+   * The refusal is also reported in this node's own log, because the caller may be a deployment script that
+   * swallows the 409 while the operator watching the rolling upgrade is the one who has to act (PR #7555 review).
+   * Throttled per capability, so a script retrying in a loop cannot bury the line that matters - and per
+   * CAPABILITY rather than globally, so a group refusal does not silence the token refusal behind it.
+   */
+  @Test
+  void aRefusalIsReportedOnceAndThenThrottledPerCapability() {
+    SecurityEntryCapabilityGate.resetRefusalLogThrottle();
+    final long t0 = 1_000_000L;
+
+    assertThat(SecurityEntryCapabilityGate.shouldLogRefusal(PeerCapabilities.SECURITY_GROUPS_ENTRY, t0))
+        .as("the first refusal is always reported").isTrue();
+    assertThat(SecurityEntryCapabilityGate.shouldLogRefusal(PeerCapabilities.SECURITY_GROUPS_ENTRY, t0 + 1_000L))
+        .as("a retry a second later is the same condition and is not reported again").isFalse();
+    assertThat(SecurityEntryCapabilityGate.shouldLogRefusal(PeerCapabilities.SECURITY_API_TOKENS_ENTRY, t0 + 1_000L))
+        .as("but the other capability's first refusal is its own event, not a repeat of this one").isTrue();
+    assertThat(SecurityEntryCapabilityGate.shouldLogRefusal(PeerCapabilities.SECURITY_GROUPS_ENTRY, t0 + 60_001L))
+        .as("and once the window has passed the condition is reported again").isTrue();
+  }
+
   // -------------------------------------------------------------------------------------------------------
   // 5. The caller: nothing is submitted on a refusal
   // -------------------------------------------------------------------------------------------------------

--- a/server/src/main/java/com/arcadedb/server/ClusterCapabilityNotReadyException.java
+++ b/server/src/main/java/com/arcadedb/server/ClusterCapabilityNotReadyException.java
@@ -18,6 +18,8 @@
  */
 package com.arcadedb.server;
 
+import java.util.List;
+
 /**
  * An operation was refused because a member of the cluster has not proved it can decode the replicated entry the
  * operation would be written as (issue #7511).
@@ -32,15 +34,78 @@ package com.arcadedb.server;
  * not a fault of the request - and {@code AbstractServerHttpHandler} answers this subtype HTTP {@code 409 Conflict}.
  * Not a 5xx: the request is well formed and authorized, and a client or load balancer must not read it as a server
  * fault worth retrying blindly. Not a 400 either: nothing about the request needs changing.
+ *
+ * <h2>Why the peers are carried as fields and not only in the message</h2>
+ *
+ * The peers that withheld the answer are the only actionable half - "the cluster is not ready" sends an operator
+ * nowhere, "peer arcadedb2 has not advertised security-groups-entry" sends them to the node that has not finished
+ * upgrading. In {@code production} mode {@code AbstractServerHttpHandler.buildErrorBody} conceals {@code detail},
+ * where the message goes, so a refusal that carried its peers only in prose arrived at the client as a bare
+ * "Cluster is not ready for this operation" (PR #7555 review). {@link #toExceptionArgs()} is the bounded,
+ * non-sensitive rendering that rides {@code exceptionArgs} instead, which every mode emits - the same split
+ * {@code ResultSetTooLargeException} makes between the sentence and the number a caller has to stay under.
  * <p>
- * The message carries the peers that withheld the answer and why each is unknown, because that is the only
- * actionable half - "the cluster is not ready" sends an operator nowhere, "peer arcadedb2 answered 404 to the
- * capability route" sends them to the node that has not finished upgrading.
+ * Bounded, and deliberately NOT carrying the per-peer reasons. A reason is free-form text built from a probe
+ * failure and can contain a host, a port or a JDK exception message; that is precisely the class of content
+ * {@code detail} exists to conceal outside development. The peer ids are cluster member names the caller - who has
+ * just passed a root-only check - can already read from {@code GET /api/v1/cluster}.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class ClusterCapabilityNotReadyException extends ServerControlPlane.OperationNotAvailableException {
-  public ClusterCapabilityNotReadyException(final String message) {
+
+  /**
+   * How many peer names {@link #toExceptionArgs()} spells out before summarising the rest. The field is a wire
+   * contract read by clients, so it stays bounded however large the cluster is; five is enough to act on, and an
+   * operator who needs the sixth reads the log or {@code GET /api/v1/cluster}.
+   */
+  private static final int MAX_PEERS_IN_ARGS = 5;
+
+  private final String       capability;
+  private final List<String> missingPeers;
+
+  /**
+   * @param message      the full refusal, including each peer's reason. Goes to {@code detail}, which production
+   *                     mode conceals.
+   * @param capability   the capability token the peers did not advertise.
+   * @param missingPeers the peers that did not advertise it, in configuration order. Copied and frozen.
+   */
+  public ClusterCapabilityNotReadyException(final String message, final String capability,
+      final List<String> missingPeers) {
     super(message);
+    this.capability = capability;
+    this.missingPeers = missingPeers != null ? List.copyOf(missingPeers) : List.of();
+  }
+
+  /** The capability token the peers of {@link #getMissingPeers()} have not advertised. */
+  public String getCapability() {
+    return capability;
+  }
+
+  /** The peers that have not advertised {@link #getCapability()}, in configuration order. Never {@code null}. */
+  public List<String> getMissingPeers() {
+    return missingPeers;
+  }
+
+  /**
+   * The refusal's actionable half as the {@code exceptionArgs} wire field: {@code <capability>|peer,peer[,+N more]}.
+   * <p>
+   * Pipe-separated like {@code DuplicatedKeyException}'s, so a client that already splits that field needs no new
+   * parsing rule, and bounded by {@link #MAX_PEERS_IN_ARGS} so a large cluster cannot turn an error body into a
+   * peer dump.
+   */
+  public String toExceptionArgs() {
+    final StringBuilder args = new StringBuilder(64);
+    if (capability != null)
+      args.append(capability);
+    args.append('|');
+    for (int i = 0; i < missingPeers.size() && i < MAX_PEERS_IN_ARGS; i++) {
+      if (i > 0)
+        args.append(',');
+      args.append(missingPeers.get(i));
+    }
+    if (missingPeers.size() > MAX_PEERS_IN_ARGS)
+      args.append(",+").append(missingPeers.size() - MAX_PEERS_IN_ARGS).append(" more");
+    return args.toString();
   }
 }

--- a/server/src/main/java/com/arcadedb/server/ClusterCapabilityNotReadyException.java
+++ b/server/src/main/java/com/arcadedb/server/ClusterCapabilityNotReadyException.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+/**
+ * An operation was refused because a member of the cluster has not proved it can decode the replicated entry the
+ * operation would be written as (issue #7511).
+ * <p>
+ * Raised by the HA plugin before anything is submitted: the point of the refusal is that nothing reaches the Raft
+ * log, because a committed entry a peer cannot decode halts that peer rather than being skipped (the #4798 rule,
+ * enforced in {@code ArcadeStateMachine}). The caller's state is therefore untouched and the request can simply be
+ * reissued once the lagging node is upgraded or reachable again.
+ * <p>
+ * <b>Its parent is what gives it a status on both transports.</b> {@code ServerControlPlane.OperationNotAvailableException}
+ * already maps to gRPC {@code FAILED_PRECONDITION}, which is exactly what this is - a precondition of the cluster,
+ * not a fault of the request - and {@code AbstractServerHttpHandler} answers this subtype HTTP {@code 409 Conflict}.
+ * Not a 5xx: the request is well formed and authorized, and a client or load balancer must not read it as a server
+ * fault worth retrying blindly. Not a 400 either: nothing about the request needs changing.
+ * <p>
+ * The message carries the peers that withheld the answer and why each is unknown, because that is the only
+ * actionable half - "the cluster is not ready" sends an operator nowhere, "peer arcadedb2 answered 404 to the
+ * capability route" sends them to the node that has not finished upgrading.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class ClusterCapabilityNotReadyException extends ServerControlPlane.OperationNotAvailableException {
+  public ClusterCapabilityNotReadyException(final String message) {
+    super(message);
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -30,6 +30,7 @@ import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.ClusterCapabilityNotReadyException;
 import com.arcadedb.server.HAReplicatedDatabase;
 import com.arcadedb.server.LeaderForwardContext;
 import com.arcadedb.server.http.ClusterAuthSessionResolver;
@@ -740,6 +741,24 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
       logUserError(committedRemotely);
       sendErrorResponse(exchange, 409, "Transaction committed cluster-wide but the local apply failed - do not retry",
               committedRemotely, null);
+      return;
+    }
+
+    // 409 Conflict: a member of the cluster has not proved it can decode the replicated entry this operation
+    // would be written as, so nothing was submitted (issue #7511). A conflict rather than a 5xx for the same
+    // reason the two arms below are: the request is well formed and authorized, the server is healthy, and what
+    // has to change before it succeeds is the state of the CLUSTER - finish the rolling upgrade, or restore
+    // contact with the peer the message names - not anything about the request. A 5xx would tell a client or load
+    // balancer to retry it blindly against another node, where it is refused identically.
+    //
+    // Before anything reaches the OperationNotAvailableException it extends: that parent means "this server cannot
+    // do this at all" (HA not enabled), a permanent property of the deployment, while this clears itself the
+    // moment the last node is up.
+    final ClusterCapabilityNotReadyException capabilityNotReady = firstOf(e, cause,
+            ClusterCapabilityNotReadyException.class);
+    if (capabilityNotReady != null) {
+      logUserError(capabilityNotReady);
+      sendErrorResponse(exchange, 409, "Cluster is not ready for this operation", capabilityNotReady, null);
       return;
     }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -758,7 +758,13 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
             ClusterCapabilityNotReadyException.class);
     if (capabilityNotReady != null) {
       logUserError(capabilityNotReady);
-      sendErrorResponse(exchange, 409, "Cluster is not ready for this operation", capabilityNotReady, null);
+      // The peers go in exceptionArgs, not only in the message: 'detail' - where the message lands - is concealed
+      // in production, and a 409 that names no node tells an operator nothing they can act on. Same split
+      // ResultSetTooLargeException makes, and the same reason. The per-peer REASONS stay in the message: they are
+      // free-form probe-failure text that can carry a host, a port or a JDK exception message, which is exactly
+      // what production mode conceals 'detail' for (PR #7555 review).
+      sendErrorResponse(exchange, 409, "Cluster is not ready for this operation", capabilityNotReady,
+              capabilityNotReady.toExceptionArgs());
       return;
     }
 

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue7511ClusterNotReadyHttpStatusTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue7511ClusterNotReadyHttpStatusTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.server.http.handler;
 
 import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
@@ -33,6 +34,8 @@ import io.undertow.util.HeaderMap;
 import io.undertow.util.Methods;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -58,12 +61,19 @@ import static org.mockito.Mockito.when;
  */
 class Issue7511ClusterNotReadyHttpStatusTest {
 
-  private static final String REFUSAL = "Refusing to replicate the group document: peer(s) [arcadedb2] have not "
-      + "advertised the 'security-groups-entry' capability";
+  private static final String CAPABILITY = "security-groups-entry";
+  private static final String LAGGING    = "arcadedb2";
+  private static final String REFUSAL    = "Refusing to replicate the group document: peer(s) [" + LAGGING
+      + "] have not advertised the '" + CAPABILITY + "' capability. Peer '" + LAGGING
+      + "': the capability route answered HTTP 404.";
+
+  private static ClusterCapabilityNotReadyException refusal() {
+    return new ClusterCapabilityNotReadyException(REFUSAL, CAPABILITY, List.of(LAGGING));
+  }
 
   @Test
   void aClusterNotReadyRefusalMapsTo409RatherThanAGeneric500() {
-    final HandledResponse response = handle(new ClusterCapabilityNotReadyException(REFUSAL));
+    final HandledResponse response = handle(refusal());
 
     assertThat(response.statusCode)
         .as("a refusal in which nothing was submitted is a conflict with the cluster's state, not a server fault "
@@ -96,20 +106,67 @@ class Issue7511ClusterNotReadyHttpStatusTest {
   @Test
   void aWrappedClusterNotReadyRefusalKeepsThe409() {
     final HandledResponse response = handle(new CommandExecutionException("Error on command execution",
-        new ClusterCapabilityNotReadyException(REFUSAL)));
+        refusal()));
 
     assertThat(response.statusCode).isEqualTo(409);
     assertThat(new JSONObject(response.body).getString("exception"))
         .isEqualTo(ClusterCapabilityNotReadyException.class.getName());
   }
 
+  /**
+   * In {@code production} mode {@code buildErrorBody} conceals {@code detail}, where the refusal's prose lives. A
+   * 409 that reaches an operator as a bare "Cluster is not ready for this operation" has told them nothing they
+   * can act on, which is the silence #7511 exists to end - so the lagging peer and the capability ride
+   * {@code exceptionArgs}, which every mode emits (PR #7555 review).
+   * <p>
+   * The per-peer REASON is deliberately absent from that field and is asserted absent: it is free-form text built
+   * from a probe failure and can carry a host, a port or a JDK exception message, which is the class of content
+   * {@code detail} is concealed for in the first place.
+   */
+  @Test
+  void inProductionModeThePeerAndTheCapabilitySurviveInExceptionArgs() {
+    final HandledResponse response = handle(refusal(), "production");
+
+    assertThat(response.statusCode).isEqualTo(409);
+
+    final JSONObject json = new JSONObject(response.body);
+    assertThat(json.has("detail"))
+        .as("production conceals the free-form cause chain, as it does for every other error")
+        .isFalse();
+    assertThat(json.getString("exceptionArgs"))
+        .as("and what is left must still name the node holding the cluster back")
+        .contains(LAGGING)
+        .contains(CAPABILITY);
+    assertThat(json.getString("exceptionArgs"))
+        .as("but not the probe-failure text, which is exactly what production mode conceals detail for")
+        .doesNotContain("404");
+  }
+
+  /** The bounded rendering stays bounded: a large cluster cannot turn one error body into a peer dump. */
+  @Test
+  void theExceptionArgsAreBoundedOnALargeCluster() {
+    final List<String> manyPeers = List.of("p1", "p2", "p3", "p4", "p5", "p6", "p7");
+    final String args = new ClusterCapabilityNotReadyException(REFUSAL, CAPABILITY, manyPeers).toExceptionArgs();
+
+    assertThat(args).startsWith(CAPABILITY + "|p1,p2,p3,p4,p5");
+    assertThat(args).endsWith(",+2 more");
+    assertThat(args).doesNotContain("p6").doesNotContain("p7");
+  }
+
   private record HandledResponse(int statusCode, String body) {
   }
 
   private HandledResponse handle(final RuntimeException toThrow) {
+    return handle(toThrow, "development");
+  }
+
+  private HandledResponse handle(final RuntimeException toThrow, final String serverMode) {
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.SERVER_MODE, serverMode);
+
     final ArcadeDBServer server = mock(ArcadeDBServer.class);
     when(server.getObservationRegistry()).thenReturn(ObservationRegistry.create());
-    when(server.getConfiguration()).thenReturn(new ContextConfiguration());
+    when(server.getConfiguration()).thenReturn(configuration);
     when(server.getServerName()).thenReturn("test");
 
     final HttpServer httpServer = mock(HttpServer.class);

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue7511ClusterNotReadyHttpStatusTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue7511ClusterNotReadyHttpStatusTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.ClusterCapabilityNotReadyException;
+import com.arcadedb.server.ServerControlPlane;
+import com.arcadedb.server.http.HttpServer;
+import com.arcadedb.server.security.ServerSecurityUser;
+import io.micrometer.observation.ObservationRegistry;
+import io.undertow.io.Sender;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderMap;
+import io.undertow.util.Methods;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #7511 on the HTTP transport: a group or API-token change refused because a peer of the cluster cannot
+ * decode the Raft entry it would be replicated as answers {@code 409 Conflict}.
+ * <p>
+ * The status is the contract, not a cosmetic detail. Falling through to the generic {@code 500} would tell every
+ * HTTP client, driver and load balancer that the SERVER broke - inviting a blind retry against another node,
+ * where the request is refused identically - about a condition in which nothing was submitted, nothing changed,
+ * and the remedy is to finish the rolling upgrade. It pairs with the {@code FAILED_PRECONDITION} the same refusal
+ * gets on gRPC, which {@code Issue7511GrpcClusterNotReadyStatusTest} pins in the {@code grpcw} module.
+ * <p>
+ * The exception is raised inside the {@code ha-raft} module, which the server module cannot depend on, so - as
+ * {@code Issue5064CommittedRemotelyHttpStatusTest} does for the same reason - the real
+ * {@code AbstractServerHttpHandler} catch chain is driven with a handler whose {@code execute()} throws it.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue7511ClusterNotReadyHttpStatusTest {
+
+  private static final String REFUSAL = "Refusing to replicate the group document: peer(s) [arcadedb2] have not "
+      + "advertised the 'security-groups-entry' capability";
+
+  @Test
+  void aClusterNotReadyRefusalMapsTo409RatherThanAGeneric500() {
+    final HandledResponse response = handle(new ClusterCapabilityNotReadyException(REFUSAL));
+
+    assertThat(response.statusCode)
+        .as("a refusal in which nothing was submitted is a conflict with the cluster's state, not a server fault "
+            + "(body=%s)", response.body)
+        .isEqualTo(409);
+
+    final JSONObject json = new JSONObject(response.body);
+    assertThat(json.getString("error")).isEqualTo("Cluster is not ready for this operation");
+    assertThat(json.getString("exception")).isEqualTo(ClusterCapabilityNotReadyException.class.getName());
+    assertThat(json.getString("detail"))
+        .as("the peer holding the cluster back is the only thing an operator can act on")
+        .contains("arcadedb2");
+  }
+
+  /**
+   * Guards the catch ORDER. The refusal extends {@code OperationNotAvailableException}, which extends
+   * {@code CommandExecutionException} - so an arm placed after the generic ones would be unreachable and this
+   * would answer 500. The two are not the same answer: "this server cannot do this at all" is a permanent
+   * property of the deployment, while this clears itself when the last node is upgraded.
+   */
+  @Test
+  void aPlainOperationNotAvailableRefusalIsNotSweptIntoTheSame409() {
+    final HandledResponse response = handle(
+        new ServerControlPlane.OperationNotAvailableException("High availability is not enabled on this server"));
+
+    assertThat(response.statusCode).isNotEqualTo(409);
+  }
+
+  /** The 409 must survive the wrapping a command planner or the auto-commit wrapper puts around it. */
+  @Test
+  void aWrappedClusterNotReadyRefusalKeepsThe409() {
+    final HandledResponse response = handle(new CommandExecutionException("Error on command execution",
+        new ClusterCapabilityNotReadyException(REFUSAL)));
+
+    assertThat(response.statusCode).isEqualTo(409);
+    assertThat(new JSONObject(response.body).getString("exception"))
+        .isEqualTo(ClusterCapabilityNotReadyException.class.getName());
+  }
+
+  private record HandledResponse(int statusCode, String body) {
+  }
+
+  private HandledResponse handle(final RuntimeException toThrow) {
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.getObservationRegistry()).thenReturn(ObservationRegistry.create());
+    when(server.getConfiguration()).thenReturn(new ContextConfiguration());
+    when(server.getServerName()).thenReturn("test");
+
+    final HttpServer httpServer = mock(HttpServer.class);
+    when(httpServer.getServer()).thenReturn(server);
+
+    final Sender sender = mock(Sender.class);
+    final HttpServerExchange exchange = mock(HttpServerExchange.class);
+    final int[] statusCode = { 200 };
+    when(exchange.setStatusCode(anyInt())).thenAnswer(invocation -> {
+      statusCode[0] = invocation.getArgument(0);
+      return exchange;
+    });
+    when(exchange.getStatusCode()).thenAnswer(invocation -> statusCode[0]);
+    when(exchange.getRequestHeaders()).thenReturn(new HeaderMap());
+    when(exchange.getResponseHeaders()).thenReturn(new HeaderMap());
+    when(exchange.getRequestMethod()).thenReturn(Methods.POST);
+    when(exchange.getRelativePath()).thenReturn("/server/groups");
+    when(exchange.getResponseSender()).thenReturn(sender);
+
+    new ThrowingHandler(httpServer, toThrow).handleRequest(exchange);
+
+    final ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
+    verify(sender).send(body.capture());
+    return new HandledResponse(statusCode[0], body.getValue());
+  }
+
+  /** Handler whose execute() throws, standing in for a group save refused by the cluster-capability interlock. */
+  private static final class ThrowingHandler extends AbstractServerHttpHandler {
+    private final RuntimeException toThrow;
+
+    private ThrowingHandler(final HttpServer httpServer, final RuntimeException toThrow) {
+      super(httpServer);
+      this.toThrow = toThrow;
+    }
+
+    @Override
+    protected ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user,
+        final JSONObject payload) {
+      throw toThrow;
+    }
+
+    @Override
+    public boolean isRequireAuthentication() {
+      // Skip the Authorization machinery: this test targets the error-mapping catch chain only.
+      return false;
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/security/Issue7511SecurityEntryGateRefusalTest.java
+++ b/server/src/test/java/com/arcadedb/server/security/Issue7511SecurityEntryGateRefusalTest.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.ClusterCapabilityNotReadyException;
+import com.arcadedb.server.HAServerPlugin;
+import com.arcadedb.server.ServerControlPlane;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7511, the half that lives above the HA plugin: what an operator-facing entry point does when the
+ * cluster-capability interlock refuses to replicate a group or API-token change.
+ * <p>
+ * The interlock itself is pinned in {@code Issue7511SecurityEntryCapabilityGateTest}, in the module that owns it.
+ * What is asserted here is everything that has to be true of the caller for the refusal to be SAFE rather than
+ * merely loud: that the refusal reaches the transport unchanged (it is the exception both transports map to a
+ * status), and that no entry point leaves half a change behind on the node that served the request. A mint that
+ * installed the token locally before the refusal, or a revocation that removed it, would turn one node into the
+ * divergence the gate exists to prevent - by a different route.
+ * <p>
+ * The fixture is {@code Issue7373ClusterWideGroupsAndTokensTest}'s, with the plugin replaced by one that refuses
+ * the way {@code RaftHAPlugin} does when a peer has not advertised the capability.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7511SecurityEntryGateRefusalTest {
+
+  private static final String CONFIG_PATH = "target/test-security-7511";
+  private static final String REFUSAL     = "peer(s) [arcadedb2] have not advertised the 'security-groups-entry' "
+      + "capability";
+
+  private FixtureServer      server;
+  private ServerSecurity     security;
+  private RefusingHAPlugin   ha;
+  private ServerControlPlane controlPlane;
+
+  @BeforeEach
+  void setUp() {
+    GlobalConfiguration.SERVER_SECURITY_SALT_ITERATIONS.setValue(1000);
+    final File dir = new File(CONFIG_PATH);
+    if (dir.exists())
+      FileUtils.deleteRecursively(dir);
+    assertThat(dir.mkdirs()).isTrue();
+
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.SERVER_ROOT_PATH, "./target");
+
+    server = new FixtureServer(configuration);
+    security = new ServerSecurity(server, configuration, CONFIG_PATH);
+    server.setSecurity(security);
+    controlPlane = new ServerControlPlane(server);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (security != null)
+      security.stopService();
+    GlobalConfiguration.SERVER_SECURITY_SALT_ITERATIONS.reset();
+    FileUtils.deleteRecursively(new File(CONFIG_PATH));
+  }
+
+  /** Joins a cluster whose peers are all upgraded: every replication is accepted. */
+  private void joinReadyCluster() {
+    ha = new RefusingHAPlugin(security, false);
+    server.setHA(ha);
+  }
+
+  /** Joins a cluster with one node too old to decode either entry type: every replication is refused. */
+  private void joinMixedVersionCluster() {
+    ha = new RefusingHAPlugin(security, true);
+    server.setHA(ha);
+  }
+
+  private static JSONObject readerGroup() {
+    return new JSONObject()
+        .put("resultSetLimit", -1L)
+        .put("readTimeout", -1L)
+        .put("access", new JSONArray())
+        .put("types", new JSONObject());
+  }
+
+  private JSONObject groupsOf(final String database) {
+    return security.groupsToJSON().getJSONObject("databases").getJSONObject(database).getJSONObject("groups");
+  }
+
+  // -------------------------------------------------------------------------------------------------------
+  // Groups: POST /api/v1/server/groups and the gRPC SaveGroup that calls the same method
+  // -------------------------------------------------------------------------------------------------------
+
+  @Test
+  void savingAGroupOnAMixedVersionClusterIsRefusedAndChangesNothingLocally() {
+    joinMixedVersionCluster();
+
+    assertThatThrownBy(() -> controlPlane.saveGroup("*", "reader", readerGroup()))
+        .isInstanceOf(ClusterCapabilityNotReadyException.class)
+        .hasMessageContaining(REFUSAL);
+
+    assertThat(groupsOf("*").has("reader"))
+        .as("the group must not exist on the node that served the refused request either")
+        .isFalse();
+    assertThat(ha.groupDocuments).isEmpty();
+  }
+
+  @Test
+  void deletingAGroupOnAMixedVersionClusterIsRefusedAndLeavesTheGroupInPlace() {
+    joinReadyCluster();
+    controlPlane.saveGroup("*", "reader", readerGroup());
+    assertThat(groupsOf("*").has("reader")).isTrue();
+
+    joinMixedVersionCluster();
+
+    assertThatThrownBy(() -> controlPlane.deleteGroup("*", "reader"))
+        .isInstanceOf(ClusterCapabilityNotReadyException.class);
+
+    assertThat(groupsOf("*").has("reader"))
+        .as("a half-applied delete would leave this node authorizing differently from every other")
+        .isTrue();
+  }
+
+  @Test
+  void savingAGroupOnAFullyUpgradedClusterStillWorks() {
+    joinReadyCluster();
+
+    controlPlane.saveGroup("*", "reader", readerGroup());
+
+    assertThat(groupsOf("*").has("reader")).isTrue();
+    assertThat(ha.groupDocuments).hasSize(1);
+  }
+
+  // -------------------------------------------------------------------------------------------------------
+  // API tokens: POST / DELETE /api/v1/server/api-tokens and their gRPC equivalents
+  // -------------------------------------------------------------------------------------------------------
+
+  @Test
+  void mintingAnApiTokenOnAMixedVersionClusterIsRefusedAndInstallsNothing() {
+    joinMixedVersionCluster();
+
+    assertThatThrownBy(() -> controlPlane.createApiToken("ci", "*", 0, new JSONObject()))
+        .isInstanceOf(ClusterCapabilityNotReadyException.class);
+
+    assertThat(controlPlane.listApiTokens().toList())
+        .as("a token that exists on one node only is the intermittent 401 issue #7373 set out to remove")
+        .isEmpty();
+    assertThat(ha.apiTokenDocuments).isEmpty();
+  }
+
+  /**
+   * The case that matters most. A revocation whose entry would halt the nodes still serving the token has not
+   * revoked anything, so it must be refused - and the token must stay usable here rather than be dropped locally,
+   * or this node starts disagreeing with the rest of the cluster about a live credential.
+   */
+  @Test
+  void revokingAnApiTokenOnAMixedVersionClusterIsRefusedAndTheTokenStaysUniformlyLive() {
+    joinReadyCluster();
+    final JSONObject minted = controlPlane.createApiToken("ci", "*", 0, new JSONObject());
+    final String tokenHash = minted.getString("tokenHash");
+
+    joinMixedVersionCluster();
+
+    assertThatThrownBy(() -> controlPlane.deleteApiToken(tokenHash))
+        .isInstanceOf(ClusterCapabilityNotReadyException.class);
+
+    assertThat(controlPlane.listApiTokens().toList())
+        .as("the revocation reached no node, so it must not have reached this one")
+        .hasSize(1);
+  }
+
+  // -------------------------------------------------------------------------------------------------------
+  // addPeer: POST /api/v1/cluster/addPeer seeds all three documents
+  // -------------------------------------------------------------------------------------------------------
+
+  /**
+   * {@code seedSecurityStateClusterWide} is best-effort per document by design, so a refused group seed must be
+   * REPORTED rather than thrown - and must not take the users seed down with it, which is the one that predates
+   * the entry types and can always be replicated.
+   */
+  @Test
+  void seedingAJoiningPeerReportsTheRefusedDocumentsAndStillSeedsTheUsers() {
+    joinMixedVersionCluster();
+
+    final List<String> failed = security.seedSecurityStateClusterWide();
+
+    assertThat(failed).containsExactlyInAnyOrder("groups", "API tokens");
+    assertThat(ha.userDocuments)
+        .as("SECURITY_USERS_ENTRY predates every build in a supported rolling upgrade and is never gated")
+        .hasSize(1);
+  }
+
+  @Test
+  void seedingAJoiningPeerOnAFullyUpgradedClusterReportsNothingFailed() {
+    joinReadyCluster();
+
+    assertThat(security.seedSecurityStateClusterWide()).isEmpty();
+    assertThat(ha.groupDocuments).hasSize(1);
+    assertThat(ha.apiTokenDocuments).hasSize(1);
+  }
+
+  // -------------------------------------------------------------------------------------------------------
+
+  /**
+   * Stands in for {@code RaftHAPlugin} with the #7511 interlock in front of it: when {@code refusing}, the two
+   * gated hooks throw before anything is submitted, exactly as
+   * {@code SecurityEntryCapabilityGate.requireEveryPeerCanDecode} makes them. The users hook is never gated.
+   */
+  private static class RefusingHAPlugin implements HAServerPlugin {
+    private final ServerSecurity security;
+    private final boolean        refusing;
+    final         List<String>   userDocuments     = new ArrayList<>();
+    final         List<String>   groupDocuments    = new ArrayList<>();
+    final         List<String>   apiTokenDocuments = new ArrayList<>();
+
+    private RefusingHAPlugin(final ServerSecurity security, final boolean refusing) {
+      this.security = security;
+      this.refusing = refusing;
+    }
+
+    @Override
+    public void replicateSecurityUsers(final String usersJsonArray) {
+      userDocuments.add(usersJsonArray);
+      security.applyReplicatedUsers(usersJsonArray);
+    }
+
+    @Override
+    public void replicateSecurityGroups(final String groupsJson) {
+      if (refusing)
+        throw new ClusterCapabilityNotReadyException("Refusing to replicate the group document: " + REFUSAL);
+      groupDocuments.add(groupsJson);
+      security.applyReplicatedGroups(groupsJson);
+    }
+
+    @Override
+    public void replicateSecurityApiTokens(final String apiTokensJson) {
+      if (refusing)
+        throw new ClusterCapabilityNotReadyException("Refusing to replicate the API-token document: peer(s) "
+            + "[arcadedb2] have not advertised the 'security-api-tokens-entry' capability");
+      apiTokenDocuments.add(apiTokensJson);
+      security.applyReplicatedApiTokens(apiTokensJson);
+    }
+
+    @Override
+    public ELECTION_STATUS getElectionStatus() {
+      return ELECTION_STATUS.DONE;
+    }
+
+    @Override
+    public void startService() {
+    }
+
+    @Override
+    public boolean isLeader() {
+      return true;
+    }
+
+    @Override
+    public String getLeaderName() {
+      return "leader";
+    }
+
+    @Override
+    public String getClusterName() {
+      return "test";
+    }
+
+    @Override
+    public Map<String, Object> getStats() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public int getConfiguredServers() {
+      return 3;
+    }
+
+    @Override
+    public String getLeaderAddress() {
+      return null;
+    }
+
+    @Override
+    public String getReplicaAddresses() {
+      return "";
+    }
+
+    @Override
+    public void shutdownRemoteServer(final String serverName) {
+    }
+
+    @Override
+    public void disconnectCluster() {
+    }
+  }
+
+  /** An {@link ArcadeDBServer} that is never started, so the security store can be supplied by the fixture. */
+  private static final class FixtureServer extends ArcadeDBServer {
+    private ServerSecurity security;
+
+    private FixtureServer(final ContextConfiguration configuration) {
+      super(configuration);
+    }
+
+    private void setSecurity(final ServerSecurity security) {
+      this.security = security;
+    }
+
+    @Override
+    public ServerSecurity getSecurity() {
+      return security;
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/security/Issue7511SecurityEntryGateRefusalTest.java
+++ b/server/src/test/java/com/arcadedb/server/security/Issue7511SecurityEntryGateRefusalTest.java
@@ -256,7 +256,8 @@ class Issue7511SecurityEntryGateRefusalTest {
     @Override
     public void replicateSecurityGroups(final String groupsJson) {
       if (refusing)
-        throw new ClusterCapabilityNotReadyException("Refusing to replicate the group document: " + REFUSAL);
+        throw new ClusterCapabilityNotReadyException("Refusing to replicate the group document: " + REFUSAL,
+            "security-groups-entry", List.of("arcadedb2"));
       groupDocuments.add(groupsJson);
       security.applyReplicatedGroups(groupsJson);
     }
@@ -265,7 +266,8 @@ class Issue7511SecurityEntryGateRefusalTest {
     public void replicateSecurityApiTokens(final String apiTokensJson) {
       if (refusing)
         throw new ClusterCapabilityNotReadyException("Refusing to replicate the API-token document: peer(s) "
-            + "[arcadedb2] have not advertised the 'security-api-tokens-entry' capability");
+            + "[arcadedb2] have not advertised the 'security-api-tokens-entry' capability",
+            "security-api-tokens-entry", List.of("arcadedb2"));
       apiTokenDocuments.add(apiTokensJson);
       security.applyReplicatedApiTokens(apiTokensJson);
     }


### PR DESCRIPTION
Closes #7511

## Summary

#7373 added two Raft log entry types, `SECURITY_GROUPS_ENTRY` (id 7) and `SECURITY_API_TOKENS_ENTRY` (id 8). A
node predating them cannot decode either, and `ArcadeStateMachine` halts rather than skip a committed entry it
cannot read - correctly, because skipping would diverge the cluster's security state silently (the #4798 rule).
During a rolling upgrade the cluster is mixed by construction, so creating a group or minting an API token against
an already-upgraded node committed an entry that halted every node still on the old build: a routine admin action,
on a routine upgrade, turned into a partial outage, with nothing in the API response saying the cluster was not
ready for it. The halt stays. What this changes is that the entry is no longer *written* while a peer cannot read
it: the two types are gated on the #7219 peer-capability handshake - two new permanent tokens,
`security-groups-entry` and `security-api-tokens-entry`, advertised over `POST /api/v1/cluster/capabilities` - and
the operation is refused instead, HTTP `409 Conflict` / gRPC `FAILED_PRECONDITION`, naming the lagging peer and the
reason its answer is missing. Nothing is submitted, so nothing halts, and the same request succeeds unchanged once
the last node is up, with no sequencing by hand.

## Why a refusal rather than a fallback, and the two consequences that shaped it

#7219 negotiates an optional *section* of `SCHEMA_ENTRY`, so its "no" degrades to shipping the whole document. An
entry *type* has no degraded mode: the entry either goes in and halts the old peer, or it does not go in at all.
That difference drove two decisions worth reviewing carefully:

- **The gate cannot read the leader-only capability cache.** The background capability monitor runs on the leader
  (`startCapabilityMonitor` is called from `startLagMonitor`), but the group and API-token REST routes do **not**
  forward to the leader - `PostGroupHandler` calls `ServerControlPlane` directly - so those operations run on
  whichever node the client or load balancer picked and submit through a Raft client that routes to the leader. A
  refusal built on `peersMissingCapability` alone would therefore refuse **every** group change ever made on a
  follower, on a perfectly healthy single-version cluster. `RaftHAServer.peersMissingCapabilityNow` reads the cache
  first and runs one bounded probe round (sequential, `PROBE_TIMEOUT_MS` per peer) only when that is not already a
  full "yes". The integration test drives exactly this arm.
- **Every unknown is a no, and that costs availability.** An old build and an unreachable node are the same
  404-or-timeout at the transport, which is what makes the gate safe - and also means an admin change is refused
  while any node is DOWN, not only while any node is OLD, **revocations included**.
  `arcadedb.ha.securityEntryCapabilityGate` (default `true`) is the escape hatch for an operator who knows from
  outside the cluster that the unreachable node understands the entry; the refusal message names it.

`SecurityEntryCapabilityGate.capabilityFor` is an exhaustive `switch` over `RaftLogEntryType` with no `default`, so
**adding a ninth entry type does not compile** until whoever adds it decides whether it needs a token - the issue
asked for a mechanism that "would cover the next entry type too", and a switch that fails the build is a stronger
guarantee than a sentence in a document. `ha-raft/CLAUDE.md` gains the section that says so.

## Test plan

- [x] `mvn -o -pl ha-raft -am test -Dtest=Issue7511SecurityEntryCapabilityGateTest` - 16 tests: the tokens and
      their permanent spellings, `capabilityFor` over every `RaftLogEntryType` value, the decision (all-capable,
      one missing, no configuration readable, interlock off), the refusal text, and - through
      `RaftHAPlugin.replicateSecurityGroups` / `replicateSecurityApiTokens` with a mocked broker - that a refusal
      hands the transaction broker **nothing**.
- [x] `mvn -o -pl server -am test -Dtest=Issue7511SecurityEntryGateRefusalTest` - 7 tests, one per operator-facing
      entry point (save/delete group, mint/revoke token, the `addPeer` seed), each asserting both that the refusal
      propagates and that the node serving it kept no half-change.
- [x] `mvn -o -pl server -am test -Dtest=Issue7511ClusterNotReadyHttpStatusTest` - the 409, wrapped and unwrapped,
      plus the catch-order guard that a plain `OperationNotAvailableException` is not swept into it.
- [x] `mvn -o -pl grpcw -am test -Dtest=Issue7511GrpcClusterNotReadyStatusTest` - the `FAILED_PRECONDITION` through
      `ArcadeDbGrpcAdminService.toStatus`, the mapper every admin RPC delegates to.
- [x] `mvn -o -pl ha-raft -am verify -DskipITs=false -Dit.test=Issue7511MixedVersionSecurityEntryIT` - a real
      3-node cluster with one node advertising a pre-#7373 capability set: the leader refuses, an **upgraded
      follower** refuses by asking the peers itself, the lagging node is still running, and the change goes through
      and converges on all three once it finishes "upgrading". 21 s, `@Tag("slow")`.
- [x] **Falsification:** with the gate call removed from both `RaftHAPlugin` methods, exactly the two caller unit
      tests go red and the IT fails with "Expecting code to raise a throwable" on both the leader and the follower
      arm. Nothing else moved, so the tests are not passing for another reason.
- [x] Regression: `ha-raft` 144 (the whole #7219/#7256/#7301/#7331/#7332/#7373/#7138 capability and codec set),
      `server` security package 89 (including `Issue7373ClusterWideGroupsAndTokensTest`), `engine` configuration
      79, `grpcw` status mapping 4. All green.

## Coverage

Every submit of entry types 7 and 8 funnels through `RaftHAPlugin.replicateSecurityGroups` /
`replicateSecurityApiTokens` - verified exhaustively: `RaftHAPlugin` is the only `HAServerPlugin` implementation in
`src/main` and the only caller of the broker's two security-config methods. The gate sits there, so one gate covers
every entry point:

| Entry point | Covered |
|---|---|
| `POST /api/v1/server/groups` -> `ServerControlPlane.saveGroup` -> `saveGroupClusterWide` | yes, tested |
| `DELETE /api/v1/server/groups` -> `deleteGroupClusterWide` | yes, tested |
| gRPC `SaveGroup` / `DeleteGroup` | yes, tested (status mapping) |
| `POST /api/v1/server/api-tokens` -> `createApiTokenClusterWide` | yes, tested |
| `DELETE /api/v1/server/api-tokens` -> `deleteApiTokenClusterWide` | yes, tested |
| gRPC `CreateApiToken` / `DeleteApiToken` | yes, tested (status mapping) |
| `POST /api/v1/cluster/addPeer` -> `seedSecurityStateClusterWide` (groups + token halves) | yes, tested |
| `SECURITY_USERS_ENTRY` (id 5) | argued: introduced by the commit that introduced Raft HA, so no build that speaks this protocol fails to decode it. Explicitly tested as NOT gated |
| `BOOTSTRAP_FINGERPRINT_ENTRY` (id 6) | argued: shipped in 26.5.1 (`git tag --contains`), written only at first cluster formation, where refusing would stop the cluster forming rather than protect a peer. Pinned by the exhaustive switch |
| `SCHEMA_ENTRY` delta section | argued: already gated by the mechanism this reuses (#7219), and degrades rather than refuses because it has a fallback |

### Known gaps

- **#7548** - Studio offers the group and token controls unconditionally and renders the 409 as a generic error; it
  does not surface the per-peer `capabilities` the cluster payload already returns.
- **#7549** - `GET /api/v1/cluster` reports peer capabilities only from the leader, so a rolling-upgrade readiness
  check has to locate the leader first. This PR works around it at the point of use (the on-demand probe) but not
  for observability.
- An unreachable peer blocks group and API-token changes, revocations included - deliberate, see above; the escape
  hatch is the new setting and the refusal names it.
- `addPeer` now reports a refused groups/API-token seed instead of silently submitting one. Reported, not thrown,
  and the users seed still goes through; what admitting such a peer means is already tracked by **#7521**.
- A rolling DOWNGRADE past this release is not protected and cannot be: negotiation governs what is written next,
  never what is already committed, and the node in trouble is the one without the check. The same boundary #7255
  documents for schema deltas, now covering entry types too; `ha-raft/CLAUDE.md` says so.

## Note on process

The orchestrator's adversarial pass is meant to run in an independent subagent. The `Task` tool was disabled in
this session, so the pass was run by the author instead - which removes its main value. Its eight findings, each
checked against the tree, and their dispositions are in
`docs/7511-ha-rolling-upgrade-security-entry-capability-gate.md`; two of them became #7548 and #7549.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEJXCdUGW61QSXqyurphpt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added compatibility checks before replicating security-group changes and API-token operations during mixed-version rolling upgrades.
  - Operations are refused when a cluster peer cannot decode the required entry, preventing unsafe commits.
  - Refused requests identify the blocking peer and return HTTP 409 Conflict or gRPC `FAILED_PRECONDITION`.
  - Added a configuration setting to enable or disable the capability gate, enabled by default.
  - Capability checks now refresh peer status when needed, including on follower nodes.
  - Refusal details remain available in production-safe error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->