### PR TITLE
fix(#7516): carry the one-hop marker on a Basic/API-token leader forward

### DIFF
--- a/docs/7516-ha-basic-auth-leader-forward-loop.md
+++ b/docs/7516-ha-basic-auth-leader-forward-loop.md
@@ -181,3 +181,24 @@ server instead. Verified by running both at `HEAD` with the patch reverted - ide
 - [x] 3. `LeaderProxy` is unreachable and `LeaderForwardContext`'s Javadoc claims it enforces the rule -
       **filed as #7551**
 - [x] 4. No request timeout on a forwarded hop - **already filed as #7507**
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/7558
+
+## Review cycles
+
+| Cycle | Head | Review outcome | Change made |
+|---|---|---|---|
+| 1 | `11ab0207` | One actionable item: `LeaderForwardContext`'s Javadoc still listed `LeaderProxy` among the places the one-hop rule is enforced, which this PR's own analysis had shown to be a claim about code nothing constructs. Also noted the test-plan boxes were unticked | Both mentions of `LeaderProxy` now say it is never constructed and point at #7551. PR body's test-plan boxes ticked for the three runs actually performed; the manual three-node check left unticked and labelled as not run |
+| 2 | `9dde04ba` | One maintainability item, flagged as optional: `LeaderCommandForwarder.effectiveClusterToken` and `AbstractServerHttpHandler.isValidClusterToken` each carried their own copy of the "plugin's token first, raw setting as fallback" order - the same duplication whose drift is the defect being fixed | Extracted `HAServerPlugin.effectiveClusterToken(ArcadeDBServer)`; both sides call it. No behaviour change. Re-ran the 4 unit cases and 10 IT cases, green |
+| 3 | `780b46f3` | "Nothing blocking". Two minor notes: the `Authorization` header was read twice per request; and `effectiveClusterToken` being a static on an otherwise instance-method interface is "a one-line note either way, not a request for change" | Collapsed the header read to one lookup shared by both readers. The static-on-interface shape was left as is - the reviewer explicitly did not ask for a change, and putting a resolver used by two collaborators on the interface that owns the concept is what keeps them from drifting apart again. Re-ran 8 unit and 5 IT cases, green |
+| 4 | `137bc4a0` | No actionable items. Traced every branch combination against the four unit cases, confirmed `constantTimeEquals` is unchanged, confirmed no unused imports and no leftover debug output, and independently re-ran the `new LeaderProxy` grep | None |
+
+**Deferred items:** none. No `review-deferred-*.md` notes file was produced in any cycle.
+
+**CodeRabbit** was rate-limited for the whole run (its check reports "pass / Review rate limited") and posted no findings, so no review threads are open.
+
+**Final state:** clean-approval on cycle 4. GitHub Actions were still finishing when the loop ended
+(`build-and-package`, `lint` and several CodeQL analyses pending); the merge, and confirming those, stay
+with the developer.

--- a/docs/7516-ha-basic-auth-leader-forward-loop.md
+++ b/docs/7516-ha-basic-auth-leader-forward-loop.md
@@ -1,0 +1,183 @@
+# #7516 - a Basic/API-token write forwarded between two followers with disagreeing leader views can ping-pong unbounded
+
+## Problem
+
+`LeaderCommandForwarder.forwardIfReplica` relays an administrative write that landed on a follower to the
+leader. The one-hop rule that stops such a forward from cycling travels as the
+`X-ArcadeDB-Forwarded-To-Leader` request header, and the receiving node honours it only inside the
+`X-ArcadeDB-Cluster-Token` branch of `AbstractServerHttpHandler`. The forwarder sets the marker only on the
+branch that authenticates with the cluster token (`Bearer AU-` session tokens). A request authenticated with
+**Basic auth or an API token** is relayed with the client's own `Authorization` header and no marker at all,
+so neither end of the one-hop rule engages: two followers whose resolved leader addresses name each other
+forward the same request back and forth, one held Undertow worker thread per hop, bounded by nothing.
+
+## Root cause
+
+The marker is gated on *cluster-token authentication* rather than on *cluster-token proof*. The two are
+conflated in one branch of `AbstractServerHttpHandler.execute`: the presence of `X-ArcadeDB-Cluster-Token`
+both proves the request came from a peer **and** switches identity resolution to
+`X-ArcadeDB-Forwarded-User`. A forward that must keep relaying the client's own stateless credentials - an
+API token carries scopes that resolving the user by name on the leader would discard - therefore cannot
+carry the token, and so cannot carry a trustworthy marker either.
+
+## Invariant the fix establishes
+
+> A request a cluster peer already forwarded to the leader is never forwarded again by the node that
+> receives it, whichever credentials the client authenticated with - and a marker that does not travel
+> beside a valid cluster token is still ignored.
+
+## Completeness
+
+### Every path that forwards a request toward the leader
+
+```
+$ grep -rn "FORWARDED_TO_LEADER_HEADER" --include='*.java' .
+./ha-raft/src/test/java/.../Issue7380RestUserRoutesLeaderGateIT.java:237   (test)
+./ha-raft/src/test/java/.../Issue6191FollowerForwardLoopIT.java:189,229    (test)
+./ha-raft/src/test/java/.../Issue6221VerifyFanOutGuardIT.java:138          (test)
+./ha-raft/src/main/java/.../RaftReplicatedDatabase.java:3533               (set)
+./ha-raft/src/main/java/.../PostVerifyDatabaseHandler.java:357             (set)
+./server/src/main/java/.../PostBatchHandler.java:1683                      (set)
+./server/src/main/java/.../AbstractServerHttpHandler.java:373              (read)
+./server/src/main/java/.../LeaderCommandForwarder.java:183                 (set)
+./server/src/main/java/com/arcadedb/server/LeaderForwardContext.java:64    (const)
+
+$ grep -rn "isAlreadyForwarded" --include='*.java' .
+./ha-raft/src/main/java/.../RaftReplicatedDatabase.java:3454
+./ha-raft/src/main/java/.../PostVerifyDatabaseHandler.java:182
+./server/src/main/java/.../PostBatchHandler.java:1543
+./server/src/main/java/.../LeaderCommandForwarder.java:107
+(+ server/src/test/.../LeaderForwardContextTest.java)
+
+$ grep -rn '"X-ArcadeDB-Cluster-Token"' --include='*.java' server/src/main/java
+./server/src/main/java/.../LeaderProxy.java:85    (inbound loop check)
+./server/src/main/java/.../LeaderProxy.java:133   (outbound)
+./server/src/main/java/.../PostBatchHandler.java:1679
+./server/src/main/java/.../AbstractServerHttpHandler.java:358
+./server/src/main/java/.../LeaderCommandForwarder.java:177
+
+$ grep -rn "forwardIfReplica" --include='*.java' .
+./server/src/main/java/.../PostServerCommandHandler.java:643
+./server/src/main/java/.../PutUserHandler.java:54
+./server/src/main/java/.../DeleteUserHandler.java:50
+./server/src/main/java/.../PostUserHandler.java:53
+
+$ grep -rn "new LeaderProxy" --include='*.java' .
+(no hits in src/main - see the argued row below)
+```
+
+### Coverage table
+
+| Entry point | Marker set outbound | Marker honoured inbound | Outcome |
+|---|---|---|---|
+| `RaftReplicatedDatabase.command` (engine write forward, `/api/v1/command`) | yes, always with cluster token + forwarded user | yes | argued - already covered by #6191, unchanged |
+| `PostBatchHandler.buildForwardRequest` (`/api/v1/batch`) | yes, always | yes | argued - already covered by #6191, unchanged |
+| `PostVerifyDatabaseHandler` leader-to-peer fan-out | yes, always | yes | argued - already covered by #6221, unchanged |
+| `LeaderCommandForwarder`, `Bearer AU-` branch (4 call sites: `POST /server`, `POST/PUT/DELETE /server/users`) | only when the **raw** `arcadedb.ha.clusterToken` setting is non-empty - which it is not on any cluster that did not declare one explicitly | yes | **fixed here** - reads the HA plugin's effective token |
+| `LeaderCommandForwarder`, Basic/API-token branch (same 4 call sites) | **no** - the reported defect | no | **fixed here** |
+| `LeaderCommandForwarder`, no `Authorization` header at all | no token, no marker | n/a | argued - a request with no credentials is refused by the leader before any forward decision; `isRequireAuthentication()` is true for all four call sites (they run `checkRootUser` first) |
+| `LeaderProxy.tryProxy` | n/a | n/a | **filed as #7551** - dead code: `grep -rn "new LeaderProxy"` has no hit in `src/main`, nothing constructs it, so it cannot reach the bug. It is also the last raw `HA_CLUSTER_TOKEN` reader left in `src/main` after this change, and guards on cluster-token presence rather than on the marker |
+| A cluster whose effective token is blank (HA plugin not started / non-Raft `HAServerPlugin`) | no token, no marker | n/a | argued - `HAServerPlugin.getClusterToken()` returns null only when HA is not active, and `forwardIfReplica` returns early (`ha == null || ha.isLeader()`) before it is read. `RaftHAServer` always derives a token at startup or throws `ConfigurationException` (`ClusterTokenProvider.initClusterToken`) |
+
+### Sub-defect found by the sweep and fixed here
+
+`LeaderCommandForwarder` read `getConfiguration().getValueAsString(HA_CLUSTER_TOKEN)` - the **raw setting**.
+`ClusterTokenProvider.initClusterToken()` derives the token (PBKDF2 over cluster name + root password) when
+the setting is empty and stores it on the provider **without writing it back into the configuration**
+(only the test-only `initClusterTokenForTest` calls `config.setValue`). The receiving node validates against
+the effective token (`AbstractServerHttpHandler.validateClusterForwardedAuth` prefers `ha.getClusterToken()`).
+So on every cluster that did not declare `arcadedb.ha.clusterToken` explicitly - which includes
+`BaseRaftHATest` - the session-token branch sent neither the cluster token nor the marker, and since that
+branch also does not relay the client's `Bearer AU-` header, the forwarded request reached the leader with
+no credentials at all and was answered 401.
+
+## Residual risk
+
+- The forward still has **no request timeout** (#7507): with the fix a cycle is two hops instead of
+  unbounded, but each hop still holds a worker thread for as long as the leader takes to answer.
+- The marker only stops a cycle; it does not make the misconfiguration go away. An operator still has to
+  declare every node's HTTP port with the `host:raftPort:httpPort` syntax in `arcadedb.ha.serverList`.
+- `LeaderProxy` remains unreachable dead code (#7551). Nothing in this change depends on it.
+
+## The fix
+
+Two changes, one on each end of the same hop.
+
+**`LeaderCommandForwarder.forwardIfReplica`** now sends `X-ArcadeDB-Cluster-Token` and the
+`X-ArcadeDB-Forwarded-To-Leader` marker together, once, before the auth branches - so the marker can never
+travel without the token that makes it believable, on any branch. The Basic/API-token branch still relays the
+caller's `Authorization` header unchanged and still sends **no** `X-ArcadeDB-Forwarded-User`: resolving the
+user by name on the leader would discard the scopes an API token carries. The token is read through
+`HAServerPlugin.getClusterToken()` (effective) with the raw setting as fallback, mirroring the receiving side.
+
+**`AbstractServerHttpHandler.execute`** splits what the cluster token proves from what it substitutes.
+`isValidClusterToken` answers "did a cluster peer send this" and gates the marker; `resolveForwardedUser`
+runs only when `X-ArcadeDB-Forwarded-User` travels with it. A peer request with the token and no forwarded
+user falls through to the ordinary `Authorization` check - and is still refused with the same
+`Missing forwarded user` 401 when it carries no credentials of its own either, so no request shape that
+exists today is answered differently.
+
+## Verification
+
+| Test | What it pins |
+|---|---|
+| `Issue7516BasicAuthForwardLoopIT.aBasicAuthWriteBetweenTwoFollowersThatNameEachOtherIsRefusedInOneHop` | the reported loop, on both call-site families (`POST /server/users` and `POST /server`), with the two followers' resolved leader addresses pointing at each other |
+| `Issue7516BasicAuthForwardLoopIT.aMarkerWithoutTheClusterTokenDoesNotSuppressForwarding` | the trust gate did not widen: a client's own marker header is still ignored |
+| `Issue7516BasicAuthForwardLoopIT.aSessionTokenWriteOnAFollowerIsForwardedAndExecutedOnTheLeader` | the effective-token fix, and the control that a forward still reaches the leader |
+| `Issue7516ClusterTokenHopProofTest` (4 cases) | the receiver split: token + relayed credentials authenticates with those credentials; an invalid token is still refused; a token alone still authenticates nobody; a forwarded user still names the principal |
+
+`Issue7516ClusterTokenHopProofTest.aClusterTokenBesideRelayedCredentialsAuthenticatesWithThoseCredentials`
+was run against the un-patched tree and fails there (401), which is what makes the other three meaningful.
+
+## Adversarial pass
+
+The orchestrator's Phase 1.5 spawns a `general-purpose` subagent that has not seen the author's reasoning.
+**No `Task` tool is exposed in this session** (this run is itself a subagent, so it cannot spawn in-process
+subagents), so the pass was run by the author against the diff instead. That is weaker by exactly the amount
+the isolation was worth - it is recorded here rather than quietly skipped.
+
+| Finding | Disposition |
+|---|---|
+| The loop test drove only `POST /server/users`. A fix that covered the REST routes and missed the `POST /api/v1/server` command path - the older of the two call-site families through the same forwarder - would have passed it | **Fixed here**: the same poisoned-address window now drives `POST /api/v1/server` too |
+| The marker was emitted whenever an effective cluster token existed, including on the branch where no `Authorization` header travels at all, i.e. potentially without the token header itself | **Fixed here**: token and marker are now set together, once, before the auth branches, so the marker cannot travel without the proof that makes it believable |
+| `exchange.getRequestHeaders().get("Authorization") == null` misses the non-null-but-empty `HeaderValues` that the ordinary auth check below already handles as absent | **Fixed here**: same `null || isEmpty()` test as the standard check |
+| `LeaderForwardContext`'s Javadoc asserts "`LeaderProxy` enforces the same one-hop rule for the requests it relays". `LeaderProxy` is never constructed (`grep -rn "new LeaderProxy"` has no hit in `src/main`), and if revived would read the raw `HA_CLUSTER_TOKEN` setting - the same defect fixed here - and guards on cluster-token presence rather than on the marker | **Real, out of scope** - filed as **#7551**. Reviving or deleting it is a decision about a component this issue does not touch |
+| Each hop still holds an Undertow worker thread with no request timeout on the forward | **Real, already filed** as #7507. The fix bounds the cycle at two hops; it does not bound a hop |
+| A leadership change in flight now turns a Basic/API-token forward into a 400 rather than a second hop that might have landed on the new leader | **Argued**: identical to the trade-off #6191 already made for the cluster-token branch, and the refusal message says "retry". A second hop cannot prove the first did not execute, which is why `RaftReplicatedDatabase.forwardCommandToLeaderViaRaft` takes the same position in its own comment |
+| Does the marker now being set on requests that reach the true leader break anything? | **Argued**: both other readers of the thread-local (`RaftReplicatedDatabase.forwardCommandToLeaderViaRaft`, `PostBatchHandler.forwardBatchToLeader`) are only reached on a node that is not the leader; verified by reading both call sites |
+
+## Test results
+
+```
+mvn -o -pl server -Dtest=Issue7516ClusterTokenHopProofTest test
+  Tests run: 4, Failures: 0, Errors: 0
+
+mvn -o -pl ha-raft -DskipITs=false -Dit.test=Issue7516BasicAuthForwardLoopIT,Issue6191FollowerForwardLoopIT,\
+  Issue7380RestUserRoutesLeaderGateIT,Issue6221VerifyFanOutGuardIT test-compile failsafe:integration-test failsafe:verify
+  Issue7516BasicAuthForwardLoopIT        Tests run: 3, Failures: 0, Errors: 0
+  Issue6191FollowerForwardLoopIT         Tests run: 5, Failures: 0, Errors: 0
+  Issue7380RestUserRoutesLeaderGateIT    Tests run: 2, Failures: 0, Errors: 0
+  Issue6221VerifyFanOutGuardIT           Tests run: 4, Failures: 0, Errors: 0
+  Tests run: 14, Failures: 0, Errors: 0
+```
+
+The three existing ITs are the regression set: #6191 owns the marker mechanism this change moves,
+#7380 owns the four call sites that share the forwarder, #6221 owns the leader-to-peer fan-out that
+reads the same thread-local.
+
+`ClusterInternalAuthTest` and `PostClusterAuthSessionHandlerTest` fail on this machine both with and
+without the patch: they dial a hard-coded `localhost:2480` while the server may bind anywhere in the
+configured `2480-2489` range, so with another test JVM already listening there the requests reach that
+server instead. Verified by running both at `HEAD` with the patch reverted - identical failures. The new
+`Issue7516ClusterTokenHopProofTest` reads `getServer(0).getHttpServer().getPort()` for that reason.
+
+## Ledger
+
+- [x] 1. A Basic/API-token forward carries no one-hop marker and can ping-pong between two followers -
+      **fixed**, on both call-site families, with an IT that drives the cycle
+- [x] 2. `LeaderCommandForwarder` reads the raw `arcadedb.ha.clusterToken` setting rather than the
+      effective token (found by the sweep, same defect class) - **fixed**, with an IT that logs in over
+      HTTP and forwards a session-token write
+- [x] 3. `LeaderProxy` is unreachable and `LeaderForwardContext`'s Javadoc claims it enforces the rule -
+      **filed as #7551**
+- [x] 4. No request timeout on a forwarded hop - **already filed as #7507**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7516BasicAuthForwardLoopIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7516BasicAuthForwardLoopIT.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.LeaderForwardContext;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.UnaryOperator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Issue #7516: the one-hop rule that stops a follower-to-leader forward from cycling travels as the
+ * {@code X-ArcadeDB-Forwarded-To-Leader} request header, and {@link LeaderForwardContext} honours it only
+ * beside a valid cluster token. {@code LeaderCommandForwarder} used to send the token only on the branch
+ * that swaps a per-node session token for a forwarded-user assertion; a write authenticated with
+ * <b>Basic auth or an API token</b> is relayed with the client's own {@code Authorization} header instead,
+ * and so carried no token and no marker at all. Two followers whose resolved leader addresses name each other - A believes the
+ * leader is B, B believes it is A - then forwarded the same request back and forth. The dial-side
+ * {@code isOwnHttpAddress} check does not see it: each node is dialling the <em>other</em> node.
+ * <p>
+ * The fix separates the two things the cluster token was doing at once. It proves the <b>hop</b> - so the
+ * marker can now travel beside a relayed {@code Authorization} header - while identity substitution stays
+ * tied to {@code X-ArcadeDB-Forwarded-User}, which a Basic/API-token forward deliberately does not send: an
+ * API token carries scopes that resolving the user by name on the leader would silently discard.
+ * <p>
+ * The ambiguity is injected the way {@code Issue6191FollowerForwardLoopIT} injects it - by rewriting the
+ * live resolved-HTTP-address map of the two followers for the duration of one test - because that reproduces
+ * the production condition at the point where it matters without making cluster startup part of what is
+ * under test.
+ */
+@Tag("slow")
+class Issue7516BasicAuthForwardLoopIT extends BaseRaftHATest {
+
+  /**
+   * Short on purpose. A build without the fix ping-pongs the request between the two followers forever, so
+   * this timeout - not an assertion - is what ends the first test, and it has to end it long before the
+   * {@link Timeout} that fails the method.
+   */
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(20);
+
+  private static final HttpClient HTTP = HttpClient.newBuilder()
+      .version(HttpClient.Version.HTTP_1_1)
+      .connectTimeout(Duration.ofSeconds(10))
+      .build();
+
+  private static final String PASSWORD = "issue7516password";
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  /**
+   * The reported defect. Both followers are told the leader lives where the other one does, so every hop
+   * lands on a node that is not the leader and resolves the same wrong address back. The request has to come
+   * to rest in one hop with the typed refusal, and nothing may have been written on the way.
+   */
+  @Test
+  @Timeout(180)
+  void aBasicAuthWriteBetweenTwoFollowersThatNameEachOtherIsRefusedInOneHop() throws Exception {
+    final int leader = findLeaderIndex();
+    assertThat(leader).as("a Raft leader must be elected").isGreaterThanOrEqualTo(0);
+    final int followerA = firstFollower(leader);
+    final int followerB = secondFollower(leader, followerA);
+
+    final RaftHAServer raftA = getRaftPlugin(followerA).getRaftHAServer();
+    final RaftHAServer raftB = getRaftPlugin(followerB).getRaftHAServer();
+    final Map<RaftPeerId, String> addressesA = raftA.getHttpAddresses();
+    final Map<RaftPeerId, String> addressesB = raftB.getHttpAddresses();
+    final Map<RaftPeerId, String> declaredA = new HashMap<>(addressesA);
+    final Map<RaftPeerId, String> declaredB = new HashMap<>(addressesB);
+    final RaftPeerId leaderPeer = RaftPeerId.valueOf(peerIdForIndex(leader));
+
+    final String created = "issue7516nevercreated";
+    try {
+      addressesA.put(leaderPeer, "localhost:" + getServer(followerB).getHttpServer().getPort());
+      addressesB.put(leaderPeer, "localhost:" + getServer(followerA).getHttpServer().getPort());
+
+      // Neither node's own self-address check can see this: each is dialling the other, not itself.
+      assertThat(raftA.isOwnHttpAddress(raftA.getLeaderHttpAddress()))
+          .as("the cycle this reproduces is exactly the one the self-address check cannot catch").isFalse();
+      assertThat(raftB.isOwnHttpAddress(raftB.getLeaderHttpAddress())).isFalse();
+
+      assertRefusedInOneHop(asRoot(followerA, "POST", "/api/v1/server/users",
+          new JSONObject().put("name", created).put("password", PASSWORD).toString()), "POST /server/users");
+
+      // The other family of call sites through the same forwarder: the POST /api/v1/server command path,
+      // which has forwarded to the leader since issue #6191 and which the three REST routes only joined in
+      // issue #7380. A fix that covered the routes and not the command would satisfy the line above.
+      assertRefusedInOneHop(asRoot(followerA, "POST", "/api/v1/server",
+          new JSONObject().put("command", "create user { \"name\": \"" + created + "\", \"password\": \""
+              + PASSWORD + "\", \"databases\": {} }").toString()), "POST /server create user");
+    } finally {
+      addressesA.clear();
+      addressesA.putAll(declaredA);
+      addressesB.clear();
+      addressesB.putAll(declaredB);
+    }
+
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(getServer(i).getSecurity().existsUser(created))
+          .as("server %d must not hold a user the forward never delivered", i).isFalse();
+  }
+
+  /**
+   * The trust gate, which the fix must not widen: the marker is honoured only when a valid cluster token
+   * travels beside it. A client that copies the header onto its own Basic-authenticated write - or a proxy
+   * that relays unknown {@code X-ArcadeDB-*} headers through - must not be able to turn its own transparent
+   * forward-to-leader into a refusal.
+   */
+  @Test
+  @Timeout(180)
+  void aMarkerWithoutTheClusterTokenDoesNotSuppressForwarding() throws Exception {
+    final int leader = findLeaderIndex();
+    assertThat(leader).as("a Raft leader must be elected").isGreaterThanOrEqualTo(0);
+    final int follower = firstFollower(leader);
+
+    final String name = "issue7516forgedmarker";
+    final HttpResponse<String> response = send(follower, "POST", "/api/v1/server/users",
+        new JSONObject().put("name", name).put("password", PASSWORD).toString(),
+        b -> b.header("Authorization", basic("root", BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS))
+            .header(LeaderForwardContext.FORWARDED_TO_LEADER_HEADER, "true"));
+
+    assertThat(response.statusCode())
+        .as("a client's own marker must not stop this follower forwarding, body: %s", response.body())
+        .isEqualTo(201);
+    awaitUserOnEveryServer(name);
+  }
+
+  /**
+   * The branch that always carried the marker, driven end to end for the first time. It authenticates to the
+   * leader with the cluster token, which {@code LeaderCommandForwarder} read from the raw
+   * {@code arcadedb.ha.clusterToken} setting - empty on every cluster that did not declare one explicitly,
+   * because {@code ClusterTokenProvider} derives the effective token at startup and never writes it back into
+   * the configuration. The forward then went out with no credentials at all and was answered 401.
+   */
+  @Test
+  @Timeout(180)
+  void aSessionTokenWriteOnAFollowerIsForwardedAndExecutedOnTheLeader() throws Exception {
+    final int leader = findLeaderIndex();
+    assertThat(leader).as("a Raft leader must be elected").isGreaterThanOrEqualTo(0);
+    final int follower = firstFollower(leader);
+
+    assertThat(getRaftPlugin(follower).getRaftHAServer().getClusterToken())
+        .as("this cluster declares no explicit cluster token, so the effective one is derived at startup")
+        .isNotBlank();
+    assertThat(getServer(follower).getConfiguration()
+        .getValueAsString(GlobalConfiguration.HA_CLUSTER_TOKEN))
+        .as("and the derived token is NOT written back into the configuration - reading it there is the defect")
+        .isNullOrEmpty();
+
+    final HttpResponse<String> login = send(follower, "POST", "/api/v1/login", null,
+        b -> b.header("Authorization", basic("root", BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS)));
+    assertThat(login.statusCode()).as("login on a follower, body: %s", login.body()).isEqualTo(200);
+    final String sessionToken = new JSONObject(login.body()).getString("token");
+    assertThat(sessionToken).startsWith("AU-");
+
+    final String name = "issue7516sessiontoken";
+    final HttpResponse<String> created = send(follower, "POST", "/api/v1/server/users",
+        new JSONObject().put("name", name).put("password", PASSWORD).toString(),
+        b -> b.header("Authorization", "Bearer " + sessionToken));
+
+    assertThat(created.statusCode())
+        .as("a session-token write forwarded to the leader must be authenticated there, body: %s", created.body())
+        .isEqualTo(201);
+    awaitUserOnEveryServer(name);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+
+  private void assertRefusedInOneHop(final HttpResponse<String> response, final String route) {
+    assertThat(response.statusCode())
+        .as("%s: the second hop must refuse the write, not relay it back, body: %s", route, response.body())
+        .isEqualTo(400);
+    assertThat(response.body())
+        .as("%s: the refusal the first follower relays to the client must say why", route)
+        .contains("already forwarded");
+  }
+
+  private void awaitUserOnEveryServer(final String name) {
+    await().atMost(30, TimeUnit.SECONDS).until(() -> {
+      for (int i = 0; i < getServerCount(); i++)
+        if (!getServer(i).getSecurity().existsUser(name))
+          return false;
+      return true;
+    });
+  }
+
+  private HttpResponse<String> asRoot(final int serverIndex, final String method, final String path,
+      final String body) throws Exception {
+    return send(serverIndex, method, path, body,
+        b -> b.header("Authorization", basic("root", BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS)));
+  }
+
+  private HttpResponse<String> send(final int serverIndex, final String method, final String path,
+      final String body, final UnaryOperator<HttpRequest.Builder> decorate) throws Exception {
+    final int port = getServer(serverIndex).getHttpServer().getPort();
+    HttpRequest.Builder builder = HttpRequest.newBuilder()
+        .uri(URI.create("http://127.0.0.1:" + port + path))
+        .timeout(REQUEST_TIMEOUT);
+    builder = decorate.apply(builder);
+    if (body != null) {
+      builder.header("Content-Type", "application/json");
+      builder.method(method, HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8));
+    } else
+      builder.method(method, HttpRequest.BodyPublishers.noBody());
+    return HTTP.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+  }
+
+  private static String basic(final String user, final String password) {
+    return "Basic " + Base64.getEncoder()
+        .encodeToString((user + ":" + password).getBytes(StandardCharsets.UTF_8));
+  }
+
+  private int firstFollower(final int leader) {
+    for (int i = 0; i < getServerCount(); i++)
+      if (i != leader)
+        return i;
+    throw new IllegalStateException("no follower in a " + getServerCount() + "-node cluster");
+  }
+
+  private int secondFollower(final int leader, final int firstFollower) {
+    for (int i = 0; i < getServerCount(); i++)
+      if (i != leader && i != firstFollower)
+        return i;
+    throw new IllegalStateException("no second follower in a " + getServerCount() + "-node cluster");
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
+++ b/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
@@ -18,6 +18,8 @@
  */
 package com.arcadedb.server;
 
+import com.arcadedb.GlobalConfiguration;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -101,6 +103,34 @@ public interface HAServerPlugin extends ServerPlugin {
    */
   default String getClusterToken() {
     return null;
+  }
+
+  /**
+   * The token {@code server}'s peers actually accept: the HA plugin's own, and the raw
+   * {@link GlobalConfiguration#HA_CLUSTER_TOKEN} setting only when the plugin has none (HA not active, or a
+   * non-Raft implementation that does not derive one).
+   * <p>
+   * The fallback is not the same value as the plugin's. {@code ClusterTokenProvider} derives the token from
+   * the cluster name and the root password when the setting is left empty, and stores it on itself
+   * <em>without</em> writing it back into the configuration - so on every cluster that did not declare a
+   * token explicitly the raw setting reads empty while the effective token is a real secret. Reading the
+   * setting alone is therefore not a conservative approximation of this: it is a different answer.
+   * <p>
+   * One method rather than one per caller, because the two ends of a forwarded hop reading the resolution
+   * order differently is the defect of issue #7516 - the sender authenticated with the raw setting while the
+   * receiver checked the derived token, so on a default-configured cluster the forward carried no usable
+   * credentials at all.
+   *
+   * @return the effective token, or null/blank when this server has none
+   */
+  static String effectiveClusterToken(final ArcadeDBServer server) {
+    if (server == null)
+      return null;
+    final HAServerPlugin ha = server.getHA();
+    final String fromPlugin = ha != null ? ha.getClusterToken() : null;
+    if (fromPlugin != null && !fromPlugin.isBlank())
+      return fromPlugin;
+    return server.getConfiguration().getValueAsString(GlobalConfiguration.HA_CLUSTER_TOKEN);
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/LeaderForwardContext.java
+++ b/server/src/main/java/com/arcadedb/server/LeaderForwardContext.java
@@ -36,16 +36,21 @@ package com.arcadedb.server;
  * request boundary and clears it in a finally block, because one of the redirect decisions is taken deep
  * inside the engine ({@code RaftReplicatedDatabase.command}) where the HTTP exchange is no longer in reach.
  * <p>
- * It is honored <em>only</em> on a request that authenticated with the cluster token, because the marker is a
- * statement one node makes to another. Trusting it from an ordinary client request would cost nothing in
- * safety - its only possible effect is a refusal, never execution on a node that is not the leader - but it
- * would let any caller (or a proxy that copies unknown {@code X-ArcadeDB-*} headers through) turn its own
- * transparent forward-to-leader into a {@code ServerIsNotTheLeaderException}. Every follower-to-leader
- * redirect that can loop authenticates with the cluster token, so nothing is left uncovered by the gate: the
- * one branch that does not - a server command forwarded with a client's own Basic/API-token credentials -
- * carries no marker at all and relies on the dial-side self-address check, which is what the reachable
- * misconfiguration (an undeclared {@code http} port, where every peer derives to this node's own address)
- * produces anyway.
+ * It is honored <em>only</em> on a request carrying a valid {@code X-ArcadeDB-Cluster-Token}, because the
+ * marker is a statement one node makes to another. Trusting it from an ordinary client request would cost
+ * nothing in safety - its only possible effect is a refusal, never execution on a node that is not the leader
+ * - but it would let any caller (or a proxy that copies unknown {@code X-ArcadeDB-*} headers through) turn
+ * its own transparent forward-to-leader into a {@code ServerIsNotTheLeaderException}.
+ * <p>
+ * That gate is on the cluster token as a <em>proof of hop</em>, not on the token having replaced the caller's
+ * identity. The distinction is what issue #7516 turns on: a server command relayed with a client's own
+ * Basic-auth or API-token header keeps those headers - resolving the user by name on the leader would discard
+ * the scopes an API token carries - and so sends the cluster token beside them rather than instead of them.
+ * Before that split it sent no token, and therefore no marker, which left the dial-side self-address check as
+ * its only bound. That check catches the reachable misconfiguration of issue #6191 (an undeclared {@code http}
+ * port, where every peer derives to this node's own address) but not a hand-written or stale
+ * {@code arcadedb.ha.serverList} in which two peers name each other: there each node dials the <em>other</em>
+ * one, so no node ever recognizes its own address and the request ping-pongs.
  * <p>
  * {@code LeaderProxy} enforces the same one-hop rule for the requests it relays, reading the exchange
  * directly since it still has one.

--- a/server/src/main/java/com/arcadedb/server/LeaderForwardContext.java
+++ b/server/src/main/java/com/arcadedb/server/LeaderForwardContext.java
@@ -52,8 +52,10 @@ package com.arcadedb.server;
  * {@code arcadedb.ha.serverList} in which two peers name each other: there each node dials the <em>other</em>
  * one, so no node ever recognizes its own address and the request ping-pongs.
  * <p>
- * {@code LeaderProxy} enforces the same one-hop rule for the requests it relays, reading the exchange
- * directly since it still has one.
+ * {@code LeaderProxy} is written to enforce a one-hop rule of its own for the requests it relays, reading the
+ * exchange directly since it still has one - but nothing constructs it ({@code grep -rn "new LeaderProxy"}
+ * has no hit under {@code src/main}), so no request has ever travelled that path. Do not count it as one of
+ * the places the rule is enforced; issue #7551 tracks reviving or deleting it.
  * <p>
  * The rule generalizes past the follower-to-leader direction, and so does the marker: the cluster-verify
  * endpoint's leader-to-peer fan-out sets it too (issue #6221), because a peer address that names the wrong node

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -352,6 +352,10 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
 
       ServerSecurityUser user = null;
 
+      // Read once and shared by both readers below: the cluster-token branch asks only whether the caller
+      // sent credentials of its own, the standard check below authenticates them.
+      final HeaderValues authorization = exchange.getRequestHeaders().get("Authorization");
+
       // Cluster-internal headers: a peer relayed this request. X-ArcadeDB-Cluster-Token proves the HOP - it
       // is the shared secret only cluster members hold - and that is all it proves. Whether it also names
       // the principal depends on what the relaying node could do with the client's credentials:
@@ -385,12 +389,11 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
           LeaderForwardContext.markAlreadyForwarded();
 
         final HeaderValues forwardedUserValues = exchange.getRequestHeaders().get("X-ArcadeDB-Forwarded-User");
-        final HeaderValues relayedAuthorization = exchange.getRequestHeaders().get("Authorization");
         if (forwardedUserValues != null && !forwardedUserValues.isEmpty()) {
           user = resolveForwardedUser(exchange, forwardedUserValues.getFirst());
           if (user == null)
             return; // 401 already sent
-        } else if (relayedAuthorization == null || relayedAuthorization.isEmpty()) {
+        } else if (authorization == null || authorization.isEmpty()) {
           // Neither a forwarded identity nor credentials of the caller's own: the cluster token proves a
           // hop, it has never been a principal. Refused here rather than falling through, so the answer to
           // this request shape is the one it has always been.
@@ -403,7 +406,6 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
       }
 
       if (user == null) {
-        final HeaderValues authorization = exchange.getRequestHeaders().get("Authorization");
         if (isRequireAuthentication() && (authorization == null || authorization.isEmpty())) {
           exchange.setStatusCode(401);
           exchange.getResponseHeaders().put(Headers.WWW_AUTHENTICATE, "Basic");

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -31,6 +31,7 @@ import com.arcadedb.serializer.json.JSONException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.HAReplicatedDatabase;
+import com.arcadedb.server.HAServerPlugin;
 import com.arcadedb.server.LeaderForwardContext;
 import com.arcadedb.server.http.ClusterAuthSessionResolver;
 import com.arcadedb.server.http.HttpAuthSession;
@@ -1197,18 +1198,11 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
    * nothing about who the request is for. What the caller does with that answer - resolve a forwarded
    * identity, honor the one-hop marker, or both - is the caller's decision (issue #7516).
    * <p>
-   * Prefers the HA plugin's effective token, which is PBKDF2-derived at startup when
-   * {@code arcadedb.ha.clusterToken} is left empty and is never written back into the configuration, over
-   * the raw setting. The raw setting is the fallback for non-Raft setups.
+   * Resolved through {@link HAServerPlugin#effectiveClusterToken}, the same helper the sending side uses, so
+   * the two ends of a forwarded hop cannot disagree about which token is current.
    */
   private boolean isValidClusterToken(final String providedToken) {
-    String clusterToken = null;
-    final var ha = httpServer.getServer().getHA();
-    if (ha != null)
-      clusterToken = ha.getClusterToken();
-    if (clusterToken == null || clusterToken.isBlank())
-      clusterToken = httpServer.getServer().getConfiguration().getValueAsString(GlobalConfiguration.HA_CLUSTER_TOKEN);
-
+    final String clusterToken = HAServerPlugin.effectiveClusterToken(httpServer.getServer());
     return clusterToken != null && !clusterToken.isBlank() && constantTimeEquals(clusterToken, providedToken);
   }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -351,27 +351,54 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
 
       ServerSecurityUser user = null;
 
-      // Cluster-internal forwarded auth: a follower forwarded a request on behalf of an
-      // end user. The original per-node session token (Bearer AU-...) cannot be resolved on
-      // the leader, so the follower substitutes X-ArcadeDB-Cluster-Token plus
-      // X-ArcadeDB-Forwarded-User. Validated before the standard Authorization header check.
+      // Cluster-internal headers: a peer relayed this request. X-ArcadeDB-Cluster-Token proves the HOP - it
+      // is the shared secret only cluster members hold - and that is all it proves. Whether it also names
+      // the principal depends on what the relaying node could do with the client's credentials:
+      //
+      //   - a per-node session token (Bearer AU-...) cannot be resolved on the node the request is relayed
+      //     to, so the relaying node substitutes X-ArcadeDB-Forwarded-User and the principal is resolved
+      //     from that name here;
+      //   - Basic auth and API tokens are stateless, so they are relayed unchanged and re-validated by the
+      //     standard Authorization check below. No forwarded user travels with them deliberately: an API
+      //     token carries scopes that resolving the user by name here would silently discard.
+      //
+      // Splitting the two is what lets the second shape carry the one-hop marker as well (issue #7516);
+      // before it, the token could only travel together with a substituted identity, so the branch that had
+      // to relay the caller's own credentials carried no marker and could cycle.
       final HeaderValues clusterTokenHeader = exchange.getRequestHeaders().get("X-ArcadeDB-Cluster-Token");
       if (clusterTokenHeader != null && !clusterTokenHeader.isEmpty()) {
-        user = validateClusterForwardedAuth(exchange,
-            clusterTokenHeader.getFirst(),
-            exchange.getRequestHeaders().get("X-ArcadeDB-Forwarded-User"));
-        if (user == null)
-          return; // 401 already sent
+        if (!isValidClusterToken(clusterTokenHeader.getFirst())) {
+          exchange.setStatusCode(401);
+          sendErrorResponse(exchange, 401, "Invalid cluster token", null, null);
+          return;
+        }
 
         // A peer already redirected this request to the leader, so this node must execute it or refuse it -
         // redirecting it again sends it round the cycle a wrong leader address creates, and nothing else in
         // the exchange says the request has been here before (issue #6191). Published onto a thread-local
         // because one of the redirect decisions is taken deep in the engine, where the exchange is out of
-        // reach. Read only here, inside the cluster-token branch: the marker is a statement one node makes to
-        // another, and honoring it from an ordinary client request would let any caller turn its own
+        // reach. Read only after the cluster token has been validated: the marker is a statement one node
+        // makes to another, and honoring it from an ordinary client request would let any caller turn its own
         // transparent forward into a refusal by copying the header through.
         if (exchange.getRequestHeaders().contains(LeaderForwardContext.FORWARDED_TO_LEADER_HEADER))
           LeaderForwardContext.markAlreadyForwarded();
+
+        final HeaderValues forwardedUserValues = exchange.getRequestHeaders().get("X-ArcadeDB-Forwarded-User");
+        final HeaderValues relayedAuthorization = exchange.getRequestHeaders().get("Authorization");
+        if (forwardedUserValues != null && !forwardedUserValues.isEmpty()) {
+          user = resolveForwardedUser(exchange, forwardedUserValues.getFirst());
+          if (user == null)
+            return; // 401 already sent
+        } else if (relayedAuthorization == null || relayedAuthorization.isEmpty()) {
+          // Neither a forwarded identity nor credentials of the caller's own: the cluster token proves a
+          // hop, it has never been a principal. Refused here rather than falling through, so the answer to
+          // this request shape is the one it has always been.
+          exchange.setStatusCode(401);
+          sendErrorResponse(exchange, 401, "Missing forwarded user", null, null);
+          return;
+        }
+        // Otherwise the peer relayed the caller's own credentials: the standard Authorization check below
+        // authenticates them here, exactly as the node the client dialled already did.
       }
 
       if (user == null) {
@@ -1165,14 +1192,16 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
   }
 
   /**
-   * Validates cluster-internal forwarded-auth headers. Returns the resolved user on success,
-   * or {@code null} after sending a 401 response.
+   * Whether {@code providedToken} is the shared secret this cluster's members authenticate to each other
+   * with. This is a proof of <em>hop</em>, not of identity: it says a cluster peer sent the request, and
+   * nothing about who the request is for. What the caller does with that answer - resolve a forwarded
+   * identity, honor the one-hop marker, or both - is the caller's decision (issue #7516).
+   * <p>
+   * Prefers the HA plugin's effective token, which is PBKDF2-derived at startup when
+   * {@code arcadedb.ha.clusterToken} is left empty and is never written back into the configuration, over
+   * the raw setting. The raw setting is the fallback for non-Raft setups.
    */
-  private ServerSecurityUser validateClusterForwardedAuth(final HttpServerExchange exchange,
-      final String providedToken, final HeaderValues forwardedUserValues) {
-
-    // Prefer the HA plugin's effective token (which may be PBKDF2-derived when not explicitly
-    // configured) over the raw config value. Falls back to the raw config for non-Raft setups.
+  private boolean isValidClusterToken(final String providedToken) {
     String clusterToken = null;
     final var ha = httpServer.getServer().getHA();
     if (ha != null)
@@ -1180,21 +1209,16 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     if (clusterToken == null || clusterToken.isBlank())
       clusterToken = httpServer.getServer().getConfiguration().getValueAsString(GlobalConfiguration.HA_CLUSTER_TOKEN);
 
-    if (clusterToken == null || clusterToken.isBlank()
-        || !constantTimeEquals(clusterToken, providedToken)) {
-      exchange.setStatusCode(401);
-      sendErrorResponse(exchange, 401, "Invalid cluster token", null, null);
-      return null;
-    }
+    return clusterToken != null && !clusterToken.isBlank() && constantTimeEquals(clusterToken, providedToken);
+  }
 
-    if (forwardedUserValues == null || forwardedUserValues.isEmpty()) {
-      exchange.setStatusCode(401);
-      sendErrorResponse(exchange, 401, "Missing forwarded user", null, null);
-      return null;
-    }
-
-    final ServerSecurityUser forwardedUser = httpServer.getServer().getSecurity()
-        .getUser(forwardedUserValues.getFirst());
+  /**
+   * Resolves the principal a peer named in {@code X-ArcadeDB-Forwarded-User}, answering 401 and returning
+   * null when this node does not know that user. Only ever called after {@link #isValidClusterToken} has
+   * accepted the request's cluster token.
+   */
+  private ServerSecurityUser resolveForwardedUser(final HttpServerExchange exchange, final String userName) {
+    final ServerSecurityUser forwardedUser = httpServer.getServer().getSecurity().getUser(userName);
     if (forwardedUser == null) {
       exchange.setStatusCode(401);
       sendErrorResponse(exchange, 401, "Unknown forwarded user", null, null);

--- a/server/src/main/java/com/arcadedb/server/http/handler/LeaderCommandForwarder.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/LeaderCommandForwarder.java
@@ -166,26 +166,37 @@ public final class LeaderCommandForwarder {
     } else
       builder.method(exchange.getRequestMethod().toString(), HttpRequest.BodyPublishers.noBody());
 
+    // The secret cluster members authenticate to each other with, and the only thing that makes the one-hop
+    // marker below believable on the far end. Read through the HA plugin, which holds the EFFECTIVE token:
+    // when arcadedb.ha.clusterToken is left empty, ClusterTokenProvider derives one at startup and stores it
+    // on itself WITHOUT writing it back into the configuration, so the raw setting reads empty on every
+    // cluster that did not declare a token explicitly. The receiving node validates against the effective
+    // token, so reading the raw setting here left the two ends of the same hop disagreeing (issue #7516).
+    final String clusterToken = effectiveClusterToken(ha);
+    if (clusterToken != null && !clusterToken.isBlank()) {
+      builder.header("X-ArcadeDB-Cluster-Token", clusterToken);
+      // One hop only: whichever node this address really names refuses the command if it is not the leader,
+      // instead of resolving the same address and forwarding it again (issue #6191). Set here, beside the
+      // token and never without it, because that is the only form in which the receiving node trusts it - a
+      // marker from an ordinary client would let any caller turn its own transparent forward into a refusal
+      // (see LeaderForwardContext). Until issue #7516 it travelled with the session-token branch alone, which
+      // left a Basic/API-token forward with no bound at all when two peers name each other as the leader: the
+      // dial-side self-address check does not fire there, because each node is dialling the OTHER one.
+      builder.header(LeaderForwardContext.FORWARDED_TO_LEADER_HEADER, "true");
+    }
+
     if (authHeader != null && authHeader.startsWith("Bearer AU-")) {
-      // Per-node session token: convert to cluster-internal identity headers
-      final String clusterToken = httpServer.getServer().getConfiguration()
-          .getValueAsString(GlobalConfiguration.HA_CLUSTER_TOKEN);
+      // Per-node session token: the leader cannot resolve it, so this node names the principal instead. The
+      // cluster token above is what makes that substitution believable.
       final String userName = user != null ? user.getName() : null;
       if (userName != null)
         builder.header("X-ArcadeDB-Forwarded-User", userName);
-      if (clusterToken != null && !clusterToken.isBlank()) {
-        builder.header("X-ArcadeDB-Cluster-Token", clusterToken);
-        // One hop only: whichever node this address really names refuses the command if it is not the leader,
-        // instead of resolving the same address and forwarding it again (issue #6191). Sent only alongside
-        // the cluster token, because that is the only form in which the receiving node trusts it - see
-        // LeaderForwardContext. The other branch below relays the client's own credentials and carries no
-        // marker; its loop protection is the self-address check above.
-        builder.header(LeaderForwardContext.FORWARDED_TO_LEADER_HEADER, "true");
-      }
-    } else if (authHeader != null) {
-      // Basic or API token: stateless, forward as-is
+    } else if (authHeader != null)
+      // Basic auth or an API token: stateless, and the leader can check them itself, so they are relayed
+      // unchanged rather than swapped for a forwarded-user assertion - an API token carries scopes that
+      // resolving the user by name on the leader would silently discard. Deliberately with no forwarded-user
+      // header, which is what keeps the leader validating what the client actually sent (issue #7516).
       builder.header("Authorization", authHeader);
-    }
 
     try {
       final HttpResponse<String> response = HTTP_CLIENT.send(builder.build(), HttpResponse.BodyHandlers.ofString());
@@ -194,5 +205,18 @@ public final class LeaderCommandForwarder {
       Thread.currentThread().interrupt();
       throw new IOException("Interrupted while forwarding server command to leader at " + leaderHttpAddress, e);
     }
+  }
+
+  /**
+   * The token this node's peers actually accept: the plugin's derived one whenever
+   * {@code arcadedb.ha.clusterToken} was not declared, and the raw setting otherwise. Mirrors the resolution
+   * order the receiving side uses in {@code AbstractServerHttpHandler}, so a forward this node sends and the
+   * check the peer runs on it cannot read two different values.
+   */
+  private String effectiveClusterToken(final HAServerPlugin ha) {
+    final String fromPlugin = ha != null ? ha.getClusterToken() : null;
+    if (fromPlugin != null && !fromPlugin.isBlank())
+      return fromPlugin;
+    return httpServer.getServer().getConfiguration().getValueAsString(GlobalConfiguration.HA_CLUSTER_TOKEN);
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/LeaderCommandForwarder.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/LeaderCommandForwarder.java
@@ -169,12 +169,11 @@ public final class LeaderCommandForwarder {
       builder.method(exchange.getRequestMethod().toString(), HttpRequest.BodyPublishers.noBody());
 
     // The secret cluster members authenticate to each other with, and the only thing that makes the one-hop
-    // marker below believable on the far end. Read through the HA plugin, which holds the EFFECTIVE token:
-    // when arcadedb.ha.clusterToken is left empty, ClusterTokenProvider derives one at startup and stores it
-    // on itself WITHOUT writing it back into the configuration, so the raw setting reads empty on every
-    // cluster that did not declare a token explicitly. The receiving node validates against the effective
-    // token, so reading the raw setting here left the two ends of the same hop disagreeing (issue #7516).
-    final String clusterToken = effectiveClusterToken(ha);
+    // marker below believable on the far end. Resolved through the shared helper the receiving node uses, so
+    // the two ends of the same hop cannot read different values - this used to read the raw
+    // arcadedb.ha.clusterToken setting, which is empty on every cluster that did not declare a token
+    // explicitly, while the receiver checked the token derived at startup (issue #7516).
+    final String clusterToken = HAServerPlugin.effectiveClusterToken(httpServer.getServer());
     if (clusterToken != null && !clusterToken.isBlank()) {
       builder.header("X-ArcadeDB-Cluster-Token", clusterToken);
       // One hop only: whichever node this address really names refuses the command if it is not the leader,
@@ -207,18 +206,5 @@ public final class LeaderCommandForwarder {
       Thread.currentThread().interrupt();
       throw new IOException("Interrupted while forwarding server command to leader at " + leaderHttpAddress, e);
     }
-  }
-
-  /**
-   * The token this node's peers actually accept: the plugin's derived one whenever
-   * {@code arcadedb.ha.clusterToken} was not declared, and the raw setting otherwise. Mirrors the resolution
-   * order the receiving side uses in {@code AbstractServerHttpHandler}, so a forward this node sends and the
-   * check the peer runs on it cannot read two different values.
-   */
-  private String effectiveClusterToken(final HAServerPlugin ha) {
-    final String fromPlugin = ha != null ? ha.getClusterToken() : null;
-    if (fromPlugin != null && !fromPlugin.isBlank())
-      return fromPlugin;
-    return httpServer.getServer().getConfiguration().getValueAsString(GlobalConfiguration.HA_CLUSTER_TOKEN);
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/LeaderCommandForwarder.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/LeaderCommandForwarder.java
@@ -152,7 +152,9 @@ public final class LeaderCommandForwarder {
       // 26.10.1 server: '?x=a{b}' is answered 400 by the parser, and URI.create rejects the same string).
       // What is guarded is the gap between those two allowances drifting apart - an Undertow upgrade, that
       // option being turned on, or an HTTP/2 ':path' that does not travel through the same parser.
-      // LeaderProxy already guards the identical call the same way, which is why this is not left to chance.
+      // LeaderProxy guards the identical call the same way, which is why this is not left to chance - though
+      // that class is never constructed, so it is a precedent for the shape of the guard and not evidence
+      // anything has exercised it (issue #7551).
       return new ExecutionResponse(400, new JSONObject()
           .put("error", "The request target cannot be forwarded to the cluster leader: " + e.getMessage())
           .toString());

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue7516ClusterTokenHopProofTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue7516ClusterTokenHopProofTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.LeaderForwardContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.function.UnaryOperator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7516: {@code X-ArcadeDB-Cluster-Token} was doing two jobs at once - proving the request came from a
+ * cluster peer, and switching identity resolution to {@code X-ArcadeDB-Forwarded-User}. A forward that has to
+ * relay the client's own stateless credentials (Basic auth, or an API token whose scopes resolving the user
+ * by name on the leader would discard) therefore could not carry the token, and so could not carry a
+ * trustworthy one-hop marker either.
+ * <p>
+ * The two jobs are now separate: a valid cluster token proves the hop, and identity substitution happens only
+ * when a forwarded user travels with it. What must not change is the fail-closed behaviour on either side of
+ * that split, which is what these cases pin. The loop the split exists to stop is driven end to end in
+ * {@code Issue7516BasicAuthForwardLoopIT}; it needs a cluster, and this does not.
+ */
+class Issue7516ClusterTokenHopProofTest extends BaseGraphServerTest {
+
+  private static final String CLUSTER_TOKEN = "issue7516-cluster-secret-token";
+  private static final HttpClient HTTP = HttpClient.newHttpClient();
+
+  @BeforeEach
+  void setClusterToken() {
+    getServer(0).getConfiguration().setValue(GlobalConfiguration.HA_CLUSTER_TOKEN, CLUSTER_TOKEN);
+  }
+
+  @AfterEach
+  void clearClusterToken() {
+    getServer(0).getConfiguration().setValue(GlobalConfiguration.HA_CLUSTER_TOKEN, "");
+  }
+
+  /**
+   * The shape a Basic/API-token forward now has: the token proves the hop, the client's own credentials
+   * authenticate the caller. Before the split this was answered 401 "Missing forwarded user".
+   */
+  @Test
+  void aClusterTokenBesideRelayedCredentialsAuthenticatesWithThoseCredentials() throws Exception {
+    final HttpResponse<String> response = command(b -> b
+        .header("X-ArcadeDB-Cluster-Token", CLUSTER_TOKEN)
+        .header("Authorization", basic("root", DEFAULT_PASSWORD_FOR_TESTS))
+        .header(LeaderForwardContext.FORWARDED_TO_LEADER_HEADER, "true"));
+
+    assertThat(response.statusCode()).as("body: %s", response.body()).isEqualTo(200);
+  }
+
+  /**
+   * Fail closed on the proof: an invalid token is refused before the relayed credentials are looked at, so a
+   * caller cannot probe the token by watching which error comes back.
+   */
+  @Test
+  void anInvalidClusterTokenIsRefusedEvenWhenTheRelayedCredentialsAreValid() throws Exception {
+    final HttpResponse<String> response = command(b -> b
+        .header("X-ArcadeDB-Cluster-Token", "not-the-cluster-token")
+        .header("Authorization", basic("root", DEFAULT_PASSWORD_FOR_TESTS)));
+
+    assertThat(response.statusCode()).isEqualTo(401);
+    assertThat(response.body()).contains("Invalid cluster token");
+  }
+
+  /**
+   * Fail closed on identity: a valid token with neither a forwarded user nor credentials of its own still
+   * authenticates nobody. The cluster token proves a hop; it has never been a principal.
+   */
+  @Test
+  void aValidClusterTokenAloneStillAuthenticatesNobody() throws Exception {
+    final HttpResponse<String> response = command(b -> b
+        .header("X-ArcadeDB-Cluster-Token", CLUSTER_TOKEN)
+        .header(LeaderForwardContext.FORWARDED_TO_LEADER_HEADER, "true"));
+
+    assertThat(response.statusCode()).isEqualTo(401);
+  }
+
+  /**
+   * And the substitution branch is untouched: a forwarded user still names the principal, and an unknown one
+   * is still refused.
+   */
+  @Test
+  void aForwardedUserStillNamesThePrincipal() throws Exception {
+    assertThat(command(b -> b
+        .header("X-ArcadeDB-Cluster-Token", CLUSTER_TOKEN)
+        .header("X-ArcadeDB-Forwarded-User", "root")).statusCode()).isEqualTo(200);
+
+    assertThat(command(b -> b
+        .header("X-ArcadeDB-Cluster-Token", CLUSTER_TOKEN)
+        .header("X-ArcadeDB-Forwarded-User", "issue7516-no-such-user")).statusCode()).isEqualTo(401);
+  }
+
+  /**
+   * The port the server actually bound, not the first of the {@code 2480-2489} range it is allowed to pick
+   * from: a hard-coded 2480 sends these requests to whatever else is listening there - another test JVM, an
+   * IDE - and the failures then read as authentication errors rather than as a port clash.
+   */
+  private HttpResponse<String> command(final UnaryOperator<HttpRequest.Builder> decorate) throws Exception {
+    HttpRequest.Builder builder = HttpRequest.newBuilder()
+        .uri(URI.create("http://localhost:" + getServer(0).getHttpServer().getPort()
+            + "/api/v1/command/" + getDatabaseName()))
+        .header("Content-Type", "application/json");
+    builder = decorate.apply(builder);
+    return HTTP.send(builder.POST(HttpRequest.BodyPublishers.ofString(
+        "{\"language\":\"sql\",\"command\":\"SELECT 1\"}", StandardCharsets.UTF_8)).build(),
+        HttpResponse.BodyHandlers.ofString());
+  }
+
+  private static String basic(final String user, final String password) {
+    return "Basic " + Base64.getEncoder()
+        .encodeToString((user + ":" + password).getBytes(StandardCharsets.UTF_8));
+  }
+}


### PR DESCRIPTION
Closes #7516

## Summary

The one-hop rule that stops a follower-to-leader forward from cycling travels as the
`X-ArcadeDB-Forwarded-To-Leader` request header, and the receiving node honoured it only inside the
`X-ArcadeDB-Cluster-Token` branch. `LeaderCommandForwarder` set the marker only on the branch that swaps a
per-node session token for a forwarded-user assertion; a write authenticated with **Basic auth or an API
token** is relayed with the client's own `Authorization` header, so it carried neither the token nor the
marker. Two followers whose resolved leader addresses name each other - A believes the leader is B, B
believes it is A - then forwarded the same request back and forth, one held Undertow worker thread per hop,
bounded by nothing. The dial-side `isOwnHttpAddress` check does not catch it, because each node is dialling
the *other* node rather than itself.

The fix separates what the cluster token **proves** from what it **substitutes**. `LeaderCommandForwarder`
now sends the token and the marker together, once, before the auth branches, so the marker can never travel
without the proof that makes it believable; the Basic/API-token branch still relays the caller's header
unchanged and still sends no `X-ArcadeDB-Forwarded-User`, because resolving the user by name on the leader
would discard the scopes an API token carries. `AbstractServerHttpHandler` validates the token as proof of
hop and gates the marker on that, resolving a forwarded identity only when one travels with it - and still
answering the same `Missing forwarded user` 401 when a peer request carries neither a forwarded identity nor
credentials of its own, so no request shape that exists today is answered differently.

The completeness sweep turned up a second defect of the same class in the same method:
`LeaderCommandForwarder` read the **raw** `arcadedb.ha.clusterToken` setting while the receiver validates
against the **effective** token. `ClusterTokenProvider.initClusterToken()` derives the token (PBKDF2 over
cluster name + root password) when the setting is empty and stores it on the provider without writing it
back into the configuration, so on every cluster that did not declare a token explicitly the session-token
forward went out with no cluster token, no marker, and - since that branch does not relay the `Bearer AU-`
header either - no credentials at all, and was answered 401. It now reads through
`HAServerPlugin.getClusterToken()` with the raw setting as fallback, mirroring the receiving side.

## Test plan

- [x] `mvn -o -pl server -am -Dtest=Issue7516ClusterTokenHopProofTest test` - 4 cases: a cluster token beside
      relayed credentials authenticates with those credentials (this one fails on `main`); an invalid token is
      refused even when the relayed credentials are valid; a valid token alone still authenticates nobody; a
      forwarded user still names the principal and an unknown one is still refused.
- [x] `mvn -o -pl ha-raft -am -DskipITs=false -Dit.test=Issue7516BasicAuthForwardLoopIT verify` - 3 cases:
      the reported cycle, driven with both followers' resolved leader addresses pointing at each other, on
      both `POST /server/users` and `POST /api/v1/server`; a client's own marker header without a cluster
      token still does not suppress forwarding; a session-token write on a follower is forwarded and executed
      on the leader (the effective-token fix).
- [x] Regression set, all green locally:
      `-Dit.test=Issue6191FollowerForwardLoopIT,Issue7380RestUserRoutesLeaderGateIT,Issue6221VerifyFanOutGuardIT`
      (14 tests across the four IT classes, 0 failures).
- [ ] Manual (not run locally - left for the reviewer): on a three-node cluster, hand-write an `arcadedb.ha.serverList` in which two followers name each
      other as the leader, then `curl -u root:... -X POST .../api/v1/server/users` at one of them. Expect a
      400 naming "already forwarded", not a hang.

## Coverage

| Entry point | Status |
|---|---|
| `LeaderCommandForwarder`, Basic/API-token branch - `POST /api/v1/server`, `POST`/`PUT`/`DELETE /api/v1/server/users` | fixed, tested through `POST /server/users` and `POST /server` |
| `LeaderCommandForwarder`, `Bearer AU-` branch (raw vs effective cluster token) | fixed, tested end to end over HTTP |
| `AbstractServerHttpHandler` marker gate | fixed, 4 direct cases |
| `RaftReplicatedDatabase.forwardCommandToLeaderViaRaft` (`/api/v1/command`) | unchanged - always sends the token and forwarded user, so the marker always travelled; regression-tested by `Issue6191FollowerForwardLoopIT` |
| `PostBatchHandler.buildForwardRequest` (`/api/v1/batch`) | unchanged, same reason; regression-tested by `Issue6191FollowerForwardLoopIT` |
| `PostVerifyDatabaseHandler` leader-to-peer fan-out | unchanged; regression-tested by `Issue6221VerifyFanOutGuardIT` |

**Known gaps**

- **#7551** - `LeaderProxy` is unreachable (`grep -rn "new LeaderProxy"` has no hit in `src/main`), yet
  `LeaderForwardContext`'s Javadoc states it "enforces the same one-hop rule for the requests it relays". It
  is also the last raw `HA_CLUSTER_TOKEN` reader left in `src/main` after this change, and its loop guard is
  on cluster-token presence rather than on the marker. Reviving or deleting it is a decision about a
  component this PR does not touch.
- **#7507** (already open) - there is still no request timeout on a forwarded hop. This change bounds the
  *cycle* at two hops; it does not bound a *hop*.
- A leadership change in flight now turns a Basic/API-token forward into a 400 rather than a second hop that
  might have landed on the new leader. That is the same trade-off #6191 already made for the cluster-token
  branch, and the refusal message says "retry": a second hop cannot prove the first did not execute.

Full analysis, the grep output behind the coverage table, and the adversarial pass are in
`docs/7516-ha-basic-auth-leader-forward-loop.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEJXCdUGW61QSXqyurphpt
