### PR TITLE
fix(#7507): bound the follower-to-leader HTTP forward so a wedged leader cannot park a worker

### DIFF
--- a/docs/7507-leader-forward-timeouts.md
+++ b/docs/7507-leader-forward-timeouts.md
@@ -186,7 +186,7 @@ have their own issue.
 
 | Test | What it pins |
 |---|---|
-| `aLeaderThatAcceptsAndNeverAnswersIsGivenUpOnAndAnswered504` | the reported failure over a real socket: a `ServerSocket` that accepts and never replies. `StallAwareStopwatch.assertGaveUpWithin` is the tripwire between the 1 s deadline and the unbounded wait; the answer is 504 and names the address and the setting |
+| `aLeaderThatAcceptsAndNeverAnswersIsGivenUpOnAndAnswered504` | the reported failure over a real socket: a `ServerSocket` that accepts and never replies. `StallAwareStopwatch.assertGaveUpWithin` is the tripwire between the 1 s deadline and the unbounded wait; the answer is 504, it names the address and the setting, and the connection is torn down rather than leaked |
 | `aLeaderThatAnswersTheHeadersAndThenStallsMidBodyIsAlsoGivenUpOn` | the case `HttpRequest.timeout` alone does not catch: a complete response head promising 100 bytes, then five (adversarial finding 1) |
 | `aLeaderThatCannotBeConnectedToIsAnsweredWithItsOwnGatewayTimeout` | a failure to connect names `HA_PROXY_CONNECT_TIMEOUT`, not the response one, and says the command did not run |
 | `everyForwardedRequestCarriesTheDefaultDeadline` | the `POST` / `PUT` / `DELETE` `/server/users` shapes all come out with the configured deadline attached |
@@ -194,7 +194,7 @@ have their own issue.
 | `onlyRestoreAndImportAreClassifiedAsLongRunning` | all seven forwarded commands, each classified |
 | `theClientCarriesTheConfiguredConnectTimeout` | the connect half of the bound |
 | `responseDeadlineIsReReadOnEveryForward` | `SET SERVER SETTING` moves the deadline without a restart |
-| `zeroOrNegativeTimeoutClampsInsteadOfDisablingTheBound` | 0 is not a back door to the old behaviour |
+| `zeroOrNegativeTimeoutClampsInsteadOfDisablingTheBound` | 0 is not a back door to the old behaviour - it clamps, and says so once in the log |
 
 `Issue7507ForwarderClientLifecycleTest.java`, 1 test: a real server on a free port, started and
 stopped, asserting `stopService()` releases the forwarder's `HttpClient` (adversarial finding 3).

--- a/docs/7507-leader-forward-timeouts.md
+++ b/docs/7507-leader-forward-timeouts.md
@@ -120,6 +120,14 @@ effect without a restart.
 
 ### Residual risk
 
+A forwarded `restore` or `import` still occupies its Undertow worker thread for as long as it runs,
+now up to `HA_PROXY_LONG_COMMAND_TIMEOUT` (1 h by default) rather than forever. That is the bug
+fixed - bounded instead of unbounded - but it is not the same as cheap: several concurrent forwarded
+restores still hold several workers for the duration. Handing the forward off to a thread that is not
+a request worker would remove even that, and is a different change from this one. Flagged rather than
+filed: nobody has hit it, and the shape of the fix depends on whether the client is meant to keep
+holding the connection.
+
 The two rows marked "filed" above still use an unbounded client: `/api/v1/batch`'s forward (#7542)
 and the Raft SQL-write forward (#7543). Both are outside this issue - different call paths, and
 their deadlines are separate policy questions (the batch forward streams a body of arbitrary size;

--- a/docs/7507-leader-forward-timeouts.md
+++ b/docs/7507-leader-forward-timeouts.md
@@ -1,0 +1,314 @@
+# #7507 - the follower-to-leader HTTP forward has no request timeout
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/7507
+Type: bug (labels: `bug`, `ha`, `server`, `concurrency`, milestone 26.10.1)
+
+## Symptom
+
+`LeaderCommandForwarder` dials the leader with a bare `HttpClient.newHttpClient()` and builds the
+request without `.timeout(...)`. There is neither a connect timeout nor a response deadline. The
+method runs on an Undertow **worker** thread - every calling handler returns `true` from
+`mustExecuteOnWorkerThread()` - so a leader that accepts the connection and then never answers holds
+that worker until the OS tears the socket down. Enough concurrent admin requests and the follower
+stops serving anything.
+
+## Root cause
+
+```java
+// server/.../handler/LeaderCommandForwarder.java (before)
+private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();   // no connectTimeout
+...
+final HttpRequest.Builder builder = HttpRequest.newBuilder().uri(leaderUri); // no .timeout(...)
+```
+
+`HttpClient.newHttpClient()` has no connect timeout, and a request built without `.timeout(...)`
+has no response deadline, so `HttpClient.send` blocks for as long as the peer keeps the socket open.
+
+## Why the obvious fix is wrong
+
+`forwardToLeaderIfReplica` carries seven commands, three of which legitimately run for minutes:
+
+```
+$ sed -n '100,106p' server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+    if (command_lc.startsWith(CREATE_DATABASE) || command_lc.startsWith(DROP_DATABASE) ||
+        command_lc.startsWith(CREATE_USER) || command_lc.startsWith(DROP_USER) ||
+        command_lc.startsWith(RESTORE_BACKUP) || command_lc.startsWith(RESTORE_DATABASE) ||
+        command_lc.startsWith(IMPORT_DATABASE)) {
+```
+
+A single `HA_PROXY_READ_TIMEOUT` (30 s) applied to every forward would start aborting `restore
+backup`, `restore database` and `import database` - exactly the operations that most need to reach
+the leader. The connect timeout is unconditionally safe; the response deadline has to distinguish
+the long-running commands from the rest.
+
+## Invariant
+
+**Every follower-to-leader HTTP forward issued by `LeaderCommandForwarder` completes, or fails with
+a typed HTTP 504, within a configured finite deadline - it can never park an Undertow worker thread
+indefinitely.**
+
+## Completeness
+
+### Enumerate every way to violate it
+
+Callers of the forwarder (every entry point that can park a worker on it):
+
+```
+$ grep -rn 'forwardIfReplica' --include='*.java' */src/main/java
+server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java:643
+server/src/main/java/com/arcadedb/server/http/handler/PutUserHandler.java:54
+server/src/main/java/com/arcadedb/server/http/handler/DeleteUserHandler.java:50
+server/src/main/java/com/arcadedb/server/http/handler/PostUserHandler.java:53
+server/src/main/java/com/arcadedb/server/http/handler/LeaderCommandForwarder.java:98   (the declaration)
+```
+
+Same-shape siblings - a `java.net.http.HttpClient` built with no connect timeout, or a request built
+with no `.timeout(...)`, sent from a server thread:
+
+```
+$ grep -rn 'HttpClient.newHttpClient()' --include='*.java' */src/main/java
+ha-raft/.../RaftReplicatedDatabase.java:309
+server/.../handler/PostBatchHandler.java:237
+server/.../handler/LeaderCommandForwarder.java:61
+
+$ grep -n '\.timeout(' server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
+(no output)
+$ grep -n '\.timeout(' ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+(no output)
+```
+
+Both of those are unbounded the same way, on different call paths (see the table).
+
+The remaining `HttpClient` users in `src/main/java` are bounded already:
+
+```
+$ grep -n '.timeout(\|mustExecuteOnWorkerThread' server/src/main/java/com/arcadedb/server/ai/AiChatHandler.java
+95:  protected boolean mustExecuteOnWorkerThread() {
+243:        .timeout(Duration.ofMinutes(5))
+411:        .timeout(Duration.ofSeconds(15))
+468:        .timeout(Duration.ofSeconds(120))
+```
+
+(`AiActivateHandler` 15 s, `AiAnalyzeProfilerHandler` 120 s, all three with
+`.connectTimeout(Duration.ofSeconds(10))` on the client; `LeaderProxy` sets both.)
+
+### Coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| `POST /api/v1/server` `create database` / `drop database` / `create user` / `drop user` -> `LeaderCommandForwarder.forwardIfReplica` (default deadline) | yes | yes |
+| `POST /api/v1/server` `restore backup` / `restore database` / `import database` -> same, long-running deadline | yes | yes |
+| `POST /api/v1/server/users` -> `PostUserHandler` -> `forwardIfReplica` (default deadline) | yes | yes |
+| `PUT /api/v1/server/users` -> `PutUserHandler` -> `forwardIfReplica` (default deadline) | yes | yes |
+| `DELETE /api/v1/server/users` -> `DeleteUserHandler` -> `forwardIfReplica` (default deadline) | yes | yes |
+| leader black-holes the TCP connect (no accept) -> client connect timeout | yes | yes |
+| leader accepts and never answers -> request deadline -> HTTP 504 | yes | yes |
+| `POST /api/v1/batch/{db}` -> `PostBatchHandler.forwardBatchToLeader` (bare `HttpClient`, no request deadline) | no - filed as #7542 | no |
+| `RaftReplicatedDatabase.forwardCommandToLeader` (bare `HttpClient`, no request deadline) | no - filed as #7543 | no |
+| `LeaderProxy.tryProxy` | argued: already bounded (`connectTimeout` + `builder.timeout(readTimeoutMs)`), and dead code - `grep -rn 'new LeaderProxy' --include='*.java' .` returns nothing |
+| `AiChatHandler`, `AiActivateHandler`, `AiAnalyzeProfilerHandler` | argued: connect timeout on the client and an explicit `.timeout(...)` on every request (greps above) |
+| `RemoteHttpComponent` (network module) | argued: client-side driver, not a server worker thread; sets `.connectTimeout(Duration.ofSeconds(60))` |
+
+### Reachability
+
+`LeaderCommandForwarder` is constructed on a live path - `HttpServer` line 153,
+`this.leaderCommandForwarder = new LeaderCommandForwarder(this)` - and reached from all four
+handlers above. No feature flag gates it. The connect timeout is read once when the client is
+built (an `HttpClient`'s connect timeout is immutable); the response deadlines are re-read from
+`ContextConfiguration` on every forward, so `SET SERVER SETTING arcadedb.ha.proxyReadTimeout` takes
+effect without a restart.
+
+### Residual risk
+
+The two rows marked "filed" above still use an unbounded client: `/api/v1/batch`'s forward (#7542)
+and the Raft SQL-write forward (#7543). Both are outside this issue - different call paths, and
+their deadlines are separate policy questions (the batch forward streams a body of arbitrary size;
+a forwarded SQL command's duration is bounded by the query, not by a command name) - and both now
+have their own issue.
+
+## The fix
+
+### `GlobalConfiguration`
+
+- **New** `HA_PROXY_LONG_COMMAND_TIMEOUT` (`arcadedb.ha.proxyLongCommandTimeout`, `Long`, default
+  `3_600_000` ms): the deadline for a forwarded `restore backup` / `restore database` /
+  `import database`. Finite, because it is still a worker thread that waits, but wide enough not to
+  abort a real restore.
+- `HA_PROXY_READ_TIMEOUT` and `HA_PROXY_CONNECT_TIMEOUT` keep their keys and defaults (30 s / 5 s);
+  their descriptions said "for the leader proxy in `AbstractServerHttpHandler`", which named only
+  `LeaderProxy` - dead code, nothing constructs it. They now say what they actually bound and where.
+
+### `LeaderCommandForwarder`
+
+- The static `HttpClient.newHttpClient()` becomes a per-instance client built with
+  `.connectTimeout(HA_PROXY_CONNECT_TIMEOUT)`. One `LeaderCommandForwarder` per `HttpServer`, so the
+  client picks up that server's configuration instead of a JVM-wide default.
+- A new package-private `Transport` owns the client and the deadlines. `Transport.newRequest` is the
+  only way the class builds a request and it attaches `.timeout(responseTimeout(longRunningCommand))`
+  unconditionally, so no call site can issue an unbounded forward.
+- `Transport.send` issues the exchange with `sendAsync` and awaits it with the same deadline applied
+  to the **whole** exchange, cancelling the future when it expires. `HttpRequest.timeout` alone is not
+  enough - see the adversarial pass below - but it is kept, because it aborts the exchange at the JDK
+  level rather than only releasing this thread.
+- A blown deadline comes back as **HTTP 504** naming the leader address, the deadline that actually
+  applied (read back off the request, so the message cannot quote a number the forward was never
+  given) and the setting that bounds it, plus one `WARNING` in the follower's log. Previously an
+  `HttpTimeoutException` would have escaped as an `IOException` and degraded to a generic 500.
+- A connect timeout gets its own 504 naming `HA_PROXY_CONNECT_TIMEOUT`, because it is a different
+  failure pointing at a different knob - and it is the one case where the follower can promise the
+  command did not run.
+- The client is released in `HttpServer.stopService()`. It is per-`HttpServer` now rather than a JVM
+  static, and a `java.net.http.HttpClient` owns a selector thread and an executor.
+- `forwardIfReplica` gains a 5-argument overload taking `longRunningCommand`; the existing 4-argument
+  signature delegates with `false`, so the three `/server/users` handlers are unchanged and get the
+  ordinary deadline.
+- 0 or a negative configured value clamps to 1 ms rather than falling back to the default. Both JDK
+  builders reject a non-positive `Duration`, and treating 0 as "no timeout" would put back the exact
+  behaviour this issue removes.
+
+### `PostServerCommandHandler`
+
+- New package-private `isLongRunningForwardedCommand(String)`, and the forward passes its result
+  through. `restore backup`, `restore database` and `import database` are true; `create database`,
+  `drop database`, `create user`, `drop user` are false.
+
+## Tests
+
+`server/src/test/java/com/arcadedb/server/http/handler/Issue7507LeaderForwardTimeoutTest.java`, 9 tests:
+
+| Test | What it pins |
+|---|---|
+| `aLeaderThatAcceptsAndNeverAnswersIsGivenUpOnAndAnswered504` | the reported failure over a real socket: a `ServerSocket` that accepts and never replies. `StallAwareStopwatch.assertGaveUpWithin` is the tripwire between the 1 s deadline and the unbounded wait; the answer is 504 and names the address and the setting |
+| `aLeaderThatAnswersTheHeadersAndThenStallsMidBodyIsAlsoGivenUpOn` | the case `HttpRequest.timeout` alone does not catch: a complete response head promising 100 bytes, then five (adversarial finding 1) |
+| `aLeaderThatCannotBeConnectedToIsAnsweredWithItsOwnGatewayTimeout` | a failure to connect names `HA_PROXY_CONNECT_TIMEOUT`, not the response one, and says the command did not run |
+| `everyForwardedRequestCarriesTheDefaultDeadline` | the `POST` / `PUT` / `DELETE` `/server/users` shapes all come out with the configured deadline attached |
+| `longRunningCommandsGetTheLongerDeadline` | a long-running forward uses `HA_PROXY_LONG_COMMAND_TIMEOUT`, and it is the larger of the two |
+| `onlyRestoreAndImportAreClassifiedAsLongRunning` | all seven forwarded commands, each classified |
+| `theClientCarriesTheConfiguredConnectTimeout` | the connect half of the bound |
+| `responseDeadlineIsReReadOnEveryForward` | `SET SERVER SETTING` moves the deadline without a restart |
+| `zeroOrNegativeTimeoutClampsInsteadOfDisablingTheBound` | 0 is not a back door to the old behaviour |
+
+`Issue7507ForwarderClientLifecycleTest.java`, 1 test: a real server on a free port, started and
+stopped, asserting `stopService()` releases the forwarder's `HttpClient` (adversarial finding 3).
+
+### Proof the tests can fail
+
+Four mutations, each run against the tests they should break - the table at the end of this document.
+
+### Test results
+
+```
+mvn -o -pl server test -Dtest=Issue7507LeaderForwardTimeoutTest,Issue7507ForwarderClientLifecycleTest,OpenApiSpecGeneratorTest
+  Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
+
+mvn -o -pl server test -Dtest=Issue7507LeaderForwardTimeoutTest,LeaderProxyTest,ExecutionResponseTest,PostBatchHandlerForwardRequestTest
+  Tests run: 24, Failures: 0, Errors: 0, Skipped: 0
+
+mvn -o -pl engine test -Dtest=ConfigurationTest,ContextConfigurationTest,GlobalConfigurationTest,GlobalConfigurationReadinessHATest,Issue7121GlobalConfigurationSweepTest,...
+  Tests run: 109, Failures: 0, Errors: 0, Skipped: 0
+
+mvn -o -pl ha-raft test -Dtest=HAConfigDefaultsTest
+  Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
+
+mvn -o install -DskipTests      # full reactor, main + test sources of every module
+  BUILD SUCCESS
+```
+
+Not run locally: the server-module suites that bind port 2480. Two other JVMs held that port for the
+whole session (`lsof -nP -iTCP:2480 -sTCP:LISTEN`), and a run against an occupied port reports
+authentication errors rather than a port conflict. Those suites do not reach the changed code anyway -
+`forwardIfReplica` returns null immediately when `getHA()` is null, which is every non-HA test server -
+and CI runs them.
+
+## Impact
+
+- A wedged leader now costs a follower one worker thread for at most `HA_PROXY_READ_TIMEOUT`
+  (30 s by default), or `HA_PROXY_LONG_COMMAND_TIMEOUT` (1 h) for a restore or an import, instead of
+  until the OS tears the socket down.
+- Clients of the four forwarding routes can see a new status: **504** where they previously saw the
+  request hang and eventually fail as a 500. The body is JSON with an `error` field, the same shape
+  every other error on these routes uses.
+- No behaviour change when the leader answers normally, and none at all on a leader or a non-HA server:
+  `forwardIfReplica` still returns null before touching the transport.
+- One `java.net.http.HttpClient` per `HttpServer` rather than one per JVM, released on `stopService()`.
+
+
+## Adversarial pass
+
+No isolated subagent was available in this session (no `Task` tool), so the pass was run against the
+cold diff rather than by a second agent - a weaker version of the exercise, and worth saying so. It
+found five things; four were real and are fixed here.
+
+### 1. `HttpRequest.timeout` does not cover a body that stalls after the headers (REAL - fixed here)
+
+The first version of the fix attached `.timeout(...)` to the request and called `HttpClient.send`.
+That bounds the wait for the response **headers** only. Measured, against a socket that answered a
+complete response head promising `Content-Length: 100` and then wrote five bytes:
+
+```
+HttpRequest.timeout = 1500ms, waited > 180s, send() had still not returned
+```
+
+A leader wedged *after* answering would therefore still have parked the worker thread - the exact bug
+this issue is about, surviving its own fix. `Transport.send` now awaits the exchange with
+`sendAsync(...).get(deadline)` so the bound covers the body, and
+`aLeaderThatAnswersTheHeadersAndThenStallsMidBodyIsAlsoGivenUpOn` pins it.
+
+### 2. The connect timeout named the response-timeout setting (REAL - fixed here)
+
+`HttpConnectTimeoutException` extends `HttpTimeoutException`, so the single catch answered a failure
+to *connect* with "did not answer within ... (arcadedb.ha.proxyReadTimeout)", sending the operator to
+the wrong setting. Verified against a live JDK 21 runtime dialling 192.0.2.1 (RFC 5737 TEST-NET-1)
+with an 800 ms connect timeout:
+
+```
+cause=java.net.http.HttpConnectTimeoutException  msg=HTTP connect timed out
+cause.cause=java.net.ConnectException
+```
+
+There is now a separate arm and a separate message. It is not driven over a real socket in the tests -
+no address reliably black-holes a connect on every CI network - so the branch is argued by the
+measurement above and the message pinned by
+`aLeaderThatCannotBeConnectedToIsAnsweredWithItsOwnGatewayTimeout`.
+
+### 3. The per-server `HttpClient` was never released (REAL - fixed here)
+
+Giving the forwarder the server's configured connect timeout meant one client per `HttpServer` in
+place of one JVM static, and each owns a selector thread and an executor. Nothing closed it.
+`HttpServer.stopService()` now calls `LeaderCommandForwarder.close()`, and
+`Issue7507ForwarderClientLifecycleTest` starts a real server on a free port, stops it, and asserts the
+client is terminated (it fails if the one-line wiring is removed).
+
+### 4. The 504 told the client the command had not run (REAL - fixed here)
+
+The first message said "The command was not executed on this node: retry it". True but misleading: the
+leader may well be executing it, and `restore database` is not something to retry blind. The message
+now says the command may still be running on the leader and to check there before retrying. The
+connect-timeout 504 is the only one that says the command did not run, because that is the only case
+where the follower knows.
+
+### 5. The new 504 was undocumented in the OpenAPI spec (REAL - fixed here)
+
+`POST /api/v1/server` and the three write operations on `/api/v1/server/users` now declare it.
+Deliberately not added to the shared helpers: `createCommandResponses()` is also used by
+`POST /api/v1/command/{database}`, and `createAdminResponses()` by the groups, API-token and
+list-users operations, none of which forward.
+
+### Not real
+
+- *"`ConnectException` (connection refused) now surfaces differently."* It does not. `sendAsync` wraps
+  it in an `ExecutionException`, and the `cause instanceof IOException io -> throw io` arm rethrows the
+  original, so a refused connection reaches the handler exactly as before.
+- *"The group and API-token routes forward too."* They do not:
+  `grep -rn 'forwardIfReplica' --include='*.java' */src/main/java` lists four call sites and none of
+  them is `PostGroupHandler`, `DeleteGroupHandler`, `PostApiTokenHandler` or `DeleteApiTokenHandler`.
+  That those routes do not forward at all is a separate gap, not this one.
+
+## Proof the tests can fail (all four mutations)
+
+| Mutation | Result |
+|---|---|
+| drop `.timeout(...)` from `Transport.newRequest` | `Tests run: 3, Failures: 3` |
+| rethrow instead of mapping the timeout to 504 | `aLeaderThatAcceptsAndNeverAnswers... » HttpTimeout request timed out` |
+| widen the future's await to 600 s (an unbounded wait in practice) | `There was a timeout in the fork` under `-Dsurefire.timeout=45` |
+| remove `leaderCommandForwarder.close()` from `stopService()` | `Tests run: 1, Failures: 1` |

--- a/docs/7507-leader-forward-timeouts.md
+++ b/docs/7507-leader-forward-timeouts.md
@@ -320,3 +320,25 @@ list-users operations, none of which forward.
 | rethrow instead of mapping the timeout to 504 | `aLeaderThatAcceptsAndNeverAnswers... » HttpTimeout request timed out` |
 | widen the future's await to 600 s (an unbounded wait in practice) | `There was a timeout in the fork` under `-Dsurefire.timeout=45` |
 | remove `leaderCommandForwarder.close()` from `stopService()` | `Tests run: 1, Failures: 1` |
+
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/7556
+
+## Review cycles
+
+| Cycle | Head | Outcome |
+|---|---|---|
+| 1 | `ea3669cc` | Non-blocking. One substantive finding: the rewritten `HA_PROXY_CONNECT_TIMEOUT` description named two live readers and there are three (`RaftHAPlugin.authSessionRpcTimeoutMs()`). Applied, with the catch-arm ordering comment, the shared OpenAPI constant and the import order. One item declined - a typed 504 for a refused connection - see `docs/review-deferred-ea3669cc.md` |
+| 2 | `e068e59b` | Non-blocking. One nit: a fully-qualified `java.net.InetAddress` in the test. Applied. The review's flagged tradeoff - a forwarded restore still holds a worker for up to an hour - is recorded under Residual risk above |
+| 3 | `d64f71fa` | Non-blocking. Three nits applied (import block, setting keys in the OpenAPI string, a WARNING when a timeout clamps). One question - "does giving up actually close the socket?" - turned into an assertion after measuring it: `docs/review-deferred-d64f71fa.md` |
+| 4 | `734d1c6b` | "No blocking issues found." Two nits applied: the clamp warning is now per setting, and the descriptions no longer present dormant `LeaderProxy` as a live reader. `docs/review-deferred-734d1c6b.md` |
+
+## Final state
+
+`max-cycles-reached` - the loop ran its four cycles. Every review was non-blocking and every
+actionable item was applied; the one declined item is argued in
+`docs/review-deferred-ea3669cc.md`. The cycle-4 commit has not itself been reviewed.
+
+Merge is the developer's.

--- a/docs/review-deferred-734d1c6b.md
+++ b/docs/review-deferred-734d1c6b.md
@@ -1,0 +1,23 @@
+# Review cycle 4 (734d1c6b) - dispositions
+
+The `claude` review on `734d1c6b9b384635704f5e07a2abd4e0b40648f9` said "No blocking issues found" and
+raised two nits. Both were fair and both are applied. Nothing deferred.
+
+1. **One `clampWarned` flag for three settings.** If an operator set two of
+   `HA_PROXY_READ_TIMEOUT`, `HA_PROXY_LONG_COMMAND_TIMEOUT` and `HA_PROXY_CONNECT_TIMEOUT` to 0, only
+   the first clamp would have been reported and the second would have been exactly the silent clamp
+   the warning exists to prevent. It is now a `Set<GlobalConfiguration>`, so each setting reports once.
+   Visible in the `zeroOrNegativeTimeoutClampsInsteadOfDisablingTheBound` run, which misconfigures all
+   three and now logs three lines where it logged one.
+
+2. **The rewritten descriptions named `LeaderProxy` as a live reader.** This PR's own sweep
+   established that nothing constructs `LeaderProxy` (`grep -rn 'new LeaderProxy' --include='*.java' .`
+   returns nothing), and then the description said the setting "applies to" it without that caveat -
+   which would send a maintainer looking for a call site that does not exist. Both descriptions now
+   say the path is dormant.
+
+## Note on this being the last cycle
+
+`--max-cycles=4` is exhausted, so the commit carrying these two changes has not itself been through a
+review cycle. Both are small and localised - a `Set` in place of an `AtomicBoolean`, and two setting
+description strings - and the full reactor build plus the affected test classes are green on it.

--- a/docs/review-deferred-d64f71fa.md
+++ b/docs/review-deferred-d64f71fa.md
@@ -1,0 +1,48 @@
+# Review cycle 3 (d64f71fa) - dispositions
+
+Five items from the `claude` review on `d64f71fac0a704bf9db6194c4327061a6e898c69`, none blocking.
+Three applied, one verified and turned into an assertion, one recorded.
+
+## Applied
+
+1. **Stray blank line splitting the `java.*` import block** in `LeaderCommandForwarder` - removed. It
+   predated this PR, but the PR moved imports around it, so it is this PR's to tidy.
+2. **`SpecBuilders.LEADER_FORWARD_TIMEOUT_DESCRIPTION` hardcoded the setting keys** as string
+   literals while `Transport.gaveUp`/`couldNotConnect` a few lines away used `getKey()`. It now reads
+   `GlobalConfiguration.HA_PROXY_READ_TIMEOUT.getKey()` and
+   `HA_PROXY_LONG_COMMAND_TIMEOUT.getKey()`, so a rename cannot leave the OpenAPI string stale.
+5. **The 0-clamps-to-1ms behaviour was silent.** It is deliberate - 0 must not be a way back to the
+   unbounded wait - but an operator who typed 0 expecting "no timeout" would have got an unexplained
+   wall of 504s. `Transport.bounded` now logs one WARNING naming the setting, the value and the clamp.
+   Once per `Transport`, because the response deadline is re-read on every forward.
+
+## Verified, and now asserted
+
+3. **"Does `pending.cancel(true)` actually tear the connection down, or only release the worker?"**
+   The right question, and it was not covered. It is now:
+   `aLeaderThatAcceptsAndNeverAnswersIsGivenUpOnAndAnswered504` reads from the stalled leader's
+   accepted socket after the 504 and asserts the client end closes within 10 s. It closes in about
+   200 ms.
+
+   Two mutations show why the assertion is not vacuous, and that the teardown has two independent
+   causes rather than one:
+
+   | Mutation | Socket still closed? |
+   |---|---|
+   | remove `pending.cancel(true)` | yes - the request-level `.timeout()` aborts the exchange at the JDK level |
+   | remove `.timeout(...)` from `newRequest`, keep the cancel | yes - cancelling the future tears the exchange down |
+
+   So neither mechanism is load-bearing alone for teardown, which is a stronger answer than the one
+   the review asked for. Both are kept: the future's deadline is the only one that covers a body that
+   stalls after the headers, and the request timeout is the only one that acts when this thread is not
+   the one waiting.
+
+## Recorded, no change
+
+4. **One `HttpClient` per `HttpServer` instead of one JVM-wide static** - "in case any harness
+   bypasses the normal stop path". Checked: `ArcadeDBServer.stop()` reaches `httpServer::stopService`
+   through `CodeUtils.executeIgnoringExceptions`, and `Issue7507ForwarderClientLifecycleTest` drives a
+   real start/stop and asserts the client is terminated (it fails if the wiring is removed). A harness
+   that leaks a server without stopping it leaks the databases and the Undertow worker pool too, which
+   is a much larger leak than one selector thread - so the client is not the thing that would surface
+   such a harness, and making it a special case would not help. Left as is.

--- a/docs/review-deferred-ea3669cc.md
+++ b/docs/review-deferred-ea3669cc.md
@@ -1,0 +1,42 @@
+# Review cycle 1 (ea3669cc) - items not applied
+
+One item from the `claude` review on `ea3669cc64be09ec6b787c69c1b5fe411fd89dc3` was deliberately not
+applied. Everything else it raised was actionable and is in the follow-up commit.
+
+## Not applied: a typed 504 for "connection refused" as well
+
+> The "connection refused" (leader process down, port not listening) case still falls through to the
+> generic `IOException`/500 path rather than getting a typed 504 like the connect-timeout and
+> response-timeout cases do. [...] just flagging it as a possible follow-up if operators end up
+> wanting a consistent 504 shape for every leader-unreachable case.
+
+**Disposition: declined for this PR, and not filed as an issue either.** The reviewer flagged it as a
+possible follow-up rather than a defect, and the reason it is outside this issue is structural rather
+than a matter of effort.
+
+This issue is about a wait that never ends. A refused connection is the opposite: the kernel answers
+`ECONNREFUSED` on the first round trip, the worker thread is returned immediately, and nothing is
+parked. It cannot violate the invariant this PR establishes, so it is not a blank row in the
+completeness table - it is a row that cannot reach the bug.
+
+What is left is a consistency argument about response shape: three ways of failing to reach the
+leader, two of which now answer 504 and one of which answers 500. That is a real if minor wart, but
+turning it into a 504 is a client-visible status change to a path that is behaving correctly today,
+and it is not obviously right - a 500 for "the leader process is not running" is arguably more honest
+than a gateway *timeout* for something that did not time out. That decision wants an operator with a
+concrete complaint behind it, which is exactly the kind of speculative issue that should not be filed
+pre-emptively.
+
+If it is wanted, the change is one arm in `LeaderCommandForwarder.Transport.send`, next to the two
+that already exist.
+
+## Applied from the same review
+
+- `HA_PROXY_CONNECT_TIMEOUT`'s rewritten description named two live readers and there are three:
+  `RaftHAPlugin.authSessionRpcTimeoutMs()` reads it as the budget for a whole peer auth-session RPC.
+  Verified (`grep -rn 'HA_PROXY_CONNECT_TIMEOUT' --include='*.java' */src/main/java`) and corrected -
+  a description rewritten to be authoritative has to actually be exhaustive.
+- The `HttpConnectTimeoutException` arm's position is now called out as load-bearing at the `if`,
+  naming the test that would catch a reorder.
+- The duplicated 504 description is now `SpecBuilders.LEADER_FORWARD_TIMEOUT_DESCRIPTION`.
+- Import ordering in `LeaderCommandForwarder`.

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2033,8 +2033,9 @@ public enum GlobalConfiguration {
   HA_PROXY_READ_TIMEOUT("arcadedb.ha.proxyReadTimeout", SCOPE.SERVER,
       """
       Milliseconds a follower waits for the leader to answer a request it forwarded before giving up and \
-      answering the client HTTP 504. Applies to the administrative forwards of LeaderCommandForwarder (the \
-      commands of POST /api/v1/server and the POST/PUT/DELETE /api/v1/server/users routes) and to LeaderProxy. \
+      answering the client HTTP 504. The live reader is LeaderCommandForwarder: the commands of \
+      POST /api/v1/server and the POST/PUT/DELETE /api/v1/server/users routes. LeaderProxy reads it too, but \
+      nothing constructs LeaderProxy, so that path is dormant. \
       The forward runs on an HTTP worker thread, so this is the bound that stops a wedged leader from parking \
       one indefinitely; 0 or a negative value does not disable it. The forwarded commands that legitimately run \
       for minutes - 'restore backup', 'restore database' and 'import database' - use \
@@ -2052,9 +2053,9 @@ public enum GlobalConfiguration {
 
   HA_PROXY_CONNECT_TIMEOUT("arcadedb.ha.proxyConnectTimeout", SCOPE.SERVER,
       """
-      Connect timeout in milliseconds for a follower dialling the leader, used by LeaderCommandForwarder and \
-      LeaderProxy. Bounds the half of the failure the response deadline cannot see: a leader whose host accepts \
-      no connection. Read once when the HTTP client is built, because a java.net.http.HttpClient's connect \
+      Connect timeout in milliseconds for a follower dialling the leader, used by LeaderCommandForwarder (and \
+      by LeaderProxy, which nothing currently constructs). Bounds the half of the failure the response deadline \
+      cannot see: a leader whose host accepts no connection. Read once when the HTTP client is built, because a java.net.http.HttpClient's connect \
       timeout is fixed at build time - a change needs a restart. RaftHAPlugin also reads it, as the budget for \
       one whole peer authentication-session RPC rather than only that RPC's connect phase: those are small \
       requests on a LAN with a client waiting on a 401-or-200, so the connect budget is the right order of \

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2055,7 +2055,10 @@ public enum GlobalConfiguration {
       Connect timeout in milliseconds for a follower dialling the leader, used by LeaderCommandForwarder and \
       LeaderProxy. Bounds the half of the failure the response deadline cannot see: a leader whose host accepts \
       no connection. Read once when the HTTP client is built, because a java.net.http.HttpClient's connect \
-      timeout is fixed at build time - a change needs a restart.""",
+      timeout is fixed at build time - a change needs a restart. RaftHAPlugin also reads it, as the budget for \
+      one whole peer authentication-session RPC rather than only that RPC's connect phase: those are small \
+      requests on a LAN with a client waiting on a 401-or-200, so the connect budget is the right order of \
+      magnitude for the lot.""",
       Long.class, 5000L),
 
   HA_PROXY_MAX_BODY_SIZE("arcadedb.ha.proxyMaxBodySize", SCOPE.SERVER,

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2031,11 +2031,31 @@ public enum GlobalConfiguration {
       Long.class, 60_000L),
 
   HA_PROXY_READ_TIMEOUT("arcadedb.ha.proxyReadTimeout", SCOPE.SERVER,
-      "Read timeout in milliseconds for the leader proxy in AbstractServerHttpHandler. Covers long-running queries proxied from a follower to the leader.",
+      """
+      Milliseconds a follower waits for the leader to answer a request it forwarded before giving up and \
+      answering the client HTTP 504. Applies to the administrative forwards of LeaderCommandForwarder (the \
+      commands of POST /api/v1/server and the POST/PUT/DELETE /api/v1/server/users routes) and to LeaderProxy. \
+      The forward runs on an HTTP worker thread, so this is the bound that stops a wedged leader from parking \
+      one indefinitely; 0 or a negative value does not disable it. The forwarded commands that legitimately run \
+      for minutes - 'restore backup', 'restore database' and 'import database' - use \
+      arcadedb.ha.proxyLongCommandTimeout instead. Re-read on every forward.""",
       Long.class, 30000L),
 
+  HA_PROXY_LONG_COMMAND_TIMEOUT("arcadedb.ha.proxyLongCommandTimeout", SCOPE.SERVER,
+      """
+      Milliseconds a follower waits for the leader to answer a forwarded 'restore backup', 'restore database' \
+      or 'import database' before giving up and answering the client HTTP 504. These commands legitimately run \
+      for minutes, so arcadedb.ha.proxyReadTimeout would abort exactly the operations that most need to reach \
+      the leader - but the wait still has to be finite, because it is an HTTP worker thread that is waiting. \
+      0 or a negative value does not disable it. Re-read on every forward.""",
+      Long.class, 3_600_000L),
+
   HA_PROXY_CONNECT_TIMEOUT("arcadedb.ha.proxyConnectTimeout", SCOPE.SERVER,
-      "Connect timeout in milliseconds for the leader proxy in AbstractServerHttpHandler.",
+      """
+      Connect timeout in milliseconds for a follower dialling the leader, used by LeaderCommandForwarder and \
+      LeaderProxy. Bounds the half of the failure the response deadline cannot see: a leader whose host accepts \
+      no connection. Read once when the HTTP client is built, because a java.net.http.HttpClient's connect \
+      timeout is fixed at build time - a change needs a restart.""",
       Long.class, 5000L),
 
   HA_PROXY_MAX_BODY_SIZE("arcadedb.ha.proxyMaxBodySize", SCOPE.SERVER,

--- a/server/src/main/java/com/arcadedb/server/http/HttpServer.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpServer.java
@@ -188,6 +188,7 @@ public class HttpServer implements ServerPlugin {
 
     sessionManager.close();
     authSessionManager.close();
+    leaderCommandForwarder.close();
   }
 
   @Override

--- a/server/src/main/java/com/arcadedb/server/http/handler/LeaderCommandForwarder.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/LeaderCommandForwarder.java
@@ -38,7 +38,9 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpTimeoutException;
 import java.time.Duration;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -246,8 +248,13 @@ public final class LeaderCommandForwarder {
     private static final long MIN_TIMEOUT_MS = 1L;
 
     private final ContextConfiguration configuration;
-    private final AtomicBoolean        clampWarned = new AtomicBoolean(false);
-    private final HttpClient           client;
+    /**
+     * Which settings have already had their clamp reported. Per setting rather than one flag for the three:
+     * misconfiguring two of them at once is not less confusing than misconfiguring one, and a shared flag would
+     * report only whichever clamped first.
+     */
+    private final Set<GlobalConfiguration> clampWarned = ConcurrentHashMap.newKeySet();
+    private final HttpClient               client;
 
     Transport(final ContextConfiguration configuration) {
       this.configuration = configuration;
@@ -414,12 +421,12 @@ public final class LeaderCommandForwarder {
       if (configuredMs >= MIN_TIMEOUT_MS)
         return Duration.ofMillis(configuredMs);
 
-      if (clampWarned.compareAndSet(false, true))
+      if (clampWarned.add(setting))
         LogManager.instance().log(this, Level.WARNING,
             "%s is set to %,d, which does not switch the bound off - a follower-to-leader forward is never "
                 + "unbounded. It is clamped to %,d ms instead, so forwarded administrative commands on this node "
                 + "will fail almost immediately. Set a positive value in milliseconds. This notice is logged only "
-                + "once.", setting.getKey(), configuredMs, MIN_TIMEOUT_MS);
+                + "once per setting.", setting.getKey(), configuredMs, MIN_TIMEOUT_MS);
 
       return Duration.ofMillis(MIN_TIMEOUT_MS);
     }

--- a/server/src/main/java/com/arcadedb/server/http/handler/LeaderCommandForwarder.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/LeaderCommandForwarder.java
@@ -33,9 +33,9 @@ import io.undertow.util.HeaderValues;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
+import java.net.http.HttpConnectTimeoutException;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.net.http.HttpConnectTimeoutException;
 import java.net.http.HttpTimeoutException;
 import java.time.Duration;
 
@@ -320,9 +320,11 @@ public final class LeaderCommandForwarder {
         return gaveUp(leaderHttpAddress, deadlineMs, longRunningCommand);
       } catch (final ExecutionException e) {
         final Throwable cause = e.getCause();
-        // The connect timeout arrives as a subclass of HttpTimeoutException, and it is a different failure with
-        // a different setting behind it - saying "did not answer within proxyReadTimeout" when the socket was
-        // never established would send the operator to the wrong knob.
+        // ORDER IS LOAD-BEARING: HttpConnectTimeoutException is a SUBCLASS of HttpTimeoutException, so this arm
+        // has to come first or it is dead code and every failure to connect reports itself as "the leader did
+        // not answer within proxyReadTimeout" - the wrong knob, and the wrong story about whether the command
+        // ran. Swapping the two arms is caught only by
+        // Issue7507LeaderForwardTimeoutTest#aLeaderThatCannotBeConnectedToIsAnsweredWithItsOwnGatewayTimeout.
         if (cause instanceof HttpConnectTimeoutException)
           return couldNotConnect(leaderHttpAddress);
         if (cause instanceof HttpTimeoutException)

--- a/server/src/main/java/com/arcadedb/server/http/handler/LeaderCommandForwarder.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/LeaderCommandForwarder.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.http.handler;
 
+import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
@@ -34,7 +35,14 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.net.http.HttpConnectTimeoutException;
+import java.net.http.HttpTimeoutException;
+import java.time.Duration;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
@@ -56,11 +64,17 @@ import java.util.logging.Level;
  * <p>
  * <b>This class performs no authorization.</b> The caller checks it first - every current call site runs
  * {@code AbstractServerHttpHandler.checkRootUser} before asking to forward.
+ * <p>
+ * <b>Every forward is bounded.</b> {@code forwardIfReplica} runs on an Undertow worker thread - all four call
+ * sites return {@code true} from {@code mustExecuteOnWorkerThread()} - so a leader that accepts the connection
+ * and then never answers would hold that worker until the OS tore the socket down, and enough of them would
+ * stop the follower serving anything (issue #7507). {@link Transport} therefore gives the client a connect
+ * timeout and every request a response deadline, and turns a blown deadline into an HTTP 504 rather than a
+ * parked thread.
  */
 public final class LeaderCommandForwarder {
-  private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
-
   private final HttpServer httpServer;
+  private final Transport  transport;
 
   /**
    * Emits the "a peer forwarded a request here and this node is not the leader either" notice only once
@@ -71,6 +85,19 @@ public final class LeaderCommandForwarder {
 
   public LeaderCommandForwarder(final HttpServer httpServer) {
     this.httpServer = httpServer;
+    this.transport = new Transport(httpServer.getServer().getConfiguration());
+  }
+
+  /**
+   * Releases the HTTP client this forwarder dials the leader with. Called when the {@link HttpServer} stops.
+   */
+  public void close() {
+    transport.close();
+  }
+
+  /** The bounded transport this forwarder sends through. Package-private, for tests. */
+  Transport transport() {
+    return transport;
   }
 
   /**
@@ -97,6 +124,23 @@ public final class LeaderCommandForwarder {
    */
   public ExecutionResponse forwardIfReplica(final HttpServerExchange exchange, final ServerSecurityUser user,
       final String targetPath, final String body) throws IOException {
+    return forwardIfReplica(exchange, user, targetPath, body, false);
+  }
+
+  /**
+   * As {@link #forwardIfReplica(HttpServerExchange, ServerSecurityUser, String, String)}, choosing which of the
+   * two response deadlines the forward is given.
+   *
+   * @param longRunningCommand true for a forwarded command that legitimately runs for minutes - {@code restore
+   *                           backup}, {@code restore database}, {@code import database} - which is given
+   *                           {@link GlobalConfiguration#HA_PROXY_LONG_COMMAND_TIMEOUT} instead of
+   *                           {@link GlobalConfiguration#HA_PROXY_READ_TIMEOUT}. Applying the short deadline to
+   *                           those would abort exactly the operations that most need to reach the leader
+   *                           (issue #7507); both deadlines are finite, because either way it is a worker
+   *                           thread that waits.
+   */
+  public ExecutionResponse forwardIfReplica(final HttpServerExchange exchange, final ServerSecurityUser user,
+      final String targetPath, final String body, final boolean longRunningCommand) throws IOException {
     final HAServerPlugin ha = httpServer.getServer().getHA();
     if (ha == null || ha.isLeader())
       return null;
@@ -158,13 +202,10 @@ public final class LeaderCommandForwarder {
           .toString());
     }
 
-    final HttpRequest.Builder builder = HttpRequest.newBuilder().uri(leaderUri);
-
-    if (body != null) {
-      builder.header("Content-Type", "application/json");
-      builder.method(exchange.getRequestMethod().toString(), HttpRequest.BodyPublishers.ofString(body));
-    } else
-      builder.method(exchange.getRequestMethod().toString(), HttpRequest.BodyPublishers.noBody());
+    // Transport.newRequest is the only way this class builds a request, and it attaches the response deadline
+    // unconditionally - so no call site can end up issuing an unbounded forward (issue #7507).
+    final HttpRequest.Builder builder = transport.newRequest(leaderUri, exchange.getRequestMethod().toString(), body,
+        longRunningCommand);
 
     if (authHeader != null && authHeader.startsWith("Bearer AU-")) {
       // Per-node session token: convert to cluster-internal identity headers
@@ -187,12 +228,177 @@ public final class LeaderCommandForwarder {
       builder.header("Authorization", authHeader);
     }
 
-    try {
-      final HttpResponse<String> response = HTTP_CLIENT.send(builder.build(), HttpResponse.BodyHandlers.ofString());
-      return new ExecutionResponse(response.statusCode(), response.body());
-    } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new IOException("Interrupted while forwarding server command to leader at " + leaderHttpAddress, e);
+    return transport.send(builder.build(), leaderHttpAddress, longRunningCommand);
+  }
+
+  /**
+   * The bounded HTTP call to the leader: an {@link HttpClient} that cannot wait forever to connect, a response
+   * deadline on every request, and HTTP 504 in place of a parked worker thread when the deadline blows
+   * (issue #7507).
+   * <p>
+   * Package-private so the bounds can be asserted without standing up a cluster.
+   */
+  static final class Transport {
+    /**
+     * A {@code Duration} of zero or less is rejected by both {@code HttpClient.Builder.connectTimeout} and
+     * {@code HttpRequest.Builder.timeout}. Clamping to 1 ms rather than falling back to the default is
+     * deliberate: 0 must not become a back door to the unbounded behaviour this class exists to remove.
+     */
+    private static final long MIN_TIMEOUT_MS = 1L;
+
+    private final ContextConfiguration configuration;
+    private final HttpClient           client;
+
+    Transport(final ContextConfiguration configuration) {
+      this.configuration = configuration;
+      // An HttpClient's connect timeout is fixed at build time, so this one is read once. The response
+      // deadlines below are read per request instead, so SET SERVER SETTING moves them without a restart.
+      this.client = HttpClient.newBuilder()
+          .connectTimeout(millis(configuration.getValueAsLong(GlobalConfiguration.HA_PROXY_CONNECT_TIMEOUT)))
+          .build();
+    }
+
+    HttpClient client() {
+      return client;
+    }
+
+    /**
+     * The deadline a forward of this kind gets, re-read from the configuration on every call.
+     */
+    Duration responseTimeout(final boolean longRunningCommand) {
+      return millis(configuration.getValueAsLong(deadlineSetting(longRunningCommand)));
+    }
+
+    /**
+     * Builds the request to send to the leader, with the response deadline already attached.
+     *
+     * @param method the HTTP method of the request being forwarded
+     * @param body   the body to relay, or null for a request that has none
+     */
+    HttpRequest.Builder newRequest(final URI leaderUri, final String method, final String body,
+        final boolean longRunningCommand) {
+      final HttpRequest.Builder builder = HttpRequest.newBuilder().uri(leaderUri)
+          .timeout(responseTimeout(longRunningCommand));
+
+      if (body != null) {
+        builder.header("Content-Type", "application/json");
+        builder.method(method, HttpRequest.BodyPublishers.ofString(body));
+      } else
+        builder.method(method, HttpRequest.BodyPublishers.noBody());
+
+      return builder;
+    }
+
+    /**
+     * Sends the request and relays the leader's answer, giving up after the deadline the request carries.
+     * <p>
+     * The wait is bounded twice over, and it has to be. {@code HttpRequest.timeout} bounds only the wait for the
+     * response <b>headers</b>: a peer that answers {@code 200 OK} with a {@code Content-Length} and then stops
+     * writing leaves {@code HttpClient.send} blocked for as long as it holds the socket open, deadline or no
+     * deadline (measured against a socket that sent headers plus five bytes of a declared hundred - the send did
+     * not return). So the exchange is issued asynchronously and awaited with the same deadline applied to the
+     * whole of it, body included, and the future is cancelled when that expires. The request-level timeout is
+     * kept because it aborts the exchange at the JDK level rather than only releasing this thread.
+     * <p>
+     * A blown deadline - either one, plus the connect timeout arriving as {@code HttpConnectTimeoutException} -
+     * comes back as HTTP 504 naming the leader and the setting that bounds the wait, instead of falling through
+     * to the generic 500 an {@link IOException} would produce.
+     */
+    ExecutionResponse send(final HttpRequest request, final String leaderHttpAddress,
+        final boolean longRunningCommand) throws IOException {
+      // The deadline that actually applied, taken from the request rather than re-read, so the message cannot
+      // quote a number the forward was never given.
+      final long deadlineMs = request.timeout().orElseGet(() -> responseTimeout(longRunningCommand)).toMillis();
+
+      final CompletableFuture<HttpResponse<String>> pending = client.sendAsync(request,
+          HttpResponse.BodyHandlers.ofString());
+      try {
+        final HttpResponse<String> response = pending.get(deadlineMs, TimeUnit.MILLISECONDS);
+        return new ExecutionResponse(response.statusCode(), response.body());
+      } catch (final TimeoutException e) {
+        pending.cancel(true);
+        return gaveUp(leaderHttpAddress, deadlineMs, longRunningCommand);
+      } catch (final ExecutionException e) {
+        final Throwable cause = e.getCause();
+        // The connect timeout arrives as a subclass of HttpTimeoutException, and it is a different failure with
+        // a different setting behind it - saying "did not answer within proxyReadTimeout" when the socket was
+        // never established would send the operator to the wrong knob.
+        if (cause instanceof HttpConnectTimeoutException)
+          return couldNotConnect(leaderHttpAddress);
+        if (cause instanceof HttpTimeoutException)
+          return gaveUp(leaderHttpAddress, deadlineMs, longRunningCommand);
+        if (cause instanceof IOException io)
+          throw io;
+        if (cause instanceof RuntimeException runtime)
+          throw runtime;
+        throw new IOException("Error forwarding server command to leader at " + leaderHttpAddress, cause);
+      } catch (final InterruptedException e) {
+        pending.cancel(true);
+        Thread.currentThread().interrupt();
+        throw new IOException("Interrupted while forwarding server command to leader at " + leaderHttpAddress, e);
+      }
+    }
+
+    /**
+     * The answer to a forward that ran out of time. 504 rather than 500: this node is acting as a gateway and it
+     * is the gateway's peer that did not answer.
+     */
+    private ExecutionResponse gaveUp(final String leaderHttpAddress, final long deadlineMs,
+        final boolean longRunningCommand) {
+      final String setting = deadlineSetting(longRunningCommand).getKey();
+      LogManager.instance().log(this, Level.WARNING,
+          "Gave up waiting for the cluster leader at %s to answer a forwarded server command after %,d ms. "
+              + "The command may still be running there. Raise %s if the operation is legitimately slower than "
+              + "that, otherwise the leader is unresponsive.", leaderHttpAddress, deadlineMs, setting);
+      return new ExecutionResponse(504, new JSONObject()
+          .put("error", "The cluster leader at " + leaderHttpAddress + " did not answer the forwarded server "
+              + "command within " + deadlineMs + " ms (" + setting + "). The command was not executed on this "
+              + "node, but it may still be running on the leader: check there before retrying, or raise "
+              + setting + " if the operation is legitimately slower than that")
+          .toString());
+    }
+
+    /**
+     * The answer to a forward that never got a connection to the leader at all, within
+     * {@link GlobalConfiguration#HA_PROXY_CONNECT_TIMEOUT}. 504 as well - same gateway, earlier failure - but it
+     * names the connect timeout and says the command certainly did not run.
+     * <p>
+     * The JDK reports this as {@code HttpConnectTimeoutException} - a subclass of {@code HttpTimeoutException},
+     * carrying a {@code ConnectException} as its own cause - which is why the arm above has to be tested first
+     * (measured against a client with an 800 ms connect timeout dialling 192.0.2.1, the RFC 5737 TEST-NET-1
+     * address, on a JDK 21 runtime).
+     */
+    ExecutionResponse couldNotConnect(final String leaderHttpAddress) {
+      final String setting = GlobalConfiguration.HA_PROXY_CONNECT_TIMEOUT.getKey();
+      final long connectMs = client.connectTimeout().map(Duration::toMillis).orElse(0L);
+      LogManager.instance().log(this, Level.WARNING,
+          "Could not connect to the cluster leader at %s within %,d ms (%s) to forward a server command.",
+          leaderHttpAddress, connectMs, setting);
+      return new ExecutionResponse(504, new JSONObject()
+          .put("error", "Could not connect to the cluster leader at " + leaderHttpAddress + " within " + connectMs
+              + " ms (" + setting + ") to forward the server command. The command did not run: retry it, or "
+              + "check that the address resolved for the leader is reachable from this node")
+          .toString());
+    }
+
+    /**
+     * Releases the client's selector thread and executor. One client per {@link HttpServer}, so without this an
+     * in-process cluster - or a test suite that starts and stops servers - would accumulate them.
+     * {@code shutdownNow} rather than {@code close}: the latter waits for in-flight exchanges, and the whole
+     * point of the deadlines above is that this node stops waiting on the leader.
+     */
+    void close() {
+      client.shutdownNow();
+    }
+
+    private static GlobalConfiguration deadlineSetting(final boolean longRunningCommand) {
+      return longRunningCommand ?
+          GlobalConfiguration.HA_PROXY_LONG_COMMAND_TIMEOUT :
+          GlobalConfiguration.HA_PROXY_READ_TIMEOUT;
+    }
+
+    private static Duration millis(final long configuredMs) {
+      return Duration.ofMillis(Math.max(MIN_TIMEOUT_MS, configuredMs));
     }
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/LeaderCommandForwarder.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/LeaderCommandForwarder.java
@@ -38,7 +38,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpTimeoutException;
 import java.time.Duration;
-
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -247,6 +246,7 @@ public final class LeaderCommandForwarder {
     private static final long MIN_TIMEOUT_MS = 1L;
 
     private final ContextConfiguration configuration;
+    private final AtomicBoolean        clampWarned = new AtomicBoolean(false);
     private final HttpClient           client;
 
     Transport(final ContextConfiguration configuration) {
@@ -254,7 +254,8 @@ public final class LeaderCommandForwarder {
       // An HttpClient's connect timeout is fixed at build time, so this one is read once. The response
       // deadlines below are read per request instead, so SET SERVER SETTING moves them without a restart.
       this.client = HttpClient.newBuilder()
-          .connectTimeout(millis(configuration.getValueAsLong(GlobalConfiguration.HA_PROXY_CONNECT_TIMEOUT)))
+          .connectTimeout(bounded(GlobalConfiguration.HA_PROXY_CONNECT_TIMEOUT,
+              configuration.getValueAsLong(GlobalConfiguration.HA_PROXY_CONNECT_TIMEOUT)))
           .build();
     }
 
@@ -266,7 +267,8 @@ public final class LeaderCommandForwarder {
      * The deadline a forward of this kind gets, re-read from the configuration on every call.
      */
     Duration responseTimeout(final boolean longRunningCommand) {
-      return millis(configuration.getValueAsLong(deadlineSetting(longRunningCommand)));
+      final GlobalConfiguration setting = deadlineSetting(longRunningCommand);
+      return bounded(setting, configuration.getValueAsLong(setting));
     }
 
     /**
@@ -399,8 +401,27 @@ public final class LeaderCommandForwarder {
           GlobalConfiguration.HA_PROXY_READ_TIMEOUT;
     }
 
-    private static Duration millis(final long configuredMs) {
-      return Duration.ofMillis(Math.max(MIN_TIMEOUT_MS, configuredMs));
+    /**
+     * The configured value as a usable {@code Duration}, clamped rather than allowed to be non-positive.
+     * <p>
+     * 0 conventionally means "no timeout" in some other settings, and here it must not: that is the behaviour
+     * this class exists to remove, and both JDK builders reject a non-positive {@code Duration} outright. What an
+     * operator who typed 0 will actually see is every forwarded administrative command on this follower failing
+     * within a millisecond, so the clamp says so in the log rather than leaving them an unexplained wall of 504s.
+     * Once per {@code Transport}: the response deadline is re-read on every forward.
+     */
+    private Duration bounded(final GlobalConfiguration setting, final long configuredMs) {
+      if (configuredMs >= MIN_TIMEOUT_MS)
+        return Duration.ofMillis(configuredMs);
+
+      if (clampWarned.compareAndSet(false, true))
+        LogManager.instance().log(this, Level.WARNING,
+            "%s is set to %,d, which does not switch the bound off - a follower-to-leader forward is never "
+                + "unbounded. It is clamped to %,d ms instead, so forwarded administrative commands on this node "
+                + "will fail almost immediately. Set a positive value in milliseconds. This notice is logged only "
+                + "once.", setting.getKey(), configuredMs, MIN_TIMEOUT_MS);
+
+      return Duration.ofMillis(MIN_TIMEOUT_MS);
     }
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -103,7 +103,8 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
         command_lc.startsWith(CREATE_USER) || command_lc.startsWith(DROP_USER) ||
         command_lc.startsWith(RESTORE_BACKUP) || command_lc.startsWith(RESTORE_DATABASE) ||
         command_lc.startsWith(IMPORT_DATABASE)) {
-      final ExecutionResponse forwarded = forwardToLeaderIfReplica(exchange, payload, user);
+      final ExecutionResponse forwarded = forwardToLeaderIfReplica(exchange, payload, user,
+          isLongRunningForwardedCommand(command_lc));
       if (forwarded != null)
         return forwarded;
     }
@@ -639,9 +640,27 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
    * that perform the same operations and used to run them wherever the request landed (issue #7380).
    */
   private ExecutionResponse forwardToLeaderIfReplica(final HttpServerExchange exchange, final JSONObject payload,
-      final ServerSecurityUser user) throws IOException {
+      final ServerSecurityUser user, final boolean longRunningCommand) throws IOException {
     return httpServer.getLeaderCommandForwarder()
-        .forwardIfReplica(exchange, user, LeaderCommandForwarder.currentPathWithQuery(exchange), payload.toString());
+        .forwardIfReplica(exchange, user, LeaderCommandForwarder.currentPathWithQuery(exchange), payload.toString(),
+            longRunningCommand);
+  }
+
+  /**
+   * Which of the forwarded commands gets the long response deadline rather than the ordinary one (issue #7507).
+   * <p>
+   * Every forward is bounded, because it is an Undertow worker thread that waits for the leader's answer. These
+   * three legitimately run for minutes though, so bounding them with {@code HA_PROXY_READ_TIMEOUT} would abort
+   * exactly the operations that most need to reach the leader; they get
+   * {@code HA_PROXY_LONG_COMMAND_TIMEOUT} instead. The set is a subset of the commands that forward at all -
+   * see the guard in {@link #execute} - so a command added to one list and not the other simply keeps the
+   * ordinary deadline.
+   *
+   * @param command_lc the command, already lower-cased and trimmed the way {@link #execute} does it
+   */
+  static boolean isLongRunningForwardedCommand(final String command_lc) {
+    return command_lc.startsWith(RESTORE_BACKUP) || command_lc.startsWith(RESTORE_DATABASE) ||
+        command_lc.startsWith(IMPORT_DATABASE);
   }
 
   private void checkServerIsLeaderIfInHA() {

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -142,10 +142,7 @@ public class CoreApiSpec implements OpenApiContributor {
     postOp.setResponses(createCommandResponses());
     // Only this operation forwards to the HA leader, so the 504 is added here rather than in the shared
     // createCommandResponses() that POST /api/v1/command/{database} also uses (issue #7507).
-    postOp.getResponses().addApiResponse("504", SpecBuilders.errorResponse(
-        "On an HA follower, the command is forwarded to the leader and the leader did not answer within "
-        + "'arcadedb.ha.proxyReadTimeout' (or 'arcadedb.ha.proxyLongCommandTimeout' for a restore or an "
-        + "import). It may still be running on the leader: check there before retrying"));
+    postOp.getResponses().addApiResponse("504", SpecBuilders.errorResponse(SpecBuilders.LEADER_FORWARD_TIMEOUT_DESCRIPTION));
     pathItem.setPost(postOp);
 
     return pathItem;

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -140,6 +140,12 @@ public class CoreApiSpec implements OpenApiContributor {
     postOp.addTagsItem("Server");
     postOp.setRequestBody(SpecBuilders.jsonBody("Command request with command and optional parameters", "CommandRequest", true));
     postOp.setResponses(createCommandResponses());
+    // Only this operation forwards to the HA leader, so the 504 is added here rather than in the shared
+    // createCommandResponses() that POST /api/v1/command/{database} also uses (issue #7507).
+    postOp.getResponses().addApiResponse("504", SpecBuilders.errorResponse(
+        "On an HA follower, the command is forwarded to the leader and the leader did not answer within "
+        + "'arcadedb.ha.proxyReadTimeout' (or 'arcadedb.ha.proxyLongCommandTimeout' for a restore or an "
+        + "import). It may still be running on the leader: check there before retrying"));
     pathItem.setPost(postOp);
 
     return pathItem;

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/SecurityAdminApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/SecurityAdminApiSpec.java
@@ -151,10 +151,7 @@ public class SecurityAdminApiSpec implements OpenApiContributor {
    */
   private ApiResponses forwardedToLeaderResponses(final String successDescription, final String successCode) {
     final ApiResponses responses = createAdminResponses(successDescription, successCode);
-    responses.addApiResponse("504", SpecBuilders.errorResponse(
-        "On an HA follower, the command is forwarded to the leader and the leader did not answer within "
-        + "'arcadedb.ha.proxyReadTimeout' (or 'arcadedb.ha.proxyLongCommandTimeout' for a restore or an "
-        + "import). It may still be running on the leader: check there before retrying"));
+    responses.addApiResponse("504", SpecBuilders.errorResponse(SpecBuilders.LEADER_FORWARD_TIMEOUT_DESCRIPTION));
     return responses;
   }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/SecurityAdminApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/SecurityAdminApiSpec.java
@@ -53,7 +53,7 @@ public class SecurityAdminApiSpec implements OpenApiContributor {
     postOp.setOperationId("createUser");
     postOp.addTagsItem("Security");
     postOp.setRequestBody(SpecBuilders.jsonBody("User creation request with name, password, and optional databases", null, true));
-    postOp.setResponses(createAdminResponses("User created", "201"));
+    postOp.setResponses(forwardedToLeaderResponses("User created", "201"));
     pathItem.setPost(postOp);
 
     final Operation putOp = new Operation();
@@ -64,7 +64,7 @@ public class SecurityAdminApiSpec implements OpenApiContributor {
     putOp.addTagsItem("Security");
     putOp.addParametersItem(SpecBuilders.queryParam("name", "User name", true));
     putOp.setRequestBody(SpecBuilders.jsonBody("User update request with optional password and databases", null, true));
-    putOp.setResponses(createAdminResponses("User updated"));
+    putOp.setResponses(forwardedToLeaderResponses("User updated", "200"));
     pathItem.setPut(putOp);
 
     final Operation deleteOp = new Operation();
@@ -74,7 +74,7 @@ public class SecurityAdminApiSpec implements OpenApiContributor {
     deleteOp.setOperationId("deleteUser");
     deleteOp.addTagsItem("Security");
     deleteOp.addParametersItem(SpecBuilders.queryParam("name", "User name to delete", true));
-    deleteOp.setResponses(createAdminResponses("User deleted"));
+    deleteOp.setResponses(forwardedToLeaderResponses("User deleted", "200"));
     pathItem.setDelete(deleteOp);
 
     return pathItem;
@@ -143,6 +143,19 @@ public class SecurityAdminApiSpec implements OpenApiContributor {
     pathItem.setDelete(deleteOp);
 
     return pathItem;
+  }
+
+  /**
+   * The responses of a write that an HA follower forwards to the leader rather than executing locally. The
+   * forward is bounded, so it can answer 504 where the other admin routes cannot (issue #7507).
+   */
+  private ApiResponses forwardedToLeaderResponses(final String successDescription, final String successCode) {
+    final ApiResponses responses = createAdminResponses(successDescription, successCode);
+    responses.addApiResponse("504", SpecBuilders.errorResponse(
+        "On an HA follower, the command is forwarded to the leader and the leader did not answer within "
+        + "'arcadedb.ha.proxyReadTimeout' (or 'arcadedb.ha.proxyLongCommandTimeout' for a restore or an "
+        + "import). It may still be running on the leader: check there before retrying"));
+    return responses;
   }
 
   private ApiResponses createAdminResponses(final String successDescription) {

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/SpecBuilders.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/SpecBuilders.java
@@ -18,6 +18,8 @@
  */
 package com.arcadedb.server.http.handler.openapi;
 
+import com.arcadedb.GlobalConfiguration;
+
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.media.Content;
@@ -45,9 +47,10 @@ public final class SpecBuilders {
    * Shared so the two specs that document such a route cannot drift apart on what it means.
    */
   public static final String LEADER_FORWARD_TIMEOUT_DESCRIPTION =
-      "On an HA follower, the command is forwarded to the leader and the leader did not answer within "
-          + "'arcadedb.ha.proxyReadTimeout' (or 'arcadedb.ha.proxyLongCommandTimeout' for a restore or an "
-          + "import). It may still be running on the leader: check there before retrying";
+      "On an HA follower, the command is forwarded to the leader and the leader did not answer within '"
+          + GlobalConfiguration.HA_PROXY_READ_TIMEOUT.getKey() + "' (or '"
+          + GlobalConfiguration.HA_PROXY_LONG_COMMAND_TIMEOUT.getKey() + "' for a restore or an import). It may "
+          + "still be running on the leader: check there before retrying";
 
   private SpecBuilders() {
   }

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/SpecBuilders.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/SpecBuilders.java
@@ -40,6 +40,15 @@ public final class SpecBuilders {
   public static final String JSON      = "application/json";
   public static final String ERROR_REF = "ErrorResponse";
 
+  /**
+   * The 504 of a route that an HA follower forwards to the leader instead of executing locally (issue #7507).
+   * Shared so the two specs that document such a route cannot drift apart on what it means.
+   */
+  public static final String LEADER_FORWARD_TIMEOUT_DESCRIPTION =
+      "On an HA follower, the command is forwarded to the leader and the leader did not answer within "
+          + "'arcadedb.ha.proxyReadTimeout' (or 'arcadedb.ha.proxyLongCommandTimeout' for a restore or an "
+          + "import). It may still be running on the leader: check there before retrying";
+
   private SpecBuilders() {
   }
 

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue7507ForwarderClientLifecycleTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue7507ForwarderClientLifecycleTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7507: bounding the forward meant giving {@link LeaderCommandForwarder} its own {@code HttpClient}
+ * (built with the server's configured connect timeout) in place of the JVM-wide static one it used before. A
+ * client owns a selector thread and an executor, and there is now one per {@code HttpServer}, so the server has
+ * to release it on the way down.
+ */
+class Issue7507ForwarderClientLifecycleTest {
+
+  private static final String DATABASE_DIRECTORY = "./target/databases-issue7507";
+
+  @Test
+  void stoppingTheServerReleasesTheForwardersHttpClient() throws Exception {
+    FileUtils.deleteRecursively(new File(DATABASE_DIRECTORY));
+
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.SERVER_NAME, "ArcadeDB_issue7507");
+    config.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, DATABASE_DIRECTORY);
+    config.setValue(GlobalConfiguration.SERVER_ROOT_PATH, "./target");
+    config.setValue(GlobalConfiguration.SERVER_ROOT_PASSWORD, "DefaultPasswordForTests123!");
+    config.setValue(GlobalConfiguration.SERVER_HTTP_INCOMING_HOST, "localhost");
+    // A free port, not the default 2480: this test must not fight whatever else is listening there.
+    config.setValue(GlobalConfiguration.SERVER_HTTP_INCOMING_PORT, String.valueOf(freePort()));
+
+    final ArcadeDBServer server = new ArcadeDBServer(config);
+    final LeaderCommandForwarder forwarder;
+    try {
+      server.start();
+      forwarder = server.getHttpServer().getLeaderCommandForwarder();
+
+      assertThat(forwarder.transport().client().connectTimeout())
+          .as("the forwarder dials the leader with a bounded client")
+          .isPresent();
+      assertThat(forwarder.transport().client().isTerminated())
+          .as("the client is live while the server is up")
+          .isFalse();
+    } finally {
+      server.stop();
+    }
+
+    assertThat(forwarder.transport().client().isTerminated())
+        .as("stopping the server releases the forwarder's HTTP client")
+        .isTrue();
+
+    FileUtils.deleteRecursively(new File(DATABASE_DIRECTORY));
+  }
+
+  private static int freePort() throws IOException {
+    try (final ServerSocket socket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+      return socket.getLocalPort();
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue7507LeaderForwardTimeoutTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue7507LeaderForwardTimeoutTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URI;
@@ -245,7 +246,7 @@ class Issue7507LeaderForwardTimeoutTest {
     }
 
     StalledLeader(final boolean answerHeadersThenStall) throws IOException, InterruptedException {
-      serverSocket = new ServerSocket(0, 16, java.net.InetAddress.getLoopbackAddress());
+      serverSocket = new ServerSocket(0, 16, InetAddress.getLoopbackAddress());
       acceptor = new Thread(() -> {
         started.countDown();
         while (!serverSocket.isClosed()) {

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue7507LeaderForwardTimeoutTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue7507LeaderForwardTimeoutTest.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.StallAwareStopwatch;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7507: {@link LeaderCommandForwarder} dialled the leader with a bare
+ * {@code HttpClient.newHttpClient()} and built the request without {@code .timeout(...)}, so a leader that
+ * accepted the connection and then never answered held the calling Undertow worker thread until the OS tore
+ * the socket down.
+ * <p>
+ * The invariant these tests pin: every forward carries a finite response deadline and the client carries a
+ * finite connect timeout, and a blown deadline is answered 504 rather than parking the caller.
+ */
+class Issue7507LeaderForwardTimeoutTest {
+
+  /**
+   * The tripwire between "the deadline fired" and "the call is unbounded". The deadline under test is 1 s, so
+   * anything under this bound proves the former; a stalled leader without the fix sits here until the OS gives
+   * up on the socket, which is minutes.
+   */
+  private static final long GAVE_UP_BOUND_MS = 30_000L;
+
+  private static ContextConfiguration configuration(final long readTimeoutMs, final long longCommandTimeoutMs,
+      final long connectTimeoutMs) {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.setValue(GlobalConfiguration.HA_PROXY_READ_TIMEOUT, readTimeoutMs);
+    cfg.setValue(GlobalConfiguration.HA_PROXY_LONG_COMMAND_TIMEOUT, longCommandTimeoutMs);
+    cfg.setValue(GlobalConfiguration.HA_PROXY_CONNECT_TIMEOUT, connectTimeoutMs);
+    return cfg;
+  }
+
+  /**
+   * The reported failure, end to end over a real socket: a leader that accepts the connection and never
+   * answers. Before the fix this parked the caller; now the deadline fires and the follower answers 504.
+   */
+  @Test
+  void aLeaderThatAcceptsAndNeverAnswersIsGivenUpOnAndAnswered504() throws Exception {
+    try (final StalledLeader leader = new StalledLeader()) {
+      final LeaderCommandForwarder.Transport transport =
+          new LeaderCommandForwarder.Transport(configuration(1_000L, 60_000L, 5_000L));
+
+      final StallAwareStopwatch watch = StallAwareStopwatch.start();
+      final ExecutionResponse response = transport.send(
+          transport.newRequest(URI.create("http://" + leader.address() + "/api/v1/server"), "POST", "{}", false).build(),
+          leader.address(), false);
+      watch.assertGaveUpWithin(GAVE_UP_BOUND_MS,
+          "a 1s forward deadline from the unbounded wait a leader that never answers used to produce");
+
+      assertThat(response.getCode()).isEqualTo(504);
+      final JSONObject body = new JSONObject(response.getResponse());
+      assertThat(body.getString("error")).contains(leader.address());
+      assertThat(body.getString("error")).contains(GlobalConfiguration.HA_PROXY_READ_TIMEOUT.getKey());
+      assertThat(leader.acceptedConnections()).isGreaterThanOrEqualTo(1);
+    }
+  }
+
+  /**
+   * The half of the wait a {@code HttpRequest.timeout} does not cover: the leader answers the headers - status
+   * line, {@code Content-Length}, blank line - and then stops writing part-way through the body. The JDK's
+   * request timeout has already been satisfied by the headers at that point, so {@code HttpClient.send} would
+   * block on the stalled body indefinitely; the forwarder bounds the whole exchange instead.
+   */
+  @Test
+  void aLeaderThatAnswersTheHeadersAndThenStallsMidBodyIsAlsoGivenUpOn() throws Exception {
+    try (final StalledLeader leader = new StalledLeader(true)) {
+      final LeaderCommandForwarder.Transport transport =
+          new LeaderCommandForwarder.Transport(configuration(1_000L, 60_000L, 5_000L));
+
+      final StallAwareStopwatch watch = StallAwareStopwatch.start();
+      final ExecutionResponse response = transport.send(
+          transport.newRequest(URI.create("http://" + leader.address() + "/api/v1/server"), "POST", "{}", false).build(),
+          leader.address(), false);
+      watch.assertGaveUpWithin(GAVE_UP_BOUND_MS,
+          "a 1s forward deadline from the unbounded wait a body that stalls after the headers used to produce");
+
+      assertThat(response.getCode()).isEqualTo(504);
+      assertThat(new JSONObject(response.getResponse()).getString("error")).contains(leader.address());
+    }
+  }
+
+  /**
+   * Every request the forwarder can build carries a deadline: {@code newRequest} is the only way
+   * {@code forwardIfReplica} constructs one, so no call site can opt out of it.
+   */
+  @Test
+  void everyForwardedRequestCarriesTheDefaultDeadline() {
+    final LeaderCommandForwarder.Transport transport =
+        new LeaderCommandForwarder.Transport(configuration(7_000L, 60_000L, 5_000L));
+
+    assertThat(transport.newRequest(URI.create("http://leader:2480/api/v1/server/users?name=bob"), "DELETE", null, false)
+        .build().timeout()).contains(Duration.ofMillis(7_000L));
+    assertThat(transport.newRequest(URI.create("http://leader:2480/api/v1/server/users"), "POST", "{\"name\":\"bob\"}", false)
+        .build().timeout()).contains(Duration.ofMillis(7_000L));
+    assertThat(transport.newRequest(URI.create("http://leader:2480/api/v1/server/users"), "PUT", "{\"name\":\"bob\"}", false)
+        .build().timeout()).contains(Duration.ofMillis(7_000L));
+  }
+
+  /**
+   * {@code restore backup}, {@code restore database} and {@code import database} legitimately run for minutes,
+   * so they get their own, larger deadline instead of being aborted by the 30 s one.
+   */
+  @Test
+  void longRunningCommandsGetTheLongerDeadline() {
+    final LeaderCommandForwarder.Transport transport =
+        new LeaderCommandForwarder.Transport(configuration(7_000L, 600_000L, 5_000L));
+
+    assertThat(transport.newRequest(URI.create("http://leader:2480/api/v1/server"), "POST", "{}", true)
+        .build().timeout()).contains(Duration.ofMillis(600_000L));
+    assertThat(transport.responseTimeout(true)).isGreaterThan(transport.responseTimeout(false));
+  }
+
+  /**
+   * Which commands claim the longer deadline. The classification lives in {@code PostServerCommandHandler}
+   * because that is where the command grammar lives, and it has to match the set of commands that forward at
+   * all, otherwise a long restore silently gets the 30 s budget.
+   */
+  @Test
+  void onlyRestoreAndImportAreClassifiedAsLongRunning() {
+    assertThat(PostServerCommandHandler.isLongRunningForwardedCommand("restore backup mybackup.zip")).isTrue();
+    assertThat(PostServerCommandHandler.isLongRunningForwardedCommand("restore database mydb")).isTrue();
+    assertThat(PostServerCommandHandler.isLongRunningForwardedCommand("import database file:///data.csv")).isTrue();
+
+    assertThat(PostServerCommandHandler.isLongRunningForwardedCommand("create database mydb")).isFalse();
+    assertThat(PostServerCommandHandler.isLongRunningForwardedCommand("drop database mydb")).isFalse();
+    assertThat(PostServerCommandHandler.isLongRunningForwardedCommand("create user { \"name\": \"bob\" }")).isFalse();
+    assertThat(PostServerCommandHandler.isLongRunningForwardedCommand("drop user bob")).isFalse();
+  }
+
+  /**
+   * The connect timeout bounds the other half of the failure: a leader whose host black-holes the SYN. It is
+   * immutable once the client is built, so it is asserted on the client rather than over a socket - an address
+   * that reliably black-holes a connect is not something a unit test can conjure portably.
+   */
+  @Test
+  void theClientCarriesTheConfiguredConnectTimeout() {
+    final LeaderCommandForwarder.Transport transport =
+        new LeaderCommandForwarder.Transport(configuration(7_000L, 60_000L, 2_500L));
+
+    assertThat(transport.client().connectTimeout()).contains(Duration.ofMillis(2_500L));
+  }
+
+  /**
+   * A leader this node cannot even reach is a different failure from one that will not answer, and it points at
+   * a different setting. It gets its own 504, saying the command certainly did not run - which, unlike the
+   * response-deadline case, is something this node can promise.
+   */
+  @Test
+  void aLeaderThatCannotBeConnectedToIsAnsweredWithItsOwnGatewayTimeout() {
+    final LeaderCommandForwarder.Transport transport =
+        new LeaderCommandForwarder.Transport(configuration(7_000L, 60_000L, 2_500L));
+
+    final ExecutionResponse response = transport.couldNotConnect("leader.example:2480");
+
+    assertThat(response.getCode()).isEqualTo(504);
+    final String error = new JSONObject(response.getResponse()).getString("error");
+    assertThat(error).contains("leader.example:2480");
+    assertThat(error).contains(GlobalConfiguration.HA_PROXY_CONNECT_TIMEOUT.getKey());
+    assertThat(error).contains("2500 ms");
+    assertThat(error).doesNotContain(GlobalConfiguration.HA_PROXY_READ_TIMEOUT.getKey());
+  }
+
+  /**
+   * The deadlines are re-read per forward, so {@code SET SERVER SETTING arcadedb.ha.proxyReadTimeout} takes
+   * effect without a restart. (The connect timeout cannot: an {@link java.net.http.HttpClient}'s is fixed at
+   * build time.)
+   */
+  @Test
+  void responseDeadlineIsReReadOnEveryForward() {
+    final ContextConfiguration cfg = configuration(7_000L, 60_000L, 5_000L);
+    final LeaderCommandForwarder.Transport transport = new LeaderCommandForwarder.Transport(cfg);
+
+    assertThat(transport.responseTimeout(false)).isEqualTo(Duration.ofMillis(7_000L));
+    cfg.setValue(GlobalConfiguration.HA_PROXY_READ_TIMEOUT, 11_000L);
+    assertThat(transport.responseTimeout(false)).isEqualTo(Duration.ofMillis(11_000L));
+  }
+
+  /**
+   * Zero and negative are not a back door to the unbounded behaviour this issue removed: they clamp to the
+   * smallest deadline the JDK accepts rather than disabling the bound.
+   */
+  @Test
+  void zeroOrNegativeTimeoutClampsInsteadOfDisablingTheBound() {
+    final LeaderCommandForwarder.Transport transport =
+        new LeaderCommandForwarder.Transport(configuration(0L, -1L, 0L));
+
+    assertThat(transport.responseTimeout(false)).isPositive();
+    assertThat(transport.responseTimeout(true)).isPositive();
+    assertThat(transport.client().connectTimeout()).isPresent();
+    assertThat(transport.client().connectTimeout().get()).isPositive();
+    // and a request can actually be built from it - Duration.ZERO would throw
+    assertThat(transport.newRequest(URI.create("http://leader:2480/api/v1/server"), "POST", "{}", false)
+        .build().timeout()).isPresent();
+  }
+
+  /**
+   * A server socket standing in for a wedged leader. In the default mode it accepts the connection and answers
+   * nothing at all; with {@code answerHeadersThenStall} it writes a complete, well-formed response head that
+   * promises a hundred bytes and then delivers five of them, which is the case an {@code HttpRequest.timeout}
+   * alone does not catch.
+   */
+  private static final class StalledLeader implements AutoCloseable {
+    private final ServerSocket   serverSocket;
+    private final Thread         acceptor;
+    private final List<Socket>   accepted = new ArrayList<>();
+    private final CountDownLatch started  = new CountDownLatch(1);
+
+    StalledLeader() throws IOException, InterruptedException {
+      this(false);
+    }
+
+    StalledLeader(final boolean answerHeadersThenStall) throws IOException, InterruptedException {
+      serverSocket = new ServerSocket(0, 16, java.net.InetAddress.getLoopbackAddress());
+      acceptor = new Thread(() -> {
+        started.countDown();
+        while (!serverSocket.isClosed()) {
+          try {
+            final Socket socket = serverSocket.accept();
+            synchronized (accepted) {
+              accepted.add(socket);
+            }
+            if (answerHeadersThenStall)
+              answerHeadersThenStall(socket);
+          } catch (final IOException e) {
+            return; // socket closed, we are done
+          }
+        }
+      }, "issue7507-stalled-leader");
+      acceptor.setDaemon(true);
+      acceptor.start();
+      started.await(10, TimeUnit.SECONDS);
+    }
+
+    private static void answerHeadersThenStall(final Socket socket) throws IOException {
+      final byte[] request = new byte[8192];
+      socket.getInputStream().read(request);
+      final OutputStream out = socket.getOutputStream();
+      out.write(("HTTP/1.1 200 OK\r\n"
+          + "Content-Type: application/json\r\n"
+          + "Content-Length: 100\r\n"
+          + "\r\n").getBytes(StandardCharsets.US_ASCII));
+      out.write("{\"res\"".getBytes(StandardCharsets.US_ASCII));
+      out.flush();
+      // and never another byte: the socket stays open until close() tears it down
+    }
+
+    String address() {
+      return serverSocket.getInetAddress().getHostAddress() + ":" + serverSocket.getLocalPort();
+    }
+
+    int acceptedConnections() {
+      synchronized (accepted) {
+        return accepted.size();
+      }
+    }
+
+    @Override
+    public void close() throws IOException {
+      serverSocket.close();
+      synchronized (accepted) {
+        for (final Socket socket : accepted)
+          try {
+            socket.close();
+          } catch (final IOException ignored) {
+            // best effort
+          }
+      }
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue7507LeaderForwardTimeoutTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue7507LeaderForwardTimeoutTest.java
@@ -29,6 +29,8 @@ import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -88,6 +90,10 @@ class Issue7507LeaderForwardTimeoutTest {
       assertThat(body.getString("error")).contains(leader.address());
       assertThat(body.getString("error")).contains(GlobalConfiguration.HA_PROXY_READ_TIMEOUT.getKey());
       assertThat(leader.acceptedConnections()).isGreaterThanOrEqualTo(1);
+      assertThat(leader.firstConnectionClosedByClientWithin(10_000L))
+          .as("giving up must tear the connection down, not just release this thread: a leader that wedges "
+              + "repeatedly would otherwise trade a parked worker for a leaked socket")
+          .isTrue();
     }
   }
 
@@ -282,6 +288,34 @@ class Issue7507LeaderForwardTimeoutTest {
 
     String address() {
       return serverSocket.getInetAddress().getHostAddress() + ":" + serverSocket.getLocalPort();
+    }
+
+    /**
+     * Blocks until the client end of the first accepted connection is closed, or the bound expires. Reads from
+     * this side of the socket: EOF means the peer closed it. Only valid in the default mode, where nothing else
+     * touches the socket's input stream.
+     */
+    boolean firstConnectionClosedByClientWithin(final long boundMs) throws IOException {
+      final Socket socket;
+      synchronized (accepted) {
+        if (accepted.isEmpty())
+          return false;
+        socket = accepted.getFirst();
+      }
+      socket.setSoTimeout((int) boundMs);
+      final byte[] drain = new byte[4096];
+      try {
+        int read;
+        while ((read = socket.getInputStream().read(drain)) != -1)
+          if (read == 0)
+            break;
+        return true;
+      } catch (final SocketTimeoutException e) {
+        return false;
+      } catch (final SocketException e) {
+        // "connection reset" is the peer tearing it down just as abruptly, which is the same answer
+        return true;
+      }
     }
 
     int acceptedConnections() {


### PR DESCRIPTION
Closes #7507

`LeaderCommandForwarder` dialled the leader with a bare `HttpClient.newHttpClient()` and built the request without `.timeout(...)`: no connect timeout, no response deadline. `forwardIfReplica` runs on an Undertow worker thread - all four call sites return `true` from `mustExecuteOnWorkerThread()` - so a leader that accepted the connection and then never answered held that worker until the OS tore the socket down, and enough of them stopped the follower serving anything. The client now carries `HA_PROXY_CONNECT_TIMEOUT` and every request a response deadline, `HA_PROXY_READ_TIMEOUT` normally and a new `HA_PROXY_LONG_COMMAND_TIMEOUT` (default 1 h) for `restore backup`, `restore database` and `import database` - the three forwarded commands that legitimately run for minutes and that a single 30 s deadline would have aborted. A blown deadline answers HTTP 504 naming the leader, the deadline that applied and the setting behind it, in place of a parked thread and the generic 500 an `IOException` produced.

## The part that is easy to get wrong

`HttpRequest.timeout` bounds only the wait for the response **headers**. A leader that answers `200 OK` with a `Content-Length` and then stops writing satisfies it and still blocks `HttpClient.send` indefinitely - measured at over 180 s against a 1500 ms request timeout. So the exchange is issued with `sendAsync` and awaited with the same deadline applied to the whole of it, body included, and the request-level timeout is kept alongside because it aborts the exchange at the JDK level rather than only releasing this thread.

Two smaller things fall out of that. `HttpConnectTimeoutException` extends `HttpTimeoutException`, so a failure to *connect* was being reported as "did not answer within `arcadedb.ha.proxyReadTimeout`" - it now has its own 504 naming the connect setting, and it is the only one that promises the command did not run; the response-deadline 504 says the command may still be running on the leader and to check before retrying, because `restore database` is not something to retry blind. And the client is per-`HttpServer` now rather than a JVM static, so `HttpServer.stopService()` releases it.

## Test plan

- [ ] `mvn -o -pl server test -Dtest=Issue7507LeaderForwardTimeoutTest,Issue7507ForwarderClientLifecycleTest` - 10 tests, green
- [ ] `mvn -o -pl server test -Dtest=LeaderProxyTest,ExecutionResponseTest,PostBatchHandlerForwardRequestTest,OpenApiSpecGeneratorTest` - no regression on the adjacent handlers or the spec
- [ ] `mvn -o -pl engine test -Dtest=ConfigurationTest,ContextConfigurationTest,GlobalConfigurationTest,Issue7121GlobalConfigurationSweepTest,...` - 109 tests, the new setting does not disturb the configuration suite
- [ ] `mvn -o -pl ha-raft test -Dtest=HAConfigDefaultsTest` - the new `arcadedb.ha.*` entry has a non-null default
- [ ] `mvn -o install -DskipTests` - full reactor, main and test sources of every module
- [ ] Manual, on a two-node cluster: `SIGSTOP` the leader, then `POST /api/v1/server {"command":"create user ..."}` on the follower. Expect a 504 after ~30 s rather than a hung request, and the follower still answering other routes throughout.

Not run locally: the server-module suites that bind port 2480 - two other JVMs held it for the whole session. They do not reach the changed code (`forwardIfReplica` returns null immediately when `getHA()` is null, which is every non-HA test server) and CI runs them.

### Proof the tests can fail

| Mutation | Result |
|---|---|
| drop `.timeout(...)` from `Transport.newRequest` | `Tests run: 3, Failures: 3` |
| rethrow instead of mapping the timeout to 504 | `» HttpTimeout request timed out` |
| widen the future's await to 600 s | `There was a timeout in the fork` under `-Dsurefire.timeout=45` |
| remove `leaderCommandForwarder.close()` from `stopService()` | `Tests run: 1, Failures: 1` |

## Coverage

Entry points this fix covers, each with a test driving it:

| Entry point | Deadline |
|---|---|
| `POST /api/v1/server` - `create database`, `drop database`, `create user`, `drop user` | `HA_PROXY_READ_TIMEOUT` |
| `POST /api/v1/server` - `restore backup`, `restore database`, `import database` | `HA_PROXY_LONG_COMMAND_TIMEOUT` |
| `POST /api/v1/server/users` (`PostUserHandler`) | `HA_PROXY_READ_TIMEOUT` |
| `PUT /api/v1/server/users` (`PutUserHandler`) | `HA_PROXY_READ_TIMEOUT` |
| `DELETE /api/v1/server/users` (`DeleteUserHandler`) | `HA_PROXY_READ_TIMEOUT` |
| leader accepts and never answers, or answers the headers and stalls mid-body | 504 |
| leader cannot be connected to | `HA_PROXY_CONNECT_TIMEOUT`, 504 |

`Transport.newRequest` is the only way the class builds a request and it attaches the deadline unconditionally, so no call site can opt out.

**Known gaps** - both found by the completeness sweep, both filed before this PR opened:

- **#7542** - `PostBatchHandler.forwardBatchToLeader` uses the same bare `HttpClient` with no request deadline. Out of scope because that forward streams the client's upload through to the leader and deliberately raises the connection read timeout for the duration of the load, so its deadline is a policy question of its own rather than a reuse of these two settings.
- **#7543** - `RaftReplicatedDatabase`'s SQL-write forward to the leader, same defect on the data plane. Out of scope because a forwarded command's duration is bounded by the query rather than by a command name, so the right deadline there is plausibly the query's own timeout, and settling that inside this PR would have changed the semantics of every forwarded write.

Argued rather than filed: `LeaderProxy` already sets both timeouts and nothing constructs it (`grep -rn 'new LeaderProxy'` returns nothing); the three `AiChatHandler`-family handlers set a connect timeout and an explicit per-request `.timeout(...)`; `RemoteHttpComponent` is the client driver, not a server worker thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEJXCdUGW61QSXqyurphpt