### PR TITLE
fix(#7568): say what the vector search responses always send, and what their object properties hold

### DIFF
--- a/docs/7568-openapi-vector-response-schema-shapes.md
+++ b/docs/7568-openapi-vector-response-schema-shapes.md
@@ -1,0 +1,238 @@
+# #7568 - OpenAPI: vector/hybrid/full-text response schemas have no `required` list, and three properties are bare `object`
+
+- Issue: https://github.com/ArcadeData/arcadedb/issues/7568
+- Branch: `fix/7568-openapi-vector-response-schema-shapes`
+- Type: bug (contract defect; the server's wire behaviour is correct and unchanged)
+
+## Finding ledger
+
+- [x] 1. `VectorSearchResponse`, `HybridSearchResponse` and `FullTextSearchResponse` declare no `required` list - **fixed**, on all three plus the two hit schemas they reach through `results[]`.
+- [x] 2. `HybridSearchRequest.weights` is a bare `object` - **fixed**, declared as a closed object of three named numbers.
+- [x] 3. `HybridSearchResponse.legs` is a bare `object` - **fixed**, declared as three named sub-objects with `vector` required.
+- [x] 4. `results[].properties` is a bare `object` on all three response schemas - **fixed**, declared an open map (`additionalProperties: true`) on both hit schemas.
+
+## Analysis
+
+`server/src/main/java/com/arcadedb/server/http/handler/openapi/VectorApiSpec.java` builds all six
+components. The three *request* schemas call `schema.setRequired(...)`; the three *response* schemas
+never do. Nothing about the running server changes - the JSON the handlers emit is the same before
+and after - only the document that describes it.
+
+Ground truth for "always sent" is the three engine writers, read directly:
+
+| Response | Writer | Unconditional keys | Conditional keys |
+|---|---|---|---|
+| `VectorSearchResponse` | `VectorSearch.search` (`engine/.../query/search/VectorSearch.java:110-117`) | `indexName`, `sparse`, `scoring`, `candidateLimit`, `truncated`, `count`, `results` | none |
+| `HybridSearchResponse` | `HybridSearch.search` (`engine/.../query/search/HybridSearch.java:199-237`) | `vectorIndexName`, `sparse`, `scoring`, `legs`, `fused`, `truncated`, `count`, `results` | `fulltextIndexName` (only when the full-text leg ran), `fusionStrategy` (only when `fused` is true) |
+| `FullTextSearchResponse` | `FullTextQuery.search` (`engine/.../query/search/FullTextQuery.java:154-158`) | `indexName`, `similarity`, `count`, `results` | none |
+| hit (`results[]`, vector + full-text) | `VectorSearch:147-153`, `FullTextQuery:149-152` | `rid`, `properties` | exactly one of `score` / `distance` |
+| fused hit (`results[]`, hybrid) | `HybridSearch:216-220` (unfused), `HybridSearch:667-679` (fused) | `rid`, `sources`, `properties` | `fusedScore` \| `score` \| `distance`, plus `depth`/`path` for an expansion hit |
+
+Two values that could have made a "required" key vanish at runtime were checked and cannot be null:
+
+- `VectorLeg.ResolvedVectorIndex.scoring()` is assigned from a string literal on both the dense and
+  the sparse branch (`VectorLeg.java:207-217`), and the method throws rather than returning a record
+  with a null scoring.
+- `FullTextSearch.getSimilarity` returns `SIMILARITY_BM25` or falls through to `SIMILARITY_CLASSIC`
+  (`FullTextSearch.java:394-400`); there is no null path.
+
+For the bare objects, the shape is knowable in every case:
+
+- `weights` is a **closed** map. `HybridSearch.validateWeights` (`HybridSearch.java:292-321`) refuses
+  any key that is not `vector`/`fulltext`/`expand`, refuses a weight for a leg the request did not
+  ask for, and refuses a value that is not a finite, non-negative number. The defaults come from the
+  `weightOf(...)` call sites: `vector` 1.0, `fulltext` 1.0, `expand` 0.5. The gRPC mirror declares it
+  `map<string, float>` (`grpc/src/main/proto/arcadedb-server.proto:307`), which agrees on the value type.
+- `legs` is a **fixed** shape with three known sub-objects: `vector` `{count}`, `fulltext`
+  `{indexName, similarity, count}` (present only when that leg ran), `expand`
+  `{direction, edgeTypes, maxDepth, truncated, seedCount, seedsTruncated, count}` (present only when
+  the request asked to expand). `vector` is always present.
+- `results[].properties` is `JsonSerializer.serializeDocument(document)` - genuinely arbitrary record
+  data of arbitrary value types, so it is an **open** map: `additionalProperties: true`.
+
+## Completeness
+
+### 1. Invariant
+
+Every field the vector, hybrid and full-text routes always send is named in its response schema's
+`required` list, and no property of those six schemas is typed as a bare `object` carrying neither
+`properties` nor `additionalProperties`.
+
+### 2. Enumeration
+
+```
+$ grep -rc 'setRequired' server/src/main/java/com/arcadedb/server/http/handler/openapi/*.java
+AiApiSpec.java:3      AuthApiSpec.java:1     CoreApiSpec.java:3     GrafanaApiSpec.java:1
+McpApiSpec.java:0     OpenApiContributor.java:0                     PluginApiSpec.java:1
+PrometheusApiSpec.java:2                     SecurityAdminApiSpec.java:0
+SpecBuilders.java:6   TimeSeriesApiSpec.java:1                      VectorApiSpec.java:3
+```
+
+`VectorApiSpec`'s three `setRequired` calls are all on request schemas (lines 158, 217, 246 before
+the fix) - confirming finding 1.
+
+```
+$ grep -rn 'addSchemas("' server/src/main/java/com/arcadedb/server/http/handler/openapi/*.java | wc -l
+55
+$ grep -rn 'setRequired' server/src/main/java/com/arcadedb/server/http/handler/openapi/*.java | grep -v SpecBuilders | wc -l
+15
+```
+
+So 40 of 55 component schemas across the whole document carry no `required` list. Six of them are
+this issue's; the rest are the same defect in other specs.
+
+```
+$ grep -rn 'addProperty([^,]*, *SpecBuilders\.object(' server/src/main/java/com/arcadedb/server/http/handler/openapi/*.java | wc -l
+15
+```
+
+Fifteen bare-`object` properties in total. Four are in `VectorApiSpec` (`weights` :189, `legs` :213,
+`hitSchema().properties` :253, `fusedHitSchema().properties` :271 - the last two are the two code
+sites behind the issue's "`results[].properties` on all three response schemas"). The other eleven
+are in `AiApiSpec` (1), `CoreApiSpec` (5), `GrafanaApiSpec` (1), `PluginApiSpec` (3) and
+`TimeSeriesApiSpec` (1).
+
+Sibling *surfaces* that describe the same three responses:
+
+```
+$ grep -rn 'outputSchema\|"output_schema"' --include='*.java' mcp/src/main/java   # no hits
+$ grep -rn 'message VectorSearchResponse\|message HybridSearchResponse\|message FullTextSearchResponse' --include='*.proto' .
+grpc/src/main/proto/arcadedb-server.proto:258,319,365
+```
+
+### 3. Coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| `VectorSearchResponse.required` vs what `VectorSearch.search` emits | yes | yes |
+| `HybridSearchResponse.required` vs what `HybridSearch.search` emits (unfused, fused, expanding) | yes | yes |
+| `FullTextSearchResponse.required` vs what `FullTextQuery.search` emits | yes | yes |
+| shared hit schema (`results[]` of the vector and full-text responses) `required` | yes | yes |
+| fused hit schema (`results[]` of the hybrid response) `required` | yes | yes |
+| `HybridSearchRequest.weights` bare object | yes | yes |
+| `HybridSearchResponse.legs` bare object | yes | yes |
+| `results[].properties` bare object, both hit schemas, all three responses | yes | yes |
+| The other 11 bare-`object` properties in `AiApiSpec`/`CoreApiSpec`/`GrafanaApiSpec`/`PluginApiSpec`/`TimeSeriesApiSpec` | no - filed as **#7577** | n/a |
+| The other ~34 component schemas across the document with no `required` list | no - filed as **#7578** | n/a |
+| The five closed value sets in these same schemas still typed as free `string` (`fusionStrategy`, `direction`, `sources[]`, `similarity`) | no - filed as **#7579** | n/a |
+| MCP tool surface for the same three searches | argued: `grep -rn 'outputSchema' mcp/src/main/java` returns no hits - MCP declares input schemas only, so there is no response contract there to under-describe |
+| gRPC surface for the same three searches | argued: `arcadedb-server.proto:258/319/365` declares each response as a protobuf message with typed scalar fields, `map<string, float> weights` and `map<string, GrpcValue> legs` - protobuf has no optional-by-omission problem for scalars and no bare-object type, so the defect cannot exist there |
+
+### 4. Reachability
+
+`VectorApiSpec` is registered as an `OpenApiContributor`, and `VectorApiSpecTest.theThreeRoutesAreDocumentedAndReachTheGeneratedDocument`
+already asserts that the routes it contributes appear in the document `OpenApiSpecGenerator` actually
+generates. The new assertions ride the same contributor, so they reach the served document, not only
+a locally-constructed `OpenAPI`.
+
+The whole generated document still validates clean after the change. Serialized with
+`io.swagger.v3.core.util.Json.pretty(new OpenApiSpecGenerator(null).generateSpec())` and fed to
+`OpenAPIV3Parser` with `resolve=true`, `SwaggerParseResult.getMessages()` came back `[]`, and the
+serialized JSON carries the new keywords in the right places:
+
+```
+"weights" : { "type" : "object", "additionalProperties" : false,
+              "properties" : { "vector" : { "minimum" : 0, "type" : "number", "default" : 1.0 }, ... } }
+"required" : [ "count", "fused", "legs", "results", "scoring", "sparse", "truncated", "vectorIndexName" ]
+"legs" : { ..., "required" : [ "vector" ] }
+hit: "required" : [ "properties", "rid", "sources" ], "properties" : { ..., "additionalProperties" : true }
+```
+
+(That check was a throwaway run, not a committed test: `OpenApiSpecGenerationIT` already validates the
+served document with the same parser, and this machine has something else on port 2480.)
+
+### 5. Residual risk
+
+The same two defects exist elsewhere in the document - 11 more bare objects (**#7577**) and roughly 34
+more component schemas with no `required` list (**#7578**). This PR does not touch them, so a client
+generated against any other part of the API keeps the same ergonomics problem until those are fixed.
+
+These six schemas also still type five closed value sets as free `string` (**#7579**), which is a third
+kind of under-description this issue did not name and this PR does not address.
+
+Nothing about the server's behaviour changes: no handler, no engine class and no wire format is
+touched. The only risk a contract change of this kind carries is marking required something the server
+may omit, which would make the document lie in the other direction; that is what
+`Issue7568VectorResponseContractMatchesBehaviourTest` exists to rule out, and it exercises the unfused
+hybrid response specifically because that is the response where `fusionStrategy` and
+`fulltextIndexName` are genuinely absent.
+
+## Implementation
+
+- `SpecBuilders.freeFormObject(String)` - new. An object declared as an open map
+  (`additionalProperties: true`), for keys that are not knowable ahead of time. Sits next to
+  `object(String)`, which stays the starting point for an object whose properties are spelled out.
+- `VectorApiSpec.createSearchResponseSchema` / `createHybridResponseSchema` /
+  `createFullTextResponseSchema` - each now calls `setRequired(...)` with the fields its writer emits
+  unconditionally.
+- `VectorApiSpec.hitSchema` - `required: [rid, properties]`, `properties` becomes a `freeFormObject`.
+- `VectorApiSpec.fusedHitSchema` - `required: [rid, sources, properties]`, same change to `properties`.
+- `VectorApiSpec.weightsSchema` - new. The three named leg weights as `number` with `minimum: 0` and
+  the fallback `HybridSearch.weightOf` applies as `default` (1.0 / 1.0 / 0.5), plus
+  `additionalProperties: false` because `validateWeights` refuses any other key outright.
+- `VectorApiSpec.legsSchema` - new. `vector` `{count}`, `fulltext` `{indexName, similarity, count}`,
+  `expand` `{direction, edgeTypes, maxDepth, truncated, seedCount, seedsTruncated, count}`, with
+  `required: [vector]`.
+
+## Tests
+
+Two new classes in `server/src/test/java/com/arcadedb/server/http/handler/openapi/`:
+
+- `Issue7568VectorResponseSchemaShapeTest` (8 tests) - the document's side. One test per fixed row, plus
+  `noSchemaInThisContributorIsABareObject`, which walks every schema this contributor registers and
+  fails with the list of bare ones. Before the fix that list read exactly
+  `[VectorSearchResponse.results[].properties, HybridSearchRequest.weights, HybridSearchResponse.legs,
+  HybridSearchResponse.results[].properties, FullTextSearchResponse.results[].properties]`.
+- `Issue7568VectorResponseContractMatchesBehaviourTest` (7 tests) - the engine's side. Builds a real
+  database with a vector index, a full-text index and an edge type, runs `VectorSearch.search`,
+  `FullTextQuery.search` and `HybridSearch.search` (unfused, fused, and expanding), and asserts that
+  every name in the corresponding schema's `required` list is a key the response actually carries. The
+  expectation is read out of `VectorApiSpec`, so it cannot drift from the document.
+
+The fourteen written before the fix all failed against the unfixed spec and pass after it; the
+fifteenth (`aHitsPropertiesMapCarriesTheRecordMarkersAlongsideTheTypesOwnProperties`) came out of the
+adversarial pass and pins the corrected description:
+
+```
+$ ./mvnw -o -pl server -am test -Dtest='Issue7568*' -Dsurefire.failIfNoSpecifiedTests=false
+   before: Tests run: 14, Failures: 11, Errors: 3
+   after:  Tests run: 15, Failures: 0, Errors: 0
+
+$ ./mvnw -o -pl server -am test -Dtest='*ApiSpec*Test,SpecBuildersTest,OpenApiSpecGeneratorTest,Issue7568*,Issue7400*' \
+      -Dsurefire.failIfNoSpecifiedTests=false
+   Tests run: 168, Failures: 0, Errors: 0, Skipped: 0 - BUILD SUCCESS
+```
+
+## Adversarial pass
+
+The orchestrator's isolated `general-purpose` subagent could not be spawned in this session (no `Task`
+tool was available to it), so the pass was run by the author re-reading the patch as the reporter
+would. That is a weaker pass by construction - the reader had already been convinced - and it is
+recorded as such. Four findings, each verified against the tree:
+
+1. **`additionalProperties: false` on `weights` claims something the server may not enforce.**
+   *Real concern, checked and held.* `HybridSearch.search` calls `validateArguments` on entry
+   (`HybridSearch.java:147`), which calls `validateWeights` (`:132`), which rejects any key that is
+   not `vector`/`fulltext`/`expand` (`:296-298`). The HTTP route reaches it through
+   `PostVectorHybridSearchHandler` -> `HybridSearch.search`. `theServerRefusesExactlyTheWeightsKeysTheSchemaRefuses`
+   now pins both halves: the three documented keys are accepted, and `graph` is refused.
+
+2. **The `properties` description said "the keys are the type's own properties". It does not hold.**
+   *Real, in scope, fixed here.* `JsonSerializer.serializeDocument` writes `@rid` (when the record has
+   an identity) and `@type` into every document it serializes (`JsonSerializer.java:100-102`,
+   `Property.RID_PROPERTY`/`TYPE_PROPERTY`). A caller reading the description would have built a map
+   key set that does not match reality. The description now names both markers, and
+   `aHitsPropertiesMapCarriesTheRecordMarkersAlongsideTheTypesOwnProperties` asserts them on a real
+   hit, so the description is verified rather than asserted. This is also the reason `properties`
+   cannot be given a closed property set instead of `additionalProperties`.
+
+3. **Five closed value sets are still documented as free `string` with the values only in prose** -
+   `fusionStrategy`, `expand.direction` (request and `legs.expand`), `results[].sources[]`, and
+   `similarity` (response and `legs.fulltext`). *Real, out of scope* - it is a third kind of
+   under-description, not one of the two this issue names. Filed as **#7579**.
+
+4. **`expand` should be closed the way `weights` is.** *Not real.* `requireExpandObject`
+   (`HybridSearch.java:260-267`) only checks that `expand` is an object; `validateExpand` (`:274-284`)
+   checks `maxDepth` and `direction` and ignores anything else. The server accepts an unknown key
+   there, so `additionalProperties: false` would make the document stricter than the server and
+   reject requests that actually work.

--- a/docs/7568-openapi-vector-response-schema-shapes.md
+++ b/docs/7568-openapi-vector-response-schema-shapes.md
@@ -236,3 +236,30 @@ recorded as such. Four findings, each verified against the tree:
    checks `maxDepth` and `direction` and ignores anything else. The server accepts an unknown key
    there, so `additionalProperties: false` would make the document stricter than the server and
    reject requests that actually work.
+
+## Review cycles
+
+### Cycle 1 - `f90129b`
+
+`claude` reviewed the patch against the engine code and confirmed every `required` list, the
+`additionalProperties: false` on `weights`, the 1.0/1.0/0.5 defaults and the open-map choice for a
+hit's `properties`. Two items, both addressed in `d?` (next commit):
+
+1. *Nit, applied.* `assertThatThrownBy` was reached through its fully-qualified name in
+   `Issue7568VectorResponseContractMatchesBehaviourTest` while `assertThat` from the same class was
+   already statically imported. Now imported.
+2. *"Possible follow-up, not a blocker" - applied here instead.* `legsSchema()`'s `fulltext` and
+   `expand` sub-objects declared no `required` list of their own. The reviewer suggested folding it
+   into #7578; it is fixed here instead, because `legsSchema()` is code this PR introduces and
+   shipping it under-described would reproduce the exact defect the PR is about, one level down.
+   Verified first: `HybridSearch` writes each sub-object as a single expression
+   (`:166` for `vector`, `:575-578` for `fulltext`, `:185-194` for `expand`), so a leg that is present
+   is present whole. `eachLegSubObjectRequiresEverythingItCarriesWhenItIsPresentAtAll` pins the
+   schemas and `theLegsAccountingMatchesTheDocumentedSubObjects` already pinned the engine's key sets
+   against them.
+
+No deferred items. CodeRabbit had not posted a review at the time of this push; it re-reviews on every
+push.
+
+`./mvnw -o -pl server -am test -Dtest='*ApiSpec*Test,SpecBuildersTest,OpenApiSpecGeneratorTest,Issue7568*,Issue7400*'`
+-> Tests run: 170, Failures: 0, Errors: 0.

--- a/docs/7568-openapi-vector-response-schema-shapes.md
+++ b/docs/7568-openapi-vector-response-schema-shapes.md
@@ -263,3 +263,34 @@ push.
 
 `./mvnw -o -pl server -am test -Dtest='*ApiSpec*Test,SpecBuildersTest,OpenApiSpecGeneratorTest,Issue7568*,Issue7400*'`
 -> Tests run: 170, Failures: 0, Errors: 0.
+
+### Cycle 2 - `fd5de1c`
+
+Both reviewers landed on this head and neither left anything actionable.
+
+- `claude`: re-verified every `required` list, the `weights` closure and defaults, and the `legs`
+  sub-object shapes field-for-field against the engine writers, and states it found no case where a
+  field is marked required that the server can omit - the failure mode that would matter here.
+  "No blocking issues found."
+- `coderabbitai`: one inline finding, on exactly the nested `legs` sub-object `required` lists that
+  cycle 1 had already fixed. It re-verified the branch itself and marked the thread
+  **"✅ Addressed in commit fd5de1c"**; the thread shows `isResolved=true`. No other threads are open.
+
+One non-blocking remark was **skipped, with rationale**: `claude` observed that this tracking doc is
+longer and more process-log-like than sibling `docs/` entries, and suggested leaving review-cycle
+narration out in future. Not applied, because the "Review cycles", "Adversarial pass" and
+"Completeness" sections are what the workflow that produced this PR requires the doc to carry - they
+are the evidence for the coverage claims, not commentary. The observation is noted here rather than in
+a separate notes file, since adding a second process document to the PR is the very thing the remark
+objects to.
+
+No deferred items and no `review-deferred-*.md` notes file: nothing in either review was actionable
+but unclear.
+
+## Final state
+
+**clean-approval** after 2 review cycles.
+
+- PR: https://github.com/ArcadeData/arcadedb/pull/7580
+- Follow-ups filed before the PR opened: #7577, #7578, #7579.
+- Merge belongs to the developer; this workflow does not merge.

--- a/docs/7569-openapi-command-ndjson-readonly-restriction.md
+++ b/docs/7569-openapi-command-ndjson-readonly-restriction.md
@@ -1,0 +1,137 @@
+# Issue #7569: OpenAPI /command declares application/x-ndjson but doesn't say streaming is read-only-only
+
+## Ledger (single finding, from the issue body)
+
+1. `POST /api/v1/command/{database}` declares `application/x-ndjson` as a `200` content type but
+   neither its `summary` nor `description` says that the ndjson response is available only for a
+   read-only statement, and that a mutating statement is refused with HTTP 400 before it runs.
+   Reporter also suggested (as an "ideally") a line noting that ndjson is selected via `Accept`.
+
+## Root cause
+
+`PostCommandHandler.requireStreamableStatement()` (server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java:492)
+refuses to stream any statement that is not provably read-only - `analyzed.isIdempotent()` and not
+DDL/CREATE/UPDATE/DELETE/SCHEMA - throwing `IllegalArgumentException` mapped to HTTP 400, before the
+statement runs. `CoreApiSpec.createCommandPath()` declares `application/x-ndjson` as a response
+media type (via `addNdJsonAlternative`) and the `Accept` parameter that selects it
+(`ndJsonAcceptParam()`), but the operation's own `description` never mentions the restriction.
+
+The `Accept`-header opt-in the reporter asked for as an "ideally" is already documented: `ndJsonAcceptParam()`
+attaches a description ("Send 'application/x-ndjson' to receive the result as a stream...") to the `Accept`
+parameter on GET query, POST query and POST command alike. That part of the ask is already satisfied - no
+change needed there.
+
+## Completeness sweep
+
+**Invariant:** every OpenAPI operation whose execution path can refuse the ndjson encoding with 400 for a
+non-read-only statement documents that restriction in its own `description`.
+
+Grep for every caller of the gate and every operation offering the ndjson media type:
+
+```
+$ grep -n "requireStreamableStatement" server/src/main/java/com/arcadedb/server/http/handler/*.java
+PostCommandHandler.java:199:      requireStreamableStatement(database, language, command);
+PostCommandHandler.java:492:  private static void requireStreamableStatement(...)
+
+$ grep -n "class PostQueryHandler" server/src/main/java/com/arcadedb/server/http/handler/PostQueryHandler.java
+public class PostQueryHandler extends PostCommandHandler {
+   // overrides only executeCommand() -> database.query(); execute() itself, including the streaming
+   // gate at line 199, is inherited unchanged.
+
+$ grep -n "requireStreamableStatement\|supportsNdJsonEncoding" server/src/main/java/com/arcadedb/server/http/handler/GetQueryHandler.java
+(no matches - GetQueryHandler streams unconditionally via a separately-implemented execute())
+```
+
+| Entry point | Calls the gate? | Status |
+|---|---|---|
+| `POST /api/v1/command/{database}` (`PostCommandHandler`) | Yes, directly | **Fixed here** - description now states the restriction |
+| `POST /api/v1/query/{database}` (`PostQueryHandler extends PostCommandHandler`) | Yes, inherited via the same `execute()` | **Fixed here** - same restriction, same shared description text, for parity with the existing `commandRequestDeclaresLimitMatchingQueryRequest` precedent of keeping shared-behavior text identical between the two operations |
+| `GET /api/v1/query/{database}/{language}/{command}` (`GetQueryHandler`) | No - separate `execute()`, calls `database.query()` directly with no analysis gate | **Filed as #7571** - there is no explicit read-only gate on this path, so nothing to document identically here; but the adversarial pass below found the absence is itself a divergence worth tracking (`BACKUP DATABASE` streams on GET while `POST /command` refuses it) |
+| `Accept` header opt-in (both POST operations, and GET query) | n/a | **Already covered** - `ndJsonAcceptParam()` already documents `Accept: application/x-ndjson` on all three operations |
+
+Every in-scope row is fixed in this PR; the one out-of-scope row is tracked by #7571.
+
+## Fix
+
+Added a shared `NDJSON_READ_ONLY_DESCRIPTION` constant to `CoreApiSpec` and appended it to the
+`description` of both `POST /api/v1/command/{database}` and `POST /api/v1/query/{database}`, kept
+byte-identical between the two operations (mirroring how `STALE_SESSION_404_DESCRIPTION` is shared).
+
+## Tests
+
+`CoreApiSpecTest.commandAndQueryDescribeTheReadOnlyStreamingRestriction()` (new) asserts:
+- both operations' `description` mention the 400 refusal and the read-only requirement;
+- the shared restriction text is identical between the two operations.
+
+## Test results
+
+`mvn -o -pl server -am test -Dtest=CoreApiSpecTest` - see run log in PR.
+
+## Residual risk
+
+This is a documentation-only change to the generated OpenAPI contract; no runtime behavior changed.
+
+The one thing this PR does NOT cover: `GET /api/v1/query/{database}/{language}/{command}` also offers
+`application/x-ndjson` and has no read-only gate at all, so it still streams a `BACKUP DATABASE` that
+`POST /command` refuses. Tracked by #7571 - see the adversarial pass below.
+
+## Adversarial pass (Phase 1.5)
+
+One finding, verified independently before filing:
+
+1. **GET `/api/v1/query/{database}/{language}/{command}` offers `application/x-ndjson` with no read-only
+   gate at all.** `GetQueryHandler.execute()` calls `database.query()` directly and never reaches
+   `PostCommandHandler.requireStreamableStatement()` (which is `private static` on a sibling class). Its
+   only stand-in is `SQLQueryEngine.query()`'s `if (!statement.isIdempotent()) throw
+   QueryNotIdempotentException`, which is strictly weaker: `BackupDatabaseStatement.isIdempotent()`
+   returns `true` while `getOperationTypes()` reports `{READ, CREATE}`, so `BACKUP DATABASE` streams on
+   GET while `POST /command` refuses it with 400.
+
+   Verified by reading `engine/src/main/java/com/arcadedb/query/sql/parser/BackupDatabaseStatement.java:56-72`
+   and `engine/src/main/java/com/arcadedb/query/sql/SQLQueryEngine.java:86-93`.
+
+   **Disposition: real, out of scope -> filed as #7571.** Out of scope because closing it means either a
+   behavior change on a third handler or a deliberate documentation of the divergence, neither of which
+   #7569 (documentation-only, about `/command`) asked for.
+
+   Narrower than the subagent framed it: the transactional hazards `requireStreamableStatement()`'s javadoc
+   describes are POST-only, since `GetQueryHandler.requiresTransaction()` returns `false` so there is no
+   auto-commit wrapper and no retry loop. #7571 says so explicitly rather than overstating the exposure.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/7572
+
+## Review cycles
+
+### Cycle 1 - 9463c26df5
+
+- **CodeRabbit:** "No actionable comments were generated." Merge risk: minimal. One pre-merge check
+  warning, "Docstring Coverage 16.67%" - **skipped as a nitpick**: the functions it counts are JUnit
+  test methods and private spec builders, and this repo documents intent in targeted javadoc/comments
+  (the new constant and the new test both carry one) rather than in per-method docstrings. Adding
+  boilerplate javadoc to satisfy a percentage would be noise.
+- **claude:** no blocking issues. Confirmed the new text matches
+  `requireStreamableStatement()`'s actual conditions, that sharing one constant between the two POST
+  operations is right, and that deferring the GET gap to #7571 keeps the PR narrow.
+- **claude, one non-blocking observation:** `requireStreamableStatement()` excludes
+  CREATE/UPDATE/DELETE/SCHEMA/DDL but not `OperationType.ADMIN`, so "if any statement reports ADMIN
+  while `isIdempotent()` returns true, it could still stream" - suggested as a possible follow-up.
+
+  **Assessed and NOT filed: the premise does not hold.** `OperationType.ADMIN` has exactly one
+  producer in the tree - `OpenCypherQueryEngine.analyze()` returns it for a `CypherAdminStatement`
+  (`engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java:116`) - and
+  `CypherAdminStatement.isReadOnly()` returns `false` unconditionally
+  (`engine/src/main/java/com/arcadedb/query/opencypher/ast/CypherAdminStatement.java:66-68`), which is
+  what `isIdempotent()` delegates to. So every ADMIN statement fails the gate's very first conjunct
+  and is refused before the operation-type set is consulted at all. There is no statement that is both
+  ADMIN and idempotent, so there is nothing to leak and no follow-up to file.
+
+  Verified by: `grep -rn "OperationType.ADMIN" --include="*.java" engine/src/main/java server/src/main/java`
+  (one hit) and reading `CypherAdminStatement`.
+
+No code changes were required by the review; no items were deferred.
+
+## Final state
+
+`clean-approval`

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -79,6 +79,15 @@ public class CoreApiSpec implements OpenApiContributor {
       "Database not found, or the session id header names a transaction that no longer resolves "
           + "(\"Remote transaction session not found or expired\")";
 
+  // Shared by POST query and POST command: PostQueryHandler extends PostCommandHandler and overrides only
+  // executeCommand(), so both reach the very same requireStreamableStatement() call in execute() before the
+  // statement runs. Held in one place so the two operations cannot describe the same gate differently (issue #7569).
+  private static final String NDJSON_READ_ONLY_DESCRIPTION = """
+      When 'Accept' requests the ndjson encoding, only a statement provably read-only may stream: one that \
+      writes - INSERT, UPDATE, DELETE, DDL, or one this analysis cannot classify - is refused with 400 before \
+      it runs, because its rows would otherwise reach the client before the transaction that produced them \
+      commits. Request the buffered 'application/json' encoding for it instead.""";
+
   @Override
   public void contribute(final OpenAPI openAPI) {
     openAPI.getPaths().addPathItem("/api/v1/server", createServerPath());
@@ -246,7 +255,7 @@ public class CoreApiSpec implements OpenApiContributor {
 
     final Operation postOp = new Operation();
     postOp.setSummary("Execute query via POST");
-    postOp.setDescription("Executes a query using POST method with query in request body");
+    postOp.setDescription("Executes a query using POST method with query in request body. " + NDJSON_READ_ONLY_DESCRIPTION);
     postOp.setOperationId("executeQueryPost");
     postOp.addTagsItem("Query");
     postOp.addParametersItem(SpecBuilders.pathParam("database", "Database name"));
@@ -266,7 +275,7 @@ public class CoreApiSpec implements OpenApiContributor {
 
     final Operation postOp = new Operation();
     postOp.setSummary("Execute command");
-    postOp.setDescription("Executes a database command");
+    postOp.setDescription("Executes a database command. " + NDJSON_READ_ONLY_DESCRIPTION);
     postOp.setOperationId("executeCommand");
     postOp.addTagsItem("Command");
     postOp.addParametersItem(SpecBuilders.pathParam("database", "Database name"));

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/SpecBuilders.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/SpecBuilders.java
@@ -167,6 +167,19 @@ public final class SpecBuilders {
     return new Schema<>().type("array").items(items).description(description);
   }
 
+  /**
+   * An object whose keys are not known ahead of time - a record's own properties, a tag map - declared as an
+   * open map. Distinct from {@link #object(String)}, which is the starting point for an object whose properties
+   * are then spelled out: a {@code type: object} left with neither {@code properties} nor
+   * {@code additionalProperties} carries no information at all, so a strict generator emits an empty model and
+   * the real content becomes unreachable through typed access (issue #7568).
+   */
+  public static Schema<Object> freeFormObject(final String description) {
+    final Schema<Object> schema = object(description);
+    schema.setAdditionalProperties(Boolean.TRUE);
+    return schema;
+  }
+
   public static Schema<?> ref(final String componentName) {
     return new Schema<>().$ref("#/components/schemas/" + componentName);
   }

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/VectorApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/VectorApiSpec.java
@@ -164,6 +164,10 @@ public class VectorApiSpec implements OpenApiContributor {
         search already returned every match it could find within 'candidateLimit'."""));
     schema.addProperty("count", SpecBuilders.integer("Number of results returned"));
     schema.addProperty("results", SpecBuilders.arrayOf(hitSchema(), "Hits, nearest or highest-scoring first"));
+    // Every one of these is written unconditionally by VectorSearch.search, so a client that has to null-check
+    // them is null-checking a case the server cannot produce. 'results' is an empty array on a search that
+    // matched nothing, not an absent field.
+    schema.setRequired(List.of("indexName", "sparse", "scoring", "candidateLimit", "truncated", "count", "results"));
     return schema;
   }
 
@@ -186,9 +190,7 @@ public class VectorApiSpec implements OpenApiContributor {
         "Full-text index the full-text leg searches. Required whenever 'fulltextQuery' is given, and refused without it"));
     schema.addProperty("fusionStrategy", SpecBuilders.string(
         "How the legs are combined. Only RRF can consume the graph expansion leg, which is ranked by traversal order"));
-    schema.addProperty("weights", SpecBuilders.object("""
-        Per-leg weight applied to every rank contribution. The only accepted keys are 'vector', 'fulltext' and \
-        'expand', and a weight for a leg the request does not ask for is refused rather than ignored."""));
+    schema.addProperty("weights", weightsSchema());
 
     final Schema<Object> expand = SpecBuilders.object("""
         Optional graph expansion leg, seeded from the union of the retrieval legs and ranked by breadth-first \
@@ -210,8 +212,7 @@ public class VectorApiSpec implements OpenApiContributor {
         "Full-text index that was searched, present whenever the full-text leg ran - including when it matched nothing"));
     schema.addProperty("sparse", SpecBuilders.bool("Whether the vector leg took the sparse path"));
     schema.addProperty("scoring", SpecBuilders.string("Scoring direction of the vector leg"));
-    schema.addProperty("legs", SpecBuilders.object(
-        "Per-leg accounting: how many rows each leg contributed, and whether the expansion hit its seed or fan-out cap"));
+    schema.addProperty("legs", legsSchema());
     schema.addProperty("fused", SpecBuilders.bool("""
         False when only one leg produced rows: fusion needs at least two sources, so the response carries that \
         leg's native distance or score instead of a fused one."""));
@@ -219,7 +220,77 @@ public class VectorApiSpec implements OpenApiContributor {
     schema.addProperty("truncated", SpecBuilders.bool("True when the result window was filled"));
     schema.addProperty("count", SpecBuilders.integer("Number of results returned"));
     schema.addProperty("results", SpecBuilders.arrayOf(fusedHitSchema(), "Fused hits, best first"));
+    // 'fulltextIndexName' and 'fusionStrategy' are the two fields this response genuinely may omit - the first
+    // when no full-text leg ran, the second when fusion did not happen - so they stay optional. Everything else
+    // is written on both the fused and the unfused branch.
+    schema.setRequired(
+        List.of("vectorIndexName", "sparse", "scoring", "legs", "fused", "truncated", "count", "results"));
     return schema;
+  }
+
+  /**
+   * The per-leg weights. Spelled out rather than left an untyped map because {@code HybridSearch.validateWeights}
+   * accepts exactly these three keys and refuses any other outright, so a generated client can reject locally
+   * what the server would reject remotely - the same contract {@link #boundedInteger} carries for the numbers.
+   */
+  private Schema<?> weightsSchema() {
+    final Schema<Object> weights = SpecBuilders.object("""
+        Per-leg weight applied to every rank contribution. The only accepted keys are 'vector', 'fulltext' and \
+        'expand', and a weight for a leg the request does not ask for is refused rather than ignored.""");
+    weights.addProperty("vector", weight("Weight of the vector leg", 1.0f));
+    weights.addProperty("fulltext", weight(
+        "Weight of the full-text leg. Refused unless the request also carries 'fulltextQuery'/'fulltextIndexName'",
+        1.0f));
+    weights.addProperty("expand", weight(
+        "Weight of the graph expansion leg. Refused unless the request also carries 'expand'", 0.5f));
+    weights.setAdditionalProperties(Boolean.FALSE);
+    return weights;
+  }
+
+  /** One leg weight: a finite number that is not negative, carrying the fallback the server applies. */
+  private Schema<?> weight(final String description, final float defaultValue) {
+    final Schema<Number> schema = SpecBuilders.number(description);
+    schema.setMinimum(BigDecimal.ZERO);
+    schema.setDefault(defaultValue);
+    return schema;
+  }
+
+  /**
+   * The per-leg accounting. A fixed set of counters rather than an open map, so a client reads
+   * {@code legs.expand.seedsTruncated} through its own type instead of through an untyped lookup.
+   */
+  private Schema<?> legsSchema() {
+    final Schema<Object> legs = SpecBuilders.object("""
+        Per-leg accounting: how many rows each leg contributed, and whether the expansion hit its seed or \
+        fan-out cap.""");
+
+    final Schema<Object> vector = SpecBuilders.object("The vector leg, which every hybrid search runs");
+    vector.addProperty("count", SpecBuilders.integer("Rows the vector leg contributed to fusion"));
+
+    final Schema<Object> fullText = SpecBuilders.object(
+        "The full-text leg, present whenever it ran - including when it matched nothing");
+    fullText.addProperty("indexName", SpecBuilders.string("Full-text index that was searched"));
+    fullText.addProperty("similarity", SpecBuilders.string("Similarity function that index scores with, e.g. BM25"));
+    fullText.addProperty("count", SpecBuilders.integer("Rows the full-text leg contributed to fusion"));
+
+    final Schema<Object> expand = SpecBuilders.object(
+        "The graph expansion leg, present whenever the request carried 'expand'");
+    expand.addProperty("direction", SpecBuilders.string("Direction walked: out, in or both"));
+    expand.addProperty("edgeTypes", SpecBuilders.arrayOf(SpecBuilders.string(null),
+        "Edge types walked; empty when the request named none, which walks them all"));
+    expand.addProperty("maxDepth", SpecBuilders.integer("Hops walked from a seed"));
+    expand.addProperty("truncated", SpecBuilders.bool("True when the expansion hit its fan-out cap"));
+    expand.addProperty("seedCount", SpecBuilders.integer("Seeds the retrieval legs supplied"));
+    expand.addProperty("seedsTruncated", SpecBuilders.bool("""
+        True when the seed budget capped the seed list, so a thin neighborhood is the cap's doing rather than \
+        the graph's."""));
+    expand.addProperty("count", SpecBuilders.integer("Rows the expansion leg contributed to fusion"));
+
+    legs.addProperty("vector", vector);
+    legs.addProperty("fulltext", fullText);
+    legs.addProperty("expand", expand);
+    legs.setRequired(List.of("vector"));
+    return legs;
   }
 
   private Schema<?> createFullTextRequestSchema() {
@@ -242,6 +313,7 @@ public class VectorApiSpec implements OpenApiContributor {
     schema.addProperty("similarity", SpecBuilders.string("Similarity function the index scores with, e.g. BM25"));
     schema.addProperty("count", SpecBuilders.integer("Number of results returned"));
     schema.addProperty("results", SpecBuilders.arrayOf(hitSchema(), "Hits, highest score first"));
+    schema.setRequired(List.of("indexName", "similarity", "count", "results"));
     return schema;
   }
 
@@ -250,7 +322,12 @@ public class VectorApiSpec implements OpenApiContributor {
     hit.addProperty("rid", SpecBuilders.string("Record id of the hit"));
     hit.addProperty("distance", SpecBuilders.number("Dense vector distance, lower is better. Absent on a scored hit"));
     hit.addProperty("score", SpecBuilders.number("Sparse or full-text score, higher is better. Absent on a distance hit"));
-    hit.addProperty("properties", SpecBuilders.object("The record's properties"));
+    hit.addProperty("properties", SpecBuilders.freeFormObject("""
+        The record's properties. An open map: besides the type's own properties it carries the record's '@rid' \
+        and '@type', which JsonSerializer writes into every serialized document."""));
+    // Which of 'distance' and 'score' a hit carries depends on the index, so neither can be required; the record
+    // id and the properties are on every hit the two callers of this schema produce.
+    hit.setRequired(List.of("rid", "properties"));
     return hit;
   }
 
@@ -268,7 +345,12 @@ public class VectorApiSpec implements OpenApiContributor {
     hit.addProperty("depth", SpecBuilders.integer("Hops from the seed, for a hit the expansion leg contributed"));
     hit.addProperty("path", SpecBuilders.arrayOf(SpecBuilders.string(null),
         "Record ids from the seed to this hit, seed included"));
-    hit.addProperty("properties", SpecBuilders.object("The record's properties"));
+    hit.addProperty("properties", SpecBuilders.freeFormObject("""
+        The record's properties. An open map: besides the type's own properties it carries the record's '@rid' \
+        and '@type', which JsonSerializer writes into every serialized document."""));
+    // 'sources' is written on both the fused and the unfused branch. The three score fields are mutually
+    // exclusive, and 'depth'/'path' belong to an expansion hit only.
+    hit.setRequired(List.of("rid", "sources", "properties"));
     return hit;
   }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/VectorApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/VectorApiSpec.java
@@ -266,12 +266,16 @@ public class VectorApiSpec implements OpenApiContributor {
 
     final Schema<Object> vector = SpecBuilders.object("The vector leg, which every hybrid search runs");
     vector.addProperty("count", SpecBuilders.integer("Rows the vector leg contributed to fusion"));
+    vector.setRequired(List.of("count"));
 
     final Schema<Object> fullText = SpecBuilders.object(
         "The full-text leg, present whenever it ran - including when it matched nothing");
     fullText.addProperty("indexName", SpecBuilders.string("Full-text index that was searched"));
     fullText.addProperty("similarity", SpecBuilders.string("Similarity function that index scores with, e.g. BM25"));
     fullText.addProperty("count", SpecBuilders.integer("Rows the full-text leg contributed to fusion"));
+    // Each sub-object is written as one expression, so a leg that is present is present whole: there is no
+    // state in which 'fulltext' exists without its index name. Same for 'expand' below.
+    fullText.setRequired(List.of("indexName", "similarity", "count"));
 
     final Schema<Object> expand = SpecBuilders.object(
         "The graph expansion leg, present whenever the request carried 'expand'");
@@ -285,6 +289,8 @@ public class VectorApiSpec implements OpenApiContributor {
         True when the seed budget capped the seed list, so a thin neighborhood is the cap's doing rather than \
         the graph's."""));
     expand.addProperty("count", SpecBuilders.integer("Rows the expansion leg contributed to fusion"));
+    expand.setRequired(List.of("direction", "edgeTypes", "maxDepth", "truncated", "seedCount", "seedsTruncated",
+        "count"));
 
     legs.addProperty("vector", vector);
     legs.addProperty("fulltext", fullText);

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
@@ -287,6 +287,45 @@ class CoreApiSpecTest {
     }
   }
 
+  /**
+   * Issue #7569: both operations declare 'application/x-ndjson' under their 200, but
+   * PostCommandHandler.requireStreamableStatement() refuses to stream a statement that is not
+   * provably read-only with a 400 before it ever runs - and nothing in the contract said so. A
+   * client author reading the contract alone had no way to know the restriction existed short of
+   * sending a mutating statement at a live server and reading the 400.
+   * <p>
+   * Checked on both /command and /query: PostQueryHandler extends PostCommandHandler and overrides
+   * only executeCommand(), so the very same requireStreamableStatement() call at execute() time
+   * guards both operations identically (the same sharing this file already pins down for 'limit'
+   * in commandRequestDeclaresLimitMatchingQueryRequest).
+   */
+  @Test
+  void commandAndQueryDescribeTheReadOnlyStreamingRestriction() {
+    // The literal text CoreApiSpec appends to both operations' description. Duplicated here rather
+    // than referencing the (private) production constant, matching how this file already pins other
+    // shared text verbatim (e.g. STALE_SESSION_404_DESCRIPTION's message in
+    // queryAndCommand404CoversAStaleSessionIdNotOnlyAMissingDatabase).
+    final String restriction = "only a statement provably read-only may stream";
+
+    final Operation command = openAPI.getPaths().get("/api/v1/command/{database}").getPost();
+    final Operation query = openAPI.getPaths().get("/api/v1/query/{database}").getPost();
+
+    for (final Operation operation : List.of(command, query)) {
+      assertThat(operation.getDescription())
+          .as(operation.getOperationId() + " must warn that the ndjson encoding is refused before "
+              + "it runs for a statement that is not provably read-only")
+          .contains(restriction)
+          .contains("400");
+    }
+
+    final String commandSuffix = command.getDescription().substring(command.getDescription().indexOf(restriction));
+    final String querySuffix = query.getDescription().substring(query.getDescription().indexOf(restriction));
+    assertThat(commandSuffix)
+        .as("both operations run through the exact same requireStreamableStatement() check, so the "
+            + "restriction text must not diverge between them and confuse a reader of the generated docs")
+        .isEqualTo(querySuffix);
+  }
+
   @Test
   void commandRequestDeclaresLanguageAsRequired() {
     final Schema<?> schema = openAPI.getComponents().getSchemas().get("CommandRequest");

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/Issue7568VectorResponseContractMatchesBehaviourTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/Issue7568VectorResponseContractMatchesBehaviourTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Issue #7568: the behaviour half of the contract. The {@code required} list a generated client trusts is only
@@ -238,8 +239,8 @@ class Issue7568VectorResponseContractMatchesBehaviourTest extends TestHelper {
 
     // ... and a key the document does not declare is refused, which is what additionalProperties:false says.
     assertThat(weights.getAdditionalProperties()).isEqualTo(Boolean.FALSE);
-    org.assertj.core.api.Assertions.assertThatThrownBy(() -> HybridSearch.search(database,
-            hybridArgs().put("weights", new JSONObject().put("graph", 1.0))))
+    assertThatThrownBy(() -> HybridSearch.search(database,
+        hybridArgs().put("weights", new JSONObject().put("graph", 1.0))))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Unknown weights key");
   }

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/Issue7568VectorResponseContractMatchesBehaviourTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/Issue7568VectorResponseContractMatchesBehaviourTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler.openapi;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.search.FullTextQuery;
+import com.arcadedb.query.search.HybridSearch;
+import com.arcadedb.query.search.VectorSearch;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.media.Schema;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7568: the behaviour half of the contract. The {@code required} list a generated client trusts is only
+ * worth trusting if the search code really does send those fields on every path, so this drives the three engine
+ * entry points against a live database and reads the expectation straight out of {@link VectorApiSpec} - the
+ * assertion cannot drift from the document because it is derived from it.
+ * <p>
+ * The handlers ({@code PostVectorSearchHandler}, {@code PostVectorHybridSearchHandler},
+ * {@code PostVectorFullTextSearchHandler}) return these objects unaltered, so the response body the route emits
+ * is the object built here.
+ *
+ * @see <a href="https://github.com/ArcadeData/arcadedb/issues/7568">issue #7568</a>
+ */
+class Issue7568VectorResponseContractMatchesBehaviourTest extends TestHelper {
+  private static final String VERTEX_TYPE   = "Doc7568";
+  private static final String EDGE_TYPE     = "Link7568";
+  private static final String VECTOR_INDEX  = VERTEX_TYPE + "[embedding]";
+  private static final String TEXT_INDEX    = VERTEX_TYPE + "[body]";
+
+  private final OpenAPI openAPI = new OpenAPI();
+
+  @BeforeEach
+  void contributeAndSeed() {
+    openAPI.setPaths(new Paths());
+    openAPI.setComponents(new Components());
+    new VectorApiSpec().contribute(openAPI);
+
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE " + VERTEX_TYPE);
+      database.command("sql", "CREATE PROPERTY " + VERTEX_TYPE + ".embedding ARRAY_OF_FLOATS");
+      database.command("sql", "CREATE PROPERTY " + VERTEX_TYPE + ".body STRING");
+      database.command("sql", "CREATE INDEX ON " + VERTEX_TYPE + " (embedding) LSM_VECTOR "
+          + "METADATA { dimensions: 3, similarity: 'COSINE' }");
+      database.command("sql", "CREATE INDEX ON " + VERTEX_TYPE + " (body) FULL_TEXT");
+      database.command("sql", "CREATE EDGE TYPE " + EDGE_TYPE);
+
+      final var first = database.newVertex(VERTEX_TYPE)
+          .set("embedding", new float[] { 1.0f, 0.0f, 0.0f }).set("body", "alpha beta").save();
+      final var second = database.newVertex(VERTEX_TYPE)
+          .set("embedding", new float[] { 0.9f, 0.1f, 0.0f }).set("body", "alpha gamma").save();
+      final var third = database.newVertex(VERTEX_TYPE)
+          .set("embedding", new float[] { 0.0f, 1.0f, 0.0f }).set("body", "delta").save();
+
+      first.newEdge(EDGE_TYPE, second).save();
+      second.newEdge(EDGE_TYPE, third).save();
+    });
+  }
+
+  private Schema<?> schema(final String name) {
+    return openAPI.getComponents().getSchemas().get(name);
+  }
+
+  /**
+   * Asserts the document's promise against one real response: every name in {@code required} is a key the
+   * response actually carries.
+   */
+  private void assertDocumentedRequiredFieldsArePresent(final String schemaName, final JSONObject response) {
+    final List<String> required = schema(schemaName).getRequired();
+    assertThat(required)
+        .as(schemaName + " must declare a required list, or a generated client types every field as optional")
+        .isNotNull().isNotEmpty();
+
+    for (final String field : required)
+      assertThat(response.has(field)).as(schemaName + " promises '" + field + "', response was " + response).isTrue();
+  }
+
+  /** The same check for the hits, which is where a caller spends most of its null-checking. */
+  private void assertDocumentedRequiredHitFieldsArePresent(final String schemaName, final JSONObject response) {
+    final List<String> required =
+        ((Schema<?>) schema(schemaName).getProperties().get("results")).getItems().getRequired();
+    assertThat(required).as(schemaName + ".results[] required list").isNotNull().isNotEmpty();
+
+    final JSONArray results = response.getJSONArray("results");
+    assertThat(results.length()).as(schemaName + " needs at least one hit for this assertion to mean anything")
+        .isGreaterThan(0);
+    for (int i = 0; i < results.length(); i++) {
+      final JSONObject hit = results.getJSONObject(i);
+      for (final String field : required)
+        assertThat(hit.has(field)).as(schemaName + " hit promises '" + field + "', hit was " + hit).isTrue();
+    }
+  }
+
+  private JSONObject vectorArgs() {
+    return new JSONObject()
+        .put("indexName", VECTOR_INDEX)
+        .put("queryVector", new JSONArray(new Object[] { 1.0f, 0.0f, 0.0f }))
+        .put("k", 5);
+  }
+
+  private JSONObject hybridArgs() {
+    return new JSONObject()
+        .put("vectorIndexName", VECTOR_INDEX)
+        .put("queryVector", new JSONArray(new Object[] { 1.0f, 0.0f, 0.0f }))
+        .put("k", 5);
+  }
+
+  @Test
+  void theVectorSearchResponseCarriesEveryFieldItsSchemaRequires() {
+    final JSONObject response = VectorSearch.search(database, vectorArgs());
+
+    assertDocumentedRequiredFieldsArePresent("VectorSearchResponse", response);
+    assertDocumentedRequiredHitFieldsArePresent("VectorSearchResponse", response);
+  }
+
+  /**
+   * {@code properties} is declared an open map, and the schema description says what a caller finds in it. The
+   * record's own properties are only part of the answer: {@code JsonSerializer.serializeDocument} writes
+   * {@code @rid} and {@code @type} into every document it serializes, so the map's keys are not the type's
+   * property names alone - which is why it cannot be given a closed set of {@code properties} instead.
+   */
+  @Test
+  void aHitsPropertiesMapCarriesTheRecordMarkersAlongsideTheTypesOwnProperties() {
+    final JSONObject hit = VectorSearch.search(database, vectorArgs()).getJSONArray("results").getJSONObject(0);
+
+    assertThat(hit.getJSONObject("properties").keySet())
+        .contains("@rid", "@type")
+        .contains("embedding", "body");
+  }
+
+  @Test
+  void theFullTextSearchResponseCarriesEveryFieldItsSchemaRequires() {
+    final JSONObject response = FullTextQuery.search(database,
+        new JSONObject().put("indexName", TEXT_INDEX).put("queryText", "alpha").put("limit", 5));
+
+    assertDocumentedRequiredFieldsArePresent("FullTextSearchResponse", response);
+    assertDocumentedRequiredHitFieldsArePresent("FullTextSearchResponse", response);
+  }
+
+  /**
+   * One leg, so no fusion. This is the path that proves {@code fusionStrategy} is rightly left out of the
+   * required list: declaring it required would make the document lie on exactly this response.
+   */
+  @Test
+  void theUnfusedHybridResponseCarriesEveryFieldItsSchemaRequiresAndNoFusionStrategy() {
+    final JSONObject response = HybridSearch.search(database, hybridArgs());
+
+    assertDocumentedRequiredFieldsArePresent("HybridSearchResponse", response);
+    assertDocumentedRequiredHitFieldsArePresent("HybridSearchResponse", response);
+
+    assertThat(response.getBoolean("fused")).isFalse();
+    assertThat(response.has("fusionStrategy")).isFalse();
+    assertThat(response.has("fulltextIndexName")).isFalse();
+  }
+
+  /** Two legs, so fusion runs and the two conditional fields do appear - both still legitimately optional. */
+  @Test
+  void theFusedHybridResponseCarriesEveryFieldItsSchemaRequires() {
+    final JSONObject response = HybridSearch.search(database,
+        hybridArgs().put("fulltextIndexName", TEXT_INDEX).put("fulltextQuery", "alpha"));
+
+    assertDocumentedRequiredFieldsArePresent("HybridSearchResponse", response);
+    assertDocumentedRequiredHitFieldsArePresent("HybridSearchResponse", response);
+
+    assertThat(response.getBoolean("fused")).isTrue();
+    assertThat(response.has("fusionStrategy")).isTrue();
+    assertThat(response.has("fulltextIndexName")).isTrue();
+  }
+
+  /**
+   * The per-leg accounting is no longer an untyped map, so what the document spells out under {@code legs} has
+   * to be exactly what the engine puts there - for each of the three legs, on the request that runs it.
+   */
+  @Test
+  void theLegsAccountingMatchesTheDocumentedSubObjects() {
+    final JSONObject response = HybridSearch.search(database,
+        hybridArgs()
+            .put("fulltextIndexName", TEXT_INDEX)
+            .put("fulltextQuery", "alpha")
+            .put("expand", new JSONObject().put("maxDepth", 1).put("direction", "out")
+                .put("edgeTypes", new JSONArray(new Object[] { EDGE_TYPE }))));
+
+    final Schema<?> legsSchema = (Schema<?>) schema("HybridSearchResponse").getProperties().get("legs");
+    final JSONObject legs = response.getJSONObject("legs");
+
+    assertThat(legs.keySet()).containsExactlyInAnyOrder("vector", "fulltext", "expand");
+    for (final String leg : List.of("vector", "fulltext", "expand")) {
+      final Schema<?> documented = (Schema<?>) legsSchema.getProperties().get(leg);
+      assertThat(documented).as("legs." + leg + " must be documented").isNotNull();
+      assertThat(legs.getJSONObject(leg).keySet())
+          .as("legs." + leg + " keys must be exactly the ones the document names")
+          .containsExactlyInAnyOrderElementsOf(documented.getProperties().keySet());
+    }
+  }
+
+  /**
+   * {@code weights} is documented as a closed map of three numbers. The closure is the server's own rule, so it
+   * is checked here rather than only asserted on the schema.
+   */
+  @Test
+  void theServerRefusesExactlyTheWeightsKeysTheSchemaRefuses() {
+    final Schema<?> weights =
+        (Schema<?>) schema("HybridSearchRequest").getProperties().get("weights");
+
+    // Every documented key is accepted on a request that owns the matching leg.
+    final JSONObject accepted = HybridSearch.search(database,
+        hybridArgs()
+            .put("fulltextIndexName", TEXT_INDEX)
+            .put("fulltextQuery", "alpha")
+            .put("expand", new JSONObject().put("maxDepth", 1))
+            .put("weights", new JSONObject().put("vector", 1.0).put("fulltext", 2.0).put("expand", 0.25)));
+    assertThat(accepted.getBoolean("fused")).isTrue();
+
+    // ... and a key the document does not declare is refused, which is what additionalProperties:false says.
+    assertThat(weights.getAdditionalProperties()).isEqualTo(Boolean.FALSE);
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> HybridSearch.search(database,
+            hybridArgs().put("weights", new JSONObject().put("graph", 1.0))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unknown weights key");
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/Issue7568VectorResponseSchemaShapeTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/Issue7568VectorResponseSchemaShapeTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler.openapi;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.media.Schema;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7568: the shape half of the contract, asserted against the document {@link VectorApiSpec} builds.
+ * <p>
+ * The three request schemas declared a {@code required} list and the three response schemas declared none, so a
+ * generated client typed {@code count}, {@code results} and {@code indexName} as optional even though the server
+ * always sends them - every caller in a statically typed language then null-checks a field that cannot be absent.
+ * Three further properties were {@code {"type": "object"}} with neither {@code properties} nor
+ * {@code additionalProperties}, which a strict generator emits as an empty model whose real content is
+ * unreachable through typed access.
+ * <p>
+ * {@link Issue7568VectorResponseContractMatchesBehaviourTest} is the other half: it drives the engine and checks
+ * that what is declared required here is what the search code actually emits.
+ *
+ * @see <a href="https://github.com/ArcadeData/arcadedb/issues/7568">issue #7568</a>
+ */
+class Issue7568VectorResponseSchemaShapeTest {
+  private final OpenAPI openAPI = new OpenAPI();
+
+  @BeforeEach
+  void contribute() {
+    openAPI.setPaths(new Paths());
+    openAPI.setComponents(new Components());
+    new VectorApiSpec().contribute(openAPI);
+  }
+
+  private Schema<?> schema(final String name) {
+    return openAPI.getComponents().getSchemas().get(name);
+  }
+
+  private static Schema<?> property(final Schema<?> owner, final String name) {
+    return (Schema<?>) owner.getProperties().get(name);
+  }
+
+  /** The hit schema of a response, reached through {@code results[]}. */
+  private static Schema<?> hitOf(final Schema<?> response) {
+    return property(response, "results").getItems();
+  }
+
+  @Test
+  void theVectorSearchResponseRequiresEveryFieldTheSearchAlwaysSends() {
+    final Schema<?> response = schema("VectorSearchResponse");
+
+    assertThat(response.getRequired())
+        .as("VectorSearch.search puts all seven unconditionally, so none of them is optional to a client")
+        .containsExactlyInAnyOrder("indexName", "sparse", "scoring", "candidateLimit", "truncated", "count",
+            "results");
+    // Nothing may be required that the schema does not even declare, or the document does not validate.
+    assertThat(response.getProperties().keySet()).containsAll(response.getRequired());
+  }
+
+  @Test
+  void theFullTextSearchResponseRequiresEveryFieldTheSearchAlwaysSends() {
+    final Schema<?> response = schema("FullTextSearchResponse");
+
+    assertThat(response.getRequired())
+        .containsExactlyInAnyOrder("indexName", "similarity", "count", "results");
+    assertThat(response.getProperties().keySet()).containsAll(response.getRequired());
+  }
+
+  /**
+   * The hybrid response is the one where {@code required} has to discriminate: two of its ten fields are
+   * genuinely conditional, and marking either of them required would make the contract lie in the other
+   * direction.
+   */
+  @Test
+  void theHybridSearchResponseRequiresTheUnconditionalFieldsAndOnlyThose() {
+    final Schema<?> response = schema("HybridSearchResponse");
+
+    assertThat(response.getRequired())
+        .containsExactlyInAnyOrder("vectorIndexName", "sparse", "scoring", "legs", "fused", "truncated", "count",
+            "results");
+    assertThat(response.getRequired())
+        .as("'fulltextIndexName' is sent only when the full-text leg ran, 'fusionStrategy' only when fused is true")
+        .doesNotContain("fulltextIndexName", "fusionStrategy");
+    assertThat(response.getProperties().keySet()).containsAll(response.getRequired());
+  }
+
+  /**
+   * The hits are what a caller actually reads. A hit always carries its record id and its properties; which of
+   * {@code distance} / {@code score} / {@code fusedScore} it carries depends on the index and on whether fusion
+   * ran, so none of those three can be required.
+   */
+  @Test
+  void everyHitRequiresTheFieldsPresentOnEveryHit() {
+    final Schema<?> vectorHit = hitOf(schema("VectorSearchResponse"));
+    assertThat(vectorHit.getRequired()).containsExactlyInAnyOrder("rid", "properties");
+    assertThat(vectorHit.getRequired()).doesNotContain("distance", "score");
+
+    final Schema<?> fullTextHit = hitOf(schema("FullTextSearchResponse"));
+    assertThat(fullTextHit.getRequired()).containsExactlyInAnyOrder("rid", "properties");
+
+    final Schema<?> fusedHit = hitOf(schema("HybridSearchResponse"));
+    assertThat(fusedHit.getRequired())
+        .as("both the fused and the unfused branch name the legs a hit came from")
+        .containsExactlyInAnyOrder("rid", "sources", "properties");
+    assertThat(fusedHit.getRequired())
+        .as("'depth' and 'path' belong to an expansion hit only")
+        .doesNotContain("fusedScore", "score", "distance", "depth", "path");
+  }
+
+  /**
+   * {@code weights} is a closed map: {@code HybridSearch.validateWeights} refuses any other key outright, so the
+   * document says so rather than leaving a client to discover it as a 400.
+   */
+  @Test
+  void theWeightsMapDeclaresItsThreeLegsAndRefusesAnythingElse() {
+    final Schema<?> weights = property(schema("HybridSearchRequest"), "weights");
+
+    assertThat(weights.getProperties().keySet()).containsExactlyInAnyOrder("vector", "fulltext", "expand");
+    assertThat(weights.getAdditionalProperties())
+        .as("an unknown weights key is rejected by the server, so the schema must reject it too")
+        .isEqualTo(Boolean.FALSE);
+
+    for (final String leg : List.of("vector", "fulltext", "expand")) {
+      final Schema<?> weight = property(weights, leg);
+      assertThat(weight.getType()).as(leg).isEqualTo("number");
+      assertThat(weight.getMinimum()).as(leg + " must be a finite number that is not negative")
+          .isEqualTo(BigDecimal.ZERO);
+    }
+    // The defaults are the fallbacks HybridSearch.weightOf actually applies.
+    assertThat(property(weights, "vector").getDefault()).isEqualTo(1.0f);
+    assertThat(property(weights, "fulltext").getDefault()).isEqualTo(1.0f);
+    assertThat(property(weights, "expand").getDefault()).isEqualTo(0.5f);
+  }
+
+  /**
+   * {@code legs} is the opposite case: a fixed set of per-leg counters, so its sub-objects are spelled out
+   * instead of being collapsed into an untyped map.
+   */
+  @Test
+  void theLegsAccountingDeclaresOneSubObjectPerLeg() {
+    final Schema<?> legs = property(schema("HybridSearchResponse"), "legs");
+
+    assertThat(legs.getProperties().keySet()).containsExactlyInAnyOrder("vector", "fulltext", "expand");
+    assertThat(legs.getRequired())
+        .as("the vector leg always runs; the other two run only when the request asks for them")
+        .containsExactly("vector");
+
+    assertThat(property(legs, "vector").getProperties().keySet()).containsExactly("count");
+    assertThat(property(legs, "fulltext").getProperties().keySet())
+        .containsExactlyInAnyOrder("indexName", "similarity", "count");
+    assertThat(property(legs, "expand").getProperties().keySet())
+        .containsExactlyInAnyOrder("direction", "edgeTypes", "maxDepth", "truncated", "seedCount", "seedsTruncated",
+            "count");
+  }
+
+  /**
+   * A record's properties are arbitrary, so this one stays a map - but an open map, declared as such, rather
+   * than a bare object a generator turns into an empty model.
+   */
+  @Test
+  void aHitsPropertiesAreDeclaredAnOpenMapRatherThanAnEmptyModel() {
+    for (final String responseName : List.of("VectorSearchResponse", "HybridSearchResponse",
+        "FullTextSearchResponse")) {
+      final Schema<?> properties = property(hitOf(schema(responseName)), "properties");
+      assertThat(properties.getAdditionalProperties()).as(responseName).isEqualTo(Boolean.TRUE);
+    }
+  }
+
+  /**
+   * The sweep that keeps the two fixes from decaying one property at a time: every object anywhere in the six
+   * components this contributor registers says what it holds.
+   */
+  @Test
+  void noSchemaInThisContributorIsABareObject() {
+    final List<String> bare = new ArrayList<>();
+    for (final Map.Entry<String, Schema> entry : openAPI.getComponents().getSchemas().entrySet())
+      collectBareObjects(entry.getKey(), entry.getValue(), bare);
+
+    assertThat(bare)
+        .as("a 'type: object' with neither 'properties' nor 'additionalProperties' generates an empty model")
+        .isEmpty();
+  }
+
+  private static void collectBareObjects(final String path, final Schema<?> schema, final List<String> bare) {
+    if (schema == null || schema.get$ref() != null)
+      return;
+
+    if ("object".equals(schema.getType())
+        && (schema.getProperties() == null || schema.getProperties().isEmpty())
+        && schema.getAdditionalProperties() == null)
+      bare.add(path);
+
+    if (schema.getProperties() != null)
+      for (final Map.Entry<String, Schema> entry : schema.getProperties().entrySet())
+        collectBareObjects(path + "." + entry.getKey(), entry.getValue(), bare);
+
+    if (schema.getItems() != null)
+      collectBareObjects(path + "[]", schema.getItems(), bare);
+
+    if (schema.getAdditionalProperties() instanceof final Schema<?> values)
+      collectBareObjects(path + ".*", values, bare);
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/Issue7568VectorResponseSchemaShapeTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/Issue7568VectorResponseSchemaShapeTest.java
@@ -179,6 +179,24 @@ class Issue7568VectorResponseSchemaShapeTest {
   }
 
   /**
+   * Whether a leg is present is conditional; what a present leg holds is not. Each sub-object is written as a
+   * single expression in {@code HybridSearch}, so a leg that appears appears whole - there is no state in which
+   * {@code legs.fulltext} exists without its index name. Leaving these lists off would have reproduced, one level
+   * down, the very defect this fix is about.
+   */
+  @Test
+  void eachLegSubObjectRequiresEverythingItCarriesWhenItIsPresentAtAll() {
+    final Schema<?> legs = property(schema("HybridSearchResponse"), "legs");
+
+    for (final String leg : List.of("vector", "fulltext", "expand")) {
+      final Schema<?> subObject = property(legs, leg);
+      assertThat(subObject.getRequired())
+          .as("legs." + leg + " is written whole or not at all")
+          .containsExactlyInAnyOrderElementsOf(subObject.getProperties().keySet());
+    }
+  }
+
+  /**
    * A record's properties are arbitrary, so this one stays a map - but an open map, declared as such, rather
    * than a bare object a generator turns into an empty model.
    */

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -3385,6 +3385,19 @@ function renderTypeLink(typeName) {
 const LIGHTWEIGHT_EDGE_HINT = "LIGHTWEIGHT: edges are stored inside the vertices, so this type keeps no records. "
   + "Query them with SELECT FROM <type> or by traversing the vertices.";
 
+// A section header sums each type's record count for a rough total. A LIGHTWEIGHT edge type reports 0
+// records by construction (see LIGHTWEIGHT_EDGE_HINT above), so a section that contains one is a lower
+// bound, not the true count - marked with a trailing "+" rather than shown as if it were exact.
+function formatSectionTotal(items) {
+  let total = 0;
+  let hasLightweight = false;
+  for (let j = 0; j < items.length; j++) {
+    total += (items[j].records || 0);
+    if (items[j].lightweight === true) hasLightweight = true;
+  }
+  return total.toLocaleString() + (hasLightweight ? "+" : "");
+}
+
 function renderTypeSidebarBadge(row, color, action) {
   let name = escapeHtml(row.name);
   let lightweight = row.lightweight === true;
@@ -3514,11 +3527,8 @@ function displaySchema(onReady) {
       let sec = sections[s];
       let items = groups[sec.key];
 
-      let total = 0;
-      for (let j = 0; j < items.length; j++) total += (items[j].records || 0);
-
       html += "<div class='sidebar-section'>";
-      html += "<div class='sidebar-section-header'><i class='fa " + sec.icon + "'></i> " + sec.label + " <span class='sidebar-count'>(" + total.toLocaleString() + ")</span>";
+      html += "<div class='sidebar-section-header'><i class='fa " + sec.icon + "'></i> " + sec.label + " <span class='sidebar-count'>(" + formatSectionTotal(items) + ")</span>";
       if (sec.key == "timeseries")
         html += "<span class='sidebar-section-header-actions'><button onclick='createTimeSeriesType(); return false;' title='Create timeseries type'><i class='fa fa-plus'></i></button></span>";
       else
@@ -3804,13 +3814,11 @@ function populateQuerySidebar() {
   }
 
   let groups = { vertex: [], edge: [], document: [], timeseries: [] };
-  let totals = { vertex: 0, edge: 0, document: 0, timeseries: 0 };
 
   for (let i in globalSchemaTypes) {
     let row = globalSchemaTypes[i];
     let cat = row.type == "vertex" ? "vertex" : (row.type == "edge" ? "edge" : (row.type == "t" ? "timeseries" : "document"));
     groups[cat].push(row);
-    totals[cat] += (row.records || 0);
   }
 
   let html = "";
@@ -3826,7 +3834,7 @@ function populateQuerySidebar() {
     let items = groups[sec.key];
     if (items.length == 0) continue;
 
-    let totalFormatted = totals[sec.key].toLocaleString();
+    let totalFormatted = formatSectionTotal(items);
     html += "<div class='sidebar-section'>";
     html += "<div class='sidebar-section-header'><i class='fa " + sec.icon + "'></i> " + sec.label + " <span class='sidebar-count'>(" + totalFormatted + ")</span></div>";
     html += "<div class='sidebar-badges'>";

--- a/studio/test/sidebar-section-total.test.js
+++ b/studio/test/sidebar-section-total.test.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+
+// Regression test, from discussion #7473 (comment https://github.com/ArcadeData/arcadedb/discussions/7473#discussioncomment-18408772)
+// after issue #7477 was fixed: the sidebar badge of a LIGHTWEIGHT edge type correctly stopped showing its
+// record count (0) as its size, but the section header above it - "Edges (N)" - still summed the raw
+// `records` field of every type in the section. A LIGHTWEIGHT type reports 0 records by construction, so a
+// graph holding a million lightweight edges still showed "Edges (0)" at the top of the sidebar. The total is
+// now marked with a trailing "+" whenever the section holds a type it cannot count, instead of presenting a
+// wrong number as if it were exact.
+//
+// Run with:
+//
+//     node --test studio/test/sidebar-section-total.test.js
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const SRC_PATH = path.join(__dirname, "..", "src", "main", "resources", "static", "js", "studio-database.js");
+const src = fs.readFileSync(SRC_PATH, "utf8");
+
+function extractFn(name) {
+  const start = src.indexOf("function " + name + "(");
+  if (start < 0) throw new Error("function not found in studio-database.js: " + name);
+  let i = src.indexOf("{", start);
+  let depth = 1;
+  i++;
+  while (i < src.length && depth > 0) {
+    const c = src[i];
+    if (c === "{") depth++;
+    else if (c === "}") depth--;
+    i++;
+  }
+  return src.substring(start, i);
+}
+
+eval(extractFn("formatSectionTotal"));
+
+test("a section with only regular types shows the exact sum", () => {
+  const total = formatSectionTotal([{ records: 3 }, { records: 4 }]);
+  assert.equal(total, "7");
+});
+
+test("a section holding a LIGHTWEIGHT edge type marks its total as a lower bound", () => {
+  const total = formatSectionTotal([{ records: 0, lightweight: true }]);
+  assert.equal(total, "0+", "a graph full of lightweight edges must not read as an empty section");
+});
+
+test("a mixed section still adds the regular types' records and marks the total", () => {
+  const total = formatSectionTotal([{ records: 5, lightweight: false }, { records: 0, lightweight: true }]);
+  assert.equal(total, "5+");
+});
+
+test("an empty section shows a plain zero", () => {
+  const total = formatSectionTotal([]);
+  assert.equal(total, "0");
+});
+
+test("a type listing from an older server, with no lightweight flag, is unaffected", () => {
+  const total = formatSectionTotal([{ records: 7 }, { records: 3 }]);
+  assert.equal(total, "10");
+});


### PR DESCRIPTION
Closes #7568

## Summary

Both problems the issue reports are in the contract, not in the server's behaviour, and this PR touches
no handler and no engine class: the JSON on the wire is identical before and after.

`VectorApiSpec`'s three *request* schemas declared a `required` list and its three *response* schemas
declared none, so a generated client typed `count`, `results` and `indexName` as optional even though
the server writes them unconditionally - every caller in a statically typed language then null-checks a
case the server cannot produce. Each response schema now names the fields its writer emits on every
path, read off `VectorSearch.search`, `HybridSearch.search` and `FullTextQuery.search`, and the two hit
schemas they reach through `results[]` get one too. `fulltextIndexName` and `fusionStrategy` stay
optional deliberately: they are the two fields the hybrid response genuinely may omit, and marking them
required would make the document lie in the other direction. For the three bare `object` properties the
fix differs by intent, as the issue suggested: `weights` becomes a **closed** object of three named,
non-negative numbers carrying the defaults `HybridSearch.weightOf` applies, because `validateWeights`
refuses any other key outright; `legs` becomes the three per-leg sub-objects it really holds, with
`vector` required; and a hit's `properties` becomes an **open** map (`additionalProperties: true`),
since `JsonSerializer.serializeDocument` writes the record's own properties plus the `@rid` and `@type`
markers and the key set is therefore not knowable ahead of time.

## Test plan

- [x] `./mvnw -o -pl server -am test -Dtest='Issue7568*' -Dsurefire.failIfNoSpecifiedTests=false` - 15 tests. The fourteen written before the fix fail against the unfixed spec (11 failures, 3 errors) and pass after it.
- [x] `./mvnw -o -pl server -am test -Dtest='*ApiSpec*Test,SpecBuildersTest,OpenApiSpecGeneratorTest,Issue7568*,Issue7400*' -Dsurefire.failIfNoSpecifiedTests=false` - 168 tests, no failures: every other OpenAPI contributor's test still passes.
- [x] The whole generated document still validates clean: serialized with `Json.pretty(new OpenApiSpecGenerator(null).generateSpec())` and parsed by `OpenAPIV3Parser` with `resolve=true`, `SwaggerParseResult.getMessages()` is `[]`. (A throwaway run, not a committed test - `OpenApiSpecGenerationIT` already does this against the served document.)
- [ ] Optional manual check: regenerate a typed client from `/api/v1/openapi.json` and confirm `count` / `results` are non-optional and `legs.expand.seedsTruncated` is reachable through its own type.

Two new test classes, in `server/src/test/java/com/arcadedb/server/http/handler/openapi/`:

- `Issue7568VectorResponseSchemaShapeTest` - the document's side. One test per fixed row, plus a sweep, `noSchemaInThisContributorIsABareObject`, that walks every schema this contributor registers and fails with the list of bare ones. Before the fix that list read exactly `[VectorSearchResponse.results[].properties, HybridSearchRequest.weights, HybridSearchResponse.legs, HybridSearchResponse.results[].properties, FullTextSearchResponse.results[].properties]`.
- `Issue7568VectorResponseContractMatchesBehaviourTest` - the engine's side, and the reason the `required` lists can be trusted. It builds a real database with a vector index, a full-text index and an edge type, runs the three searches (hybrid in its unfused, fused and expanding forms) and asserts that every name in the schema's `required` list is a key the response actually carries. The expectation is read out of `VectorApiSpec`, so it cannot drift from the document.

## Coverage

Covered by this PR, each with a test driving it through its own entry point:

| Entry point | Fixed | Tested |
|---|---|---|
| `VectorSearchResponse.required` vs what `VectorSearch.search` emits | yes | yes |
| `HybridSearchResponse.required` vs `HybridSearch.search` - unfused, fused and expanding | yes | yes |
| `FullTextSearchResponse.required` vs what `FullTextQuery.search` emits | yes | yes |
| shared hit schema (`results[]` of the vector and full-text responses) | yes | yes |
| fused hit schema (`results[]` of the hybrid response) | yes | yes |
| `HybridSearchRequest.weights` bare object | yes | yes |
| `HybridSearchResponse.legs` bare object | yes | yes |
| `results[].properties` bare object, both hit schemas, all three responses | yes | yes |

Argued rather than fixed, with evidence:

- **MCP surface for the same three searches** - `grep -rn 'outputSchema' mcp/src/main/java` returns no hits. MCP declares input schemas only, so there is no response contract there to under-describe.
- **gRPC surface** - `arcadedb-server.proto:258/319/365` declares each response as a protobuf message with typed scalar fields, `map<string, float> weights` and `map<string, GrpcValue> legs`. Protobuf has no optional-by-omission problem for scalars and no bare-object type, so neither defect can exist there. (The proto's `map<string, float>` is also independent confirmation of the value type chosen for `weights` here.)

### Known gaps

Every one of these is filed, not left for the reporter:

- **#7577** - eleven more bare-`object` properties in `AiApiSpec` (1), `CoreApiSpec` (5), `GrafanaApiSpec` (1), `PluginApiSpec` (3) and `TimeSeriesApiSpec` (1). The sweep that found them is in the tracking doc.
- **#7578** - roughly 34 of the document's 55 component schemas still declare no `required` list at all; `McpApiSpec` and `SecurityAdminApiSpec` have none whatsoever. This PR took `VectorApiSpec` from 3 to 8.
- **#7579** - came out of the adversarial pass: these same six schemas type five closed value sets as free `string` with the values only in the prose (`fusionStrategy`, `expand.direction`, `results[].sources[]`, `similarity`). A third kind of under-description, not one of the two this issue names.

The adversarial pass also caught one defect **in this patch** and it is fixed here: the first draft described a hit's `properties` as "the keys are the type's own properties", which `JsonSerializer.serializeDocument` does not hold - it writes `@rid` and `@type` into every document. The description now says so, and `aHitsPropertiesMapCarriesTheRecordMarkersAlongsideTheTypesOwnProperties` asserts it on a real hit rather than leaving it a claim. The pass is recorded in `docs/7568-openapi-vector-response-schema-shapes.md`, including the one finding that was *not* real (closing `expand` the way `weights` is closed would make the document stricter than the server, which accepts unknown keys there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6gidX7u247f1WKYokvFqH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated OpenAPI definitions for vector, hybrid, and full-text search responses.
  - Required response and result fields are now clearly identified.
  - Record properties support dynamic fields, including record identifiers and type markers.
  - Hybrid search request weights and response legs now have documented structures and constraints.
  - Added validation coverage to confirm the published schemas match actual search responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->