### PR TITLE
fix(#7569): say in the contract that ndjson streams only a read-only statement

### DIFF
--- a/docs/7569-openapi-command-ndjson-readonly-restriction.md
+++ b/docs/7569-openapi-command-ndjson-readonly-restriction.md
@@ -1,0 +1,99 @@
+# Issue #7569: OpenAPI /command declares application/x-ndjson but doesn't say streaming is read-only-only
+
+## Ledger (single finding, from the issue body)
+
+1. `POST /api/v1/command/{database}` declares `application/x-ndjson` as a `200` content type but
+   neither its `summary` nor `description` says that the ndjson response is available only for a
+   read-only statement, and that a mutating statement is refused with HTTP 400 before it runs.
+   Reporter also suggested (as an "ideally") a line noting that ndjson is selected via `Accept`.
+
+## Root cause
+
+`PostCommandHandler.requireStreamableStatement()` (server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java:492)
+refuses to stream any statement that is not provably read-only - `analyzed.isIdempotent()` and not
+DDL/CREATE/UPDATE/DELETE/SCHEMA - throwing `IllegalArgumentException` mapped to HTTP 400, before the
+statement runs. `CoreApiSpec.createCommandPath()` declares `application/x-ndjson` as a response
+media type (via `addNdJsonAlternative`) and the `Accept` parameter that selects it
+(`ndJsonAcceptParam()`), but the operation's own `description` never mentions the restriction.
+
+The `Accept`-header opt-in the reporter asked for as an "ideally" is already documented: `ndJsonAcceptParam()`
+attaches a description ("Send 'application/x-ndjson' to receive the result as a stream...") to the `Accept`
+parameter on GET query, POST query and POST command alike. That part of the ask is already satisfied - no
+change needed there.
+
+## Completeness sweep
+
+**Invariant:** every OpenAPI operation whose execution path can refuse the ndjson encoding with 400 for a
+non-read-only statement documents that restriction in its own `description`.
+
+Grep for every caller of the gate and every operation offering the ndjson media type:
+
+```
+$ grep -n "requireStreamableStatement" server/src/main/java/com/arcadedb/server/http/handler/*.java
+PostCommandHandler.java:199:      requireStreamableStatement(database, language, command);
+PostCommandHandler.java:492:  private static void requireStreamableStatement(...)
+
+$ grep -n "class PostQueryHandler" server/src/main/java/com/arcadedb/server/http/handler/PostQueryHandler.java
+public class PostQueryHandler extends PostCommandHandler {
+   // overrides only executeCommand() -> database.query(); execute() itself, including the streaming
+   // gate at line 199, is inherited unchanged.
+
+$ grep -n "requireStreamableStatement\|supportsNdJsonEncoding" server/src/main/java/com/arcadedb/server/http/handler/GetQueryHandler.java
+(no matches - GetQueryHandler streams unconditionally via a separately-implemented execute())
+```
+
+| Entry point | Calls the gate? | Status |
+|---|---|---|
+| `POST /api/v1/command/{database}` (`PostCommandHandler`) | Yes, directly | **Fixed here** - description now states the restriction |
+| `POST /api/v1/query/{database}` (`PostQueryHandler extends PostCommandHandler`) | Yes, inherited via the same `execute()` | **Fixed here** - same restriction, same shared description text, for parity with the existing `commandRequestDeclaresLimitMatchingQueryRequest` precedent of keeping shared-behavior text identical between the two operations |
+| `GET /api/v1/query/{database}/{language}/{command}` (`GetQueryHandler`) | No - separate `execute()`, calls `database.query()` directly with no analysis gate | **Filed as #7571** - there is no explicit read-only gate on this path, so nothing to document identically here; but the adversarial pass below found the absence is itself a divergence worth tracking (`BACKUP DATABASE` streams on GET while `POST /command` refuses it) |
+| `Accept` header opt-in (both POST operations, and GET query) | n/a | **Already covered** - `ndJsonAcceptParam()` already documents `Accept: application/x-ndjson` on all three operations |
+
+Every in-scope row is fixed in this PR; the one out-of-scope row is tracked by #7571.
+
+## Fix
+
+Added a shared `NDJSON_READ_ONLY_DESCRIPTION` constant to `CoreApiSpec` and appended it to the
+`description` of both `POST /api/v1/command/{database}` and `POST /api/v1/query/{database}`, kept
+byte-identical between the two operations (mirroring how `STALE_SESSION_404_DESCRIPTION` is shared).
+
+## Tests
+
+`CoreApiSpecTest.commandAndQueryDescribeTheReadOnlyStreamingRestriction()` (new) asserts:
+- both operations' `description` mention the 400 refusal and the read-only requirement;
+- the shared restriction text is identical between the two operations.
+
+## Test results
+
+`mvn -o -pl server -am test -Dtest=CoreApiSpecTest` - see run log in PR.
+
+## Residual risk
+
+This is a documentation-only change to the generated OpenAPI contract; no runtime behavior changed.
+
+The one thing this PR does NOT cover: `GET /api/v1/query/{database}/{language}/{command}` also offers
+`application/x-ndjson` and has no read-only gate at all, so it still streams a `BACKUP DATABASE` that
+`POST /command` refuses. Tracked by #7571 - see the adversarial pass below.
+
+## Adversarial pass (Phase 1.5)
+
+One finding, verified independently before filing:
+
+1. **GET `/api/v1/query/{database}/{language}/{command}` offers `application/x-ndjson` with no read-only
+   gate at all.** `GetQueryHandler.execute()` calls `database.query()` directly and never reaches
+   `PostCommandHandler.requireStreamableStatement()` (which is `private static` on a sibling class). Its
+   only stand-in is `SQLQueryEngine.query()`'s `if (!statement.isIdempotent()) throw
+   QueryNotIdempotentException`, which is strictly weaker: `BackupDatabaseStatement.isIdempotent()`
+   returns `true` while `getOperationTypes()` reports `{READ, CREATE}`, so `BACKUP DATABASE` streams on
+   GET while `POST /command` refuses it with 400.
+
+   Verified by reading `engine/src/main/java/com/arcadedb/query/sql/parser/BackupDatabaseStatement.java:56-72`
+   and `engine/src/main/java/com/arcadedb/query/sql/SQLQueryEngine.java:86-93`.
+
+   **Disposition: real, out of scope -> filed as #7571.** Out of scope because closing it means either a
+   behavior change on a third handler or a deliberate documentation of the divergence, neither of which
+   #7569 (documentation-only, about `/command`) asked for.
+
+   Narrower than the subagent framed it: the transactional hazards `requireStreamableStatement()`'s javadoc
+   describes are POST-only, since `GetQueryHandler.requiresTransaction()` returns `false` so there is no
+   auto-commit wrapper and no retry loop. #7571 says so explicitly rather than overstating the exposure.

--- a/docs/7569-openapi-command-ndjson-readonly-restriction.md
+++ b/docs/7569-openapi-command-ndjson-readonly-restriction.md
@@ -97,3 +97,41 @@ One finding, verified independently before filing:
    Narrower than the subagent framed it: the transactional hazards `requireStreamableStatement()`'s javadoc
    describes are POST-only, since `GetQueryHandler.requiresTransaction()` returns `false` so there is no
    auto-commit wrapper and no retry loop. #7571 says so explicitly rather than overstating the exposure.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/7572
+
+## Review cycles
+
+### Cycle 1 - 9463c26df5
+
+- **CodeRabbit:** "No actionable comments were generated." Merge risk: minimal. One pre-merge check
+  warning, "Docstring Coverage 16.67%" - **skipped as a nitpick**: the functions it counts are JUnit
+  test methods and private spec builders, and this repo documents intent in targeted javadoc/comments
+  (the new constant and the new test both carry one) rather than in per-method docstrings. Adding
+  boilerplate javadoc to satisfy a percentage would be noise.
+- **claude:** no blocking issues. Confirmed the new text matches
+  `requireStreamableStatement()`'s actual conditions, that sharing one constant between the two POST
+  operations is right, and that deferring the GET gap to #7571 keeps the PR narrow.
+- **claude, one non-blocking observation:** `requireStreamableStatement()` excludes
+  CREATE/UPDATE/DELETE/SCHEMA/DDL but not `OperationType.ADMIN`, so "if any statement reports ADMIN
+  while `isIdempotent()` returns true, it could still stream" - suggested as a possible follow-up.
+
+  **Assessed and NOT filed: the premise does not hold.** `OperationType.ADMIN` has exactly one
+  producer in the tree - `OpenCypherQueryEngine.analyze()` returns it for a `CypherAdminStatement`
+  (`engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java:116`) - and
+  `CypherAdminStatement.isReadOnly()` returns `false` unconditionally
+  (`engine/src/main/java/com/arcadedb/query/opencypher/ast/CypherAdminStatement.java:66-68`), which is
+  what `isIdempotent()` delegates to. So every ADMIN statement fails the gate's very first conjunct
+  and is refused before the operation-type set is consulted at all. There is no statement that is both
+  ADMIN and idempotent, so there is nothing to leak and no follow-up to file.
+
+  Verified by: `grep -rn "OperationType.ADMIN" --include="*.java" engine/src/main/java server/src/main/java`
+  (one hit) and reading `CypherAdminStatement`.
+
+No code changes were required by the review; no items were deferred.
+
+## Final state
+
+`clean-approval`

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -79,6 +79,15 @@ public class CoreApiSpec implements OpenApiContributor {
       "Database not found, or the session id header names a transaction that no longer resolves "
           + "(\"Remote transaction session not found or expired\")";
 
+  // Shared by POST query and POST command: PostQueryHandler extends PostCommandHandler and overrides only
+  // executeCommand(), so both reach the very same requireStreamableStatement() call in execute() before the
+  // statement runs. Held in one place so the two operations cannot describe the same gate differently (issue #7569).
+  private static final String NDJSON_READ_ONLY_DESCRIPTION = """
+      When 'Accept' requests the ndjson encoding, only a statement provably read-only may stream: one that \
+      writes - INSERT, UPDATE, DELETE, DDL, or one this analysis cannot classify - is refused with 400 before \
+      it runs, because its rows would otherwise reach the client before the transaction that produced them \
+      commits. Request the buffered 'application/json' encoding for it instead.""";
+
   @Override
   public void contribute(final OpenAPI openAPI) {
     openAPI.getPaths().addPathItem("/api/v1/server", createServerPath());
@@ -246,7 +255,7 @@ public class CoreApiSpec implements OpenApiContributor {
 
     final Operation postOp = new Operation();
     postOp.setSummary("Execute query via POST");
-    postOp.setDescription("Executes a query using POST method with query in request body");
+    postOp.setDescription("Executes a query using POST method with query in request body. " + NDJSON_READ_ONLY_DESCRIPTION);
     postOp.setOperationId("executeQueryPost");
     postOp.addTagsItem("Query");
     postOp.addParametersItem(SpecBuilders.pathParam("database", "Database name"));
@@ -266,7 +275,7 @@ public class CoreApiSpec implements OpenApiContributor {
 
     final Operation postOp = new Operation();
     postOp.setSummary("Execute command");
-    postOp.setDescription("Executes a database command");
+    postOp.setDescription("Executes a database command. " + NDJSON_READ_ONLY_DESCRIPTION);
     postOp.setOperationId("executeCommand");
     postOp.addTagsItem("Command");
     postOp.addParametersItem(SpecBuilders.pathParam("database", "Database name"));

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
@@ -287,6 +287,45 @@ class CoreApiSpecTest {
     }
   }
 
+  /**
+   * Issue #7569: both operations declare 'application/x-ndjson' under their 200, but
+   * PostCommandHandler.requireStreamableStatement() refuses to stream a statement that is not
+   * provably read-only with a 400 before it ever runs - and nothing in the contract said so. A
+   * client author reading the contract alone had no way to know the restriction existed short of
+   * sending a mutating statement at a live server and reading the 400.
+   * <p>
+   * Checked on both /command and /query: PostQueryHandler extends PostCommandHandler and overrides
+   * only executeCommand(), so the very same requireStreamableStatement() call at execute() time
+   * guards both operations identically (the same sharing this file already pins down for 'limit'
+   * in commandRequestDeclaresLimitMatchingQueryRequest).
+   */
+  @Test
+  void commandAndQueryDescribeTheReadOnlyStreamingRestriction() {
+    // The literal text CoreApiSpec appends to both operations' description. Duplicated here rather
+    // than referencing the (private) production constant, matching how this file already pins other
+    // shared text verbatim (e.g. STALE_SESSION_404_DESCRIPTION's message in
+    // queryAndCommand404CoversAStaleSessionIdNotOnlyAMissingDatabase).
+    final String restriction = "only a statement provably read-only may stream";
+
+    final Operation command = openAPI.getPaths().get("/api/v1/command/{database}").getPost();
+    final Operation query = openAPI.getPaths().get("/api/v1/query/{database}").getPost();
+
+    for (final Operation operation : List.of(command, query)) {
+      assertThat(operation.getDescription())
+          .as(operation.getOperationId() + " must warn that the ndjson encoding is refused before "
+              + "it runs for a statement that is not provably read-only")
+          .contains(restriction)
+          .contains("400");
+    }
+
+    final String commandSuffix = command.getDescription().substring(command.getDescription().indexOf(restriction));
+    final String querySuffix = query.getDescription().substring(query.getDescription().indexOf(restriction));
+    assertThat(commandSuffix)
+        .as("both operations run through the exact same requireStreamableStatement() check, so the "
+            + "restriction text must not diverge between them and confuse a reader of the generated docs")
+        .isEqualTo(querySuffix);
+  }
+
   @Test
   void commandRequestDeclaresLanguageAsRequired() {
     final Schema<?> schema = openAPI.getComponents().getSchemas().get("CommandRequest");


### PR DESCRIPTION
Closes #7569

## Summary

`POST /api/v1/command/{database}` and `POST /api/v1/query/{database}` both declare
`application/x-ndjson` under their `200`, so from the contract alone they look like the streaming
encoding is available for anything they accept. It is not:
`PostCommandHandler.requireStreamableStatement()` refuses to stream a statement that is not provably
read-only - `UPDATE`, `INSERT`, DDL, `UPDATE ... RETURN AFTER`, and anything the language cannot
analyze - with a 400 raised before the statement runs. The rule is right (a streamed response sends
rows before the surrounding transaction commits, and that commit can still roll back), but neither
operation's `description` mentioned it, so a client author discovered it only by sending a mutating
statement at a live server and reading the 400.

This adds that sentence to both operations' `description`, held in one shared
`NDJSON_READ_ONLY_DESCRIPTION` constant the way `STALE_SESSION_404_DESCRIPTION` already is: they run
through the very same gate (`PostQueryHandler extends PostCommandHandler` and overrides only
`executeCommand()`), so the two must not describe it differently.

Documentation-only - no runtime behavior changed.

The issue's secondary "ideally" - a line saying ndjson is selected by `Accept` - turned out to be
already satisfied: `ndJsonAcceptParam()` attaches exactly that description to the `Accept` parameter
on GET query, POST query and POST command alike. No change was needed there, and none was made.

## Test plan

- [x] `mvn -o -pl server test -Dtest=CoreApiSpecTest` - 25/25 pass, including the new
      `commandAndQueryDescribeTheReadOnlyStreamingRestriction()`
- [x] The new test was confirmed to FAIL against the pre-fix descriptions (reverted them temporarily:
      `Expecting actual: "Executes a database command" to contain: "only a statement provably read-only may stream"`)
- [x] `mvn -o -pl server test -Dtest='*ApiSpecTest,*SpecTest'` - 135/135 pass, no regression in any
      other OpenAPI contributor's spec test
- [x] Grepped for any other snapshot or fixture pinning the two old description strings - only
      `CoreApiSpec.java` itself carries them

## Coverage

| Entry point | Shares the gate? | Covered |
|---|---|---|
| `POST /api/v1/command/{database}` (`PostCommandHandler`) | Yes, calls `requireStreamableStatement()` directly | Yes - description states the restriction |
| `POST /api/v1/query/{database}` (`PostQueryHandler`) | Yes, inherits the same `execute()` | Yes - same shared text, asserted identical by the new test |
| `Accept`-header opt-in on all three ndjson operations | n/a | Already documented by `ndJsonAcceptParam()` |

### Known gaps

- **#7571** - `GET /api/v1/query/{database}/{language}/{command}` also offers `application/x-ndjson`
  but reaches no read-only gate at all: `GetQueryHandler` calls `database.query()` directly, and
  `SQLQueryEngine.query()` gates on `isIdempotent()` alone. That is strictly weaker than
  `requireStreamableStatement()` - `BackupDatabaseStatement.isIdempotent()` is `true` while its
  `getOperationTypes()` reports `{READ, CREATE}` - so `BACKUP DATABASE` streams on GET while
  `POST /command` refuses it with 400. Out of scope here (it needs either a behavior change on a
  third handler or a deliberate documentation of the divergence, neither of which #7569 asked for),
  and narrower than it first looks: `GetQueryHandler.requiresTransaction()` is `false`, so the
  auto-commit and retry hazards that motivate the POST gate do not apply there. #7571 says so
  explicitly rather than overstating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6gidX7u247f1WKYokvFqH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that NDJSON streaming for POST command and query requests is limited to provably read-only statements.
  * Documented that write or unclassified statements are rejected with HTTP 400 before execution.
  * Updated API reference descriptions consistently across both endpoints.

* **Tests**
  * Added coverage verifying that the OpenAPI descriptions include matching NDJSON read-only restrictions and the resulting error response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->