### PR TITLE
fix(ha): dial peers over HTTPS on an SSL cluster for shutdown and bootstrap-state

### DIFF
--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -3381,9 +3381,15 @@ public class ArcadeStateMachine extends BaseStateMachine {
 
     // Same two questions the other HealthMonitor-driven backstop asks before burning a throttle slot
     // (issue #6202): the address must identify a single peer and must not be our own.
-    final String leaderHttpAddr = raftHA.getUnambiguousPeerHttpAddress(raftHA.getLeaderId());
+    final RaftPeerId leaderId = raftHA.getLeaderId();
+    final String leaderHttpAddr = raftHA.getUnambiguousPeerHttpAddress(leaderId);
     if (leaderHttpAddr == null || raftHA.isOwnHttpAddress(leaderHttpAddr))
       return; // no leader to compare against yet
+    // Both endpoints from the SAME leader identity, resolved here rather than inside the queued task:
+    // leadership can move between this check and the probe, and an HTTPS address resolved from a second
+    // getLeaderId() could then name a different node than the HTTP address these two questions were
+    // asked about (issue #7546 review).
+    final String leaderHttpsAddr = raftHA.getPeerHttpsAddress(leaderId);
 
     // Floored at the snapshot cadence so a WAN cluster that has widened its watchdog does not get probed
     // more often than it resyncs.
@@ -3405,7 +3411,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
       // the worst case, not for the length of a download.
       lifecycleExecutor.submit(() -> {
         final Map<String, BootstrapBaseline> leaderStates = BootstrapElection.fetchBootstrapState(
-            raftHA, leaderHttpAddr, raftHA.getPeerHttpsAddress(raftHA.getLeaderId()), clusterToken, pending,
+            raftHA, leaderHttpAddr, leaderHttpsAddr, clusterToken, pending,
             BOOTSTRAP_DIVERGENCE_PROBE_TIMEOUT_MS);
         if (leaderStates == null) {
           // The throttle slot is spent whether or not the probe answered, exactly as the stale-snapshot

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -3389,7 +3389,16 @@ public class ArcadeStateMachine extends BaseStateMachine {
     // leadership can move between this check and the probe, and an HTTPS address resolved from a second
     // getLeaderId() could then name a different node than the HTTP address these two questions were
     // asked about (issue #7546 review).
-    final String leaderHttpsAddr = raftHA.getPeerHttpsAddress(leaderId);
+    // The HTTPS endpoint needs the self-check of its own that the HTTP one just passed: on a cluster that
+    // declares no HTTPS endpoints, a peer's HTTPS address is derived from that peer's Raft host plus THIS
+    // node's HTTPS port, so a leader whose HTTP address is plainly not ours can still collapse onto our own
+    // HTTPS listener on a single-machine cluster (issue #6204). A node that probed itself would read back
+    // its own bootstrap state, which matches the local comparison every time, and a real divergence would
+    // stop being detected. preferredLeaderHttpsAddress is the pure decision behind getLeaderHttpsAddress();
+    // used directly because that method re-derives getLeaderId() internally, which is the very window this
+    // call site closes by capturing leaderId once.
+    final String leaderHttpsAddr = RaftHAServer.preferredLeaderHttpsAddress(BootstrapElection.useSSL(raftHA),
+        raftHA.getPeerHttpsAddress(leaderId), raftHA.getLocalHttpsAddress());
 
     // Floored at the snapshot cadence so a WAN cluster that has widened its watchdog does not get probed
     // more often than it resyncs.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -3405,7 +3405,8 @@ public class ArcadeStateMachine extends BaseStateMachine {
       // the worst case, not for the length of a download.
       lifecycleExecutor.submit(() -> {
         final Map<String, BootstrapBaseline> leaderStates = BootstrapElection.fetchBootstrapState(
-            leaderHttpAddr, clusterToken, pending, BOOTSTRAP_DIVERGENCE_PROBE_TIMEOUT_MS);
+            raftHA, leaderHttpAddr, raftHA.getPeerHttpsAddress(raftHA.getLeaderId()), clusterToken, pending,
+            BOOTSTRAP_DIVERGENCE_PROBE_TIMEOUT_MS);
         if (leaderStates == null) {
           // The throttle slot is spent whether or not the probe answered, exactly as the stale-snapshot
           // backstop spends its own on a failed attempt: the next try is the next check window, not the

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/BootstrapElection.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/BootstrapElection.java
@@ -50,6 +50,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BooleanSupplier;
 import java.util.logging.Level;
@@ -118,6 +119,9 @@ class BootstrapElection {
   }
 
   private static final String BOOTSTRAP_STATE_ROUTE = "/api/v1/cluster/bootstrap-state";
+
+  /** One notice per JVM for the SSL-on-but-plain-HTTP probe, like LeaderDatabaseQuery's. */
+  private static final AtomicBoolean PLAIN_HTTP_FALLBACK_WARNED = new AtomicBoolean(false);
 
   private static final HttpClient HTTP = HttpClient.newBuilder()
       .connectTimeout(Duration.ofSeconds(5))
@@ -461,6 +465,15 @@ class BootstrapElection {
   static String bootstrapStateUrl(final String httpAddr, final String httpsAddr, final boolean useSSL) {
     if (useSSL && httpsAddr != null)
       return "https://" + httpsAddr + BOOTSTRAP_STATE_ROUTE;
+    // SSL on with no HTTPS endpoint for the peer: the probe still carries the cluster token, so say so once
+    // rather than leave the operator to infer it. Named after LeaderDatabaseQuery's warning for the same
+    // configuration on the same endpoint - the fallback itself is the package-wide rule, not this dial's
+    // choice, and refusing here alone would make this the one probe that behaves differently.
+    if (useSSL && PLAIN_HTTP_FALLBACK_WARNED.compareAndSet(false, true))
+      LogManager.instance().log(BootstrapElection.class, Level.WARNING,
+          "SSL is enabled but no HTTPS address is known for a peer; probing its bootstrap-state over plain HTTP, "
+              + "which sends the cluster token in the clear. Declare each node's HTTPS endpoint in %s to avoid it. "
+              + "This notice is logged only once.", GlobalConfiguration.HA_SERVER_LIST.getKey());
     return "http://" + httpAddr + BOOTSTRAP_STATE_ROUTE;
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/BootstrapElection.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/BootstrapElection.java
@@ -450,8 +450,12 @@ class BootstrapElection {
         || statusCode == 429 || statusCode >= 500;
   }
 
-  /** Whether this cluster is configured for SSL; the same key every other peer dial reads. */
-  private static boolean useSSL(final RaftHAServer haServer) {
+  /**
+   * Whether this cluster is configured for SSL; the same key every other peer dial reads. Package-private
+   * so a caller that resolves a peer's HTTPS address for this probe reads the flag from here, rather than
+   * from a second copy of the key that could disagree with what {@link #fetchBootstrapState} then uses.
+   */
+  static boolean useSSL(final RaftHAServer haServer) {
     return haServer.getServer().getConfiguration().getValueAsBoolean(GlobalConfiguration.NETWORK_USE_SSL);
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/BootstrapElection.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/BootstrapElection.java
@@ -31,6 +31,7 @@ import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -115,6 +116,8 @@ class BootstrapElection {
     COMMITTED,                  // we committed BOOTSTRAP_FINGERPRINT_ENTRY for at least one DB
     FAILED                      // unexpected error; bootstrap will be re-attempted on next leader change
   }
+
+  private static final String BOOTSTRAP_STATE_ROUTE = "/api/v1/cluster/bootstrap-state";
 
   private static final HttpClient HTTP = HttpClient.newBuilder()
       .connectTimeout(Duration.ofSeconds(5))
@@ -443,14 +446,34 @@ class BootstrapElection {
         || statusCode == 429 || statusCode >= 500;
   }
 
+  /** Whether this cluster is configured for SSL; the same key every other peer dial reads. */
+  private static boolean useSSL(final RaftHAServer haServer) {
+    return haServer.getServer().getConfiguration().getValueAsBoolean(GlobalConfiguration.NETWORK_USE_SSL);
+  }
+
   /**
-   * Builds the authenticated {@code POST /api/v1/cluster/bootstrap-state} request for {@code httpAddr}.
-   * Shared by the election's async fan-out and the synchronous single-peer probe
-   * {@link #fetchBootstrapState}, so both reach the endpoint with the same credentials (issue #6124).
+   * Picks the URL and scheme for the probe. Prefers HTTPS when SSL is enabled and an HTTPS address is
+   * available; otherwise plain HTTP. The same rule {@link LeaderDatabaseQuery#chooseEndpoint} applies to
+   * this very endpoint, and that every other peer-to-peer dial in the package already follows - the probe
+   * carries the cluster token, so sending it in the clear on an SSL cluster is exactly what that rule
+   * exists to prevent (issue #7546). Package-private and pure for unit testing.
    */
-  static HttpRequest bootstrapStateRequest(final String httpAddr, final String clusterToken, final long timeoutMs) {
+  static String bootstrapStateUrl(final String httpAddr, final String httpsAddr, final boolean useSSL) {
+    if (useSSL && httpsAddr != null)
+      return "https://" + httpsAddr + BOOTSTRAP_STATE_ROUTE;
+    return "http://" + httpAddr + BOOTSTRAP_STATE_ROUTE;
+  }
+
+  /**
+   * Builds the authenticated {@code POST /api/v1/cluster/bootstrap-state} request for a peer.
+   * Shared by the election's async fan-out and the synchronous single-peer probe
+   * {@link #fetchBootstrapState}, so both reach the endpoint with the same credentials (issue #6124)
+   * and over the same scheme (issue #7546).
+   */
+  static HttpRequest bootstrapStateRequest(final String httpAddr, final String httpsAddr, final boolean useSSL,
+      final String clusterToken, final long timeoutMs) {
     final HttpRequest.Builder builder = HttpRequest.newBuilder()
-        .uri(URI.create("http://" + httpAddr + "/api/v1/cluster/bootstrap-state"))
+        .uri(URI.create(bootstrapStateUrl(httpAddr, httpsAddr, useSSL)))
         .timeout(Duration.ofMillis(timeoutMs))
         .header("Content-Type", "application/json")
         .POST(HttpRequest.BodyPublishers.ofString("{}"));
@@ -458,6 +481,18 @@ class BootstrapElection {
       builder.header("X-ArcadeDB-Cluster-Token", clusterToken);
     builder.header("X-ArcadeDB-Forwarded-User", "root");
     return builder.build();
+  }
+
+  /**
+   * The client for a probe request: the cluster trust context for an HTTPS dial, the shared plain client
+   * otherwise. Same selection as {@code PeerAuthSessionQuery}, so one cluster truststore serves every
+   * peer-to-peer dial in the package.
+   */
+  private static HttpClient probeClient(final RaftHAServer haServer, final HttpRequest request)
+      throws IOException {
+    if (!"https".equals(request.uri().getScheme()))
+      return HTTP;
+    return haServer.getHttpsClients().clientFor(haServer.getServer());
   }
 
   /**
@@ -486,11 +521,14 @@ class BootstrapElection {
    * on any failure (unreachable peer, non-200, malformed body) - the caller retries on a later health
    * tick rather than drawing a conclusion from a failed probe.
    */
-  static Map<String, ArcadeStateMachine.BootstrapBaseline> fetchBootstrapState(final String httpAddr,
-      final String clusterToken, final Set<String> dbFilter, final long timeoutMs) {
+  static Map<String, ArcadeStateMachine.BootstrapBaseline> fetchBootstrapState(final RaftHAServer haServer,
+      final String httpAddr, final String httpsAddr, final String clusterToken, final Set<String> dbFilter,
+      final long timeoutMs) {
     try {
-      final HttpResponse<String> response = HTTP.send(bootstrapStateRequest(httpAddr, clusterToken, timeoutMs),
-          HttpResponse.BodyHandlers.ofString());
+      final HttpRequest request = bootstrapStateRequest(httpAddr, httpsAddr, useSSL(haServer), clusterToken,
+          timeoutMs);
+      final HttpResponse<String> response = probeClient(haServer, request)
+          .send(request, HttpResponse.BodyHandlers.ofString());
       if (response.statusCode() != 200) {
         LogManager.instance().log(BootstrapElection.class, Level.INFO,
             "bootstrap-state probe of %s answered HTTP %d", httpAddr, response.statusCode());
@@ -509,9 +547,24 @@ class BootstrapElection {
 
   private CompletableFuture<ProbeOutcome> queryPeer(final RaftPeerId peerId,
       final String httpAddr, final Set<String> dbFilter, final long attemptTimeoutMs) {
-    final HttpRequest request = bootstrapStateRequest(httpAddr, haServer.getClusterToken(), attemptTimeoutMs);
+    // The HTTPS endpoint is resolved per peer rather than threaded through the fan-out's address map:
+    // getPeerHttpsAddress answers null whenever SSL is off, this node has no HTTPS listener, or the peer
+    // has none, which is exactly when the probe must stay on plain HTTP.
+    final HttpRequest request = bootstrapStateRequest(httpAddr, haServer.getPeerHttpsAddress(peerId),
+        useSSL(haServer), haServer.getClusterToken(), attemptTimeoutMs);
 
-    return HTTP.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+    final HttpClient client;
+    try {
+      client = probeClient(haServer, request);
+    } catch (final IOException e) {
+      // No cluster trust context: refusing is retryable, and the alternative would be to fall back to
+      // plain HTTP and send the cluster token in the clear - the thing this scheme selection prevents.
+      LogManager.instance().log(this, Level.WARNING,
+          "Bootstrap: cannot build the cluster HTTPS context to probe %s: %s", peerId, e.getMessage());
+      return CompletableFuture.completedFuture(ProbeOutcome.retryable(e.getMessage()));
+    }
+
+    return client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
         .thenApply(resp -> {
           final int status = resp.statusCode();
           if (status != 200) {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
 /**
@@ -55,6 +56,9 @@ import java.util.logging.Level;
 public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider {
 
   private static final String SHUTDOWN_ROUTE = "/api/v1/server";
+
+  /** One notice per JVM for the SSL-on-but-plain-HTTP shutdown dial, like LeaderDatabaseQuery's. */
+  private static final AtomicBoolean PLAIN_HTTP_FALLBACK_WARNED = new AtomicBoolean(false);
 
   // One client for the shutdown command, which is operator-driven and rare. Plain HTTP only; the SSL
   // case borrows the cluster trust context from RaftHAServer, as every other dial does.
@@ -534,6 +538,14 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
   static String shutdownUrl(final String httpAddr, final String httpsAddr, final boolean useSSL) {
     if (useSSL && httpsAddr != null)
       return "https://" + httpsAddr + SHUTDOWN_ROUTE;
+    // SSL on with no HTTPS endpoint for the peer: the command still carries the bearer token, so say so once.
+    // The fallback is the package-wide rule (LeaderDatabaseQuery warns for the same configuration); refusing an
+    // operator's explicit shutdown here alone would be a policy change for one verb.
+    if (useSSL && PLAIN_HTTP_FALLBACK_WARNED.compareAndSet(false, true))
+      LogManager.instance().log(RaftHAPlugin.class, Level.WARNING,
+          "SSL is enabled but no HTTPS address is known for the peer being shut down; sending the command over "
+              + "plain HTTP, which sends the cluster token in the clear. Declare each node's HTTPS endpoint in %s "
+              + "to avoid it. This notice is logged only once.", GlobalConfiguration.HA_SERVER_LIST.getKey());
     return "http://" + httpAddr + SHUTDOWN_ROUTE;
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -496,6 +496,14 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
     if (targetAddr == null)
       throw new ServerException("Cannot find server '" + serverName + "' in the cluster");
 
+    sendShutdownCommand(serverName, targetAddr, targetId);
+  }
+
+  /**
+   * Posts the shutdown command to one resolved peer. Split out of {@link #shutdownRemoteServer} so that
+   * method stays the peer lookup it was, and this one is the dial.
+   */
+  private void sendShutdownCommand(final String serverName, final String targetAddr, final RaftPeerId targetId) {
     // The request carries the cluster token, so on an SSL cluster it goes over HTTPS like every other
     // peer-to-peer dial in the package: getPeerHttpsAddress answers null whenever SSL is off, this node
     // has no HTTPS listener or the peer has none, which is exactly when plain HTTP is still correct
@@ -515,8 +523,8 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
     if (token != null && !token.isEmpty())
       builder.header("Authorization", "Bearer " + token);
 
+    final HttpRequest request = builder.build();
     try {
-      final HttpRequest request = builder.build();
       final HttpClient client = "https".equals(request.uri().getScheme())
           ? raftHAServer.getHttpsClients().clientFor(server)
           : SHUTDOWN_HTTP;
@@ -525,9 +533,9 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
       client.send(request, HttpResponse.BodyHandlers.discarding());
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new RuntimeException("Interrupted while shutting down remote server '" + serverName + "'", e);
+      throw new ServerException("Interrupted while shutting down remote server '" + serverName + "'", e);
     } catch (final IOException e) {
-      throw new RuntimeException("Failed to shutdown remote server '" + serverName + "'", e);
+      throw new ServerException("Failed to shutdown remote server '" + serverName + "'", e);
     }
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -34,10 +34,12 @@ import org.apache.ratis.protocol.RaftPeerId;
 import com.arcadedb.database.DatabaseInternal;
 
 import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -51,6 +53,14 @@ import java.util.logging.Level;
  * {@code HA_SERVER_LIST} is non-blank (a configured server list implies HA intent).
  */
 public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider {
+
+  private static final String SHUTDOWN_ROUTE = "/api/v1/server";
+
+  // One client for the shutdown command, which is operator-driven and rare. Plain HTTP only; the SSL
+  // case borrows the cluster trust context from RaftHAServer, as every other dial does.
+  private static final HttpClient SHUTDOWN_HTTP = HttpClient.newBuilder()
+      .connectTimeout(Duration.ofSeconds(5))
+      .build();
 
   private          ArcadeDBServer       server;
   private          ContextConfiguration configuration;
@@ -469,10 +479,12 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
     if (raftHAServer == null)
       throw new RuntimeException("Raft HA server not started");
 
+    RaftPeerId targetId = null;
     String targetAddr = null;
     for (final var peer : raftHAServer.getRaftGroup().getPeers()) {
       final String httpAddr = raftHAServer.getHttpAddresses().get(peer.getId());
       if (httpAddr != null && (peer.getId().toString().contains(serverName) || httpAddr.contains(serverName))) {
+        targetId = peer.getId();
         targetAddr = httpAddr;
         break;
       }
@@ -480,23 +492,49 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
     if (targetAddr == null)
       throw new ServerException("Cannot find server '" + serverName + "' in the cluster");
 
+    // The request carries the cluster token, so on an SSL cluster it goes over HTTPS like every other
+    // peer-to-peer dial in the package: getPeerHttpsAddress answers null whenever SSL is off, this node
+    // has no HTTPS listener or the peer has none, which is exactly when plain HTTP is still correct
+    // (issue #7546).
+    final String url = shutdownUrl(targetAddr, raftHAServer.getPeerHttpsAddress(targetId),
+        server.getConfiguration().getValueAsBoolean(GlobalConfiguration.NETWORK_USE_SSL));
+
+    // No request timeout, as before: HttpURLConnection was used without one, and a shutdown command is
+    // operator-driven rather than on any timed path. The client's connect timeout is new and bounds the
+    // one case that used to hang indefinitely - a peer whose address no longer answers at all.
+    final HttpRequest.Builder builder = HttpRequest.newBuilder()
+        .uri(URI.create(url))
+        .header("Content-Type", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString("{\"command\":\"shutdown\"}", StandardCharsets.UTF_8));
+
+    final String token = raftHAServer.getClusterToken();
+    if (token != null && !token.isEmpty())
+      builder.header("Authorization", "Bearer " + token);
+
     try {
-      final HttpURLConnection conn = (HttpURLConnection)
-          new URL("http://" + targetAddr + "/api/v1/server").openConnection();
-      conn.setRequestMethod("POST");
-      conn.setDoOutput(true);
-      conn.setRequestProperty("Content-Type", "application/json");
-
-      final String token = raftHAServer.getClusterToken();
-      if (token != null && !token.isEmpty())
-        conn.setRequestProperty("Authorization", "Bearer " + token);
-
-      conn.getOutputStream().write("{\"command\":\"shutdown\"}".getBytes(StandardCharsets.UTF_8));
-      conn.getResponseCode();
-      conn.disconnect();
+      final HttpRequest request = builder.build();
+      final HttpClient client = "https".equals(request.uri().getScheme())
+          ? raftHAServer.getHttpsClients().clientFor(server)
+          : SHUTDOWN_HTTP;
+      // The response is awaited and discarded, which is what conn.getResponseCode() did: the command's
+      // effect is the peer shutting down, and the body carries nothing this caller acts on.
+      client.send(request, HttpResponse.BodyHandlers.discarding());
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted while shutting down remote server '" + serverName + "'", e);
     } catch (final IOException e) {
       throw new RuntimeException("Failed to shutdown remote server '" + serverName + "'", e);
     }
+  }
+
+  /**
+   * Picks the URL and scheme for the shutdown command. Prefers HTTPS when SSL is enabled and an HTTPS
+   * address is available; otherwise plain HTTP. Package-private and pure for unit testing (issue #7546).
+   */
+  static String shutdownUrl(final String httpAddr, final String httpsAddr, final boolean useSSL) {
+    if (useSSL && httpsAddr != null)
+      return "https://" + httpsAddr + SHUTDOWN_ROUTE;
+    return "http://" + httpAddr + SHUTDOWN_ROUTE;
   }
 
   @Override

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BootstrapStateProbeParsingTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BootstrapStateProbeParsingTest.java
@@ -45,7 +45,8 @@ class BootstrapStateProbeParsingTest {
 
   @Test
   void theRequestCarriesTheClusterCredentialsEveryPeerRpcUses() {
-    final HttpRequest request = BootstrapElection.bootstrapStateRequest("host:2480", "the-token", 1234L);
+    final HttpRequest request = BootstrapElection.bootstrapStateRequest("host:2480", null, false, "the-token",
+        1234L);
 
     assertThat(request.uri().toString()).isEqualTo("http://host:2480/api/v1/cluster/bootstrap-state");
     assertThat(request.method()).isEqualTo("POST");
@@ -55,8 +56,45 @@ class BootstrapStateProbeParsingTest {
 
   @Test
   void aBlankTokenIsOmittedRatherThanSentEmpty() {
-    final HttpRequest request = BootstrapElection.bootstrapStateRequest("host:2480", "  ", 1234L);
+    final HttpRequest request = BootstrapElection.bootstrapStateRequest("host:2480", null, false, "  ", 1234L);
     assertThat(request.headers().firstValue("X-ArcadeDB-Cluster-Token")).isEmpty();
+  }
+
+  /**
+   * The probe carries the cluster token, so on an SSL cluster it must not be the one dial in the package
+   * that sends it in the clear (issue #7546). The rule is the one every other peer dial follows: HTTPS
+   * when SSL is enabled AND an HTTPS address resolved, plain HTTP otherwise - never an HTTPS scheme
+   * forced onto the plain HTTP port.
+   */
+  @Test
+  void anSSLClusterProbesOverHTTPSWhenTheEncryptedEndpointIsKnown() {
+    assertThat(BootstrapElection.bootstrapStateUrl("host:2480", "host:2490", true))
+        .isEqualTo("https://host:2490/api/v1/cluster/bootstrap-state");
+    assertThat(BootstrapElection.bootstrapStateRequest("host:2480", "host:2490", true, "the-token", 1234L)
+        .uri().toString()).isEqualTo("https://host:2490/api/v1/cluster/bootstrap-state");
+  }
+
+  @Test
+  void theProbeStaysOnPlainHTTPWithoutSSLOrWithoutAnEncryptedEndpoint() {
+    // SSL off: the encrypted address, even when known, is not used.
+    assertThat(BootstrapElection.bootstrapStateUrl("host:2480", "host:2490", false))
+        .isEqualTo("http://host:2480/api/v1/cluster/bootstrap-state");
+    // SSL on but no HTTPS endpoint resolved for the peer: the HTTP port keeps the HTTP scheme rather
+    // than being dialled as if it spoke TLS.
+    assertThat(BootstrapElection.bootstrapStateUrl("host:2480", null, true))
+        .isEqualTo("http://host:2480/api/v1/cluster/bootstrap-state");
+  }
+
+  /**
+   * The same endpoint is reached by {@link LeaderDatabaseQuery}, and the two must not disagree about the
+   * scheme for one address pair - that disagreement is what left this probe on plain HTTP.
+   */
+  @Test
+  void theProbeAgreesWithTheDatabaseListQueryAboutTheScheme() {
+    for (final boolean useSSL : new boolean[] { true, false })
+      for (final String httpsAddr : new String[] { "host:2490", null })
+        assertThat(BootstrapElection.bootstrapStateUrl("host:2480", httpsAddr, useSSL))
+            .isEqualTo(LeaderDatabaseQuery.chooseEndpoint("host:2480", httpsAddr, useSSL).url());
   }
 
   @Test

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BootstrapStateProbeParsingTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BootstrapStateProbeParsingTest.java
@@ -86,6 +86,36 @@ class BootstrapStateProbeParsingTest {
   }
 
   /**
+   * The divergence check resolves the leader's HTTPS endpoint itself, so it owes the same self-check it
+   * already runs on the HTTP one. On a cluster that declares no HTTPS endpoints, a peer's HTTPS address is
+   * derived from that peer's Raft host plus this node's HTTPS port - so on a single-machine cluster the
+   * leader's HTTPS address collapses onto our own listener even though its HTTP address plainly does not
+   * (issue #6204). Probing ourselves would return our own bootstrap state, which matches the local
+   * comparison every time, so the divergence the check exists to find would stop being reported.
+   */
+  @Test
+  void aLeaderHTTPSAddressThatCollapsedOntoThisNodeIsNotProbed() {
+    final String localHttps = "localhost:2490";
+    // What resolveHttpsAddress derives for the leader when the 5th server-list field is absent and both
+    // nodes run on one host: the leader's Raft host with THIS node's HTTPS port.
+    final String derivedForLeader = "localhost:2490";
+
+    final String leaderHttps = RaftHAServer.preferredLeaderHttpsAddress(true, derivedForLeader, localHttps);
+    assertThat(leaderHttps).isNull();
+    // Which leaves the leader's own HTTP port - vetted as neither ambiguous nor ours - and not an HTTPS
+    // dial at this node's own listener.
+    assertThat(BootstrapElection.bootstrapStateUrl("localhost:2481", leaderHttps, true))
+        .isEqualTo("http://localhost:2481/api/v1/cluster/bootstrap-state");
+
+    // The guard is not a blanket refusal of HTTPS: a leader that resolves to a different socket is still
+    // probed over TLS, which is what issue #7546 was about.
+    assertThat(RaftHAServer.preferredLeaderHttpsAddress(true, "localhost:2491", localHttps))
+        .isEqualTo("localhost:2491");
+    assertThat(BootstrapElection.bootstrapStateUrl("localhost:2481", "localhost:2491", true))
+        .isEqualTo("https://localhost:2491/api/v1/cluster/bootstrap-state");
+  }
+
+  /**
    * The same endpoint is reached by {@link LeaderDatabaseQuery}, and the two must not disagree about the
    * scheme for one address pair - that disagreement is what left this probe on plain HTTP.
    */

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAPluginTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAPluginTest.java
@@ -42,6 +42,28 @@ class RaftHAPluginTest {
     assertThat(plugin.isLeader()).isFalse();
   }
 
+  /**
+   * The shutdown command carries the cluster token in an {@code Authorization: Bearer} header, so on an
+   * SSL cluster it must not be the one dial in the package that sends it in the clear (issue #7546).
+   * Same rule as every other peer-to-peer dial: HTTPS when SSL is enabled AND an HTTPS address resolved.
+   */
+  @Test
+  void theShutdownCommandGoesOverHTTPSOnAnSSLCluster() {
+    assertThat(RaftHAPlugin.shutdownUrl("host:2480", "host:2490", true))
+        .isEqualTo("https://host:2490/api/v1/server");
+  }
+
+  @Test
+  void theShutdownCommandStaysOnPlainHTTPWithoutSSLOrWithoutAnEncryptedEndpoint() {
+    // SSL off: the encrypted address, even when known, is not used.
+    assertThat(RaftHAPlugin.shutdownUrl("host:2480", "host:2490", false))
+        .isEqualTo("http://host:2480/api/v1/server");
+    // SSL on but no HTTPS endpoint resolved for the peer: the HTTP port keeps the HTTP scheme rather
+    // than being dialled as if it spoke TLS.
+    assertThat(RaftHAPlugin.shutdownUrl("host:2480", null, true))
+        .isEqualTo("http://host:2480/api/v1/server");
+  }
+
   @Test
   void startServiceDoesNothingWhenNotConfigured() {
     final RaftHAPlugin plugin = new RaftHAPlugin();


### PR DESCRIPTION
## What does this PR do?

Puts the two remaining peer-to-peer dials on the scheme rule the rest of the package already follows: HTTPS when SSL is enabled **and** an HTTPS address resolved, plain HTTP otherwise — never an HTTPS scheme forced onto the plain HTTP port.

**1. `BootstrapElection` — the `/bootstrap-state` probe.** `bootstrapStateRequest` now takes the peer's HTTPS address and the SSL flag, and picks the URL through a pure `bootstrapStateUrl(httpAddr, httpsAddr, useSSL)`. Both callers follow:

- the election's async fan-out (`queryPeer`) resolves the peer's HTTPS endpoint with `haServer.getPeerHttpsAddress(peerId)` rather than threading a second address through the retry machinery's map — that accessor already answers `null` whenever SSL is off, this node has no HTTPS listener, or the peer has none, which is exactly when plain HTTP is still right;
- the synchronous single-peer probe (`fetchBootstrapState`) takes the `RaftHAServer` so it can resolve both the scheme and the client; its one caller in `ArcadeStateMachine` passes the leader's HTTPS address alongside the HTTP one, the same pairing that path already uses for the reconciler at `:1625-1634`.

The client is selected the way `PeerAuthSessionQuery` does it — `getHttpsClients().clientFor(server)` for an HTTPS dial, the shared plain client otherwise — so one cluster truststore serves every dial in the package. When that context cannot be built the probe reports a **retryable** failure rather than falling back to plain HTTP: falling back would send the cluster token in the clear, which is the thing this change prevents.

**2. `RaftHAPlugin.shutdownRemoteServer`.** Same scheme selection through a pure `shutdownUrl(...)`, and the dial moves from `HttpURLConnection` to `java.net.http.HttpClient` so it can borrow the cluster trust context like every other dial. `Authorization: Bearer <clusterToken>`, the JSON body and the peer-matching loop are unchanged.

## Motivation

Both dials carry the cluster token — `Authorization: Bearer` in the shutdown command, `X-ArcadeDB-Cluster-Token` in the probe — and both were hardcoded to `http://`, so on a cluster with `arcadedb.ssl.enabled` the token went out in the clear. #7508 fixed the leader-forward paths; these two are not leader forwards, which is why they were out of scope there.

The inconsistency was sharpest for the probe: `LeaderDatabaseQuery.chooseEndpoint` reaches **the same endpoint** and already picked the scheme correctly. There is now a test asserting the two agree for every `(httpsAddr, useSSL)` combination, so they cannot drift apart again.

## Related issues

Fixes #7546. Follows #7508 (leader-forward scheme selection) and reuses the `useSSL && httpsAddr != null` rule established there and in #4470 / #6221.

## Additional Notes

Three deliberate scope lines, each a decision rather than an oversight:

1. **The shutdown command still resolves its peer through `getHttpAddresses()`, not `PeerDialAddress`.** The issue notes it inherits none of the ambiguity/self-address guards, and that is true. Routing it through `PeerDialAddress.resolve` would turn an ambiguous address into a *refusal* of an operator's explicit shutdown — safer, but an operator-visible policy change that deserves its own decision rather than riding along with a scheme fix. Happy to add it here if you want it in one go.
2. **No request timeout on the shutdown dial**, matching `HttpURLConnection`'s absence of one; the new client's 5 s **connect** timeout is the only bound added, and it bounds the one case that used to hang forever — a peer address that no longer answers at all. I deliberately did not borrow `HA_PROXY_CONNECT_TIMEOUT` for it, since that knob is about the proxy path.
3. **`azure_ai`-style third spellings left alone.** Every other plaintext `"http://"` in `ha-raft/src/main/java` after this change is either already scheme-selected (`RaftHAServer:936`, `SnapshotInstaller:977`, `PeerAuthSessionQuery:144`, `LeaderDatabaseQuery:136`) or a leader forward covered by #7508 (`RaftReplicatedDatabase:3522`), except `PeerCapabilityQuery:170` — that one is the read-only capability probe whose own doc explains why it takes a shared endpoint, so I left it for you to judge rather than changing it unasked.

## Checklist

- [x] My unit tests cover both failure and success scenarios
- [ ] I have run the build using `mvn clean package` command

On the last box, stated exactly rather than ticked: I ran the `ha-raft` unit suite on Temurin 21.0.12 / macOS aarch64 (`./mvnw -pl ha-raft test`, ITs skipped), not a full-project `clean package`.

**1411 tests run, 2 failures** — both in `ArcadeStateMachinePerDatabaseHaltTest` (`peekWalTransactionId`, `ArcadeStateMachine.java:1828`), and both **pre-existing on a clean `origin/main`**: verified by stashing this branch and re-running that class alone, which fails identically. The classes this change touches are green: `BootstrapStateProbeParsingTest` 9/9, `RaftHAPluginTest` 6/6, `LeaderDatabaseQueryTest` 4/4.

Negative control: deleting just the two `if (useSSL && httpsAddr != null) return "https://" + …;` lines and re-running fails exactly 3 assertions — `anSSLClusterProbesOverHTTPSWhenTheEncryptedEndpointIsKnown`, `theProbeAgreesWithTheDatabaseListQueryAboutTheScheme`, and `theShutdownCommandGoesOverHTTPSOnAnSSLCluster` — and nothing else, so the new tests fail for the reason they exist. The plain-HTTP cases pass in both states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Bootstrap-state checks and remote shutdown requests now use HTTPS when SSL is enabled and a secure endpoint is available.
  * Bootstrap probes retry when a secure connection cannot be established instead of sending cluster credentials over plain HTTP.
  * A warning is logged when SSL is enabled but no secure endpoint is available.

* **Bug Fixes**
  * Improved endpoint consistency when leadership changes during bootstrap checks.
  * Improved endpoint selection and fallback behavior for bootstrap probes and remote shutdown operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
