### PR TITLE
fix(#7509): compare-and-set a replicated security document instead of overwriting it

### DIFF
--- a/docs/7509-ha-security-document-compare-and-set.md
+++ b/docs/7509-ha-security-document-compare-and-set.md
@@ -135,16 +135,70 @@ was run by hand against the diff. It produced one finding that is real and one c
   it; the caller then gets an explicit "concurrent change, retry" error instead of a silent loss, which is the
   behaviour the issue asks for.
 - **A follower-submitted security mutation still replicates unconditionally** (#7559): the compare-and-set is
-  withheld there because the peer-capability registry is leader-only. Nothing regresses relative to today, but
-  the fix does not reach those callers.
+  withheld there because the peer-capability registry is leader-only. This is NOT limited to the upgrade
+  window - on a fully upgraded cluster, any admin request a load balancer routes to a follower
+  (`DeleteDropUserHandler`, the group and API-token REST routes, openCypher `DROP USER`) keeps the pre-fix
+  behaviour indefinitely. Nothing regresses relative to today, but the fix does not reach those callers.
 - **Nothing here changes the local (non-HA) path.** `createUser`/`updateUser`/`dropUserLocally` are already
   serialised by the same monitor on the only node that holds the document.
 
+## Review cycles
+
+### Cycle 1 - `cfb2ceddc9`
+
+The `claude-review` job raised four items. Three were verified as real and fixed on this branch; one was a
+framing correction to an already-filed follow-up.
+
+1. **TOCTOU between the payload and its precondition** (correctness, fixed). Every mutator read the volatile
+   document twice - once to build the payload, once to fingerprint the precondition - and `applyReplicated*`
+   swaps that reference from the Raft apply thread *without* this monitor, by design. A swap landing between
+   the two reads produced a payload built from the OLD document under a precondition describing the NEW one:
+   the compare-and-set then PASSES and the stale payload installs, which is #7509 reopened on a window a few
+   bytecodes wide. Fixed by reading the document once per attempt and deriving both halves from that snapshot:
+   `snapshotWith(Map, ...)`, `usersFingerprintOf(Map)`, `groupsDocumentWith(JSONObject, ...)`, `groupsJsonOf`,
+   and - for tokens, where the read lives behind another object's monitor -
+   `ApiTokenConfiguration.MintedToken.documentBeforeJson()` and `DocumentChange(before, after)`, both produced
+   inside the same `synchronized` block as the payload. Covered by the three
+   `the*PreconditionFingerprintsTheDocumentTheSubmittedPayloadWasBuiltFrom` tests and by
+   `Issue7509TokenDocumentPairAtomicityTest`.
+2. **A corrupted precondition section failed OPEN** (correctness, fixed). `readSecurityPrecondition` wrapped
+   both `readUTF` calls in one `try` returning `null`, so a section that identified itself as ours and was then
+   unreadable degraded to "no precondition, install unconditionally" - the one default this field must never
+   fall back to. The name read and the fingerprint read are now separate: an unreadable NAME is still an
+   unrecognised section and is skipped (the #7138 contract), while a failure after the name matched is reported
+   as corruption and reaches the caller as a `RaftLogEntryDecodeException`. Covered by
+   `aCorruptedPreconditionSectionFailsTheEntryInsteadOfApplyingItUnconditionally` and
+   `aSectionWhoseNameCannotBeReadIsStillSkipped`.
+3. **The retry's catch-up wait was done under the shared monitor** (availability, fixed).
+   `RaftHAPlugin.reportSecurityOutcome` called `waitForLocalApply()` - bounded by `arcadedb.ha.quorumTimeout`,
+   10s by default - before returning to `ServerSecurity`, i.e. still inside `synchronized (this)`. Five attempts
+   meant one caller could hold the monitor all seven mutators share for ~50s, queueing unrelated group and
+   token changes behind a retry storm. The wait moved to `HAServerPlugin.awaitLocalApply()`, called from
+   `ServerSecurity.awaitSupersededChange` OUTSIDE the monitor. Covered by
+   `theCatchUpWaitBetweenRetriesHappensOutsideTheSharedMonitor`, which asserts with `Thread.holdsLock` that the
+   wait happens and that the monitor is not held while it does.
+4. **The #7559 framing undersells it** (accepted, no code change). The follower-submission gap is not only a
+   rolling-upgrade transient: on a fully upgraded cluster any admin request a load balancer routes to a
+   follower still gets the precondition withheld indefinitely. Recorded on #7559 and in *Residual risk* below.
+
+Deliberately not changed, with reasons:
+
+- **Caching the fingerprint of the document in force.** It would make `isSuperseded` O(1) instead of O(document
+  size), but it adds a second piece of state that has to be invalidated on every path that installs a document
+  - including the failure paths of `applyReplicated*` - and a stale cache there is a compare-and-set that
+  passes when it should refuse. The cost it saves is one canonicalisation per security entry per node, and
+  security entries are administration rather than traffic.
+- **Extracting the seven retry loops into one helper.** Their early exits genuinely differ (`return`,
+  `return false`, `return true`, `return response`, and two `throw`s on preconditions that are not the CAS), so
+  the shared shape is the four lines around them. The dead `boolean applied = false;` initialisers the review
+  flagged are gone; every one is now a definitely-assigned `final boolean`.
+
 ## Test results
 
-- `server`: `com.arcadedb.server.security.*Test` - 102 tests, 0 failures (11 of them new in
-  `Issue7509ConcurrentSecurityChangeTest`, 9 in `SecurityDocumentFingerprintTest`).
-- `ha-raft`: 1409 tests, 2 failures - `ArcadeStateMachinePerDatabaseHaltTest.perDatabaseApplyErrorDoesNot
+- `server`: `com.arcadedb.server.security.*Test` - 109 tests, 0 failures (15 of them new in
+  `Issue7509ConcurrentSecurityChangeTest`, 9 in `SecurityDocumentFingerprintTest`, 3 in
+  `Issue7509TokenDocumentPairAtomicityTest`).
+- `ha-raft`: 1411 tests, 2 failures - `ArcadeStateMachinePerDatabaseHaltTest.perDatabaseApplyErrorDoesNot
   TripNodeWideHalt` and `.otherDatabasesKeepApplyingAfterOneDatabaseFails`. **Both fail identically on
   unmodified `origin/main`** (verified in a pristine worktree: 1391 tests, the same 2 failures), and neither
   touches a security entry - they assert on a `TX_ENTRY` WAL decode message. Pre-existing, not a regression

--- a/docs/7509-ha-security-document-compare-and-set.md
+++ b/docs/7509-ha-security-document-compare-and-set.md
@@ -193,6 +193,21 @@ Deliberately not changed, with reasons:
   the shared shape is the four lines around them. The dead `boolean applied = false;` initialisers the review
   flagged are gone; every one is now a definitely-assigned `final boolean`.
 
+### Cycle 2 - `45965839e9`
+
+No blocking issues: the reviewer re-verified the cycle-1 fixes against the source, including that the three
+"in force" fingerprint helpers serialise the same way the submitter-side snapshot helpers do. Three
+non-blocking observations:
+
+1. **`SecurityDocumentFingerprint.appendString` escapes only `"` and `\`** - correct, but worth saying so
+   explicitly. Applied: the javadoc now states that the canonical form is a COMPARISON KEY and not a
+   serialization format, that it escapes only what could make two different documents produce the same bytes,
+   and that the structural characters a JSON writer would escape cannot move a boundary inside a string this
+   method delimits itself.
+2. **Per-apply hashing cost** - the reviewer agreed with the cycle-1 decision not to cache, flagging it only as
+   something to revisit if these documents ever grow to thousands of entries. No change.
+3. **#7559** - agreed it is out of scope here and belongs to #7219/#7559. No change.
+
 ## Test results
 
 - `server`: `com.arcadedb.server.security.*Test` - 109 tests, 0 failures (15 of them new in

--- a/docs/7509-ha-security-document-compare-and-set.md
+++ b/docs/7509-ha-security-document-compare-and-set.md
@@ -1,0 +1,160 @@
+# #7509 - HA: a replicated security document is read-modify-write, so a concurrent admin change on another node is lost
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/7509
+
+## Problem
+
+The three node-scoped security documents - the user list (`SECURITY_USERS_ENTRY`), the group document
+(`SECURITY_GROUPS_ENTRY`) and the API-token document (`SECURITY_API_TOKENS_ENTRY`) - are replicated as the
+WHOLE document, built by reading the current one, mutating a copy and submitting it. The read-compute-submit
+sequence is serialised by `synchronized (this)` on `ServerSecurity`, which is a per-NODE monitor. Two nodes
+doing it at the same time each build a document from their own view; Raft linearises the two entries and the
+second one, built without the first in it, silently reverts the first - on every node, including the one that
+accepted it and answered 200.
+
+## Root cause
+
+`ServerSecurity.createUserClusterWide` and its six siblings submit an unconditional "install this document"
+entry. The apply has no way to tell a document built from the current state from one built from a stale one,
+so it installs whatever arrives.
+
+## Completeness
+
+### Invariant
+
+**A replicated security document is installed only when the document its submitter read is still the one in
+force at the moment the entry applies; an entry built on a stale view is refused identically on every node,
+and its submitter re-reads and retries instead of reporting success.**
+
+### Entry points found by command
+
+Writers of the three documents (every caller of the `replicate*` API, main sources only):
+
+```
+$ grep -rn "replicateSecurityUsers\|replicateSecurityGroups\|replicateSecurityApiTokens" --include='*.java' */src/main/java \
+    | grep -v "HAServerPlugin.java\|RaftHAPlugin.java\|RaftTransactionBroker.java"
+server/src/main/java/com/arcadedb/server/ServerControlPlane.java:226      (seed after connect cluster)
+server/src/main/java/com/arcadedb/server/security/ServerSecurity.java:422 (createUserClusterWide)
+server/src/main/java/com/arcadedb/server/security/ServerSecurity.java:448 (updateUserClusterWide)
+server/src/main/java/com/arcadedb/server/security/ServerSecurity.java:475 (dropUserClusterWide)
+server/src/main/java/com/arcadedb/server/security/ServerSecurity.java:1024 (saveGroupClusterWide)
+server/src/main/java/com/arcadedb/server/security/ServerSecurity.java:1043 (deleteGroupClusterWide)
+server/src/main/java/com/arcadedb/server/security/ServerSecurity.java:1151 (seedUsersClusterWide)
+server/src/main/java/com/arcadedb/server/security/ServerSecurity.java:1158 (seedGroupsClusterWide)
+server/src/main/java/com/arcadedb/server/security/ServerSecurity.java:1165 (seedApiTokensClusterWide)
+server/src/main/java/com/arcadedb/server/security/ServerSecurity.java:1187 (createApiTokenClusterWide)
+server/src/main/java/com/arcadedb/server/security/ServerSecurity.java:1208 (deleteApiTokenClusterWide)
+```
+
+Callers of the seven cluster-wide mutators (main sources only) all funnel through those seven methods:
+`ServerControlPlane` (REST/gRPC `POST /api/v1/server` commands and the `/server/users`, `/server/groups`,
+`/server/api-tokens` routes), `PostUserHandler`, `PutUserHandler`, `DeleteUserHandler`,
+`DeleteDropUserHandler`, `ServerSecurity.dropUser` (the openCypher `DROP USER` path) and
+`ServerSecurity.setUserPassword`. No caller reaches `HAServerPlugin.replicateSecurity*` directly except the
+seed sites above.
+
+### Coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| `ServerSecurity.createUserClusterWide` | yes - CAS + retry | yes |
+| `ServerSecurity.updateUserClusterWide` | yes - CAS + retry | yes |
+| `ServerSecurity.dropUserClusterWide` | yes - CAS + retry | yes |
+| `ServerSecurity.saveGroupClusterWide` | yes - CAS + retry | yes |
+| `ServerSecurity.deleteGroupClusterWide` | yes - CAS + retry | yes |
+| `ServerSecurity.createApiTokenClusterWide` | yes - CAS + retry | yes |
+| `ServerSecurity.deleteApiTokenClusterWide` | yes - CAS + retry | yes |
+| `ServerSecurity.seed{Users,Groups,ApiTokens}ClusterWide` | **argued** - seeding is deliberately unconditional | n/a |
+| `ServerControlPlane.connectCluster` users seed | **argued** - same: a seed must overwrite | n/a |
+| apply of an entry from a node that predates this fix | **argued** - no precondition section, applies as today | yes (codec) |
+| a node that predates this fix APPLYING a conditional entry | yes - the precondition is gated on peer capability | yes |
+| a mutation submitted on a FOLLOWER | **filed as #7559** - the capability registry is leader-only | n/a |
+
+**Argued rows.** A seed exists precisely to overwrite whatever a joining peer holds with the cluster's
+current document; giving it a precondition would make an `addPeer` fail whenever an unrelated admin change
+raced it, which is the opposite of what it is for. The three seed helpers and `connectCluster` therefore
+submit with a `null` precondition, which is the pre-fix behaviour, and they already hold the monitor across
+the read and the submit (issue #7373), so the document they seed is a real point-in-time state of this node.
+
+A node that predates this fix writes no precondition section; a node that has it skips the absent section and
+applies unconditionally, exactly as before. See "Residual risk" for the reverse direction.
+
+## Fix
+
+1. **Carry the precondition.** The submitter fingerprints the document it read and ships that fingerprint in
+   a framed extension section on the security entry (the #7138 mechanism, which exists so a non-schema entry
+   can grow a field without halting older peers).
+2. **Check it at the apply**, which is the only point that is linearised across nodes. Fingerprint mismatch
+   means the document changed between the read and the apply: the entry is NOT installed, on every node, and
+   the outcome is identical everywhere because applies are ordered and deterministic.
+3. **Tell the submitter.** The state machine answers the Ratis client with `SECURITY_ENTRY_SUPERSEDED`
+   instead of `OK`, so the verdict comes from the LEADER's apply and reaches the submitter whether it is the
+   leader or a follower. The submitter waits for its own node to catch up, re-reads, rebuilds and resubmits,
+   up to a bounded number of attempts - an MVCC retry, affordable because security administration is rare.
+4. **Write the precondition only when every peer can read one**, through the peer-capability negotiation of
+   #7219 - the gate `RaftLogEntryCodec`'s own javadoc demands of every new optional section. A peer that
+   predates the section skips it and installs unconditionally, so an ungated precondition would have a losing
+   entry refused on the upgraded nodes and applied on the older one: a DIVERGENCE, which is worse than the
+   lost update, because the same credentials then resolve differently depending on which node answers.
+   Withholding it keeps the pre-#7509 behaviour uniform, is fail-closed (an unknown, unreachable or stale peer
+   counts as missing the capability), and needs no operator step: the check engages by itself once the last
+   node is upgraded. A throttled INFO line names the peers responsible, so "the check is not running" is never
+   silent.
+
+The fingerprint is a SHA-256 over a canonicalised form of the document (object keys sorted, the user list and
+the token list sorted by their identity field), so two nodes holding the same logical document always agree on
+it regardless of map iteration order.
+
+## Adversarial pass
+
+The `Task` tool was not available in this session, so the Phase 1.5 subagent could not be spawned and the pass
+was run by hand against the diff. It produced one finding that is real and one clarification:
+
+1. **The compare-and-set engages only for mutations submitted on the LEADER** - `RaftHAServer` starts the
+   peer-capability monitor on gaining leadership and stops it on losing it, so a follower's registry is empty
+   or stale, `peersMissingCapability` names every peer, and the precondition is withheld. Verified by reading
+   `startCapabilityMonitor`/`stopCapabilityMonitor`, and by reading every handler: the `/server/users` routes,
+   the `POST /api/v1/server` commands and the gRPC admin RPCs all reach the leader already, while
+   `DeleteDropUserHandler`, the group and API-token routes and openCypher `DROP USER` do not. Real, and the
+   mechanism fix belongs to #7219 rather than here, so it is **filed as #7559**.
+2. **Number canonicalisation** - `SecurityDocumentFingerprint` renders a non-string scalar with its
+   `toString`, so an `Integer -1` read back from a file and a `Long -1L` held in memory fingerprint the same
+   (both `"-1"`), which is what these documents need. It would NOT hold for a fractional value whose
+   `toString` differs between representations; none of the three documents carries one - `version`,
+   `resultSetLimit`, `readTimeout`, `createdAt` and `expiresAt` are all integral. Not a defect, recorded
+   because the next field added to one of these documents could make it one.
+
+## Residual risk
+
+- **A half-upgraded cluster keeps the old behaviour, and that is on purpose.** While any peer has not
+  advertised `security-precondition`, no precondition is written at all, so two concurrent security changes on
+  two nodes can still lose one of them exactly as they did before this fix. It is reported (throttled INFO,
+  naming the peers) rather than silent, and it resolves itself when the last node is upgraded. Issue #7557 was
+  filed for this gap and then closed, because the gate is in this PR.
+- **The retry budget is finite.** Sustained concurrent security administration from several nodes can exhaust
+  it; the caller then gets an explicit "concurrent change, retry" error instead of a silent loss, which is the
+  behaviour the issue asks for.
+- **A follower-submitted security mutation still replicates unconditionally** (#7559): the compare-and-set is
+  withheld there because the peer-capability registry is leader-only. Nothing regresses relative to today, but
+  the fix does not reach those callers.
+- **Nothing here changes the local (non-HA) path.** `createUser`/`updateUser`/`dropUserLocally` are already
+  serialised by the same monitor on the only node that holds the document.
+
+## Test results
+
+- `server`: `com.arcadedb.server.security.*Test` - 102 tests, 0 failures (11 of them new in
+  `Issue7509ConcurrentSecurityChangeTest`, 9 in `SecurityDocumentFingerprintTest`).
+- `ha-raft`: 1409 tests, 2 failures - `ArcadeStateMachinePerDatabaseHaltTest.perDatabaseApplyErrorDoesNot
+  TripNodeWideHalt` and `.otherDatabasesKeepApplyingAfterOneDatabaseFails`. **Both fail identically on
+  unmodified `origin/main`** (verified in a pristine worktree: 1391 tests, the same 2 failures), and neither
+  touches a security entry - they assert on a `TX_ENTRY` WAL decode message. Pre-existing, not a regression
+  from this branch.
+- Five `ha-raft` classes that stand up a real multi-node cluster (`LeaveClusterTest`, `DynamicMembershipTest`,
+  `WaitForApplyTest`, `Issue6965SharedPageCrossNodeWritersTest`, `BaseCompactionIndexCompletenessTest`) could
+  not run in this environment: port 2480 was held by another process, and they take the forked JVM down with
+  them. `LeaveClusterTest` crashes the same way on pristine `main` here, so this is the environment and not
+  the branch.
+- **Proof the new tests can fail:** with `ServerSecurity.isSuperseded` forced to return `false` - the
+  pre-#7509 unconditional apply - 10 of the 11 `Issue7509ConcurrentSecurityChangeTest` methods fail. The
+  eleventh (`theApplyInstallsAnEntryThatCarriesNoPreconditionAtAll`) passes both ways by design: it pins the
+  back-compatible path.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -135,6 +135,17 @@ import java.util.zip.CRC32;
 public class ArcadeStateMachine extends BaseStateMachine {
 
   /**
+   * What {@link #applyTransaction} answers the Ratis client when a node-scoped security entry was NOT installed
+   * because its compare-and-set precondition no longer held (issue #7509). Anything else - "OK", or no message
+   * at all from a leader that predates this - means the entry was applied.
+   * <p>
+   * The verdict has to travel in the REPLY rather than be observed locally: the submitting node is not
+   * necessarily the leader, and a follower's own apply of the entry can lag the reply it gets back. The reply
+   * carries the LEADER's verdict, which is the authoritative one because applies are ordered and deterministic.
+   */
+  public static final String SECURITY_ENTRY_SUPERSEDED_REPLY = "SECURITY_ENTRY_SUPERSEDED";
+
+  /**
    * Test-only WAL gap counter. When non-null, incremented each time a follower detects a
    * WAL page-version gap. Used by deterministic tests to verify no gap occurred.
    * <p>
@@ -923,15 +934,21 @@ public class ArcadeStateMachine extends BaseStateMachine {
           appended.originatedLocally() :
           Boolean.TRUE.equals(context);
 
+      // Set by the three security applies when the entry's compare-and-set precondition no longer held, so the
+      // reply below can tell the submitter its change did not land (issue #7509). A one-element array rather
+      // than a field: applyWithRetry can re-run the lambda, and a field would outlive this entry.
+      final boolean[] securitySuperseded = new boolean[1];
+
       applyWithRetry(index, decoded.databaseName(), () -> {
+        securitySuperseded[0] = false;
         switch (decoded.type()) {
         case TX_ENTRY -> applyTxEntry(decoded, index, context instanceof AppendedEntry appended ? appended.pages() : null);
         case SCHEMA_ENTRY -> applySchemaEntry(decoded, index, originatedLocally);
         case INSTALL_DATABASE_ENTRY -> applyInstallDatabaseEntry(decoded, index);
         case DROP_DATABASE_ENTRY -> applyDropDatabaseEntry(decoded);
-        case SECURITY_USERS_ENTRY -> applySecurityUsersEntry(decoded);
-        case SECURITY_GROUPS_ENTRY -> applySecurityGroupsEntry(decoded);
-        case SECURITY_API_TOKENS_ENTRY -> applySecurityApiTokensEntry(decoded);
+        case SECURITY_USERS_ENTRY -> securitySuperseded[0] = !applySecurityUsersEntry(decoded);
+        case SECURITY_GROUPS_ENTRY -> securitySuperseded[0] = !applySecurityGroupsEntry(decoded);
+        case SECURITY_API_TOKENS_ENTRY -> securitySuperseded[0] = !applySecurityApiTokensEntry(decoded);
         case BOOTSTRAP_FINGERPRINT_ENTRY -> applyBootstrapFingerprintEntry(decoded, index, originatedLocally);
         }
       });
@@ -969,7 +986,11 @@ public class ArcadeStateMachine extends BaseStateMachine {
           }
         }
       }
-      return CompletableFuture.completedFuture(Message.valueOf("OK"));
+      // A superseded security entry IS applied - as a no-op, identically on every node, so the applied index
+      // advances exactly as it does for any other entry. Only the ANSWER differs, so the submitter learns its
+      // document was built from a view the cluster had already moved past (issue #7509).
+      return CompletableFuture.completedFuture(
+          Message.valueOf(securitySuperseded[0] ? SECURITY_ENTRY_SUPERSEDED_REPLY : "OK"));
 
     } catch (final ReplicationException e) {
       // A resync-required signal for an already-quarantined database repeats on every committed entry
@@ -3637,15 +3658,26 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * The classification lives here, at the apply site, rather than in the generic handler: whether a failure
    * can diverge replicated state is a property of the apply, not of the entry's database scoping, so a future
    * node-scoped entry that CAN diverge still reaches the halt it needs.
+   *
+   * @return false when the entry carried a compare-and-set precondition that no longer holds, so the user list
+   * was deliberately NOT installed (issue #7509). The decision is the same on every node, because the payload
+   * and the state it is compared against are both replicated and applies are ordered
    */
-  private void applySecurityUsersEntry(final RaftLogEntryCodec.DecodedEntry decoded) {
+  private boolean applySecurityUsersEntry(final RaftLogEntryCodec.DecodedEntry decoded) {
     final String payload = decoded.usersJson();
     if (payload == null) {
       LogManager.instance().log(this, Level.WARNING, "SECURITY_USERS_ENTRY has null payload, skipping");
-      return;
+      return true;
     }
     try {
-      server.getSecurity().applyReplicatedUsers(payload);
+      // An entry with no precondition takes the unconditional apply verbatim - that is a seed, and it is also
+      // every entry a node that predates issue #7509 wrote. Only a conditional entry goes through the
+      // compare-and-set overload, so nothing about the pre-#7509 path changes shape.
+      final String precondition = decoded.securityPrecondition();
+      if (precondition == null)
+        server.getSecurity().applyReplicatedUsers(payload);
+      else if (!server.getSecurity().applyReplicatedUsers(payload, precondition))
+        return false;
     } catch (final ReplicatedUsersPersistenceException e) {
       LogManager.instance().log(this, Level.SEVERE,
           "Could not fully apply a replicated user list on this node: %s. The node keeps running and, when the "
@@ -3666,6 +3698,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
     // read a committed entry its peers applied", and it still reaches the node-wide halt - the case #4798
     // argues must never be skipped quietly. Catching RuntimeException here would have downgraded it silently.
     HALog.log(this, HALog.DETAILED, "Applied SECURITY_USERS_ENTRY (%d bytes)", payload.length());
+    return true;
   }
 
   /**
@@ -3682,14 +3715,18 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * {@link #applySecurityUsersEntry}, which applies verbatim: reissue the group change on the leader once the
    * volume is fixed.
    */
-  private void applySecurityGroupsEntry(final RaftLogEntryCodec.DecodedEntry decoded) {
+  private boolean applySecurityGroupsEntry(final RaftLogEntryCodec.DecodedEntry decoded) {
     final String payload = decoded.usersJson();
     if (payload == null) {
       LogManager.instance().log(this, Level.WARNING, "SECURITY_GROUPS_ENTRY has null payload, skipping");
-      return;
+      return true;
     }
     try {
-      server.getSecurity().applyReplicatedGroups(payload);
+      final String precondition = decoded.securityPrecondition();
+      if (precondition == null)
+        server.getSecurity().applyReplicatedGroups(payload);
+      else if (!server.getSecurity().applyReplicatedGroups(payload, precondition))
+        return false;
     } catch (final ReplicatedSecurityConfigPersistenceException e) {
       LogManager.instance().log(this, Level.SEVERE,
           "Could not fully apply a replicated group document on this node: %s. The node keeps running and is "
@@ -3702,6 +3739,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
               + "new groups in memory, only their durability to disk failed", e);
     }
     HALog.log(this, HALog.DETAILED, "Applied SECURITY_GROUPS_ENTRY (%d bytes)", payload.length());
+    return true;
   }
 
   /**
@@ -3713,14 +3751,18 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * authenticating here even when the write failed. What is outstanding is only that a restart would read the
    * stale file back - which is why the operator instruction is to reissue the revocation, not to wait.
    */
-  private void applySecurityApiTokensEntry(final RaftLogEntryCodec.DecodedEntry decoded) {
+  private boolean applySecurityApiTokensEntry(final RaftLogEntryCodec.DecodedEntry decoded) {
     final String payload = decoded.usersJson();
     if (payload == null) {
       LogManager.instance().log(this, Level.WARNING, "SECURITY_API_TOKENS_ENTRY has null payload, skipping");
-      return;
+      return true;
     }
     try {
-      server.getSecurity().applyReplicatedApiTokens(payload);
+      final String precondition = decoded.securityPrecondition();
+      if (precondition == null)
+        server.getSecurity().applyReplicatedApiTokens(payload);
+      else if (!server.getSecurity().applyReplicatedApiTokens(payload, precondition))
+        return false;
     } catch (final ReplicatedSecurityConfigPersistenceException e) {
       LogManager.instance().log(this, Level.SEVERE,
           "Could not fully apply a replicated API-token document on this node: %s. The node keeps running and is "
@@ -3734,6 +3776,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
               + "set in memory, only its durability to disk failed", e);
     }
     HALog.log(this, HALog.DETAILED, "Applied SECURITY_API_TOKENS_ENTRY (%d bytes)", payload.length());
+    return true;
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerCapabilities.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerCapabilities.java
@@ -52,11 +52,24 @@ public final class PeerCapabilities {
   public static final String SCHEMA_DELTA = "schema-delta";
 
   /**
+   * This node reads the compare-and-set precondition section of the three node-scoped security entries - the user
+   * list, the group document and the API-token document (issue #7509).
+   * <p>
+   * Advertising it says this node REFUSES a security document whose precondition no longer matches what is in
+   * force. That is what makes the section unsafe to write to a peer without it: such a peer skips the section and
+   * installs the document unconditionally, so the losing entry would be refused on the upgraded nodes and applied
+   * on the older one - a divergence of the security state, where an ungated pre-#7509 cluster at least lost the
+   * same change everywhere. A leader that cannot see this token on every peer therefore writes no precondition and
+   * keeps the pre-#7509 behaviour uniformly.
+   */
+  public static final String SECURITY_PRECONDITION = "security-precondition";
+
+  /**
    * Everything this build can decode. Immutable, and deliberately a whitelist written out by hand rather than
    * derived from anything: a capability is a promise about the wire format, and the only thing that can make it
    * true is a human having checked that the decoder is present.
    */
-  public static final Set<String> LOCAL = Set.of(SCHEMA_DELTA);
+  public static final Set<String> LOCAL = Set.of(SCHEMA_DELTA, SECURITY_PRECONDITION);
 
   private PeerCapabilities() {
     // utility class

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGroupCommitter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGroupCommitter.java
@@ -174,6 +174,18 @@ class RaftGroupCommitter {
    * machine) wait for this index; see {@code RaftReplicatedDatabase} and issue #5503.
    */
   long submitAndWait(final byte[] entry) {
+    return submitAndWaitForEntry(entry).logIndex;
+  }
+
+  /**
+   * {@link #submitAndWait(byte[])}, returning what the LEADER's state machine answered for the entry instead of
+   * the log index (issue #7509). Null when the reply carried no message.
+   */
+  String submitAndWaitForReply(final byte[] entry) {
+    return submitAndWaitForEntry(entry).applyReply;
+  }
+
+  private CancellablePendingEntry submitAndWaitForEntry(final byte[] entry) {
     // Pre-check the entry against the maximum size the cluster can actually replicate - the SMALLER
     // of arcadedb.ha.grpcMessageSizeMax and arcadedb.ha.appendBufferSize (see
     // RaftPropertiesBuilder.maxReplicatedEntrySize). Dispatching an oversized entry is far worse than
@@ -290,7 +302,7 @@ class RaftGroupCommitter {
       throw dispatchAware(pending, "Group commit failed: " + e.getMessage());
     }
 
-    return pending.logIndex;
+    return pending;
   }
 
   /**
@@ -563,6 +575,12 @@ class RaftGroupCommitter {
         }
 
         batch.get(i).logIndex = reply.getLogIndex();
+        // What the LEADER's state machine answered for this entry. Normally "OK"; a security entry whose
+        // compare-and-set precondition no longer held answers SECURITY_ENTRY_SUPERSEDED, and the submitter
+        // retries against the fresh document rather than believing its change landed (issue #7509).
+        batch.get(i).applyReply = reply.getMessage() != null ?
+            reply.getMessage().getContent().toStringUtf8() :
+            null;
         batch.get(i).future.complete(null); // success - after ALL check
       } catch (final InterruptedException ie) {
         // The flusher was interrupted (client refresh after leader churn, or shutdown) while
@@ -654,6 +672,10 @@ class RaftGroupCommitter {
     // the submitting thread can wait for its OWN entry to be applied locally (#5503). Stays -1 on every
     // failure path, where there is no committed index to wait for.
     volatile long logIndex = -1;
+
+    // The leader state machine's reply for this entry, published beside logIndex (issue #7509). Null on
+    // every failure path and on any Ratis reply that carried no message.
+    volatile String applyReply = null;
 
     CancellablePendingEntry(final byte[] entry) {
       this.entry = entry;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGroupCommitter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGroupCommitter.java
@@ -578,6 +578,11 @@ class RaftGroupCommitter {
         // What the LEADER's state machine answered for this entry. Normally "OK"; a security entry whose
         // compare-and-set precondition no longer held answers SECURITY_ENTRY_SUPERSEDED, and the submitter
         // retries against the fresh document rather than believing its change landed (issue #7509).
+        //
+        // Decoded for EVERY entry rather than only for the three security types, which this class cannot tell
+        // apart without parsing the payload it is deliberately opaque to. The reply content is a short constant
+        // - "OK" today - so the cost is one small String per committed entry, against a per-type dispatch that
+        // would push entry-format knowledge down into the committer.
         batch.get(i).applyReply = reply.getMessage() != null ?
             reply.getMessage().getContent().toStringUtf8() :
             null;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -335,14 +335,12 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
   }
 
   /**
-   * Logs the outcome of a security entry and, when it was refused, waits for THIS node to catch up with the
-   * committed log before the caller re-reads (issue #7509).
+   * Logs the outcome of a security entry (issue #7509).
    * <p>
-   * The refusal verdict comes from the leader's apply, which this node may not have reached yet when it
-   * submitted as a follower. Retrying straight away would rebuild the document from the same stale view and be
-   * refused again, so the wait is what makes the retry converge rather than burn the attempt budget.
-   * {@code waitForLocalApply()} is best-effort and bounded by the quorum timeout; blocking here is safe because
-   * the state-machine apply thread never takes the {@code ServerSecurity} monitor the caller holds.
+   * The catch-up wait a refused submitter needs before it retries is deliberately NOT done here: this method runs
+   * with the caller's {@code ServerSecurity} monitor held, and that monitor is shared by every cluster-wide
+   * security mutation on the node. {@link #awaitLocalApply()} is called instead by
+   * {@code ServerSecurity.awaitSupersededChange}, outside the monitor.
    */
   private boolean reportSecurityOutcome(final String document, final boolean applied) {
     if (applied) {
@@ -351,10 +349,22 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
     }
 
     LogManager.instance().log(this, Level.INFO,
-        "Security %s entry was refused: the document changed between the read and the apply. Waiting for this "
-            + "node to catch up so the caller can retry against the current document", document);
-    raftHAServer.waitForLocalApply();
+        "Security %s entry was refused: the document changed between this node's read and the apply, so the "
+            + "caller retries against the current document", document);
     return false;
+  }
+
+  /**
+   * Waits, bounded by {@code arcadedb.ha.quorumTimeout}, for this node's state machine to catch up with the
+   * committed log (issue #7509). Best-effort: {@code waitForLocalApply()} returns rather than failing when the
+   * deadline passes. Safe to block in, because the state-machine apply thread never takes the
+   * {@code ServerSecurity} monitor - and the caller does not hold it here anyway.
+   */
+  @Override
+  public void awaitLocalApply() {
+    final RaftHAServer raft = raftHAServer;
+    if (raft != null)
+      raft.waitForLocalApply();
   }
 
   @Override

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -61,6 +61,12 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
   // database per plugin lifetime instead of on every (re)wrap.
   private final Set<String> warnedSingleBucketDatabases = ConcurrentHashMap.newKeySet();
 
+  /** How often a cluster that cannot use the #7509 compare-and-set may say so. */
+  private static final long SECURITY_PRECONDITION_WITHHELD_LOG_THROTTLE_MS = 5 * 60_000L;
+
+  // When the "security changes are replicating without the concurrency check" line was last logged.
+  private volatile long lastSecurityPreconditionWithheldLog;
+
   // Handlers registered by registerAPI() that own a background executor. A fresh RaftHAPlugin
   // instance (and thus fresh handler instances) is created by PluginManager on every server
   // start, so stopService() must close the ones THIS instance created rather than relying on any
@@ -202,47 +208,153 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
 
   @Override
   public void replicateSecurityUsers(final String usersJsonArray) {
+    // Overridden alongside the two-argument form because the interface's default for THIS one is the no-op:
+    // inheriting it would make the seed paths - PostAddPeerHandler, ServerControlPlane.connectCluster - stop
+    // replicating altogether.
+    replicateSecurityUsers(usersJsonArray, null);
+  }
+
+  @Override
+  public boolean replicateSecurityUsers(final String usersJsonArray, final String expectedFingerprint) {
     if (raftHAServer == null)
       throw new TransactionException("Raft HA server not started");
 
+    final boolean applied;
     try {
-      raftHAServer.getTransactionBroker().replicateSecurityUsers(usersJsonArray);
+      applied = raftHAServer.getTransactionBroker()
+          .replicateSecurityUsers(usersJsonArray, preconditionEveryPeerCanRead(expectedFingerprint));
     } catch (final TransactionException e) {
       throw e;
     } catch (final Exception e) {
       throw new TransactionException("Error sending security-users entry via Raft", e);
     }
-    LogManager.instance().log(this, Level.INFO, "Security users entry committed via Raft");
+    return reportSecurityOutcome("users", applied);
   }
 
   @Override
   public void replicateSecurityGroups(final String groupsJson) {
+    replicateSecurityGroups(groupsJson, null);
+  }
+
+  @Override
+  public boolean replicateSecurityGroups(final String groupsJson, final String expectedFingerprint) {
     if (raftHAServer == null)
       throw new TransactionException("Raft HA server not started");
 
+    final boolean applied;
     try {
-      raftHAServer.getTransactionBroker().replicateSecurityGroups(groupsJson);
+      applied = raftHAServer.getTransactionBroker()
+          .replicateSecurityGroups(groupsJson, preconditionEveryPeerCanRead(expectedFingerprint));
     } catch (final TransactionException e) {
       throw e;
     } catch (final Exception e) {
       throw new TransactionException("Error sending security-groups entry via Raft", e);
     }
-    LogManager.instance().log(this, Level.INFO, "Security groups entry committed via Raft");
+    return reportSecurityOutcome("groups", applied);
   }
 
   @Override
   public void replicateSecurityApiTokens(final String apiTokensJson) {
+    replicateSecurityApiTokens(apiTokensJson, null);
+  }
+
+  @Override
+  public boolean replicateSecurityApiTokens(final String apiTokensJson, final String expectedFingerprint) {
     if (raftHAServer == null)
       throw new TransactionException("Raft HA server not started");
 
+    final boolean applied;
     try {
-      raftHAServer.getTransactionBroker().replicateSecurityApiTokens(apiTokensJson);
+      applied = raftHAServer.getTransactionBroker()
+          .replicateSecurityApiTokens(apiTokensJson, preconditionEveryPeerCanRead(expectedFingerprint));
     } catch (final TransactionException e) {
       throw e;
     } catch (final Exception e) {
       throw new TransactionException("Error sending security-api-tokens entry via Raft", e);
     }
-    LogManager.instance().log(this, Level.INFO, "Security API-tokens entry committed via Raft");
+    return reportSecurityOutcome("API-tokens", applied);
+  }
+
+  /**
+   * The precondition to actually write, which is {@code expectedFingerprint} only while EVERY peer has advertised
+   * that it can read one (issue #7509), and null otherwise.
+   * <p>
+   * This is the gate {@code RaftLogEntryCodec}'s own javadoc demands of any new optional section, and it is not a
+   * formality here. A peer that predates the section skips it and installs the document unconditionally, so an
+   * ungated precondition during a rolling upgrade would have the losing entry REFUSED on the upgraded nodes and
+   * APPLIED on the older one - the security state of the cluster diverging, which is worse than the lost update
+   * #7509 is about, because the same credentials then resolve differently depending on which node answers.
+   * Withholding the precondition instead keeps the pre-#7509 behaviour uniformly until the last node is upgraded,
+   * at which point the compare-and-set starts working on its own with no operator step.
+   * <p>
+   * Read per submission rather than cached, exactly as {@code RaftReplicatedDatabase.schemaDeltaEnabled} reads it:
+   * a peer that stops answering stops receiving preconditions from the next mutation on, and one that finishes
+   * upgrading starts receiving them without a leader restart.
+   */
+  private String preconditionEveryPeerCanRead(final String expectedFingerprint) {
+    return expectedFingerprint == null ?
+        null :
+        preconditionForPeers(expectedFingerprint,
+            raftHAServer.peersMissingCapability(PeerCapabilities.SECURITY_PRECONDITION));
+  }
+
+  /**
+   * The decision {@link #preconditionEveryPeerCanRead} makes, separated from the peer lookup it makes it on so it
+   * can be driven directly: a precondition is written only when NO peer is missing the capability.
+   * Package-private for tests.
+   */
+  String preconditionForPeers(final String expectedFingerprint, final List<String> peersMissingTheCapability) {
+    if (expectedFingerprint == null)
+      return null;
+    if (peersMissingTheCapability.isEmpty())
+      return expectedFingerprint;
+
+    logSecurityPreconditionWithheld(peersMissingTheCapability);
+    return null;
+  }
+
+  /**
+   * Reports, at most once per {@link #SECURITY_PRECONDITION_WITHHELD_LOG_THROTTLE_MS}, that the compare-and-set is
+   * not engaged and WHICH peers are the reason.
+   * <p>
+   * Silence would put an operator back where issue #7509 found them: believing concurrent security changes are safe
+   * while they are not. Throttled because a cluster left half-upgraded is a steady state, not an event.
+   */
+  private void logSecurityPreconditionWithheld(final List<String> peersMissingTheCapability) {
+    final long now = System.currentTimeMillis();
+    if (now - lastSecurityPreconditionWithheldLog < SECURITY_PRECONDITION_WITHHELD_LOG_THROTTLE_MS)
+      return;
+    // Racy by design: two administrators crossing the window at the same instant cost one duplicate line.
+    lastSecurityPreconditionWithheldLog = now;
+    LogManager.instance().log(this, Level.INFO,
+        "Security changes are replicating WITHOUT the concurrency check of issue #7509: peer(s) %s have not "
+            + "advertised the '%s' capability, so a precondition could not be read there. Until they are upgraded "
+            + "or reachable again, two security changes made on two nodes at the same time can still lose one of "
+            + "them - the pre-#7509 behaviour. Nothing has to be turned on afterwards; the check resumes by itself.",
+        peersMissingTheCapability, PeerCapabilities.SECURITY_PRECONDITION);
+  }
+
+  /**
+   * Logs the outcome of a security entry and, when it was refused, waits for THIS node to catch up with the
+   * committed log before the caller re-reads (issue #7509).
+   * <p>
+   * The refusal verdict comes from the leader's apply, which this node may not have reached yet when it
+   * submitted as a follower. Retrying straight away would rebuild the document from the same stale view and be
+   * refused again, so the wait is what makes the retry converge rather than burn the attempt budget.
+   * {@code waitForLocalApply()} is best-effort and bounded by the quorum timeout; blocking here is safe because
+   * the state-machine apply thread never takes the {@code ServerSecurity} monitor the caller holds.
+   */
+  private boolean reportSecurityOutcome(final String document, final boolean applied) {
+    if (applied) {
+      LogManager.instance().log(this, Level.INFO, "Security %s entry committed via Raft", document);
+      return true;
+    }
+
+    LogManager.instance().log(this, Level.INFO,
+        "Security %s entry was refused: the document changed between the read and the apply. Waiting for this "
+            + "node to catch up so the caller can retry against the current document", document);
+    raftHAServer.waitForLocalApply();
+    return false;
   }
 
   @Override

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
@@ -927,16 +927,32 @@ public final class RaftLogEntryCodec {
    * Reads the security compare-and-set precondition out of one extension section, or returns null when the
    * section is something else - a section this version does not recognise is skipped, which is the whole point
    * of the framing (issue #7138).
+   * <p>
+   * <b>The two reads are deliberately not in one {@code try}.</b> Failing to read the section NAME means this is
+   * not our section, and skipping it is correct. Failing to read the fingerprint AFTER the name matched means our
+   * section is corrupt - and returning null for that would quietly demote the entry to "no precondition, install
+   * unconditionally", which is the one default this field must never fall back to: it is the guard that stops a
+   * stale document from reverting a committed change. A corrupt one is reported as corruption, like every other
+   * malformed payload in this class, and reaches the caller as a {@code RaftLogEntryDecodeException}.
    */
   private static String readSecurityPrecondition(final byte[] section) {
-    try (final DataInputStream dis = new DataInputStream(new ByteArrayInputStream(section))) {
+    final DataInputStream dis = new DataInputStream(new ByteArrayInputStream(section));
+    try {
       if (!SECURITY_PRECONDITION_SECTION.equals(dis.readUTF()))
         return null;
-      return dis.readUTF();
     } catch (final IOException e) {
       // A section whose first field is not a readable UTF string is not one of ours; treat it as unrecognised
       // rather than failing the entry, exactly as an unknown section name is treated.
       return null;
+    }
+
+    try {
+      return dis.readUTF();
+    } catch (final IOException e) {
+      throw new IllegalStateException(
+          "Corrupted Raft log entry: the '" + SECURITY_PRECONDITION_SECTION + "' extension section carries no "
+              + "readable fingerprint. Refusing the entry rather than applying its document unconditionally, "
+              + "which would let a stale security document revert a committed change", e);
     }
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
@@ -22,6 +22,7 @@ import com.arcadedb.compression.CompressionFactory;
 import com.arcadedb.network.binary.ReplicatedEntryTooLargeException;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -133,6 +134,12 @@ public final class RaftLogEntryCodec {
 
   /** Bytes one extension frame spends on its header ({@link #EXTENSION_MAGIC} + length). */
   private static final int EXTENSION_HEADER_BYTES = 8;
+
+  /**
+   * Name of the extension section carrying a security entry's compare-and-set precondition (issue #7509). Every
+   * section starts with its own name so sections added later to the same entry type stay distinguishable.
+   */
+  static final String SECURITY_PRECONDITION_SECTION = "security-precondition";
 
   /**
    * Appends one self-describing extension section to an entry being encoded. Call this AFTER the type's own
@@ -325,8 +332,24 @@ public final class RaftLogEntryCodec {
        * predates this section, and every entry produced with {@code arcadedb.ha.schemaDelta} off. When it is
        * set, {@code schemaJson} is empty and the applier merges the delta into its own schema instead.
        */
-      SchemaDelta.Payload schemaDelta
+      SchemaDelta.Payload schemaDelta,
+      /**
+       * The compare-and-set precondition of a node-scoped security entry: the fingerprint of the document its
+       * submitter READ, as {@code SecurityDocumentFingerprint} computes it (issue #7509). Null on every other
+       * entry type, on a seed - which must overwrite whatever the joining peer holds - and on a security entry
+       * written by a node that predates the section, all three of which apply unconditionally as before.
+       */
+      String securityPrecondition
   ) {
+
+    /** The same entry with {@code securityPrecondition} replaced; the decoder reads the section after the body. */
+    DecodedEntry withSecurityPrecondition(final String precondition) {
+      return precondition == null ?
+          this :
+          new DecodedEntry(type, databaseName, walData, bucketRecordDelta, schemaJson, filesToAdd, filesToRemove,
+              walEntries, bucketDeltas, usersJson, forceSnapshot, bootstrapFingerprint, bootstrapLastTxId,
+              sealedFileBlobs, moreChunksFollow, sealedFileChunks, schemaDelta, precondition);
+    }
   }
 
   /**
@@ -669,7 +692,16 @@ public final class RaftLogEntryCodec {
    * three security entries share.
    */
   public static ByteString encodeSecurityUsersEntry(final String usersJson) {
-    return encodeSecurityEntry(RaftLogEntryType.SECURITY_USERS_ENTRY, usersJson);
+    return encodeSecurityUsersEntry(usersJson, null);
+  }
+
+  /**
+   * Encodes a security-users entry that installs {@code usersJson} only while the document in force still
+   * fingerprints to {@code expectedFingerprint} (issue #7509). A null fingerprint means "install
+   * unconditionally", which is what a seed wants and what every entry written before this section carried.
+   */
+  public static ByteString encodeSecurityUsersEntry(final String usersJson, final String expectedFingerprint) {
+    return encodeSecurityEntry(RaftLogEntryType.SECURITY_USERS_ENTRY, usersJson, expectedFingerprint);
   }
 
   /**
@@ -677,7 +709,12 @@ public final class RaftLogEntryCodec {
    * Same wire shape as {@link #encodeSecurityUsersEntry}; the type byte is what tells the two apart.
    */
   public static ByteString encodeSecurityGroupsEntry(final String groupsJson) {
-    return encodeSecurityEntry(RaftLogEntryType.SECURITY_GROUPS_ENTRY, groupsJson);
+    return encodeSecurityGroupsEntry(groupsJson, null);
+  }
+
+  /** {@link #encodeSecurityUsersEntry(String, String)} for the group document (issue #7509). */
+  public static ByteString encodeSecurityGroupsEntry(final String groupsJson, final String expectedFingerprint) {
+    return encodeSecurityEntry(RaftLogEntryType.SECURITY_GROUPS_ENTRY, groupsJson, expectedFingerprint);
   }
 
   /**
@@ -685,7 +722,12 @@ public final class RaftLogEntryCodec {
    * (issue #7373). The document carries token hashes, never token material.
    */
   public static ByteString encodeSecurityApiTokensEntry(final String apiTokensJson) {
-    return encodeSecurityEntry(RaftLogEntryType.SECURITY_API_TOKENS_ENTRY, apiTokensJson);
+    return encodeSecurityApiTokensEntry(apiTokensJson, null);
+  }
+
+  /** {@link #encodeSecurityUsersEntry(String, String)} for the API-token document (issue #7509). */
+  public static ByteString encodeSecurityApiTokensEntry(final String apiTokensJson, final String expectedFingerprint) {
+    return encodeSecurityEntry(RaftLogEntryType.SECURITY_API_TOKENS_ENTRY, apiTokensJson, expectedFingerprint);
   }
 
   /**
@@ -694,7 +736,8 @@ public final class RaftLogEntryCodec {
    * Binary format: type byte, empty databaseName (UTF), jsonLength (int), UTF-8 bytes.
    * The empty databaseName slot keeps the decoder symmetric with other entry types.
    */
-  private static ByteString encodeSecurityEntry(final RaftLogEntryType type, final String json) {
+  private static ByteString encodeSecurityEntry(final RaftLogEntryType type, final String json,
+      final String expectedFingerprint) {
     try {
       final ByteArrayOutputStream baos = new ByteArrayOutputStream();
       final DataOutputStream dos = new DataOutputStream(baos);
@@ -705,11 +748,29 @@ public final class RaftLogEntryCodec {
       dos.writeInt(bytes.length);
       dos.write(bytes);
 
+      // Written as an EXTENSION SECTION rather than as a field, so a peer that predates issue #7509 skips it
+      // and applies the document unconditionally instead of failing to decode the entry (issue #7138).
+      if (expectedFingerprint != null)
+        writeExtensionSection(dos, securityPreconditionSection(expectedFingerprint));
+
       dos.flush();
       return ByteString.copyFrom(baos.toByteArray());
     } catch (final IOException e) {
       throw new IllegalStateException("Failed to encode " + type + " entry", e);
     }
+  }
+
+  /**
+   * The body of the security compare-and-set extension section: its own name, then the fingerprint. The name is
+   * what lets a later reader tell this section apart from another one added to the same entry type.
+   */
+  private static byte[] securityPreconditionSection(final String expectedFingerprint) throws IOException {
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    final DataOutputStream dos = new DataOutputStream(baos);
+    dos.writeUTF(SECURITY_PRECONDITION_SECTION);
+    dos.writeUTF(expectedFingerprint);
+    dos.flush();
+    return baos.toByteArray();
   }
 
   /**
@@ -776,7 +837,7 @@ public final class RaftLogEntryCodec {
       final RaftLogEntryType type = RaftLogEntryType.fromId(typeByte);
       if (type == null)
         return new DecodedEntry(null, null, null, null, null, null, null, null, null, null, false, null, -1L,
-            Collections.emptyList(), false, Collections.emptyList(), null);
+            Collections.emptyList(), false, Collections.emptyList(), null, null);
       final String databaseName = dis.readUTF();
 
       try {
@@ -811,14 +872,12 @@ public final class RaftLogEntryCodec {
       case INSTALL_DATABASE_ENTRY -> decodeInstallDatabaseEntry(dis, databaseName);
       case DROP_DATABASE_ENTRY -> new DecodedEntry(RaftLogEntryType.DROP_DATABASE_ENTRY, databaseName,
           null, null, null, null, null, null, null, null, false, null, -1L, Collections.emptyList(), false,
-          Collections.emptyList(), null);
+          Collections.emptyList(), null, null);
       case SECURITY_USERS_ENTRY, SECURITY_GROUPS_ENTRY, SECURITY_API_TOKENS_ENTRY -> decodeSecurityEntry(dis, type);
       case BOOTSTRAP_FINGERPRINT_ENTRY -> decodeBootstrapFingerprintEntry(dis, databaseName);
     };
 
-    skipTrailingExtensionSections(dis, type);
-
-    return result;
+    return result.withSecurityPrecondition(readTrailingExtensionSections(dis, type));
   }
 
   /**
@@ -835,11 +894,12 @@ public final class RaftLogEntryCodec {
    * of those sections, so there is nothing left here to frame. It extends through its own mechanism instead; see
    * {@link #EXTENSION_MAGIC}.
    */
-  private static void skipTrailingExtensionSections(final DataInputStream dis, final RaftLogEntryType type)
+  private static String readTrailingExtensionSections(final DataInputStream dis, final RaftLogEntryType type)
       throws IOException {
     if (type == RaftLogEntryType.SCHEMA_ENTRY)
-      return;
+      return null;
 
+    String securityPrecondition = null;
     while (dis.available() > 0) {
       if (dis.available() < EXTENSION_HEADER_BYTES)
         throw new IllegalStateException("Corrupted Raft log entry: " + dis.available()
@@ -853,7 +913,30 @@ public final class RaftLogEntryCodec {
 
       final int length = dis.readInt();
       checkByteLength(length, dis.available(), type + " extension section");
-      dis.skipNBytes(length);
+      final byte[] section = new byte[length];
+      dis.readFully(section);
+
+      final String precondition = readSecurityPrecondition(section);
+      if (precondition != null)
+        securityPrecondition = precondition;
+    }
+    return securityPrecondition;
+  }
+
+  /**
+   * Reads the security compare-and-set precondition out of one extension section, or returns null when the
+   * section is something else - a section this version does not recognise is skipped, which is the whole point
+   * of the framing (issue #7138).
+   */
+  private static String readSecurityPrecondition(final byte[] section) {
+    try (final DataInputStream dis = new DataInputStream(new ByteArrayInputStream(section))) {
+      if (!SECURITY_PRECONDITION_SECTION.equals(dis.readUTF()))
+        return null;
+      return dis.readUTF();
+    } catch (final IOException e) {
+      // A section whose first field is not a readable UTF string is not one of ours; treat it as unrecognised
+      // rather than failing the entry, exactly as an unknown section name is treated.
+      return null;
     }
   }
 
@@ -877,7 +960,7 @@ public final class RaftLogEntryCodec {
 
     return new DecodedEntry(RaftLogEntryType.TX_ENTRY, databaseName, walData, bucketRecordDelta,
         null, null, null, null, null, null, false, null, -1L, Collections.emptyList(), false, Collections.emptyList(),
-        null);
+        null, null);
   }
 
   private static DecodedEntry decodeSchemaEntry(final DataInputStream dis, final String databaseName) throws IOException {
@@ -1032,7 +1115,7 @@ public final class RaftLogEntryCodec {
 
     return new DecodedEntry(RaftLogEntryType.SCHEMA_ENTRY, databaseName, null, null,
         schemaJson, filesToAdd, filesToRemove, walEntries, bucketDeltas, null, false, null, -1L, sealedFileBlobs,
-        moreChunksFollow, sealedFileChunks, schemaDelta);
+        moreChunksFollow, sealedFileChunks, schemaDelta, null);
   }
 
   private static DecodedEntry decodeInstallDatabaseEntry(final DataInputStream dis, final String databaseName) throws IOException {
@@ -1044,7 +1127,7 @@ public final class RaftLogEntryCodec {
     }
     return new DecodedEntry(RaftLogEntryType.INSTALL_DATABASE_ENTRY, databaseName,
         null, null, null, null, null, null, null, null, forceSnapshot, null, -1L, Collections.emptyList(), false,
-        Collections.emptyList(), null);
+        Collections.emptyList(), null, null);
   }
 
   private static DecodedEntry decodeBootstrapFingerprintEntry(final DataInputStream dis, final String databaseName)
@@ -1057,7 +1140,7 @@ public final class RaftLogEntryCodec {
     final long lastTxId = dis.readLong();
     return new DecodedEntry(RaftLogEntryType.BOOTSTRAP_FINGERPRINT_ENTRY, databaseName,
         null, null, null, null, null, null, null, null, false, fingerprint, lastTxId, Collections.emptyList(), false,
-        Collections.emptyList(), null);
+        Collections.emptyList(), null, null);
   }
 
   /**
@@ -1074,7 +1157,7 @@ public final class RaftLogEntryCodec {
     final String json = new String(bytes, StandardCharsets.UTF_8);
     return new DecodedEntry(type, "",
         null, null, null, null, null, null, null, json, false, null, -1L, Collections.emptyList(), false,
-        Collections.emptyList(), null);
+        Collections.emptyList(), null, null);
   }
 
   private static void writeFileMap(final DataOutputStream dos, final Map<Integer, String> fileMap) throws IOException {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftTransactionBroker.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftTransactionBroker.java
@@ -437,26 +437,43 @@ public class RaftTransactionBroker {
 
   /**
    * Replicates a security users entry so all nodes update their user files.
+   *
+   * @param expectedFingerprint the fingerprint of the user list the submitter read, or null to install
+   *                            unconditionally (a seed). See {@link #wasApplied} (issue #7509)
+   *
+   * @return false when the entry was refused because the document had changed since it was read
    */
-  public void replicateSecurityUsers(final String usersJson) {
-    final ByteString entry = RaftLogEntryCodec.encodeSecurityUsersEntry(usersJson);
-    groupCommitter.submitAndWait(entry.toByteArray());
+  public boolean replicateSecurityUsers(final String usersJson, final String expectedFingerprint) {
+    final ByteString entry = RaftLogEntryCodec.encodeSecurityUsersEntry(usersJson, expectedFingerprint);
+    return wasApplied(groupCommitter.submitAndWaitForReply(entry.toByteArray()));
   }
 
   /**
-   * Replicates a security-groups entry so all nodes update their group document (issue #7373).
+   * Replicates a security-groups entry so all nodes update their group document (issue #7373). See
+   * {@link #replicateSecurityUsers} for {@code expectedFingerprint} and the return value.
    */
-  public void replicateSecurityGroups(final String groupsJson) {
-    final ByteString entry = RaftLogEntryCodec.encodeSecurityGroupsEntry(groupsJson);
-    groupCommitter.submitAndWait(entry.toByteArray());
+  public boolean replicateSecurityGroups(final String groupsJson, final String expectedFingerprint) {
+    final ByteString entry = RaftLogEntryCodec.encodeSecurityGroupsEntry(groupsJson, expectedFingerprint);
+    return wasApplied(groupCommitter.submitAndWaitForReply(entry.toByteArray()));
   }
 
   /**
-   * Replicates a security API-tokens entry so all nodes update their token store (issue #7373).
+   * Replicates a security API-tokens entry so all nodes update their token store (issue #7373). See
+   * {@link #replicateSecurityUsers} for {@code expectedFingerprint} and the return value.
    */
-  public void replicateSecurityApiTokens(final String apiTokensJson) {
-    final ByteString entry = RaftLogEntryCodec.encodeSecurityApiTokensEntry(apiTokensJson);
-    groupCommitter.submitAndWait(entry.toByteArray());
+  public boolean replicateSecurityApiTokens(final String apiTokensJson, final String expectedFingerprint) {
+    final ByteString entry = RaftLogEntryCodec.encodeSecurityApiTokensEntry(apiTokensJson, expectedFingerprint);
+    return wasApplied(groupCommitter.submitAndWaitForReply(entry.toByteArray()));
+  }
+
+  /**
+   * Reads the leader state machine's answer for a security entry (issue #7509). Anything that is not the
+   * explicit "superseded" marker counts as applied: a leader that predates the marker answers "OK", and a reply
+   * that carried no message at all is indistinguishable from that, so the conservative reading is the one that
+   * preserves the pre-#7509 behaviour rather than one that reports a phantom conflict.
+   */
+  private static boolean wasApplied(final String applyReply) {
+    return !ArcadeStateMachine.SECURITY_ENTRY_SUPERSEDED_REPLY.equals(applyReply);
   }
 
   /**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7337SealedShardsOfEntryTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7337SealedShardsOfEntryTest.java
@@ -86,6 +86,6 @@ class Issue7337SealedShardsOfEntryTest {
   private static RaftLogEntryCodec.DecodedEntry entry(final List<RaftLogEntryCodec.TsSealedBlob> blobs,
       final List<RaftLogEntryCodec.TsSealedChunk> chunks) {
     return new RaftLogEntryCodec.DecodedEntry(RaftLogEntryType.SCHEMA_ENTRY, "graph", null, null, null, null, null,
-        null, null, null, false, null, -1L, blobs, false, chunks, null);
+        null, null, null, false, null, -1L, blobs, false, chunks, null, null);
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7373SecurityConfigBrokerEntryTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7373SecurityConfigBrokerEntryTest.java
@@ -52,14 +52,14 @@ class Issue7373SecurityConfigBrokerEntryTest {
   @Test
   void replicateSecurityGroupsSubmitsAnEntry() {
     assertThatThrownBy(() ->
-        broker.replicateSecurityGroups("{\"databases\":{\"*\":{\"groups\":{}}},\"version\":2}"))
+        broker.replicateSecurityGroups("{\"databases\":{\"*\":{\"groups\":{}}},\"version\":2}", null))
         .isInstanceOf(QuorumNotReachedException.class);
   }
 
   @Test
   void replicateSecurityApiTokensSubmitsAnEntry() {
     assertThatThrownBy(() ->
-        broker.replicateSecurityApiTokens("{\"version\":1,\"tokens\":[]}"))
+        broker.replicateSecurityApiTokens("{\"version\":1,\"tokens\":[]}", null))
         .isInstanceOf(QuorumNotReachedException.class);
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7509SecurityPreconditionCapabilityGateTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7509SecurityPreconditionCapabilityGateTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7509's rolling-upgrade guard: the compare-and-set precondition is written only while EVERY peer has
+ * proved it can read one.
+ * <p>
+ * Without the gate a mixed cluster is worse off than an ungated one, not better. A peer that predates the
+ * section skips it and installs the document unconditionally, so a losing entry would be REFUSED on the
+ * upgraded nodes and APPLIED on the older one: the security state diverges, and the same credentials then
+ * resolve differently depending on which node answers - the failure #7373 exists to prevent. Withholding the
+ * precondition keeps the pre-#7509 behaviour uniform instead, and the check resumes by itself once the last
+ * node is upgraded.
+ */
+class Issue7509SecurityPreconditionCapabilityGateTest {
+
+  private static final String FINGERPRINT = "0f".repeat(32);
+
+  @Test
+  void thisBuildAdvertisesThatItReadsASecurityPrecondition() {
+    // Without this a cluster of nodes that can all read one would never agree to write one.
+    assertThat(PeerCapabilities.LOCAL).contains(PeerCapabilities.SECURITY_PRECONDITION);
+  }
+
+  @Test
+  void theFingerprintIsWrittenWhenNoPeerIsMissingTheCapability() {
+    assertThat(new RaftHAPlugin().preconditionForPeers(FINGERPRINT, List.of())).isEqualTo(FINGERPRINT);
+  }
+
+  @Test
+  void theFingerprintIsWithheldWhileAnyPeerIsMissingTheCapability() {
+    assertThat(new RaftHAPlugin().preconditionForPeers(FINGERPRINT, List.of("arcadedb2"))).isNull();
+  }
+
+  /** A seed carries no fingerprint to begin with, gate or no gate. */
+  @Test
+  void aSubmissionWithNoPreconditionStaysWithoutOne() {
+    assertThat(new RaftHAPlugin().preconditionForPeers(null, List.of())).isNull();
+  }
+
+  /**
+   * What "missing" means is the registry's answer, and it is fail-closed: a peer that is unknown - never probed,
+   * unreachable, or probed and stale - counts as missing exactly like one that answered without the token. That is
+   * what makes the gate safe without an operator sequencing the upgrade by hand.
+   */
+  @Test
+  void anUnknownPeerCountsAsMissingTheCapability() {
+    final PeerCapabilityRegistry registry = new PeerCapabilityRegistry();
+    final long generation = registry.generation();
+    registry.record(generation, "arcadedb0", Set.of(PeerCapabilities.SECURITY_PRECONDITION), "26.10.1");
+
+    assertThat(registry.peersMissing(List.of("arcadedb0"), PeerCapabilities.SECURITY_PRECONDITION)).isEmpty();
+    assertThat(registry.peersMissing(List.of("arcadedb0", "arcadedb1"), PeerCapabilities.SECURITY_PRECONDITION))
+        .as("a peer that has never advertised anything must not be credited with the capability")
+        .containsExactly("arcadedb1");
+  }
+
+  @Test
+  void aPeerThatAdvertisesWithoutTheTokenCountsAsMissingIt() {
+    final PeerCapabilityRegistry registry = new PeerCapabilityRegistry();
+    final long generation = registry.generation();
+    registry.record(generation, "arcadedb1", Set.of(PeerCapabilities.SCHEMA_DELTA), "26.9.1");
+
+    assertThat(registry.peersMissing(List.of("arcadedb1"), PeerCapabilities.SECURITY_PRECONDITION))
+        .containsExactly("arcadedb1");
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7509SecurityPreconditionCodecTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7509SecurityPreconditionCodecTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Wire coverage for the compare-and-set precondition issue #7509 adds to the three node-scoped security
+ * entries.
+ * <p>
+ * The precondition rides in an extension section rather than in a new field, because of what has to stay true
+ * during a rolling upgrade: a peer that predates the section must still be able to DECODE the entry - it skips
+ * what it does not recognise (issue #7138) and installs the document unconditionally, which is exactly the
+ * behaviour it had before. That is the property {@link #anEntryWrittenWithoutAPreconditionDecodesToNull} and
+ * {@link #anUnrelatedExtensionSectionDoesNotHideThePrecondition} pin: the section is optional in both
+ * directions, and one section never swallows another.
+ */
+class Issue7509SecurityPreconditionCodecTest {
+
+  private static final String USERS       = "[{\"name\":\"root\"}]";
+  private static final String GROUPS      = "{\"databases\":{\"*\":{\"groups\":{}}},\"version\":2}";
+  private static final String TOKENS      = "{\"version\":1,\"tokens\":[]}";
+  private static final String FINGERPRINT = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08";
+
+  @Test
+  void aUsersEntryCarriesItsPreconditionAndItsPayloadUnchanged() {
+    final RaftLogEntryCodec.DecodedEntry decoded =
+        RaftLogEntryCodec.decode(RaftLogEntryCodec.encodeSecurityUsersEntry(USERS, FINGERPRINT));
+
+    assertThat(decoded.type()).isEqualTo(RaftLogEntryType.SECURITY_USERS_ENTRY);
+    assertThat(decoded.usersJson()).as("the section must not disturb the document").isEqualTo(USERS);
+    assertThat(decoded.securityPrecondition()).isEqualTo(FINGERPRINT);
+  }
+
+  @Test
+  void aGroupsEntryCarriesItsPrecondition() {
+    final RaftLogEntryCodec.DecodedEntry decoded =
+        RaftLogEntryCodec.decode(RaftLogEntryCodec.encodeSecurityGroupsEntry(GROUPS, FINGERPRINT));
+
+    assertThat(decoded.type()).isEqualTo(RaftLogEntryType.SECURITY_GROUPS_ENTRY);
+    assertThat(decoded.usersJson()).isEqualTo(GROUPS);
+    assertThat(decoded.securityPrecondition()).isEqualTo(FINGERPRINT);
+  }
+
+  @Test
+  void anApiTokensEntryCarriesItsPrecondition() {
+    final RaftLogEntryCodec.DecodedEntry decoded =
+        RaftLogEntryCodec.decode(RaftLogEntryCodec.encodeSecurityApiTokensEntry(TOKENS, FINGERPRINT));
+
+    assertThat(decoded.type()).isEqualTo(RaftLogEntryType.SECURITY_API_TOKENS_ENTRY);
+    assertThat(decoded.usersJson()).isEqualTo(TOKENS);
+    assertThat(decoded.securityPrecondition()).isEqualTo(FINGERPRINT);
+  }
+
+  /** A seed, and every entry a node that predates issue #7509 writes: no section, so no precondition. */
+  @Test
+  void anEntryWrittenWithoutAPreconditionDecodesToNull() {
+    assertThat(RaftLogEntryCodec.decode(RaftLogEntryCodec.encodeSecurityUsersEntry(USERS)).securityPrecondition())
+        .isNull();
+    assertThat(RaftLogEntryCodec.decode(RaftLogEntryCodec.encodeSecurityUsersEntry(USERS, null)).securityPrecondition())
+        .isNull();
+    assertThat(RaftLogEntryCodec.decode(RaftLogEntryCodec.encodeSecurityGroupsEntry(GROUPS)).securityPrecondition())
+        .isNull();
+    assertThat(RaftLogEntryCodec.decode(RaftLogEntryCodec.encodeSecurityApiTokensEntry(TOKENS)).securityPrecondition())
+        .isNull();
+  }
+
+  /**
+   * A future section appended after this one - the case the framing exists for - is skipped, and the
+   * precondition in front of it is still read.
+   */
+  @Test
+  void anUnrelatedExtensionSectionDoesNotHideThePrecondition() {
+    final ByteString entry = RaftLogEntryCodec.appendExtensionSection(
+        RaftLogEntryCodec.encodeSecurityUsersEntry(USERS, FINGERPRINT),
+        "some-future-section".getBytes(StandardCharsets.UTF_8));
+
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(entry);
+
+    assertThat(decoded.usersJson()).isEqualTo(USERS);
+    assertThat(decoded.securityPrecondition()).isEqualTo(FINGERPRINT);
+  }
+
+  /** And an entry that carries ONLY a section this version does not know still decodes, with no precondition. */
+  @Test
+  void anEntryCarryingOnlyAnUnknownSectionStillDecodes() {
+    final ByteString entry = RaftLogEntryCodec.appendExtensionSection(
+        RaftLogEntryCodec.encodeSecurityUsersEntry(USERS),
+        "some-future-section".getBytes(StandardCharsets.UTF_8));
+
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(entry);
+
+    assertThat(decoded.usersJson()).isEqualTo(USERS);
+    assertThat(decoded.securityPrecondition()).isNull();
+  }
+
+  /** No other entry type grows a precondition by accident. */
+  @Test
+  void aNonSecurityEntryHasNoPrecondition() {
+    assertThat(RaftLogEntryCodec.decode(RaftLogEntryCodec.encodeDropDatabaseEntry("graph")).securityPrecondition())
+        .isNull();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7509SecurityPreconditionCodecTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7509SecurityPreconditionCodecTest.java
@@ -21,9 +21,13 @@ package com.arcadedb.server.ha.raft;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Wire coverage for the compare-and-set precondition issue #7509 adds to the three node-scoped security
@@ -113,6 +117,60 @@ class Issue7509SecurityPreconditionCodecTest {
 
     assertThat(decoded.usersJson()).isEqualTo(USERS);
     assertThat(decoded.securityPrecondition()).isNull();
+  }
+
+  /**
+   * A section that IDENTIFIES ITSELF as the precondition but cannot be read past its name is corruption, and must
+   * not degrade into "no precondition, install unconditionally".
+   * <p>
+   * That default is safe for an unrecognised section - it is what the #7138 framing is for - and is exactly wrong
+   * for this one: the precondition is the guard that stops a stale security document from reverting a committed
+   * change, so silently dropping it turns a corrupt entry into the divergence the guard exists to prevent. It
+   * has to fail the entry like any other malformed payload in the codec.
+   */
+  @Test
+  void aCorruptedPreconditionSectionFailsTheEntryInsteadOfApplyingItUnconditionally() {
+    final ByteString truncated = RaftLogEntryCodec.appendExtensionSection(
+        RaftLogEntryCodec.encodeSecurityUsersEntry(USERS), utf(RaftLogEntryCodec.SECURITY_PRECONDITION_SECTION));
+
+    assertThatThrownBy(() -> RaftLogEntryCodec.decode(truncated))
+        .isInstanceOf(RaftLogEntryDecodeException.class)
+        .hasMessageContaining("SECURITY_USERS_ENTRY");
+
+    // Same for a fingerprint whose own UTF frame is cut short rather than absent entirely.
+    final byte[] name = utf(RaftLogEntryCodec.SECURITY_PRECONDITION_SECTION);
+    final byte[] halfAFingerprint = new byte[name.length + 3];
+    System.arraycopy(name, 0, halfAFingerprint, 0, name.length);
+    halfAFingerprint[name.length] = 0;
+    halfAFingerprint[name.length + 1] = 32;   // declares 32 bytes of fingerprint...
+    halfAFingerprint[name.length + 2] = 'a';  // ...and carries one
+
+    assertThatThrownBy(() -> RaftLogEntryCodec.decode(
+        RaftLogEntryCodec.appendExtensionSection(RaftLogEntryCodec.encodeSecurityUsersEntry(USERS), halfAFingerprint)))
+        .isInstanceOf(RaftLogEntryDecodeException.class);
+  }
+
+  /** A section whose NAME is unreadable is not ours, so it is skipped - the #7138 contract, unchanged. */
+  @Test
+  void aSectionWhoseNameCannotBeReadIsStillSkipped() {
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(
+        RaftLogEntryCodec.appendExtensionSection(RaftLogEntryCodec.encodeSecurityUsersEntry(USERS),
+            new byte[] { 0, 40, 'x' }));   // declares a 40-byte name, carries one
+
+    assertThat(decoded.usersJson()).isEqualTo(USERS);
+    assertThat(decoded.securityPrecondition()).isNull();
+  }
+
+  private static byte[] utf(final String value) {
+    try {
+      final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      final DataOutputStream dos = new DataOutputStream(baos);
+      dos.writeUTF(value);
+      dos.flush();
+      return baos.toByteArray();
+    } catch (final IOException e) {
+      throw new IllegalStateException(e);
+    }
   }
 
   /** No other entry type grows a precondition by accident. */

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7509SupersededSecurityEntryReplyTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue7509SupersededSecurityEntryReplyTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.security.ServerSecurity;
+import org.apache.ratis.proto.RaftProtos.LogEntryProto;
+import org.apache.ratis.proto.RaftProtos.StateMachineLogEntryProto;
+import org.apache.ratis.protocol.Message;
+import org.apache.ratis.server.RaftServer;
+import org.apache.ratis.statemachine.TransactionContext;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #7509, the half a {@code ServerSecurity} test cannot reach: what the state machine ANSWERS for a
+ * security entry whose compare-and-set precondition no longer holds.
+ * <p>
+ * Refusing the entry is only half a fix. The node that submitted it has already answered its operator, and
+ * unless the refusal travels back that operator is told a change landed that was thrown away - the silent
+ * success the issue is about, just relocated. The verdict has to ride the REPLY rather than be observed
+ * locally, because the submitter is not necessarily the leader and a follower's own apply of the entry can lag
+ * the reply it gets back.
+ * <p>
+ * So what is pinned here is the contract between the apply and {@code RaftTransactionBroker.wasApplied}: a
+ * refused entry completes NORMALLY - the applied index must advance, it is a no-op on every node, not a
+ * failure - carrying {@link ArcadeStateMachine#SECURITY_ENTRY_SUPERSEDED_REPLY}, and an installed one carries
+ * something else.
+ */
+class Issue7509SupersededSecurityEntryReplyTest {
+
+  private static final String USERS_JSON  = "[{\"name\":\"root\",\"password\":\"x\"}]";
+  private static final String FINGERPRINT = "0f".repeat(32);
+
+  @Test
+  void aRefusedUsersEntryAnswersTheSupersededMarkerAndDoesNotFail() {
+    final ServerSecurity security = securityThatRefuses();
+    final ArcadeStateMachine sm = stateMachine(security);
+
+    final CompletableFuture<Message> future = sm.applyTransaction(
+        entry(sm, 5L, RaftLogEntryCodec.encodeSecurityUsersEntry(USERS_JSON, FINGERPRINT)));
+
+    assertThat(future.isCompletedExceptionally())
+        .as("a refusal is a no-op apply, not a failed one: the applied index must still advance").isFalse();
+    assertThat(future.join().getContent().toStringUtf8())
+        .isEqualTo(ArcadeStateMachine.SECURITY_ENTRY_SUPERSEDED_REPLY);
+    assertThat(sm.isHaltedAfterCriticalError()).isFalse();
+  }
+
+  @Test
+  void anInstalledUsersEntryAnswersSomethingElse() {
+    final ServerSecurity security = mock(ServerSecurity.class);
+    when(security.applyReplicatedUsers(anyString(), anyString())).thenReturn(true);
+    final ArcadeStateMachine sm = stateMachine(security);
+
+    final CompletableFuture<Message> future = sm.applyTransaction(
+        entry(sm, 5L, RaftLogEntryCodec.encodeSecurityUsersEntry(USERS_JSON, FINGERPRINT)));
+
+    assertThat(future.join().getContent().toStringUtf8())
+        .isNotEqualTo(ArcadeStateMachine.SECURITY_ENTRY_SUPERSEDED_REPLY);
+  }
+
+  @Test
+  void aRefusedGroupsEntryAnswersTheSupersededMarker() {
+    final ServerSecurity security = mock(ServerSecurity.class);
+    when(security.applyReplicatedGroups(anyString(), anyString())).thenReturn(false);
+    final ArcadeStateMachine sm = stateMachine(security);
+
+    final CompletableFuture<Message> future = sm.applyTransaction(entry(sm, 5L,
+        RaftLogEntryCodec.encodeSecurityGroupsEntry("{\"databases\":{},\"version\":2}", FINGERPRINT)));
+
+    assertThat(future.join().getContent().toStringUtf8())
+        .isEqualTo(ArcadeStateMachine.SECURITY_ENTRY_SUPERSEDED_REPLY);
+  }
+
+  @Test
+  void aRefusedApiTokensEntryAnswersTheSupersededMarker() {
+    final ServerSecurity security = mock(ServerSecurity.class);
+    when(security.applyReplicatedApiTokens(anyString(), anyString())).thenReturn(false);
+    final ArcadeStateMachine sm = stateMachine(security);
+
+    final CompletableFuture<Message> future = sm.applyTransaction(entry(sm, 5L,
+        RaftLogEntryCodec.encodeSecurityApiTokensEntry("{\"version\":1,\"tokens\":[]}", FINGERPRINT)));
+
+    assertThat(future.join().getContent().toStringUtf8())
+        .isEqualTo(ArcadeStateMachine.SECURITY_ENTRY_SUPERSEDED_REPLY);
+  }
+
+  /**
+   * An entry with no precondition - a seed, and every entry a node that predates issue #7509 wrote - must not
+   * even reach the compare-and-set overload: it goes to the unconditional apply, unchanged.
+   */
+  @Test
+  void anEntryWithoutAPreconditionTakesTheUnconditionalApply() {
+    final ServerSecurity security = mock(ServerSecurity.class);
+    final ArcadeStateMachine sm = stateMachine(security);
+
+    final CompletableFuture<Message> future = sm.applyTransaction(
+        entry(sm, 5L, RaftLogEntryCodec.encodeSecurityUsersEntry(USERS_JSON)));
+
+    verify(security).applyReplicatedUsers(USERS_JSON);
+    assertThat(future.join().getContent().toStringUtf8())
+        .isNotEqualTo(ArcadeStateMachine.SECURITY_ENTRY_SUPERSEDED_REPLY);
+  }
+
+  private static ServerSecurity securityThatRefuses() {
+    final ServerSecurity security = mock(ServerSecurity.class);
+    when(security.applyReplicatedUsers(anyString(), anyString())).thenReturn(false);
+    return security;
+  }
+
+  private static ArcadeStateMachine stateMachine(final ServerSecurity security) {
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.getSecurity()).thenReturn(security);
+    when(server.getConfiguration()).thenReturn(new ContextConfiguration());
+
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    sm.setServer(server);
+    return sm;
+  }
+
+  private static TransactionContext entry(final ArcadeStateMachine sm, final long index, final ByteString payload) {
+    final LogEntryProto logEntry = LogEntryProto.newBuilder()
+        .setTerm(1L)
+        .setIndex(index)
+        .setStateMachineLogEntry(StateMachineLogEntryProto.newBuilder().setLogData(payload).build())
+        .build();
+    return TransactionContext.newBuilder().setStateMachine(sm).setLogEntry(logEntry).build();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftTransactionBrokerTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftTransactionBrokerTest.java
@@ -79,7 +79,7 @@ class RaftTransactionBrokerTest {
   @Test
   void replicateSecurityUsersEncodesCorrectEntryType() {
     assertThatThrownBy(() ->
-        broker.replicateSecurityUsers("[{\"name\":\"root\"}]"))
+        broker.replicateSecurityUsers("[{\"name\":\"root\"}]", null))
         .isInstanceOf(QuorumNotReachedException.class);
   }
 

--- a/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
+++ b/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
@@ -305,6 +305,19 @@ public interface HAServerPlugin extends ServerPlugin {
   default void revokeAuthSession(final String token) {
   }
 
+  /**
+   * Waits, bounded, for THIS node's state machine to catch up with the committed log (issue #7509).
+   * <p>
+   * A node that lost a security compare-and-set has to see the winning entry before it rebuilds its document, or
+   * the retry is built from the same stale view and loses again. The submitter may be a follower, whose own apply
+   * lags the reply it got back from the leader, so "the submit returned" is not "this node has applied it".
+   * Best-effort by contract: it returns when the deadline passes rather than failing, and the retry then simply
+   * has one more chance to lose. Default is a no-op for non-HA setups.
+   */
+  default void awaitLocalApply() {
+    // No-op by default; Raft implementation overrides.
+  }
+
   default void replicateSecurityUsers(final String usersJsonArray) {
     // No-op by default; Raft implementation overrides.
   }

--- a/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
+++ b/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
@@ -310,6 +310,30 @@ public interface HAServerPlugin extends ServerPlugin {
   }
 
   /**
+   * Replicates the full user list, installing it only while the list in force still fingerprints to
+   * {@code expectedFingerprint} (issue #7509).
+   * <p>
+   * The whole document is replicated, built by reading the current one and mutating a copy, and the
+   * read-compute-submit sequence is serialised by a per-NODE monitor. Without a precondition two nodes each
+   * build a document from their own view and the one Raft orders second silently reverts the first. The
+   * precondition moves the decision to the apply, which is the only point ordered across nodes.
+   *
+   * @param expectedFingerprint the fingerprint of the document the submitter read, or null to install
+   *                            unconditionally - which is what a seed of a joining peer wants
+   *
+   * @return true when the entry was applied, false when it was refused because the document had changed since
+   * the submitter read it; the caller re-reads and retries
+   */
+  default boolean replicateSecurityUsers(final String usersJsonArray, final String expectedFingerprint) {
+    // Delegates to the unconditional form, so an implementation that only knows the pre-#7509 signature keeps
+    // replicating - it just installs unconditionally, which is exactly what it did before the precondition
+    // existed. Reporting the entry as applied is the conservative answer: it preserves that behaviour instead
+    // of making every mutation report a phantom conflict.
+    replicateSecurityUsers(usersJsonArray);
+    return true;
+  }
+
+  /**
    * Replicates the full {@code server-groups.json} document across the cluster (issue #7373). Called by
    * {@code ServerSecurity.saveGroupClusterWide} / {@code deleteGroupClusterWide}, and by
    * {@code PostAddPeerHandler} to seed newly-joined peers. Default is a no-op for non-HA setups; the Raft
@@ -325,6 +349,17 @@ public interface HAServerPlugin extends ServerPlugin {
   }
 
   /**
+   * {@link #replicateSecurityUsers(String, String)} for the group document (issue #7509).
+   *
+   * @return true when the entry was applied, false when the document had changed since the submitter read it
+   */
+  default boolean replicateSecurityGroups(final String groupsJson, final String expectedFingerprint) {
+    // See replicateSecurityUsers(String, String) for why this delegates rather than no-oping.
+    replicateSecurityGroups(groupsJson);
+    return true;
+  }
+
+  /**
    * Replicates the full {@code server-api-tokens.json} document across the cluster (issue #7373). Called by
    * {@code ServerSecurity.createApiTokenClusterWide} / {@code deleteApiTokenClusterWide}, and by
    * {@code PostAddPeerHandler} to seed newly-joined peers. Default is a no-op for non-HA setups; the Raft
@@ -337,5 +372,16 @@ public interface HAServerPlugin extends ServerPlugin {
    */
   default void replicateSecurityApiTokens(final String apiTokensJson) {
     // No-op by default; Raft implementation overrides.
+  }
+
+  /**
+   * {@link #replicateSecurityUsers(String, String)} for the API-token document (issue #7509).
+   *
+   * @return true when the entry was applied, false when the document had changed since the submitter read it
+   */
+  default boolean replicateSecurityApiTokens(final String apiTokensJson, final String expectedFingerprint) {
+    // See replicateSecurityUsers(String, String) for why this delegates rather than no-oping.
+    replicateSecurityApiTokens(apiTokensJson);
+    return true;
   }
 }

--- a/server/src/main/java/com/arcadedb/server/security/ApiTokenConfiguration.java
+++ b/server/src/main/java/com/arcadedb/server/security/ApiTokenConfiguration.java
@@ -260,10 +260,26 @@ public class ApiTokenConfiguration {
    * A token minted but NOT yet installed: the one-time response for the caller, and the whole token document to
    * replicate (issue #7373).
    *
-   * @param response     the created token including its plaintext under {@code "token"}
-   * @param documentJson the complete token store with the new token in it, for {@link #applyReplicated}
+   * @param response           the created token including its plaintext under {@code "token"}
+   * @param documentBeforeJson the complete token store as it was when the mint was computed, read in the SAME
+   *                           critical section as {@code documentJson} so a cluster-wide caller can use it as
+   *                           the compare-and-set precondition of {@code documentJson} (issue #7509). Reading it
+   *                           separately would let a concurrent replicated apply slip between the two, and the
+   *                           precondition would then describe a token set the payload was not built from
+   * @param documentJson       the complete token store with the new token in it, for {@link #applyReplicated}
    */
-  public record MintedToken(JSONObject response, String documentJson) {
+  public record MintedToken(JSONObject response, String documentBeforeJson, String documentJson) {
+  }
+
+  /**
+   * A prospective change to the token document: what it is NOW and what it would become, both read in one
+   * critical section (issue #7509). See {@link MintedToken#documentBeforeJson()} for why the pair has to be
+   * atomic.
+   *
+   * @param before the document the change was computed from, usable as a compare-and-set precondition
+   * @param after  the document to replicate
+   */
+  public record DocumentChange(String before, String after) {
   }
 
   /**
@@ -286,16 +302,17 @@ public class ApiTokenConfiguration {
     final JSONObject response = minted.document().copy();
     response.put("token", minted.plaintext());
 
-    return new MintedToken(response, documentOf(next).toString());
+    return new MintedToken(response, documentOf(tokens.values()).toString(), documentOf(next).toString());
   }
 
   /**
-   * The token document with {@code tokenHash} removed, or {@code null} when no token has that hash - the
-   * cluster-wide half of {@link #deleteToken} (issue #7373). Nothing local is mutated.
+   * The token document with {@code tokenHash} removed - beside the document it was removed FROM - or
+   * {@code null} when no token has that hash. The cluster-wide half of {@link #deleteToken} (issue #7373).
+   * Nothing local is mutated.
    *
    * @throws IllegalArgumentException when handed a plaintext token instead of a hash
    */
-  public synchronized String documentWithout(final String tokenHash) {
+  public synchronized DocumentChange documentWithout(final String tokenHash) {
     if (tokenHash.startsWith(TOKEN_PREFIX))
       throw new IllegalArgumentException("Use token hash instead of plaintext token for deletion");
     if (!tokens.containsKey(tokenHash))
@@ -306,7 +323,9 @@ public class ApiTokenConfiguration {
       if (!entry.getKey().equals(tokenHash))
         next.add(entry.getValue());
 
-    return documentOf(next).toString();
+    // The before/after pair leaves this monitor together, so a cluster-wide revocation can pin its
+    // compare-and-set to the very document it removed the token from (issue #7509).
+    return new DocumentChange(documentOf(tokens.values()).toString(), documentOf(next).toString());
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/security/SecurityDocumentFingerprint.java
+++ b/server/src/main/java/com/arcadedb/server/security/SecurityDocumentFingerprint.java
@@ -85,6 +85,13 @@ public final class SecurityDocumentFingerprint {
    * Appends {@code value}'s canonical form to {@code out}: object keys in ascending order, array elements
    * ordered by their own canonical form, scalars as their {@code toString}. Strings are quoted and every
    * quote and backslash inside them escaped, so {@code ["a","b"]} and {@code ["ab"]} cannot collide.
+   * <p>
+   * <b>The result is a comparison key, not a serialization format.</b> It is hashed and compared, never parsed
+   * back, so it escapes only what could make two DIFFERENT documents produce the same bytes - the quote that
+   * ends a string and the backslash that could escape it. It deliberately does not escape the structural
+   * characters a JSON writer would ({@code &#123;}, {@code &#125;}, {@code [}, {@code ]}, {@code :},
+   * {@code ,}), because inside an already-delimited string they cannot move a boundary: the delimiters
+   * themselves are written by this method, not taken from the value. Do not reuse this output as JSON.
    */
   private static void canonicalize(final Object value, final StringBuilder out) {
     switch (value) {
@@ -123,6 +130,7 @@ public final class SecurityDocumentFingerprint {
     }
   }
 
+  /** See {@link #canonicalize}: this closes the string so its contents cannot be mistaken for structure. */
   private static void appendString(final String value, final StringBuilder out) {
     out.append('"');
     for (int i = 0; i < value.length(); i++) {

--- a/server/src/main/java/com/arcadedb/server/security/SecurityDocumentFingerprint.java
+++ b/server/src/main/java/com/arcadedb/server/security/SecurityDocumentFingerprint.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.TreeSet;
+
+/**
+ * The compare-and-set precondition of a replicated security document (issue #7509).
+ * <p>
+ * The user list, the group document and the API-token document are replicated whole: the submitter reads the
+ * current one, mutates a copy and submits it. The read-compute-submit sequence is serialised by a per-NODE
+ * monitor, so two nodes can each build a document from their own view and the one that Raft orders second
+ * silently reverts the first. The fix carries this fingerprint of the document the submitter READ alongside
+ * the document it submits, and the apply - the only point that is linearised across nodes - refuses an entry
+ * whose fingerprint no longer matches what is in force.
+ * <p>
+ * <b>Why it is not a hash of the payload string.</b> Two nodes holding the same logical document do not
+ * necessarily serialise it the same way: the user map is a {@code ConcurrentHashMap} and the group document is
+ * assembled key by key, so iteration order is not part of the state and must not be part of the fingerprint.
+ * {@link #canonicalize} therefore sorts object keys and array elements before hashing, which makes the
+ * fingerprint a function of the document's CONTENT. All three documents are sets - a user list, a token list,
+ * a map of databases to groups - so sorting an array loses nothing that the documents mean.
+ */
+public final class SecurityDocumentFingerprint {
+
+  private SecurityDocumentFingerprint() {
+    // utility class
+  }
+
+  /**
+   * The fingerprint of a security document, as the hex SHA-256 of its canonical form.
+   *
+   * @param json the document, either a JSON object (groups, API tokens) or a JSON array (users)
+   *
+   * @return the fingerprint, never null
+   *
+   * @throws IllegalArgumentException when the string is not JSON this method can canonicalise
+   */
+  public static String of(final String json) {
+    if (json == null)
+      throw new IllegalArgumentException("Cannot fingerprint a null security document");
+
+    final StringBuilder canonical = new StringBuilder(json.length());
+    canonicalize(parse(json), canonical);
+    return sha256Hex(canonical.toString());
+  }
+
+  private static Object parse(final String json) {
+    final String trimmed = json.trim();
+    try {
+      if (trimmed.startsWith("["))
+        return new JSONArray(trimmed);
+      return new JSONObject(trimmed);
+    } catch (final RuntimeException e) {
+      throw new IllegalArgumentException("Security document is not valid JSON and cannot be fingerprinted", e);
+    }
+  }
+
+  /**
+   * Appends {@code value}'s canonical form to {@code out}: object keys in ascending order, array elements
+   * ordered by their own canonical form, scalars as their {@code toString}. Strings are quoted and every
+   * quote and backslash inside them escaped, so {@code ["a","b"]} and {@code ["ab"]} cannot collide.
+   */
+  private static void canonicalize(final Object value, final StringBuilder out) {
+    switch (value) {
+    case final JSONObject object -> {
+      out.append('{');
+      boolean first = true;
+      for (final String key : new TreeSet<>(object.keySet())) {
+        if (!first)
+          out.append(',');
+        first = false;
+        appendString(key, out);
+        out.append(':');
+        canonicalize(object.get(key), out);
+      }
+      out.append('}');
+    }
+    case final JSONArray array -> {
+      final List<String> elements = new ArrayList<>(array.length());
+      for (int i = 0; i < array.length(); i++) {
+        final StringBuilder element = new StringBuilder();
+        canonicalize(array.get(i), element);
+        elements.add(element.toString());
+      }
+      Collections.sort(elements);
+      out.append('[');
+      for (int i = 0; i < elements.size(); i++) {
+        if (i > 0)
+          out.append(',');
+        out.append(elements.get(i));
+      }
+      out.append(']');
+    }
+    case null -> out.append("null");
+    case final String string -> appendString(string, out);
+    default -> out.append(value);
+    }
+  }
+
+  private static void appendString(final String value, final StringBuilder out) {
+    out.append('"');
+    for (int i = 0; i < value.length(); i++) {
+      final char c = value.charAt(i);
+      if (c == '"' || c == '\\')
+        out.append('\\');
+      out.append(c);
+    }
+    out.append('"');
+  }
+
+  private static String sha256Hex(final String canonical) {
+    final byte[] digest;
+    try {
+      digest = MessageDigest.getInstance("SHA-256").digest(canonical.getBytes(StandardCharsets.UTF_8));
+    } catch (final NoSuchAlgorithmException e) {
+      // SHA-256 is mandated by the JLS for every conformant JRE, so this arm is unreachable in practice; it
+      // exists because MessageDigest declares the checked exception.
+      throw new IllegalStateException("SHA-256 is not available in this JRE", e);
+    }
+    final StringBuilder hex = new StringBuilder(digest.length * 2);
+    for (final byte b : digest)
+      hex.append(Character.forDigit((b >> 4) & 0xF, 16)).append(Character.forDigit(b & 0xF, 16));
+    return hex.toString();
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -95,6 +95,17 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
   private static final long                               PASSWORD_LOCKOUT_MS   = 30_000;
   private final        ConcurrentHashMap<String, long[]>  passwordFailures      = new ConcurrentHashMap<>();
 
+  /**
+   * How many times a cluster-wide security mutation rebuilds its document and resubmits after losing a
+   * compare-and-set race (issue #7509).
+   * <p>
+   * Small on purpose. Every attempt costs a Raft round trip, and a node only loses the race to a security change
+   * committed on ANOTHER node inside that window - which is administration, not traffic, so a handful of retries
+   * covers the concurrency a real cluster produces. Exhausting it reports a conflict the caller can retry, which
+   * is what issue #7509 asks for: never a silent success over a change that was thrown away.
+   */
+  private static final int                                SECURITY_CAS_MAX_ATTEMPTS = 5;
+
   public ServerSecurity(final ArcadeDBServer server, final ContextConfiguration configuration, final String configPath) {
     this.server = server;
     this.algorithm = configuration.getValueAsString(SERVER_SECURITY_ALGORITHM);
@@ -397,15 +408,20 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
    * divergence in by overwriting every peer with the serving node's whole list (issue #6808).
    * <p>
    * The {@code synchronized} block serialises the read-compute-submit sequence against any other user
-   * mutation on this node, so two concurrent calls cannot overwrite each other's in-flight change. It must
-   * NOT be held across anything that can block on the Raft apply thread; {@link #applyReplicatedUsers}, which
-   * unblocks the submit, deliberately does not take this monitor.
+   * mutation on this node. It must NOT be held across anything that can block on the Raft apply thread;
+   * {@link #applyReplicatedUsers(String)}, which unblocks the submit, deliberately does not take this monitor.
    * <p>
-   * Note what that costs, for whoever adds a fourth cluster-wide mutator here by symmetry: the monitor IS
+   * Note what that costs, for whoever adds another cluster-wide mutator here by symmetry: the monitor IS
    * held across the Raft round trip, so every user create/update/drop on this node serialises for the
-   * duration of consensus. That is deliberate - the payload is the whole user list, so two concurrent
-   * submits would otherwise each overwrite the other's change - and it is affordable only because user
-   * administration is rare. Nothing on a request hot path may be put inside this monitor.
+   * duration of consensus. It is affordable only because user administration is rare, and nothing on a request
+   * hot path may be put inside this monitor.
+   * <p>
+   * <b>The monitor is per-NODE, so it is not what makes the payload safe.</b> Two nodes can each build a whole
+   * user list from their own view at the same time, and the entry Raft orders second would silently revert the
+   * first (issue #7509). What prevents that is the COMPARE-AND-SET: the fingerprint of the list this node read
+   * rides along with the entry, the apply refuses to install a list whose fingerprint no longer matches the one
+   * in force, and this loop then re-reads and resubmits - up to {@link #SECURITY_CAS_MAX_ATTEMPTS} times, after
+   * which the caller is told the request changed nothing rather than that it succeeded.
    */
   public void createUserClusterWide(final JSONObject userConfiguration) {
     final HAServerPlugin ha = server != null ? server.getHA() : null;
@@ -415,12 +431,32 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     }
 
     final String name = userConfiguration.getString("name");
-    synchronized (this) {
-      if (users.containsKey(name))
-        throw new ServerSecurityException("User '" + name + "' already exists");
+    for (int attempt = 1; ; attempt++) {
+      synchronized (this) {
+        if (users.containsKey(name))
+          throw new ServerSecurityException("User '" + name + "' already exists");
 
-      ha.replicateSecurityUsers(replicationPayloadWith(name, userConfiguration));
+        if (ha.replicateSecurityUsers(replicationPayloadWith(name, userConfiguration), usersFingerprint()))
+          return;
+      }
+      exhausted("create user '" + name + "'", "user list", attempt);
     }
+  }
+
+  /**
+   * Fails a cluster-wide security mutation that lost the compare-and-set race {@link #SECURITY_CAS_MAX_ATTEMPTS}
+   * times, and otherwise returns so the caller retries (issue #7509).
+   */
+  private void exhausted(final String what, final String document, final int attempt) {
+    if (attempt < SECURITY_CAS_MAX_ATTEMPTS) {
+      LogManager.instance().log(this, Level.INFO,
+          "Retrying to %s: the %s changed on another node between this node's read and the apply (attempt %d of %d)",
+          what, document, attempt, SECURITY_CAS_MAX_ATTEMPTS);
+      return;
+    }
+    throw new ServerSecurityException("Could not " + what + " after " + SECURITY_CAS_MAX_ATTEMPTS
+        + " attempts: the " + document + " keeps being changed concurrently on another node of the cluster. "
+        + "Nothing was changed; retry the request");
   }
 
   /**
@@ -437,15 +473,21 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     }
 
     final String name = userConfiguration.getString("name");
-    final boolean passwordChanged;
-    synchronized (this) {
-      final ServerSecurityUser previous = users.get(name);
-      if (previous == null)
-        throw new ServerSecurityException("User '" + name + "' not found");
+    boolean passwordChanged = false;
+    for (int attempt = 1; ; attempt++) {
+      boolean applied = false;
+      synchronized (this) {
+        final ServerSecurityUser previous = users.get(name);
+        if (previous == null)
+          throw new ServerSecurityException("User '" + name + "' not found");
 
-      passwordChanged = !Objects.equals(previous.getPassword(), userConfiguration.getString("password", null));
+        passwordChanged = !Objects.equals(previous.getPassword(), userConfiguration.getString("password", null));
 
-      ha.replicateSecurityUsers(replicationPayloadWith(name, userConfiguration));
+        applied = ha.replicateSecurityUsers(replicationPayloadWith(name, userConfiguration), usersFingerprint());
+      }
+      if (applied)
+        break;
+      exhausted("update user '" + name + "'", "user list", attempt);
     }
 
     // Applying the replicated list already dropped this principal's LOGIN sessions on every node, this one
@@ -468,11 +510,17 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     if (ha == null)
       return dropUserLocally(userName);
 
-    synchronized (this) {
-      if (!users.containsKey(userName))
-        return false;
+    for (int attempt = 1; ; attempt++) {
+      boolean applied = false;
+      synchronized (this) {
+        if (!users.containsKey(userName))
+          return false;
 
-      ha.replicateSecurityUsers(replicationPayloadWith(userName, null));
+        applied = ha.replicateSecurityUsers(replicationPayloadWith(userName, null), usersFingerprint());
+      }
+      if (applied)
+        break;
+      exhausted("drop user '" + userName + "'", "user list", attempt);
     }
 
     // Same rationale (and the same OUTSIDE-the-monitor placement) as dropUser(): a recreated same-name
@@ -890,6 +938,65 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
   }
 
   /**
+   * {@link #applyReplicatedUsers(String)} with the compare-and-set precondition the entry carried (issue #7509):
+   * when {@code expectedFingerprint} is not null and no longer matches the user list in force, the payload was
+   * built from a view the cluster has already moved past and is NOT installed.
+   * <p>
+   * The refusal is deterministic - the payload, the precondition and the state they are compared against are all
+   * replicated, and Raft applies entries in one order on every node - so every node refuses the same entry and
+   * none of them diverges. The submitter learns about it from the reply
+   * {@code ArcadeStateMachine.applyTransaction} sends back, and retries against the current document.
+   * <p>
+   * The install itself stays in {@link #applyReplicatedUsers(String)} rather than being inlined here: that is
+   * the method the fault-injection fixtures of issues #7137, #7227 and #7252 override, and moving the body would
+   * make three regression tests pass against a path they no longer exercise.
+   *
+   * @return true when the list was installed, false when the precondition no longer held
+   */
+  public boolean applyReplicatedUsers(final String usersJsonArray, final String expectedFingerprint) {
+    if (isSuperseded("user list", expectedFingerprint, usersFingerprint()))
+      return false;
+
+    applyReplicatedUsers(usersJsonArray);
+    return true;
+  }
+
+  /**
+   * Whether a replicated security entry must be refused because the document it was built from is no longer the
+   * one in force (issue #7509). A null {@code expected} is an unconditional install - a seed, or an entry from a
+   * node that predates the precondition - and is never refused.
+   */
+  private boolean isSuperseded(final String document, final String expected, final String current) {
+    if (expected == null || expected.equals(current))
+      return false;
+
+    LogManager.instance().log(this, Level.WARNING,
+        "Refusing a replicated %s: it was built from a document that is no longer in force (expected fingerprint "
+            + "%s, current %s). Installing it would revert a change this node has already applied; the node that "
+            + "submitted it retries against the current document",
+        document, expected, current);
+    return true;
+  }
+
+  /**
+   * The compare-and-set fingerprint of the user list currently in force (issue #7509). Non-blocking and free of
+   * the {@code ServerSecurity} monitor, so the Raft apply thread may call it.
+   */
+  public String usersFingerprint() {
+    return SecurityDocumentFingerprint.of(getUsersJsonPayload());
+  }
+
+  /** The compare-and-set fingerprint of the group document currently in force (issue #7509). */
+  public String groupsFingerprint() {
+    return SecurityDocumentFingerprint.of(getGroupsJsonPayload());
+  }
+
+  /** The compare-and-set fingerprint of the API-token document currently in force (issue #7509). */
+  public String apiTokensFingerprint() {
+    return SecurityDocumentFingerprint.of(getApiTokensJsonPayload());
+  }
+
+  /**
    * Writes the users file, returning the failure instead of throwing it so the caller can finish applying the
    * list before reporting (issue #7137). Inlining the try/catch at the call site would force a non-final local:
    * javac treats every statement in a {@code try} as able to throw, so an assignment made after the call is
@@ -1003,10 +1110,12 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
    * credentials authenticated everywhere but resolved to a group that existed on one node only - the same
    * principal getting different authorization depending on which node the load balancer picked.
    * <p>
-   * The {@code synchronized} block and its cost are exactly those of {@link #createUserClusterWide}: the monitor
-   * is held across the Raft round trip so two concurrent group changes cannot each overwrite the other's
-   * document, which is affordable only because group administration is rare. Nothing on a request hot path may
-   * be put inside it, and {@link #applyReplicatedGroups} - which unblocks the submit - must never take it.
+   * The {@code synchronized} block and its cost are exactly those of {@link #createUserClusterWide}, and so is
+   * the compare-and-set retry around it (issue #7509): the monitor serialises this node's own group changes,
+   * while the fingerprint carried with the entry is what stops a group change committed on ANOTHER node from
+   * being reverted. Holding the monitor across the Raft round trip is affordable only because group
+   * administration is rare; nothing on a request hot path may be put inside it, and
+   * {@link #applyReplicatedGroups(String)} - which unblocks the submit - must never take it.
    */
   public void saveGroupClusterWide(final String database, final String name, final JSONObject groupConfig) {
     if (groupConfig == null)
@@ -1020,8 +1129,12 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
       return;
     }
 
-    synchronized (this) {
-      ha.replicateSecurityGroups(groupsDocumentWith(database, name, groupConfig).toString());
+    for (int attempt = 1; ; attempt++) {
+      synchronized (this) {
+        if (ha.replicateSecurityGroups(groupsDocumentWith(database, name, groupConfig).toString(), groupsFingerprint()))
+          return;
+      }
+      exhausted("save group '" + name + "' of database '" + database + "'", "group document", attempt);
     }
   }
 
@@ -1035,14 +1148,17 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     if (ha == null)
       return deleteGroup(database, name);
 
-    synchronized (this) {
-      final JSONObject root = groupsDocumentWith(database, name, null);
-      if (root == null)
-        return false;
+    for (int attempt = 1; ; attempt++) {
+      synchronized (this) {
+        final JSONObject root = groupsDocumentWith(database, name, null);
+        if (root == null)
+          return false;
 
-      ha.replicateSecurityGroups(root.toString());
+        if (ha.replicateSecurityGroups(root.toString(), groupsFingerprint()))
+          return true;
+      }
+      exhausted("delete group '" + name + "' of database '" + database + "'", "group document", attempt);
     }
-    return true;
   }
 
   /**
@@ -1094,6 +1210,21 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
               + "'; this node enforces the new document now, but a restart reverts it to the stale file and the "
               + "change must then be reissued", persistFailure);
     }
+  }
+
+  /**
+   * {@link #applyReplicatedGroups(String)} with the compare-and-set precondition the entry carried (issue
+   * #7509). See {@link #applyReplicatedUsers(String, String)} for why the refusal cannot diverge the cluster,
+   * and for why the install stays in the single-argument method.
+   *
+   * @return true when the document was installed, false when the precondition no longer held
+   */
+  public boolean applyReplicatedGroups(final String groupsJson, final String expectedFingerprint) {
+    if (isSuperseded("group document", expectedFingerprint, groupsFingerprint()))
+      return false;
+
+    applyReplicatedGroups(groupsJson);
+    return true;
   }
 
   /**
@@ -1182,10 +1313,17 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     if (ha == null)
       return apiTokenConfig.createToken(name, database, expiresAt, permissions);
 
-    synchronized (this) {
-      final ApiTokenConfiguration.MintedToken minted = apiTokenConfig.mintToken(name, database, expiresAt, permissions);
-      ha.replicateSecurityApiTokens(minted.documentJson());
-      return minted.response();
+    for (int attempt = 1; ; attempt++) {
+      synchronized (this) {
+        // Re-minted on every attempt rather than minted once and resubmitted: mintToken() derives the document
+        // from the token set THIS node currently holds, so a document built before a lost race would put back
+        // the very tokens the winning entry revoked. The plaintext of a losing attempt reaches nobody - it is
+        // returned only from the attempt that commits.
+        final ApiTokenConfiguration.MintedToken minted = apiTokenConfig.mintToken(name, database, expiresAt, permissions);
+        if (ha.replicateSecurityApiTokens(minted.documentJson(), apiTokensFingerprint()))
+          return minted.response();
+      }
+      exhausted("create API token '" + name + "'", "API-token document", attempt);
     }
   }
 
@@ -1200,14 +1338,17 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     if (ha == null)
       return apiTokenConfig.deleteToken(tokenHash);
 
-    synchronized (this) {
-      final String document = apiTokenConfig.documentWithout(tokenHash);
-      if (document == null)
-        return false;
+    for (int attempt = 1; ; attempt++) {
+      synchronized (this) {
+        final String document = apiTokenConfig.documentWithout(tokenHash);
+        if (document == null)
+          return false;
 
-      ha.replicateSecurityApiTokens(document);
+        if (ha.replicateSecurityApiTokens(document, apiTokensFingerprint()))
+          return true;
+      }
+      exhausted("delete the API token", "API-token document", attempt);
     }
-    return true;
   }
 
   /**
@@ -1228,6 +1369,21 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
               + "'; this node enforces the new set now, but a restart reverts it to the stale file and the change "
               + "must then be reissued", persistFailure);
     }
+  }
+
+  /**
+   * {@link #applyReplicatedApiTokens(String)} with the compare-and-set precondition the entry carried (issue
+   * #7509). See {@link #applyReplicatedUsers(String, String)} for why the refusal cannot diverge the cluster,
+   * and for why the install stays in the single-argument method.
+   *
+   * @return true when the document was installed, false when the precondition no longer held
+   */
+  public boolean applyReplicatedApiTokens(final String apiTokensJson, final String expectedFingerprint) {
+    if (isSuperseded("API-token document", expectedFingerprint, apiTokensFingerprint()))
+      return false;
+
+    applyReplicatedApiTokens(apiTokensJson);
+    return true;
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -432,31 +432,47 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
 
     final String name = userConfiguration.getString("name");
     for (int attempt = 1; ; attempt++) {
+      final boolean applied;
       synchronized (this) {
-        if (users.containsKey(name))
+        // ONE read of the volatile map: the payload and the precondition must describe the same document.
+        final Map<String, ServerSecurityUser> current = this.users;
+        if (current.containsKey(name))
           throw new ServerSecurityException("User '" + name + "' already exists");
 
-        if (ha.replicateSecurityUsers(replicationPayloadWith(name, userConfiguration), usersFingerprint()))
-          return;
+        applied = ha.replicateSecurityUsers(replicationPayloadWith(current, name, userConfiguration),
+            usersFingerprintOf(current));
       }
-      exhausted("create user '" + name + "'", "user list", attempt);
+      if (applied)
+        return;
+      awaitSupersededChange(ha, "create user '" + name + "'", "user list", attempt);
     }
   }
 
   /**
-   * Fails a cluster-wide security mutation that lost the compare-and-set race {@link #SECURITY_CAS_MAX_ATTEMPTS}
-   * times, and otherwise returns so the caller retries (issue #7509).
+   * Prepares the next attempt of a cluster-wide security mutation that lost the compare-and-set race, or fails it
+   * once {@link #SECURITY_CAS_MAX_ATTEMPTS} have gone (issue #7509).
+   * <p>
+   * <b>Called OUTSIDE the monitor, deliberately.</b> The refusal verdict is the LEADER's, and this node may not
+   * have applied the winning entry yet - it can be a follower, whose own apply lags the reply it got back - so
+   * retrying immediately would rebuild the payload from the same stale view and lose again, burning the budget
+   * without ever converging. {@link HAServerPlugin#awaitLocalApply()} waits for this node to catch up, bounded by
+   * the quorum timeout. That wait must not happen inside {@code synchronized (this)}: the monitor is shared by
+   * all seven cluster-wide mutators, so holding it across up to {@link #SECURITY_CAS_MAX_ATTEMPTS} such waits
+   * would queue every unrelated user, group and token change on this node behind one caller's retry storm - a
+   * far worse cost than the race it is recovering from, and it would make the surrounding javadoc's "held across
+   * one Raft round trip" untrue.
    */
-  private void exhausted(final String what, final String document, final int attempt) {
-    if (attempt < SECURITY_CAS_MAX_ATTEMPTS) {
-      LogManager.instance().log(this, Level.INFO,
-          "Retrying to %s: the %s changed on another node between this node's read and the apply (attempt %d of %d)",
-          what, document, attempt, SECURITY_CAS_MAX_ATTEMPTS);
-      return;
-    }
-    throw new ServerSecurityException("Could not " + what + " after " + SECURITY_CAS_MAX_ATTEMPTS
-        + " attempts: the " + document + " keeps being changed concurrently on another node of the cluster. "
-        + "Nothing was changed; retry the request");
+  private void awaitSupersededChange(final HAServerPlugin ha, final String what, final String document,
+      final int attempt) {
+    if (attempt >= SECURITY_CAS_MAX_ATTEMPTS)
+      throw new ServerSecurityException("Could not " + what + " after " + SECURITY_CAS_MAX_ATTEMPTS
+          + " attempts: the " + document + " keeps being changed concurrently on another node of the cluster. "
+          + "Nothing was changed; retry the request");
+
+    LogManager.instance().log(this, Level.INFO,
+        "Retrying to %s: the %s changed on another node between this node's read and the apply (attempt %d of %d)",
+        what, document, attempt, SECURITY_CAS_MAX_ATTEMPTS);
+    ha.awaitLocalApply();
   }
 
   /**
@@ -473,21 +489,23 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     }
 
     final String name = userConfiguration.getString("name");
-    boolean passwordChanged = false;
+    boolean passwordChanged;
     for (int attempt = 1; ; attempt++) {
-      boolean applied = false;
+      final boolean applied;
       synchronized (this) {
-        final ServerSecurityUser previous = users.get(name);
+        final Map<String, ServerSecurityUser> current = this.users;
+        final ServerSecurityUser previous = current.get(name);
         if (previous == null)
           throw new ServerSecurityException("User '" + name + "' not found");
 
         passwordChanged = !Objects.equals(previous.getPassword(), userConfiguration.getString("password", null));
 
-        applied = ha.replicateSecurityUsers(replicationPayloadWith(name, userConfiguration), usersFingerprint());
+        applied = ha.replicateSecurityUsers(replicationPayloadWith(current, name, userConfiguration),
+            usersFingerprintOf(current));
       }
       if (applied)
         break;
-      exhausted("update user '" + name + "'", "user list", attempt);
+      awaitSupersededChange(ha, "update user '" + name + "'", "user list", attempt);
     }
 
     // Applying the replicated list already dropped this principal's LOGIN sessions on every node, this one
@@ -511,16 +529,18 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
       return dropUserLocally(userName);
 
     for (int attempt = 1; ; attempt++) {
-      boolean applied = false;
+      final boolean applied;
       synchronized (this) {
-        if (!users.containsKey(userName))
+        final Map<String, ServerSecurityUser> current = this.users;
+        if (!current.containsKey(userName))
           return false;
 
-        applied = ha.replicateSecurityUsers(replicationPayloadWith(userName, null), usersFingerprint());
+        applied = ha.replicateSecurityUsers(replicationPayloadWith(current, userName, null),
+            usersFingerprintOf(current));
       }
       if (applied)
         break;
-      exhausted("drop user '" + userName + "'", "user list", attempt);
+      awaitSupersededChange(ha, "drop user '" + userName + "'", "user list", attempt);
     }
 
     // Same rationale (and the same OUTSIDE-the-monitor placement) as dropUser(): a recreated same-name
@@ -804,6 +824,22 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
    * third not.
    */
   private List<JSONObject> snapshotWith(final String name, final JSONObject replacement) {
+    return snapshotWith(this.users, name, replacement);
+  }
+
+  /**
+   * {@link #snapshotWith(String, JSONObject)} against an explicit snapshot of the user map.
+   * <p>
+   * The overload exists because {@code users} is a volatile reference that {@link #applyReplicatedUsers(String)}
+   * swaps <b>without</b> taking this monitor - it must not, or it would deadlock with a submitter blocked on the
+   * very entry it is applying. A cluster-wide mutator that read the field once to build its payload and again to
+   * fingerprint its precondition could therefore be handed two DIFFERENT documents, and would then submit a
+   * payload built from the old one under a precondition describing the new one - a compare-and-set that passes
+   * over a change it is about to revert, which is issue #7509 reopened on a narrower window. Every such caller
+   * reads the field exactly once and derives both halves from that one snapshot.
+   */
+  private static List<JSONObject> snapshotWith(final Map<String, ServerSecurityUser> users, final String name,
+      final JSONObject replacement) {
     final List<JSONObject> snapshot = new ArrayList<>(users.size() + 1);
     boolean found = false;
     for (final ServerSecurityUser user : users.values()) {
@@ -824,10 +860,19 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
    * takes. Must be called while holding this monitor, so the read-compute-submit sequence is serialised
    * against any other user mutation on this node.
    */
-  private String replicationPayloadWith(final String name, final JSONObject replacement) {
+  private String replicationPayloadWith(final Map<String, ServerSecurityUser> users, final String name,
+      final JSONObject replacement) {
     final JSONArray array = new JSONArray();
-    for (final JSONObject entry : snapshotWith(name, replacement))
+    for (final JSONObject entry : snapshotWith(users, name, replacement))
       array.put(entry);
+    return array.toString();
+  }
+
+  /** The user list of {@code users} in the shape {@link #getUsersJsonPayload} produces for the live map. */
+  private static String usersJsonOf(final Map<String, ServerSecurityUser> users) {
+    final JSONArray array = new JSONArray();
+    for (final ServerSecurityUser user : users.values())
+      array.put(user.toJSON());
     return array.toString();
   }
 
@@ -986,6 +1031,28 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     return SecurityDocumentFingerprint.of(getUsersJsonPayload());
   }
 
+  /**
+   * {@link #usersFingerprint()} of an explicit snapshot, so a submitter can fingerprint the very map its payload
+   * was built from. See {@link #snapshotWith(Map, String, JSONObject)} for why reading the volatile field twice
+   * is not the same thing.
+   */
+  private static String usersFingerprintOf(final Map<String, ServerSecurityUser> users) {
+    return SecurityDocumentFingerprint.of(usersJsonOf(users));
+  }
+
+  /**
+   * The group document in the shape {@link #getGroupsJsonPayload} produces, built from an explicit read of the
+   * repository's current document rather than from a second one. Same reason as
+   * {@link #snapshotWith(Map, String, JSONObject)}: the repository publishes a new document by swapping a
+   * volatile reference, which the group apply does without this monitor.
+   */
+  private static String groupsJsonOf(final JSONObject currentGroups) {
+    return new JSONObject()
+        .put("databases", currentGroups.getJSONObject("databases"))
+        .put("version", LATEST_VERSION)
+        .toString();
+  }
+
   /** The compare-and-set fingerprint of the group document currently in force (issue #7509). */
   public String groupsFingerprint() {
     return SecurityDocumentFingerprint.of(getGroupsJsonPayload());
@@ -1063,7 +1130,17 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
    * the replicated document end up differing in a corner nobody exercises.
    */
   private JSONObject groupsDocumentWith(final String database, final String name, final JSONObject groupConfig) {
-    final JSONObject root = groupRepository.getGroups().copy();
+    return groupsDocumentWith(groupRepository.getGroups(), database, name, groupConfig);
+  }
+
+  /**
+   * {@link #groupsDocumentWith(String, String, JSONObject)} against an explicit read of the current group
+   * document, so a cluster-wide mutator can fingerprint the same read its payload is derived from
+   * (issue #7509). See {@link #snapshotWith(Map, String, JSONObject)}.
+   */
+  private static JSONObject groupsDocumentWith(final JSONObject currentGroups, final String database,
+      final String name, final JSONObject groupConfig) {
+    final JSONObject root = currentGroups.copy();
     final JSONObject databases = root.getJSONObject("databases");
 
     if (groupConfig == null) {
@@ -1130,11 +1207,16 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     }
 
     for (int attempt = 1; ; attempt++) {
+      final boolean applied;
       synchronized (this) {
-        if (ha.replicateSecurityGroups(groupsDocumentWith(database, name, groupConfig).toString(), groupsFingerprint()))
-          return;
+        // ONE read of the repository's current document, for both halves.
+        final JSONObject current = groupRepository.getGroups();
+        applied = ha.replicateSecurityGroups(groupsDocumentWith(current, database, name, groupConfig).toString(),
+            SecurityDocumentFingerprint.of(groupsJsonOf(current)));
       }
-      exhausted("save group '" + name + "' of database '" + database + "'", "group document", attempt);
+      if (applied)
+        return;
+      awaitSupersededChange(ha, "save group '" + name + "' of database '" + database + "'", "group document", attempt);
     }
   }
 
@@ -1149,15 +1231,20 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
       return deleteGroup(database, name);
 
     for (int attempt = 1; ; attempt++) {
+      final boolean applied;
       synchronized (this) {
-        final JSONObject root = groupsDocumentWith(database, name, null);
+        final JSONObject current = groupRepository.getGroups();
+        final JSONObject root = groupsDocumentWith(current, database, name, null);
         if (root == null)
           return false;
 
-        if (ha.replicateSecurityGroups(root.toString(), groupsFingerprint()))
-          return true;
+        applied = ha.replicateSecurityGroups(root.toString(),
+            SecurityDocumentFingerprint.of(groupsJsonOf(current)));
       }
-      exhausted("delete group '" + name + "' of database '" + database + "'", "group document", attempt);
+      if (applied)
+        return true;
+      awaitSupersededChange(ha, "delete group '" + name + "' of database '" + database + "'", "group document",
+          attempt);
     }
   }
 
@@ -1314,16 +1401,24 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
       return apiTokenConfig.createToken(name, database, expiresAt, permissions);
 
     for (int attempt = 1; ; attempt++) {
+      final JSONObject response;
+      final boolean applied;
       synchronized (this) {
         // Re-minted on every attempt rather than minted once and resubmitted: mintToken() derives the document
         // from the token set THIS node currently holds, so a document built before a lost race would put back
         // the very tokens the winning entry revoked. The plaintext of a losing attempt reaches nobody - it is
         // returned only from the attempt that commits.
+        //
+        // The document it was built FROM comes back with it, read in the same critical section, so the
+        // precondition cannot describe a token set the payload was not derived from (issue #7509).
         final ApiTokenConfiguration.MintedToken minted = apiTokenConfig.mintToken(name, database, expiresAt, permissions);
-        if (ha.replicateSecurityApiTokens(minted.documentJson(), apiTokensFingerprint()))
-          return minted.response();
+        response = minted.response();
+        applied = ha.replicateSecurityApiTokens(minted.documentJson(),
+            SecurityDocumentFingerprint.of(minted.documentBeforeJson()));
       }
-      exhausted("create API token '" + name + "'", "API-token document", attempt);
+      if (applied)
+        return response;
+      awaitSupersededChange(ha, "create API token '" + name + "'", "API-token document", attempt);
     }
   }
 
@@ -1339,15 +1434,18 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
       return apiTokenConfig.deleteToken(tokenHash);
 
     for (int attempt = 1; ; attempt++) {
+      final boolean applied;
       synchronized (this) {
-        final String document = apiTokenConfig.documentWithout(tokenHash);
-        if (document == null)
+        final ApiTokenConfiguration.DocumentChange revocation = apiTokenConfig.documentWithout(tokenHash);
+        if (revocation == null)
           return false;
 
-        if (ha.replicateSecurityApiTokens(document, apiTokensFingerprint()))
-          return true;
+        applied = ha.replicateSecurityApiTokens(revocation.after(),
+            SecurityDocumentFingerprint.of(revocation.before()));
       }
-      exhausted("delete the API token", "API-token document", attempt);
+      if (applied)
+        return true;
+      awaitSupersededChange(ha, "delete the API token", "API-token document", attempt);
     }
   }
 

--- a/server/src/test/java/com/arcadedb/server/security/Issue7509ConcurrentSecurityChangeTest.java
+++ b/server/src/test/java/com/arcadedb/server/security/Issue7509ConcurrentSecurityChangeTest.java
@@ -1,0 +1,438 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.HAServerPlugin;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #7509: a replicated security document is read-modify-write, so a concurrent admin
+ * change on another node used to be lost.
+ * <p>
+ * All three node-scoped security documents - the user list, the group document and the API-token document - are
+ * replicated WHOLE: the submitter reads the current one, mutates a copy and submits it. The read-compute-submit
+ * sequence is serialised by {@code synchronized (this)} on {@code ServerSecurity}, which is a per-NODE monitor.
+ * Two nodes doing it at the same time each build a document from their own view; Raft linearises the two
+ * entries and the one ordered second, built without the first in it, silently reverted the first - on every
+ * node, including the one that accepted it and answered 200.
+ * <p>
+ * <b>How the race is reproduced deterministically.</b> {@link RacingHAPlugin} stands in for the Raft round
+ * trip. Before it evaluates the submitted entry it applies ONE competing document - the one another node built
+ * from the same starting state - which is exactly what "Raft ordered the other node's entry first" looks like
+ * from here. It then evaluates the submitted entry against the state that competing document left behind,
+ * which is what {@code ArcadeStateMachine} does on the leader, and answers whether it was installed.
+ * <p>
+ * Every test therefore asserts two things: the competing change SURVIVED (that is the defect), and the
+ * submitted change landed too (the retry converged rather than giving up).
+ */
+class Issue7509ConcurrentSecurityChangeTest {
+
+  private static final String CONFIG_PATH = "target/test-security-7509";
+  private static final String DATABASE    = "graph";
+
+  private FixtureServer   server;
+  private ServerSecurity  security;
+  private RacingHAPlugin  ha;
+
+  @BeforeEach
+  void setUp() {
+    GlobalConfiguration.SERVER_SECURITY_SALT_ITERATIONS.setValue(1000);
+    final File dir = new File(CONFIG_PATH);
+    if (dir.exists())
+      FileUtils.deleteRecursively(dir);
+    assertThat(dir.mkdirs()).isTrue();
+
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.SERVER_ROOT_PATH, "./target");
+
+    server = new FixtureServer(configuration);
+    security = new ServerSecurity(server, configuration, CONFIG_PATH);
+    server.setSecurity(security);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (security != null)
+      security.stopService();
+    GlobalConfiguration.SERVER_SECURITY_SALT_ITERATIONS.reset();
+    FileUtils.deleteRecursively(new File(CONFIG_PATH));
+  }
+
+  /** Puts this node in a cluster whose next entry is preceded by {@code competing}, committed on another node. */
+  private void joinClusterRacing(final Runnable competing) {
+    ha = new RacingHAPlugin(security, competing, 1);
+    server.setHA(ha);
+  }
+
+  // ===========================================================================================
+  // Users: createUserClusterWide / updateUserClusterWide / dropUserClusterWide
+  // ===========================================================================================
+
+  @Test
+  void aConcurrentUserCreateOnAnotherNodeSurvivesThisNodesCreate() {
+    joinClusterRacing(() -> applyUserListWith("bob"));
+
+    security.createUserClusterWide(userJson("alice"));
+
+    assertThat(security.getUsers())
+        .as("the user another node created in the same window must not be reverted by this node's create")
+        .contains("bob", "alice");
+    assertThat(ha.submits)
+        .as("the first submit lost the compare-and-set and was retried against the fresh list").isEqualTo(2);
+  }
+
+  @Test
+  void aConcurrentUserCreateOnAnotherNodeSurvivesThisNodesUpdate() {
+    security.createUser(userJson("alice"));
+    joinClusterRacing(() -> applyUserListWith("bob"));
+
+    final JSONObject updated = userJson("alice").put("databases", new JSONObject().put(DATABASE, new JSONArray()));
+    security.updateUserClusterWide(updated);
+
+    assertThat(security.getUsers()).contains("bob", "alice");
+    assertThat(security.getUser("alice").toJSON().getJSONObject("databases").has(DATABASE))
+        .as("this node's own update landed as well").isTrue();
+    assertThat(ha.submits).isEqualTo(2);
+  }
+
+  @Test
+  void aConcurrentUserCreateOnAnotherNodeSurvivesThisNodesDrop() {
+    security.createUser(userJson("alice"));
+    joinClusterRacing(() -> applyUserListWith("bob"));
+
+    assertThat(security.dropUserClusterWide("alice")).isTrue();
+
+    assertThat(security.getUsers())
+        .as("the concurrently created user survives and the drop still took effect")
+        .contains("bob").doesNotContain("alice");
+    assertThat(ha.submits).isEqualTo(2);
+  }
+
+  // ===========================================================================================
+  // Groups: saveGroupClusterWide / deleteGroupClusterWide
+  // ===========================================================================================
+
+  @Test
+  void aConcurrentGroupSaveOnAnotherNodeSurvivesThisNodesSave() {
+    joinClusterRacing(() -> applyGroupDocumentWith("auditors"));
+
+    security.saveGroupClusterWide(DATABASE, "editors", group());
+
+    assertThat(groupNames()).contains("auditors", "editors");
+    assertThat(ha.submits).isEqualTo(2);
+  }
+
+  @Test
+  void aConcurrentGroupSaveOnAnotherNodeSurvivesThisNodesDelete() {
+    security.saveGroup(DATABASE, "editors", group());
+    joinClusterRacing(() -> applyGroupDocumentWith("auditors"));
+
+    assertThat(security.deleteGroupClusterWide(DATABASE, "editors")).isTrue();
+
+    assertThat(groupNames()).contains("auditors").doesNotContain("editors");
+    assertThat(ha.submits).isEqualTo(2);
+  }
+
+  // ===========================================================================================
+  // API tokens: createApiTokenClusterWide / deleteApiTokenClusterWide
+  // ===========================================================================================
+
+  @Test
+  void aConcurrentTokenMintOnAnotherNodeSurvivesThisNodesMint() {
+    joinClusterRacing(() -> applyTokenDocumentWith("other-node-token"));
+
+    final JSONObject minted = security.createApiTokenClusterWide("my-token", DATABASE, -1L, new JSONObject());
+
+    assertThat(minted.getString("token"))
+        .as("the plaintext returned is the one from the attempt that actually committed").isNotEmpty();
+    assertThat(tokenNames()).contains("other-node-token", "my-token");
+    assertThat(ha.submits).isEqualTo(2);
+  }
+
+  @Test
+  void aConcurrentTokenMintOnAnotherNodeSurvivesThisNodesRevocation() {
+    final JSONObject mine = security.createApiTokenClusterWide("my-token", DATABASE, -1L, new JSONObject());
+    joinClusterRacing(() -> applyTokenDocumentWith("other-node-token"));
+
+    assertThat(security.deleteApiTokenClusterWide(mine.getString("tokenHash"))).isTrue();
+
+    assertThat(tokenNames())
+        .as("a revocation must not put back a token another node minted in the same window")
+        .contains("other-node-token").doesNotContain("my-token");
+    assertThat(ha.submits).isEqualTo(2);
+  }
+
+  // ===========================================================================================
+  // The apply, driven directly: this is what every peer does with the entry
+  // ===========================================================================================
+
+  @Test
+  void theApplyRefusesADocumentBuiltFromAListThatIsNoLongerInForce() {
+    security.createUser(userJson("alice"));
+    final String staleList = security.getUsersJsonPayload();
+    final String stale = security.usersFingerprint();
+
+    // Another node's change lands first, so the fingerprint the stale submission carries no longer matches.
+    applyUserListWith("bob");
+
+    assertThat(security.applyReplicatedUsers(staleList, stale))
+        .as("an entry whose precondition no longer holds is refused").isFalse();
+    assertThat(security.getUsers()).as("and the list it would have reverted is untouched").contains("bob");
+
+    // The same payload with the CURRENT fingerprint is installed: the refusal is the precondition, not the
+    // payload, so this test cannot pass by refusing everything.
+    assertThat(security.applyReplicatedUsers(security.getUsersJsonPayload(), security.usersFingerprint())).isTrue();
+  }
+
+  @Test
+  void theApplyInstallsAnEntryThatCarriesNoPreconditionAtAll() {
+    security.createUser(userJson("alice"));
+
+    // A seed, and every entry written by a node that predates issue #7509: no precondition, installed as before.
+    assertThat(security.applyReplicatedUsers(new JSONArray().put(userJson("bob")).toString(), null)).isTrue();
+    assertThat(security.getUsers()).containsExactly("bob");
+  }
+
+  @Test
+  void theGroupAndTokenAppliesRefuseAStalePreconditionToo() {
+    security.saveGroup(DATABASE, "editors", group());
+    final String staleGroups = security.getGroupsJsonPayload();
+    final String staleGroupFingerprint = security.groupsFingerprint();
+    applyGroupDocumentWith("auditors");
+    assertThat(security.applyReplicatedGroups(staleGroups, staleGroupFingerprint)).isFalse();
+    assertThat(groupNames()).contains("auditors");
+
+    final String staleTokens = security.getApiTokensJsonPayload();
+    final String staleTokenFingerprint = security.apiTokensFingerprint();
+    applyTokenDocumentWith("other-node-token");
+    assertThat(security.applyReplicatedApiTokens(staleTokens, staleTokenFingerprint)).isFalse();
+    assertThat(tokenNames()).contains("other-node-token");
+  }
+
+  // ===========================================================================================
+  // The budget
+  // ===========================================================================================
+
+  @Test
+  void aMutationThatKeepsLosingTheRaceReportsAConflictInsteadOfASilentSuccess() {
+    // A competing change before EVERY submit, so no attempt can ever win.
+    ha = new RacingHAPlugin(security, () -> applyUserListWith("filler-" + System.nanoTime()), Integer.MAX_VALUE);
+    server.setHA(ha);
+
+    assertThatThrownBy(() -> security.createUserClusterWide(userJson("alice")))
+        .isInstanceOf(ServerSecurityException.class)
+        .hasMessageContaining("changed concurrently")
+        .hasMessageContaining("Nothing was changed");
+
+    assertThat(security.getUsers()).as("and the user really was not created").doesNotContain("alice");
+    assertThat(ha.submits).as("the budget is bounded, not unlimited").isEqualTo(5);
+  }
+
+  // ===========================================================================================
+  // Fixtures
+  // ===========================================================================================
+
+  private JSONObject userJson(final String name) {
+    return new JSONObject()
+        .put("name", name)
+        .put("password", security.encodePassword(name + "-password"))
+        .put("databases", new JSONObject());
+  }
+
+  private static JSONObject group() {
+    return new JSONObject()
+        .put("resultSetLimit", -1L)
+        .put("readTimeout", -1L)
+        .put("access", new JSONArray())
+        .put("types", new JSONObject());
+  }
+
+  /** Another node's user list: the one in force here, plus {@code name}. Applied as a committed entry. */
+  private void applyUserListWith(final String name) {
+    final JSONArray list = new JSONArray(security.getUsersJsonPayload());
+    list.put(userJson(name));
+    security.applyReplicatedUsers(list.toString(), null);
+  }
+
+  /** Another node's group document: the one in force here, plus a group named {@code name}. */
+  private void applyGroupDocumentWith(final String name) {
+    final JSONObject root = new JSONObject(security.getGroupsJsonPayload());
+    final JSONObject databases = root.getJSONObject("databases");
+    if (!databases.has(DATABASE))
+      databases.put(DATABASE, new JSONObject().put("groups", new JSONObject()));
+    databases.getJSONObject(DATABASE).getJSONObject("groups").put(name, group());
+    security.applyReplicatedGroups(root.toString(), null);
+  }
+
+  /** Another node's token document: the one in force here, plus a token named {@code name}. */
+  private void applyTokenDocumentWith(final String name) {
+    final JSONObject root = new JSONObject(security.getApiTokensJsonPayload());
+    root.getJSONArray("tokens").put(new JSONObject()
+        .put("tokenHash", "hash-of-" + name)
+        .put("name", name)
+        .put("database", DATABASE)
+        .put("createdAt", 0L)
+        .put("expiresAt", -1L)
+        .put("permissions", new JSONObject()));
+    security.applyReplicatedApiTokens(root.toString(), null);
+  }
+
+  private List<String> groupNames() {
+    final JSONObject databases = security.groupsToJSON().getJSONObject("databases");
+    if (!databases.has(DATABASE))
+      return List.of();
+    return new ArrayList<>(databases.getJSONObject(DATABASE).getJSONObject("groups").keySet());
+  }
+
+  private List<String> tokenNames() {
+    final JSONArray tokens = new JSONObject(security.getApiTokensJsonPayload()).getJSONArray("tokens");
+    final List<String> names = new ArrayList<>(tokens.length());
+    for (int i = 0; i < tokens.length(); i++)
+      names.add(tokens.getJSONObject(i).getString("name"));
+    return names;
+  }
+
+  /**
+   * The Raft round trip, reduced to what this test needs: another node's entry commits FIRST, then the
+   * submitted entry is evaluated against the state that left behind - which is what the leader's state machine
+   * does before {@code submitAndWait} returns.
+   */
+  private static final class RacingHAPlugin implements HAServerPlugin {
+    private final ServerSecurity security;
+    private final Runnable       competing;
+    private final int            competeForFirstNSubmits;
+    int                          submits;
+
+    private RacingHAPlugin(final ServerSecurity security, final Runnable competing, final int competeForFirstNSubmits) {
+      this.security = security;
+      this.competing = competing;
+      this.competeForFirstNSubmits = competeForFirstNSubmits;
+    }
+
+    private void race() {
+      if (submits < competeForFirstNSubmits)
+        competing.run();
+      submits++;
+    }
+
+    @Override
+    public boolean replicateSecurityUsers(final String usersJson, final String expectedFingerprint) {
+      race();
+      return security.applyReplicatedUsers(usersJson, expectedFingerprint);
+    }
+
+    @Override
+    public boolean replicateSecurityGroups(final String groupsJson, final String expectedFingerprint) {
+      race();
+      return security.applyReplicatedGroups(groupsJson, expectedFingerprint);
+    }
+
+    @Override
+    public boolean replicateSecurityApiTokens(final String apiTokensJson, final String expectedFingerprint) {
+      race();
+      return security.applyReplicatedApiTokens(apiTokensJson, expectedFingerprint);
+    }
+
+    @Override
+    public ELECTION_STATUS getElectionStatus() {
+      return ELECTION_STATUS.DONE;
+    }
+
+    @Override
+    public void startService() {
+    }
+
+    @Override
+    public boolean isLeader() {
+      return true;
+    }
+
+    @Override
+    public String getLeaderName() {
+      return "leader";
+    }
+
+    @Override
+    public String getClusterName() {
+      return "test";
+    }
+
+    @Override
+    public Map<String, Object> getStats() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public int getConfiguredServers() {
+      return 3;
+    }
+
+    @Override
+    public String getLeaderAddress() {
+      return null;
+    }
+
+    @Override
+    public String getReplicaAddresses() {
+      return "";
+    }
+
+    @Override
+    public void shutdownRemoteServer(final String serverName) {
+    }
+
+    @Override
+    public void disconnectCluster() {
+    }
+  }
+
+  private static final class FixtureServer extends ArcadeDBServer {
+    private ServerSecurity security;
+
+    private FixtureServer(final ContextConfiguration configuration) {
+      super(configuration);
+    }
+
+    private void setSecurity(final ServerSecurity security) {
+      this.security = security;
+    }
+
+    @Override
+    public ServerSecurity getSecurity() {
+      return security;
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/security/Issue7509ConcurrentSecurityChangeTest.java
+++ b/server/src/test/java/com/arcadedb/server/security/Issue7509ConcurrentSecurityChangeTest.java
@@ -262,6 +262,74 @@ class Issue7509ConcurrentSecurityChangeTest {
   }
 
   // ===========================================================================================
+  // The precondition must describe the document the payload was BUILT FROM
+  // ===========================================================================================
+
+  /**
+   * The payload and its precondition are both derived from the security document, and if they come from two
+   * separate reads of it a replicated apply can land in the gap: the payload is then built from the OLD document
+   * while the precondition describes the NEW one, the compare-and-set passes, and the stale payload installs
+   * over a change it was never aware of - issue #7509 reopened on a window a few bytecodes wide. The apply
+   * thread swaps that reference deliberately WITHOUT this monitor, so holding the monitor does not close it.
+   * <p>
+   * What is asserted is the property that makes the gap unreachable: the submitted precondition is the
+   * fingerprint of the submitted payload with this node's own change undone - i.e. of the document the payload
+   * was built from - rather than of whatever the live document happened to be a moment later.
+   */
+  @Test
+  void theUserPreconditionFingerprintsTheListTheSubmittedPayloadWasBuiltFrom() {
+    joinClusterRacing(() -> applyUserListWith("bob"));
+
+    security.createUserClusterWide(userJson("alice"));
+
+    final String[] winning = ha.submitted.getLast();
+    assertThat(fingerprintOfUsersWithout(winning[0], "alice"))
+        .as("the precondition must be the fingerprint of the list this payload was derived from")
+        .isEqualTo(winning[1]);
+  }
+
+  @Test
+  void theGroupPreconditionFingerprintsTheDocumentTheSubmittedPayloadWasBuiltFrom() {
+    joinClusterRacing(() -> applyGroupDocumentWith("auditors"));
+
+    security.saveGroupClusterWide(DATABASE, "editors", group());
+
+    final String[] winning = ha.submitted.getLast();
+    assertThat(fingerprintOfGroupsWithout(winning[0], "editors")).isEqualTo(winning[1]);
+  }
+
+  @Test
+  void theTokenPreconditionFingerprintsTheDocumentTheSubmittedPayloadWasBuiltFrom() {
+    joinClusterRacing(() -> applyTokenDocumentWith("other-node-token"));
+
+    final JSONObject minted = security.createApiTokenClusterWide("my-token", DATABASE, -1L, new JSONObject());
+
+    final String[] winning = ha.submitted.getLast();
+    assertThat(fingerprintOfTokensWithout(winning[0], minted.getString("tokenHash"))).isEqualTo(winning[1]);
+  }
+
+  // ===========================================================================================
+  // The retry's catch-up wait must not be done under the shared monitor
+  // ===========================================================================================
+
+  /**
+   * A refused submitter has to see the winning entry before it rebuilds, and on a follower that means waiting for
+   * the local state machine - bounded by the quorum timeout. Doing that inside {@code synchronized (this)} would
+   * hold the monitor all seven cluster-wide mutators share for up to five such waits, so an unrelated group or
+   * token change on the same node would queue behind one caller's retry storm.
+   */
+  @Test
+  void theCatchUpWaitBetweenRetriesHappensOutsideTheSharedMonitor() {
+    joinClusterRacing(() -> applyUserListWith("bob"));
+
+    security.createUserClusterWide(userJson("alice"));
+
+    assertThat(ha.awaits).as("a refused attempt must wait for this node to catch up before rebuilding").isEqualTo(1);
+    assertThat(ha.awaitedUnderTheMonitor)
+        .as("but never while holding the monitor every security mutation on this node shares").isFalse();
+  }
+
+  // ===========================================================================================
   // Fixtures
   // ===========================================================================================
 
@@ -310,6 +378,33 @@ class Issue7509ConcurrentSecurityChangeTest {
     security.applyReplicatedApiTokens(root.toString(), null);
   }
 
+  /** The fingerprint of {@code usersPayload} with {@code name} removed: the list it was built from. */
+  private static String fingerprintOfUsersWithout(final String usersPayload, final String name) {
+    final JSONArray payload = new JSONArray(usersPayload);
+    final JSONArray before = new JSONArray();
+    for (int i = 0; i < payload.length(); i++)
+      if (!name.equals(payload.getJSONObject(i).getString("name")))
+        before.put(payload.getJSONObject(i));
+    return SecurityDocumentFingerprint.of(before.toString());
+  }
+
+  private static String fingerprintOfGroupsWithout(final String groupsPayload, final String name) {
+    final JSONObject before = new JSONObject(groupsPayload);
+    before.getJSONObject("databases").getJSONObject(DATABASE).getJSONObject("groups").remove(name);
+    return SecurityDocumentFingerprint.of(before.toString());
+  }
+
+  private static String fingerprintOfTokensWithout(final String tokensPayload, final String tokenHash) {
+    final JSONObject payload = new JSONObject(tokensPayload);
+    final JSONArray tokens = payload.getJSONArray("tokens");
+    final JSONArray before = new JSONArray();
+    for (int i = 0; i < tokens.length(); i++)
+      if (!tokenHash.equals(tokens.getJSONObject(i).getString("tokenHash")))
+        before.put(tokens.getJSONObject(i));
+    return SecurityDocumentFingerprint.of(new JSONObject().put("version", payload.get("version"))
+        .put("tokens", before).toString());
+  }
+
   private List<String> groupNames() {
     final JSONObject databases = security.groupsToJSON().getJSONObject("databases");
     if (!databases.has(DATABASE))
@@ -336,33 +431,50 @@ class Issue7509ConcurrentSecurityChangeTest {
     private final int            competeForFirstNSubmits;
     int                          submits;
 
+    /** The (payload, precondition) pair of every submission, newest last. */
+    final List<String[]> submitted = new ArrayList<>();
+
+    /** True if any {@link #awaitLocalApply()} happened with the {@code ServerSecurity} monitor held. */
+    boolean awaitedUnderTheMonitor;
+    int     awaits;
+
     private RacingHAPlugin(final ServerSecurity security, final Runnable competing, final int competeForFirstNSubmits) {
       this.security = security;
       this.competing = competing;
       this.competeForFirstNSubmits = competeForFirstNSubmits;
     }
 
-    private void race() {
+    private void race(final String payload, final String expectedFingerprint) {
+      submitted.add(new String[] { payload, expectedFingerprint });
       if (submits < competeForFirstNSubmits)
         competing.run();
       submits++;
     }
 
     @Override
+    public void awaitLocalApply() {
+      awaits++;
+      // The monitor is shared by all seven cluster-wide mutators, so waiting for the local state machine while
+      // holding it would queue every unrelated security change on this node behind one caller's retry storm.
+      if (Thread.holdsLock(security))
+        awaitedUnderTheMonitor = true;
+    }
+
+    @Override
     public boolean replicateSecurityUsers(final String usersJson, final String expectedFingerprint) {
-      race();
+      race(usersJson, expectedFingerprint);
       return security.applyReplicatedUsers(usersJson, expectedFingerprint);
     }
 
     @Override
     public boolean replicateSecurityGroups(final String groupsJson, final String expectedFingerprint) {
-      race();
+      race(groupsJson, expectedFingerprint);
       return security.applyReplicatedGroups(groupsJson, expectedFingerprint);
     }
 
     @Override
     public boolean replicateSecurityApiTokens(final String apiTokensJson, final String expectedFingerprint) {
-      race();
+      race(apiTokensJson, expectedFingerprint);
       return security.applyReplicatedApiTokens(apiTokensJson, expectedFingerprint);
     }
 

--- a/server/src/test/java/com/arcadedb/server/security/Issue7509TokenDocumentPairAtomicityTest.java
+++ b/server/src/test/java/com/arcadedb/server/security/Issue7509TokenDocumentPairAtomicityTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7509: a cluster-wide token mint or revocation submits a document AND the compare-and-set precondition
+ * of the document it was derived from, and the two have to leave {@link ApiTokenConfiguration}'s monitor
+ * together.
+ * <p>
+ * Reading them separately - mint under the monitor, then fingerprint the live store outside it - lets a
+ * replicated apply land in between, and the submission then carries a payload built from the OLD token set under
+ * a precondition describing the NEW one. The compare-and-set passes and the stale payload installs, putting back
+ * tokens the winning entry revoked, which is worse than the lost update it was meant to prevent.
+ */
+class Issue7509TokenDocumentPairAtomicityTest {
+
+  private static final String CONFIG_PATH = "target/test-api-tokens-7509";
+
+  private ApiTokenConfiguration config;
+
+  @BeforeEach
+  void setUp() {
+    final File dir = new File(CONFIG_PATH);
+    if (dir.exists())
+      FileUtils.deleteRecursively(dir);
+    assertThat(dir.mkdirs()).isTrue();
+    config = new ApiTokenConfiguration(CONFIG_PATH);
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(CONFIG_PATH));
+  }
+
+  @Test
+  void aMintCarriesTheDocumentItWasDerivedFrom() {
+    config.createToken("existing", "mydb", 0, new JSONObject());
+    final String before = config.toJsonPayload();
+
+    final ApiTokenConfiguration.MintedToken minted = config.mintToken("new", "mydb", 0, new JSONObject());
+
+    assertThat(minted.documentBeforeJson())
+        .as("the precondition half is the store as it was, not a second read of it").isEqualTo(before);
+    assertThat(minted.documentJson())
+        .as("and the payload half carries the new token").contains("\"name\":\"new\"");
+    assertThat(config.toJsonPayload())
+        .as("mintToken installs nothing locally; only the replicated apply does").isEqualTo(before);
+  }
+
+  @Test
+  void aRevocationCarriesTheDocumentItWasRemovedFrom() {
+    final JSONObject doomed = config.createToken("doomed", "mydb", 0, new JSONObject());
+    config.createToken("kept", "mydb", 0, new JSONObject());
+    final String before = config.toJsonPayload();
+
+    final ApiTokenConfiguration.DocumentChange revocation = config.documentWithout(doomed.getString("tokenHash"));
+
+    assertThat(revocation.before()).isEqualTo(before);
+    assertThat(revocation.after())
+        .as("the payload drops the revoked token and keeps the other")
+        .doesNotContain(doomed.getString("tokenHash")).contains("\"name\":\"kept\"");
+    assertThat(config.toJsonPayload()).as("nothing local is mutated").isEqualTo(before);
+  }
+
+  @Test
+  void revokingAnUnknownTokenReportsNoChangeAtAll() {
+    assertThat(config.documentWithout("no-such-hash")).isNull();
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/security/SecurityDocumentFingerprintTest.java
+++ b/server/src/test/java/com/arcadedb/server/security/SecurityDocumentFingerprintTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The compare-and-set precondition of issue #7509 is only as good as this fingerprint.
+ * <p>
+ * Two properties have to hold at once, and they pull in opposite directions. It must be INSENSITIVE to how a
+ * node happens to have serialised the document - the user map is a {@code ConcurrentHashMap}, the group
+ * document is assembled key by key, and a fingerprint that changed with iteration order would refuse every
+ * entry between two healthy nodes. And it must be SENSITIVE to content, or it would accept the stale document
+ * the issue is about.
+ */
+class SecurityDocumentFingerprintTest {
+
+  @Test
+  void objectKeyOrderIsNotPartOfTheDocument() {
+    assertThat(SecurityDocumentFingerprint.of("{\"version\":2,\"databases\":{\"a\":1,\"b\":2}}"))
+        .isEqualTo(SecurityDocumentFingerprint.of("{\"databases\":{\"b\":2,\"a\":1},\"version\":2}"));
+  }
+
+  @Test
+  void arrayOrderIsNotPartOfTheDocument() {
+    assertThat(SecurityDocumentFingerprint.of("[{\"name\":\"alice\"},{\"name\":\"bob\"}]"))
+        .isEqualTo(SecurityDocumentFingerprint.of("[{\"name\":\"bob\"},{\"name\":\"alice\"}]"));
+  }
+
+  @Test
+  void whitespaceIsNotPartOfTheDocument() {
+    assertThat(SecurityDocumentFingerprint.of("{\"a\": 1}"))
+        .isEqualTo(SecurityDocumentFingerprint.of("{\"a\":1}"));
+  }
+
+  @Test
+  void anAddedEntryChangesTheFingerprint() {
+    assertThat(SecurityDocumentFingerprint.of("[{\"name\":\"alice\"}]"))
+        .isNotEqualTo(SecurityDocumentFingerprint.of("[{\"name\":\"alice\"},{\"name\":\"bob\"}]"));
+  }
+
+  @Test
+  void aRemovedEntryChangesTheFingerprint() {
+    assertThat(SecurityDocumentFingerprint.of("[{\"name\":\"alice\"},{\"name\":\"bob\"}]"))
+        .isNotEqualTo(SecurityDocumentFingerprint.of("[{\"name\":\"alice\"}]"));
+  }
+
+  @Test
+  void aChangedValueChangesTheFingerprint() {
+    assertThat(SecurityDocumentFingerprint.of("[{\"name\":\"alice\",\"password\":\"one\"}]"))
+        .isNotEqualTo(SecurityDocumentFingerprint.of("[{\"name\":\"alice\",\"password\":\"two\"}]"));
+  }
+
+  /**
+   * Two strings must not be able to run together into one: without escaping, {@code ["a","b"]} and
+   * {@code ["ab"]} would canonicalise to the same characters and a revocation could be made to look like the
+   * document it revoked.
+   */
+  @Test
+  void adjacentStringsCannotCollide() {
+    assertThat(SecurityDocumentFingerprint.of("[\"a\",\"b\"]"))
+        .isNotEqualTo(SecurityDocumentFingerprint.of("[\"ab\"]"));
+    assertThat(SecurityDocumentFingerprint.of("[\"a\\\"\",\"b\"]"))
+        .isNotEqualTo(SecurityDocumentFingerprint.of("[\"a\",\"\\\"b\"]"));
+  }
+
+  @Test
+  void theSameDocumentAlwaysFingerprintsTheSame() {
+    final String document = "{\"version\":1,\"tokens\":[{\"tokenHash\":\"ab12\",\"name\":\"ci\"}]}";
+    assertThat(SecurityDocumentFingerprint.of(document))
+        .isEqualTo(SecurityDocumentFingerprint.of(document))
+        .hasSize(64);
+  }
+
+  @Test
+  void aDocumentThatIsNotJsonIsRejectedRatherThanFingerprinted() {
+    assertThatThrownBy(() -> SecurityDocumentFingerprint.of("not json"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> SecurityDocumentFingerprint.of(null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}


### PR DESCRIPTION
Closes #7509

## Summary

The three node-scoped security documents - the user list (`SECURITY_USERS_ENTRY`), the group document and
the API-token document (`SECURITY_GROUPS_ENTRY` / `SECURITY_API_TOKENS_ENTRY`) - are replicated **whole**: the
submitter reads the current one, mutates a copy and submits it. That read-compute-submit sequence is serialised
by `synchronized (this)` on `ServerSecurity`, which is a per-**node** monitor, so two nodes could each build a
document from their own view; Raft linearised the two entries and the one ordered second, built without the
first in it, silently reverted the first on every node - including the one that had accepted it and answered
`200`. For a `DELETE` that meant a revocation could be undone by an unrelated concurrent change.

This adds the compare-and-set the issue asks for. The submitter fingerprints the document it read and carries
that fingerprint with the entry; **the apply** - the only point ordered across nodes - refuses to install a
document whose fingerprint no longer matches what is in force, identically on every node, because the payload,
the precondition and the state they are compared against are all replicated and applies are ordered. The state
machine answers the Ratis client `SECURITY_ENTRY_SUPERSEDED` instead of `OK`, so the verdict comes from the
**leader's** apply and reaches the submitter whether it is the leader or a follower; the submitter then waits
for its own node to catch up, re-reads, rebuilds and resubmits - an MVCC-shaped retry, bounded at five
attempts, after which the caller is told the request changed nothing rather than that it succeeded.

Three details worth the reviewer's attention:

- **The fingerprint is content-addressed, not a hash of the payload string.** Two healthy nodes do not
  necessarily serialise the same logical document the same way (the user map is a `ConcurrentHashMap`), so
  `SecurityDocumentFingerprint` canonicalises - object keys sorted, array elements sorted by their own
  canonical form, strings escaped so `["a","b"]` cannot collide with `["ab"]` - before hashing. All three
  documents are sets, so sorting loses nothing they mean.
- **The precondition rides an extension section (#7138), and writing it is gated on peer-capability
  negotiation (#7219).** A peer without the capability skips the section and installs unconditionally, so an
  ungated precondition would have a losing entry *refused* on the upgraded nodes and *applied* on the older one
  - a divergence of the security state, which is worse than the lost update, since the same credentials would
  then resolve differently depending on which node answers. Withholding it keeps the pre-fix behaviour uniform,
  is fail-closed (an unknown, unreachable or stale peer counts as missing the capability) and needs no operator
  step. A throttled INFO line names the peers responsible, so "the check is not running" is never silent.
- **Seeding a joining peer still submits with no precondition, deliberately.** A seed exists to overwrite
  whatever the peer holds; giving it one would make `addPeer` fail whenever an unrelated admin change raced it.

## Test plan

- [ ] `mvn -o -pl server -am -Dtest='com.arcadedb.server.security.*Test' test` - 102 tests, green. The new
      `Issue7509ConcurrentSecurityChangeTest` drives all seven cluster-wide mutators through a deterministic
      race (another node's entry commits first, then the submitted entry is evaluated against what it left)
      and asserts both halves: the competing change SURVIVED, and this node's change landed on the retry.
- [ ] `mvn -o -pl ha-raft -am test` - `Issue7509SecurityPreconditionCodecTest` (the section is optional in
      both directions and one section never swallows another), `Issue7509SupersededSecurityEntryReplyTest`
      (a refused entry completes **normally**, so the applied index still advances, carrying the marker) and
      `Issue7509SecurityPreconditionCapabilityGateTest` (the fingerprint is withheld while any peer is missing
      the capability, and an unknown peer counts as missing).
- [ ] **Proof the tests can fail:** force `ServerSecurity.isSuperseded` to return `false` - the pre-fix
      unconditional apply - and 10 of the 11 `Issue7509ConcurrentSecurityChangeTest` methods fail. The
      eleventh passes both ways by design; it pins the back-compatible path.
- [ ] Manual, 3-node cluster: `POST /api/v1/server/groups/{db}/a` on node 1 and `.../b` on node 2 in the same
      second; both groups must exist on all three nodes afterwards.

## Coverage

Entry points the fix covers, each with a test that drives the invariant through *that* path:

| Entry point | Fixed | Tested |
|---|---|---|
| `ServerSecurity.createUserClusterWide` | yes | yes |
| `ServerSecurity.updateUserClusterWide` | yes | yes |
| `ServerSecurity.dropUserClusterWide` | yes | yes |
| `ServerSecurity.saveGroupClusterWide` | yes | yes |
| `ServerSecurity.deleteGroupClusterWide` | yes | yes |
| `ServerSecurity.createApiTokenClusterWide` | yes | yes |
| `ServerSecurity.deleteApiTokenClusterWide` | yes | yes |
| applying an entry from a node that predates the section | yes (unconditional, as today) | yes |
| a node that predates the section applying a *conditional* entry | yes - gated on #7219 capability | yes |

Argued, not fixed: the three `seed*ClusterWide` helpers and `ServerControlPlane.connectCluster` submit with a
`null` precondition. A seed must overwrite the joining peer's document by definition, and they already read and
submit under the monitor (#7373), so what they seed is a real point-in-time state of the seeding node.

### Known gaps

- **#7559 - the compare-and-set engages only for mutations submitted on the LEADER.** `RaftHAServer` starts the
  peer-capability monitor on gaining leadership and stops it on losing it, so a follower's registry is empty or
  stale and the precondition is withheld there. The `/server/users` routes (#7380), the `POST /api/v1/server`
  commands and the gRPC admin RPCs all reach the leader already; `DeleteDropUserHandler`, the group and
  API-token routes and openCypher `DROP USER` do not, and keep the pre-fix behaviour. Fixing it means either
  running the capability refresh on every node - which touches #7219's per-term invalidation contract (#7301) -
  or extending #7380's leader gate to the remaining routes. Neither belongs in this PR.
- **#7557 was filed for the rolling-upgrade divergence and then closed**, because the gate it asks for turned
  out to be already merged (#7219) and is implemented here.

## Pre-existing red, not from this branch

`ArcadeStateMachinePerDatabaseHaltTest.perDatabaseApplyErrorDoesNotTripNodeWideHalt` and
`.otherDatabasesKeepApplyingAfterOneDatabaseFails` fail on this branch **and identically on unmodified
`origin/main`** (verified in a pristine worktree: 1391 tests / the same 2 failures there, 1409 / the same 2
here). They assert on a `TX_ENTRY` WAL-decode message and touch no security entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEJXCdUGW61QSXqyurphpt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved high-availability replication for users, groups, and API tokens to prevent concurrent changes from overwriting one another.
  - Stale security updates are now detected and retried automatically, with a clear conflict result when retries are exhausted.
  - Rolling upgrades remain compatible by applying safeguards only when all cluster members support them.

- **Documentation**
  - Added design and implementation documentation for the high-availability security replication improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->