### PR TITLE
fix(#7570): schematize the /batch request body and refuse a reserved key on a line

### DIFF
--- a/docs/7569-openapi-command-ndjson-readonly-restriction.md
+++ b/docs/7569-openapi-command-ndjson-readonly-restriction.md
@@ -1,0 +1,137 @@
+# Issue #7569: OpenAPI /command declares application/x-ndjson but doesn't say streaming is read-only-only
+
+## Ledger (single finding, from the issue body)
+
+1. `POST /api/v1/command/{database}` declares `application/x-ndjson` as a `200` content type but
+   neither its `summary` nor `description` says that the ndjson response is available only for a
+   read-only statement, and that a mutating statement is refused with HTTP 400 before it runs.
+   Reporter also suggested (as an "ideally") a line noting that ndjson is selected via `Accept`.
+
+## Root cause
+
+`PostCommandHandler.requireStreamableStatement()` (server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java:492)
+refuses to stream any statement that is not provably read-only - `analyzed.isIdempotent()` and not
+DDL/CREATE/UPDATE/DELETE/SCHEMA - throwing `IllegalArgumentException` mapped to HTTP 400, before the
+statement runs. `CoreApiSpec.createCommandPath()` declares `application/x-ndjson` as a response
+media type (via `addNdJsonAlternative`) and the `Accept` parameter that selects it
+(`ndJsonAcceptParam()`), but the operation's own `description` never mentions the restriction.
+
+The `Accept`-header opt-in the reporter asked for as an "ideally" is already documented: `ndJsonAcceptParam()`
+attaches a description ("Send 'application/x-ndjson' to receive the result as a stream...") to the `Accept`
+parameter on GET query, POST query and POST command alike. That part of the ask is already satisfied - no
+change needed there.
+
+## Completeness sweep
+
+**Invariant:** every OpenAPI operation whose execution path can refuse the ndjson encoding with 400 for a
+non-read-only statement documents that restriction in its own `description`.
+
+Grep for every caller of the gate and every operation offering the ndjson media type:
+
+```
+$ grep -n "requireStreamableStatement" server/src/main/java/com/arcadedb/server/http/handler/*.java
+PostCommandHandler.java:199:      requireStreamableStatement(database, language, command);
+PostCommandHandler.java:492:  private static void requireStreamableStatement(...)
+
+$ grep -n "class PostQueryHandler" server/src/main/java/com/arcadedb/server/http/handler/PostQueryHandler.java
+public class PostQueryHandler extends PostCommandHandler {
+   // overrides only executeCommand() -> database.query(); execute() itself, including the streaming
+   // gate at line 199, is inherited unchanged.
+
+$ grep -n "requireStreamableStatement\|supportsNdJsonEncoding" server/src/main/java/com/arcadedb/server/http/handler/GetQueryHandler.java
+(no matches - GetQueryHandler streams unconditionally via a separately-implemented execute())
+```
+
+| Entry point | Calls the gate? | Status |
+|---|---|---|
+| `POST /api/v1/command/{database}` (`PostCommandHandler`) | Yes, directly | **Fixed here** - description now states the restriction |
+| `POST /api/v1/query/{database}` (`PostQueryHandler extends PostCommandHandler`) | Yes, inherited via the same `execute()` | **Fixed here** - same restriction, same shared description text, for parity with the existing `commandRequestDeclaresLimitMatchingQueryRequest` precedent of keeping shared-behavior text identical between the two operations |
+| `GET /api/v1/query/{database}/{language}/{command}` (`GetQueryHandler`) | No - separate `execute()`, calls `database.query()` directly with no analysis gate | **Filed as #7571** - there is no explicit read-only gate on this path, so nothing to document identically here; but the adversarial pass below found the absence is itself a divergence worth tracking (`BACKUP DATABASE` streams on GET while `POST /command` refuses it) |
+| `Accept` header opt-in (both POST operations, and GET query) | n/a | **Already covered** - `ndJsonAcceptParam()` already documents `Accept: application/x-ndjson` on all three operations |
+
+Every in-scope row is fixed in this PR; the one out-of-scope row is tracked by #7571.
+
+## Fix
+
+Added a shared `NDJSON_READ_ONLY_DESCRIPTION` constant to `CoreApiSpec` and appended it to the
+`description` of both `POST /api/v1/command/{database}` and `POST /api/v1/query/{database}`, kept
+byte-identical between the two operations (mirroring how `STALE_SESSION_404_DESCRIPTION` is shared).
+
+## Tests
+
+`CoreApiSpecTest.commandAndQueryDescribeTheReadOnlyStreamingRestriction()` (new) asserts:
+- both operations' `description` mention the 400 refusal and the read-only requirement;
+- the shared restriction text is identical between the two operations.
+
+## Test results
+
+`mvn -o -pl server -am test -Dtest=CoreApiSpecTest` - see run log in PR.
+
+## Residual risk
+
+This is a documentation-only change to the generated OpenAPI contract; no runtime behavior changed.
+
+The one thing this PR does NOT cover: `GET /api/v1/query/{database}/{language}/{command}` also offers
+`application/x-ndjson` and has no read-only gate at all, so it still streams a `BACKUP DATABASE` that
+`POST /command` refuses. Tracked by #7571 - see the adversarial pass below.
+
+## Adversarial pass (Phase 1.5)
+
+One finding, verified independently before filing:
+
+1. **GET `/api/v1/query/{database}/{language}/{command}` offers `application/x-ndjson` with no read-only
+   gate at all.** `GetQueryHandler.execute()` calls `database.query()` directly and never reaches
+   `PostCommandHandler.requireStreamableStatement()` (which is `private static` on a sibling class). Its
+   only stand-in is `SQLQueryEngine.query()`'s `if (!statement.isIdempotent()) throw
+   QueryNotIdempotentException`, which is strictly weaker: `BackupDatabaseStatement.isIdempotent()`
+   returns `true` while `getOperationTypes()` reports `{READ, CREATE}`, so `BACKUP DATABASE` streams on
+   GET while `POST /command` refuses it with 400.
+
+   Verified by reading `engine/src/main/java/com/arcadedb/query/sql/parser/BackupDatabaseStatement.java:56-72`
+   and `engine/src/main/java/com/arcadedb/query/sql/SQLQueryEngine.java:86-93`.
+
+   **Disposition: real, out of scope -> filed as #7571.** Out of scope because closing it means either a
+   behavior change on a third handler or a deliberate documentation of the divergence, neither of which
+   #7569 (documentation-only, about `/command`) asked for.
+
+   Narrower than the subagent framed it: the transactional hazards `requireStreamableStatement()`'s javadoc
+   describes are POST-only, since `GetQueryHandler.requiresTransaction()` returns `false` so there is no
+   auto-commit wrapper and no retry loop. #7571 says so explicitly rather than overstating the exposure.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/7572
+
+## Review cycles
+
+### Cycle 1 - 9463c26df5
+
+- **CodeRabbit:** "No actionable comments were generated." Merge risk: minimal. One pre-merge check
+  warning, "Docstring Coverage 16.67%" - **skipped as a nitpick**: the functions it counts are JUnit
+  test methods and private spec builders, and this repo documents intent in targeted javadoc/comments
+  (the new constant and the new test both carry one) rather than in per-method docstrings. Adding
+  boilerplate javadoc to satisfy a percentage would be noise.
+- **claude:** no blocking issues. Confirmed the new text matches
+  `requireStreamableStatement()`'s actual conditions, that sharing one constant between the two POST
+  operations is right, and that deferring the GET gap to #7571 keeps the PR narrow.
+- **claude, one non-blocking observation:** `requireStreamableStatement()` excludes
+  CREATE/UPDATE/DELETE/SCHEMA/DDL but not `OperationType.ADMIN`, so "if any statement reports ADMIN
+  while `isIdempotent()` returns true, it could still stream" - suggested as a possible follow-up.
+
+  **Assessed and NOT filed: the premise does not hold.** `OperationType.ADMIN` has exactly one
+  producer in the tree - `OpenCypherQueryEngine.analyze()` returns it for a `CypherAdminStatement`
+  (`engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java:116`) - and
+  `CypherAdminStatement.isReadOnly()` returns `false` unconditionally
+  (`engine/src/main/java/com/arcadedb/query/opencypher/ast/CypherAdminStatement.java:66-68`), which is
+  what `isIdempotent()` delegates to. So every ADMIN statement fails the gate's very first conjunct
+  and is refused before the operation-type set is consulted at all. There is no statement that is both
+  ADMIN and idempotent, so there is nothing to leak and no follow-up to file.
+
+  Verified by: `grep -rn "OperationType.ADMIN" --include="*.java" engine/src/main/java server/src/main/java`
+  (one hit) and reading `CypherAdminStatement`.
+
+No code changes were required by the review; no items were deferred.
+
+## Final state
+
+`clean-approval`

--- a/docs/7570-openapi-batch-request-body-schema.md
+++ b/docs/7570-openapi-batch-request-body-schema.md
@@ -1,0 +1,248 @@
+# #7570 - `/batch` request body has no schema, and its natural misreading silently stores wrong data
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/7570
+
+## Finding ledger
+
+- [x] 1. **Fixed.** The request body of `POST /api/v1/batch/{database}` is declared as `type: string` on all three
+  media types. Nothing in the contract names `@type`, `@class`, `@id`, `@from`, `@to`, nor says that a
+  vertex line and an edge line are different shapes. The gRPC sibling (`GraphBatchRecord`) is
+  schematized; only the HTTP encoding of the same model is not.
+- [x] 2. **Fixed.** The natural misreading - nesting properties under a `properties` key, because
+  `GraphBatchRecord` has a `properties` map - is accepted with a 200 and stores a property literally
+  named `properties`. The counters are right and the data is wrong.
+- [x] 3. **Fixed.** The `text/csv` variant is equally undocumented: "Header row followed by data rows" does not say
+  how a header names `@class`, a temp id, or an edge's endpoints.
+- [x] 4. **Fixed.** The issue's closing note - that the temporary-id error message "is better documentation than the
+  contract carries" and "would be worth lifting into the operation's `description`" - is now a paragraph of the
+  request-body description: a temporary id resolves only within the request that declared it and only for a vertex
+  that appeared earlier in the same payload, and a vertex from an earlier request must be referenced by RID.
+
+## Analysis
+
+### Where the payload is parsed
+
+Two parsers, both under `server/src/main/java/com/arcadedb/server/http/handler/batch/`:
+
+- `JsonlBatchRecordStream` - serves `application/x-ndjson` and `application/jsonl`.
+  `META_KEYS = {"@type","@class","@id","@from","@to"}`; every key **not** in that set is copied into
+  the record as a property (`parseLine`, line 164). So `properties` becomes a property named
+  `properties`, and so does any unrecognised `@`-prefixed key (`@rid`, `@cat`, a typo'd `@clas`).
+- `CsvBatchRecordStream` - serves `text/csv`. `parseHeader` recognises the same five column names;
+  every other column becomes a property (`parseLine`, line 197), including an unrecognised
+  `@`-prefixed one.
+
+Both are constructed in exactly one place, `PostBatchHandler.streamRecords` lines 380-381, selected by
+content type.
+
+### Where the contract is declared
+
+`CoreApiSpec.createBatchPath()` lines 448-457: one `MediaType` shared by `application/x-ndjson` and
+`application/jsonl` carrying `Schema.type("string").description("One JSON object per line")`, and a
+second for `text/csv` with `"Header row followed by data rows"`.
+
+### Root cause
+
+There is no notion of a *reserved* key in either parser. "Not one of the five meta keys" and "is data"
+are the same predicate, so a control key the parser does not understand, and the nested `properties`
+object that the flat encoding never produces, both fall through into the property list. Nothing can
+fail, because storing an arbitrary key is the documented behaviour of the fall-through.
+
+## Completeness
+
+### Invariant
+
+> A `/batch` line key that the loader cannot interpret as data - an `@`-prefixed key outside the five
+> it understands, or a `properties` key whose value is a JSON object, which is the nested-form
+> misreading and never the flat encoding - is refused with a 400 naming the line, instead of being
+> stored as a property under that name.
+
+### Enumeration
+
+```
+$ grep -rn "addProperty(" --include='*.java' server/src/main/java/com/arcadedb/server/http/handler/batch/
+server/.../CsvBatchRecordStream.java:197:        record.addProperty(headers[i], parseValue(value));
+server/.../BatchRecord.java:51:  public void addProperty(final String key, final Object value) {
+server/.../JsonlBatchRecordStream.java:164:      record.addProperty(key, unwrap(json.get(key)));
+```
+
+Two producers of a property key, one per encoding. `BatchRecord.addProperty` is the sink, not a
+producer.
+
+```
+$ grep -rn "implements BatchRecordStream" --include='*.java' .
+server/.../CsvBatchRecordStream.java:46
+server/.../JsonlBatchRecordStream.java:46
+```
+
+Two implementations, no others in the tree.
+
+```
+$ grep -rn "new JsonlBatchRecordStream\|new CsvBatchRecordStream" --include='*.java' server/src/main grpc/src/main
+server/.../PostBatchHandler.java:380:        ? new CsvBatchRecordStream(inputStream)
+server/.../PostBatchHandler.java:381:        : new JsonlBatchRecordStream(inputStream);
+```
+
+One construction site in production code, so the HTTP `/batch` endpoint is the only live caller.
+
+Same-shape siblings - request/response bodies still declared as an opaque `string`:
+
+```
+$ grep -rn 'type("string")' --include='*.java' server/src/main/java/com/arcadedb/server/http/handler/openapi/ \
+    | grep -v "queryParam\|pathParam\|headerParam"
+SpecBuilders.java:97,104,122        (parameter/header schemas, not bodies)
+SpecBuilders.java:189               rawBody(...)
+PrometheusApiSpec.java:105          Snappy protobuf ReadResponse, format: binary
+CoreApiSpec.java:451                the /batch JSONL body            <- this issue
+CoreApiSpec.java:455                the /batch CSV body              <- this issue
+AiApiSpec.java:154                  text/event-stream SSE response
+PluginApiSpec.java:360              binary backup upload
+```
+
+Seven hits, five of them fine:
+
+- `PrometheusApiSpec:105` and `PluginApiSpec:360` are `format: binary` opaque blobs; an OpenAPI
+  `string/binary` is the correct encoding for one.
+- `SpecBuilders.rawBody` is used three times (`TimeSeriesApiSpec:71`, `PrometheusApiSpec:71,98`), each
+  for a payload defined by an **external, named** specification - InfluxDB Line Protocol, Prometheus
+  remote-write/remote-read protobuf. A client can look those up; the `/batch` grammar is
+  ArcadeDB-proprietary and written down nowhere.
+- `AiApiSpec:154` is the genuine sibling: an ArcadeDB-proprietary, line-oriented SSE stream
+  (`session`, `tool_call`, `tool_start`, `tool_end`, `done`) declared as one `string`. Out of scope
+  here - different domain, a response rather than a request, and no silent-corruption half. **Filed as
+  #7573.**
+
+Existing payloads that this change could refuse:
+
+```
+$ grep -rn '@type.*@class' --include='*.java' server/src/test | grep -o '@[a-zA-Z]*' | sort | uniq -c
+ 162 @type
+ 162 @class
+  69 @id
+  50 @from
+  49 @to
+```
+
+Every `@`-key in every batch payload in the test tree is one of the five understood ones, and no
+payload carries a `properties` key. The rejection adds no new failure to existing usage.
+
+### Coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| `POST /api/v1/batch/{db}` `application/x-ndjson` / `application/jsonl` → `JsonlBatchRecordStream.parseLine`, unknown `@`-key | yes | yes - `Issue7570ReservedBatchKeyTest`, `Issue7570BatchReservedKeyIT` |
+| same → `JsonlBatchRecordStream.parseLine`, nested `properties` object | yes | yes - `Issue7570ReservedBatchKeyTest`, `Issue7570BatchReservedKeyIT` |
+| `POST /api/v1/batch/{db}` `text/csv` → `CsvBatchRecordStream.parseHeader`, unknown `@`-column | yes | yes - `Issue7570ReservedBatchKeyTest`, `Issue7570BatchReservedKeyIT` |
+| OpenAPI contract for the three request media types (`CoreApiSpec.createBatchPath`) | yes | yes - `Issue7570BatchRequestBodySchemaTest`, plus the swagger-parser validation in `OpenApiSpecGenerationIT` |
+| `text/csv` → `CsvBatchRecordStream`, a column literally named `properties` | **argued** | n/a |
+| gRPC `InsertBidirectional` → `GraphBatchRecord` | **argued** | n/a |
+| Streaming (`Accept: application/x-ndjson`) answer for a rejected line | yes (same throw site) | yes - IT asserts the buffered 400; the streaming encoding reports it as the terminal `error` line by the existing mechanism |
+| AI `text/event-stream` response schema | **filed** - #7573 | n/a |
+| `@id` on an edge line / `@from`,`@to` on a vertex line - understood meta keys, silently unused | **filed** - #7574 | n/a |
+
+Arguments:
+
+- **CSV `properties` column.** `CsvBatchRecordStream.parseValue` returns only `Boolean`, `Long`,
+  `Double`, `String` or `null` - never a `Map`. The nested-form misreading has no CSV spelling, so a
+  `properties` column in CSV is an ordinary scalar property and refusing it would break data that is
+  not a mistake. The JSONL rule is deliberately keyed on the value being an object for the same
+  reason: `{"properties": "public"}` is data, `{"properties": {...}}` is the mistake.
+- **gRPC.** `GraphBatchRecord` (`grpc/src/main/proto/arcadedb-server.proto:744`) has typed
+  `kind`, `type_name`, `temp_id`, `from_ref`, `to_ref` fields and a separate
+  `map<string, GrpcValue> properties`. Control and data live in different fields, so no key can be
+  mistaken for the other kind. The defect is specific to the flat HTTP encoding.
+
+### Residual risk
+
+1. A **known** meta key in the wrong place is still silently ignored: `@id` on an edge line, and
+   `@from`/`@to` on a vertex line. It is a silent drop rather than silent corruption, and CSV's
+   documented shared-header form makes a placement rule genuinely ambiguous there, so it is filed as
+   #7574 rather than fixed.
+2. A line may still carry a property name that the schema does not declare; the batch loader creates
+   it. That is the documented behaviour of a schemaless load, not a defect.
+3. The OpenAPI `oneOf` describes **one line**, not the whole body. OpenAPI 3.0 cannot express
+   "newline-delimited instances of this schema" for a request body; the media-type schema being the
+   single-line schema is the convention this spec already uses for its NDJSON *responses*
+   (`NdJsonQueryEvent`, `NdJsonBatchEvent`), so request and response now read the same way. The
+   line-orientation is stated in the request body description.
+
+### Why the '@' namespace is the right thing to reserve
+
+Not an aesthetic choice: the engine already treats it as metadata everywhere a property map crosses a boundary.
+
+```
+$ grep -rn 'startsWith("@")' --include='*.java' engine/src/main/java/com/arcadedb/database/MutableDocument.java
+113:      if (key.startsWith("@"))        // fromMap(Map)   - SKIP METADATA
+361:      if (propertyName.startsWith("@"))  // set(Map)    - SKIP METADATA
+```
+
+`MutableDocument.fromMap` and `set(Map)` drop `@`-prefixed keys as metadata. The batch loader reached the record
+through `set(String, Object)` instead (`GraphBatch.java:563`), which applies no such filter, so it was the one door
+in that let an `@`-prefixed property name through. Refusing it at the parser closes the hole at the boundary where
+the client can still be told about it.
+
+## Implementation
+
+| File | Change |
+|---|---|
+| `JsonlBatchRecordStream` | `rejectReservedKey(key, value)` in the property loop: refuses an `@`-prefixed key outside `META_KEYS`, and a `properties` key whose value is a `Map`. Throws plain `IllegalArgumentException`, never the `MalformedBatchRecordException` subclass that `PostBatchHandler` may report as a 408. |
+| `CsvBatchRecordStream` | `rejectReservedColumn(column)` from the header switch's `default` branch: refuses an unrecognised `@`-prefixed column, at the header where CSV names its control keys. |
+| `CoreApiSpec` | `BatchLine` (`oneOf` + `@type` discriminator, all four accepted spellings mapped), `BatchVertexLine`, `BatchEdgeLine`; the two JSON line media types now `$ref` the line schema instead of `type: string`; the CSV media type describes the real grammar; both carry an `example`; the request body and the 400 state the reserved-key rule. |
+
+## Test results
+
+```
+mvn -o -pl server test  -Dtest='com.arcadedb.server.http.**'            -> Tests run: 856, Failures: 0, Errors: 0, Skipped: 2
+mvn -o -pl server verify -DskipITs=false -Dit.test='Issue7570BatchReservedKeyIT' -> Tests run: 7,  Failures: 0, Errors: 0
+mvn -o -pl server verify -DskipITs=false -Dit.test='*Batch*IT,OpenApi*IT,...'    -> Tests run: 133, Failures: 0, Errors: 1 (see below)
+```
+
+Before the fix, the same two new unit-test classes reported **15 failures** out of 20 - every refusal assertion, on
+every entry point - while the five "this still works" guards passed. That is the proof that the parsers accepted all
+of it.
+
+The one error in the wide IT sweep is `RemoteGraphBatchIT.mapAndListPropertiesRoundTrip`, failing in `endTest` on
+`RemoteServer.drop` with `EOFException: EOF reached while reading`. It is **not** this change:
+
+- the failure is in teardown, not in the test body, and nothing in this diff is on the `drop` path;
+- the class hardcodes `127.0.0.1:2480` in 17 places, and a Homebrew ArcadeDB 26.9.1 server had held `*:2480` on this
+  machine for over a day, so the test was talking to that server rather than to its own;
+- re-run alone, the class is green: `Tests run: 15, Failures: 0, Errors: 0`.
+
+The new IT deliberately does **not** repeat that mistake: it derives its URL from
+`getServer(0).getHttpServer().getPort()`.
+
+## Breaking change
+
+This tightens a **write** path. A payload that carried an `@`-prefixed key outside the five, or a nested
+`properties` object, used to load with a 200 and now answers 400. That is the point of the issue - the 200 was the
+defect - but it is a behaviour change and not only a documentation one.
+
+The blast radius was measured rather than assumed:
+
+```
+$ grep -rhoE '\{[^{}]*"@type"[^{}]*\}' --include='*.java' --include='*.md' --include='*.js' --include='*.py' \
+      --include='*.json' --include='*.ts' . | grep -v node_modules | grep -E '"(vertex|edge|v|e)\\?"' \
+  | grep -o '"@[a-zA-Z_]*"' | sort | uniq -c | sort -rn
+  86 "@type"     86 "@class"     46 "@id"     24 "@to"     24 "@from"     2 "@cat"
+```
+
+Every batch payload literal in the whole tree uses only the five control keys. The two `@cat` hits are the new tests
+in this branch. Nothing shipped in this repository sends a payload the refusal would now reject.
+
+## Adversarial pass
+
+The `Task` tool is not available in this environment, so the isolated subagent the workflow asks for could not be
+spawned. The pass was run by re-reading the diff against the issue instead; that is weaker - the reviewer had already
+been convinced by its own reasoning - and is recorded as such.
+
+| Finding | Disposition |
+|---|---|
+| `@id` on an edge line, `@from`/`@to` on a vertex line: understood control keys used on the wrong kind, still silently dropped | **Real, out of scope** - filed as #7574 |
+| The AI chat SSE response is still one opaque `string`, the same defect this issue reports for the request | **Real, out of scope** - filed as #7573 |
+| `{"properties": ["..."]}` - an ARRAY rather than an object - is still accepted as a list property named `properties` | **Not fixed, argued.** The misreading this refusal targets comes from `GraphBatchRecord.properties`, which is a `map`; a client guessing from it sends an object. Refusing a list too would break a domain whose `properties` field is genuinely a list, with no corresponding mistake to prevent |
+| The IT copied `http://127.0.0.1:2480` from `Issue5618BatchLineAccountingIT` | **Real, fixed here** before the first run: the IT now derives the port from `getServer(0).getHttpServer().getPort()`. The hardcoded form would have been answered by the machine's standing server |
+| The IT asserted `countType("Person") == 0` on a database shared across the class's methods, so it would pass or fail on execution order | **Real, fixed here**: every method now has its own vertex type |
+| `assertThat(...query("SELECT properties FROM ..."))` in the IT leaned on `properties` not being a reserved SQL word | **Real, fixed here**: replaced with an `iterateType` read, which cannot be confused by the parser |
+| The error message embeds literal JSON with quotes and has to survive being placed in a JSON error body | **Not a defect** - verified empirically: the IT parses the 400 body with `JSONObject` and reads `error` back |
+| A generated client may still treat `application/x-ndjson` as opaque regardless of the schema | **Real limitation, stated** in residual risk 3. The schema is still the only written description of the payload, and it matches how the spec already documents its NDJSON responses |

--- a/docs/7570-openapi-batch-request-body-schema.md
+++ b/docs/7570-openapi-batch-request-body-schema.md
@@ -262,3 +262,43 @@ PR: https://github.com/ArcadeData/arcadedb/pull/7583
 | `rejectReservedKey`'s `@`-branch and `rejectReservedColumn` are near-duplicate logic in two classes; the reviewer flagged it as *not* worth extracting today | **Declined, agreed with the reviewer.** The two differ in what they inspect (a JSON key on a data line vs a column name on a header row), in when they run (per property vs once per header), and in their message wording. The classes share no base type, so a helper would mean a new utility for about four lines of code and would put the JSONL and CSV messages under one roof where they would drift toward a generic wording. Worth revisiting only if a third encoding is added, which is exactly what the reviewer said |
 
 No item was unclear, so nothing was deferred for the developer and no `review-deferred-*.md` notes file was produced.
+
+### Cycle 2 - 270082b530
+
+`claude` reviewed again and found no correctness bug and nothing blocking. It independently re-verified the three
+claims this fix rests on - that `parseValue` genuinely never returns a `Map`, that the
+`MalformedBatchRecordException`-vs-`IllegalArgumentException` split is what actually drives 408 vs 400 in
+`PostBatchHandler`, and that the control-key matching really is case-sensitive - and confirmed the OpenAPI
+`required` lists match the parsers field-for-field. Two notes:
+
+| Note | Disposition |
+|---|---|
+| `Issue7570BatchReservedKeyIT.post(...)` reimplements a raw `HttpURLConnection` POST helper that other ITs in the package also have; CLAUDE.md asks for reuse. Flagged by the reviewer itself as a nice-to-have, not a blocker, and as "already widespread across ~57 test files" rather than something this PR introduces | **Declined, with the base class checked first.** `BaseGraphServerTest` has no helper that posts a body: `readResponse`/`readError` only drain a stream and collapse newlines, and `executeCommand` is pinned to `/api/v1/command/graph`, asserts 200 so it cannot express the 400 these tests are about, and builds its URL as `248<serverIndex>` - the hardcoded-port form this IT deliberately avoids. Reusing it is not possible; adding a new protected helper to a base class shared by dozens of suites is a wider change than this PR should carry, and it would be the right change to make once, for all ~57 files, rather than as a side effect here |
+| The cycle-1 decision not to extract the shared `@`-prefix check | **Confirmed by the reviewer**, no action |
+
+No item was unclear; nothing deferred for the developer; no `review-deferred-*.md` notes file was produced by
+either cycle. (The `docs/review-deferred-*.md` files present in the tree predate this branch - they came in with
+PR #7210 and others.)
+
+## Final state
+
+**clean-approval** after 2 review cycles.
+
+| | |
+|---|---|
+| PR | https://github.com/ArcadeData/arcadedb/pull/7583 |
+| Branch | `fix/7570-openapi-batch-request-body-schema` |
+| Cycle 1 | `16bb1ef3d7` - 3 non-blocking notes, 2 applied, 1 declined with reasoning |
+| Cycle 2 | `270082b530` - 2 non-blocking notes, both declined with reasoning; no correctness bug found |
+| Follow-ups filed | #7573, #7574 |
+
+### Outstanding for the developer
+
+- **CodeRabbit never reviewed this PR.** It hit its free-tier rate limit at the first push ("Review limit reached,
+  next included review available in 32 minutes") and its check reports `pass` only because it was skipped. There are
+  therefore zero CodeRabbit threads to resolve - which reads the same as "all resolved" but is not. The repository's
+  own merge bar asks for CodeRabbit threads to be resolved, so it is worth a `@coderabbitai review` once the limit
+  resets before merging.
+- **Downstream drivers.** The blast-radius grep covers this repository only. The refusal is a behaviour change on a
+  write path, so the arcadedb-drivers clients - the reporter's own starting point - are worth a look before release.
+- Merge is the developer's. This workflow does not merge.

--- a/docs/7570-openapi-batch-request-body-schema.md
+++ b/docs/7570-openapi-batch-request-body-schema.md
@@ -246,3 +246,19 @@ been convinced by its own reasoning - and is recorded as such.
 | `assertThat(...query("SELECT properties FROM ..."))` in the IT leaned on `properties` not being a reserved SQL word | **Real, fixed here**: replaced with an `iterateType` read, which cannot be confused by the parser |
 | The error message embeds literal JSON with quotes and has to survive being placed in a JSON error body | **Not a defect** - verified empirically: the IT parses the 400 body with `JSONObject` and reads `error` back |
 | A generated client may still treat `application/x-ndjson` as opaque regardless of the schema | **Real limitation, stated** in residual risk 3. The schema is still the only written description of the payload, and it matches how the spec already documents its NDJSON responses |
+
+## Review cycles
+
+PR: https://github.com/ArcadeData/arcadedb/pull/7583
+
+### Cycle 1 - 16bb1ef3d7
+
+`claude` reviewed and found no correctness bug and nothing blocking the merge. Three notes, all non-blocking:
+
+| Note | Disposition |
+|---|---|
+| The control keys are matched case-sensitively, so `@Type` now lands in the "unknown control key" branch. Not a regression (it misbehaved before the fix too), but worth a line in the request-body description | **Applied.** Verified first: `META_KEYS` is a `Set.of` queried with `contains`, `@type` values go through `equals`, and the CSV header is an exact `switch`; only the CSV boolean literals use `equalsIgnoreCase`. That asymmetry is unguessable and the refusal makes it visible as a 400, so the contract now states it, with an assertion in `Issue7570BatchRequestBodySchemaTest` |
+| The PR body's Test plan boxes were unticked although the runs are recorded as passing | **Applied.** Ticked, with the measured counts inline |
+| `rejectReservedKey`'s `@`-branch and `rejectReservedColumn` are near-duplicate logic in two classes; the reviewer flagged it as *not* worth extracting today | **Declined, agreed with the reviewer.** The two differ in what they inspect (a JSON key on a data line vs a column name on a header row), in when they run (per property vs once per header), and in their message wording. The classes share no base type, so a helper would mean a new utility for about four lines of code and would put the JSONL and CSV messages under one roof where they would drift toward a generic wording. Worth revisiting only if a third encoding is added, which is exactly what the reviewer said |
+
+No item was unclear, so nothing was deferred for the developer and no `review-deferred-*.md` notes file was produced.

--- a/server/src/main/java/com/arcadedb/server/http/handler/batch/CsvBatchRecordStream.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/batch/CsvBatchRecordStream.java
@@ -41,6 +41,10 @@ import java.util.List;
  * The first line is the header. A {@code ---} sentinel row separates vertex and edge sections.
  * A new header row is expected after the sentinel.
  * <p>
+ * Every other column is a property. The {@code @} prefix is what separates control from data, so a column that
+ * begins with {@code @} and is not one of the five understood names is refused at the header rather than loaded as a
+ * property with that name (issue #7570).
+ * <p>
  * Handles RFC 4180 quoting (double-quote escaping) for single-line fields.
  */
 public class CsvBatchRecordStream implements BatchRecordStream {
@@ -143,6 +147,7 @@ public class CsvBatchRecordStream implements BatchRecordStream {
       case "@id" -> idCol = i;
       case "@from" -> fromCol = i;
       case "@to" -> toCol = i;
+      default -> rejectReservedColumn(headers[i]);
       }
     }
 
@@ -152,6 +157,23 @@ public class CsvBatchRecordStream implements BatchRecordStream {
       throw new IllegalArgumentException("CSV header missing @class column at line " + lineNumber);
 
     headerParsed = true;
+  }
+
+  /**
+   * Refuses an unrecognised {@code @}-prefixed column. CSV names its control keys in the header, so the header is
+   * where the JSONL reserved-key rule has to be applied: an unknown one used to become a property column, and a load
+   * built on it answered 200 holding a property whose name starts with {@code @} (issue #7570).
+   * <p>
+   * There is no CSV counterpart of the nested {@code properties} refusal the JSONL parser also makes: every value
+   * {@link #parseValue} produces is a scalar, never a {@link java.util.Map}, so a {@code properties} column can only
+   * ever be ordinary data.
+   */
+  private void rejectReservedColumn(final String column) {
+    if (!column.isEmpty() && column.charAt(0) == '@')
+      throw new IllegalArgumentException("Unknown control column '" + column + "' in the CSV header at line "
+          + lineNumber + ": the '@' prefix is reserved by the batch encoding and only "
+          + "@type, @class, @id, @from and @to are understood. A property column cannot start with '@': rename the "
+          + "column, or drop it");
   }
 
   private void parseLine(final String line) {

--- a/server/src/main/java/com/arcadedb/server/http/handler/batch/JsonlBatchRecordStream.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/batch/JsonlBatchRecordStream.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -38,6 +39,13 @@ import java.util.Set;
  * </pre>
  * Blank lines are skipped. The record object is reused across calls.
  * <p>
+ * Properties sit FLAT beside the control keys; they are not nested under a {@code properties} object. Control and
+ * data therefore share one namespace, and the {@code @} prefix is what separates them: a key outside
+ * {@link #META_KEYS} that begins with {@code @} is refused rather than stored as a property with that name, and so is
+ * a {@code properties} key carrying an object, which is the nested-form misreading the gRPC sibling's
+ * {@code GraphBatchRecord.properties} map invites. Both used to be accepted and turned into a property, so a payload
+ * built on the obvious guess loaded with the right counters and the wrong data (issue #7570).
+ * <p>
  * Parsing errors are surfaced as {@link IllegalArgumentException} so the HTTP layer maps them
  * to a 400 Bad Request with a clear message instead of a generic 500. A line that did not form a well-formed JSON
  * object at all uses the {@link MalformedBatchRecordException} subclass, because a truncated upload produces exactly
@@ -46,6 +54,17 @@ import java.util.Set;
 public class JsonlBatchRecordStream implements BatchRecordStream {
 
   private static final Set<String> META_KEYS = Set.of("@type", "@class", "@id", "@from", "@to");
+
+  /** Named in the refusal messages so the client is told what the five understood control keys are. */
+  private static final String META_KEY_LIST = "@type, @class, @id, @from and @to";
+
+  /**
+   * The one non-{@code @} key that cannot be taken at face value: {@code GraphBatchRecord} carries a
+   * {@code properties} map, so a reader of the gRPC contract nests the properties under this name. Only refused when
+   * its value is an object - {@code {"properties":"public"}} is ordinary data and a domain is allowed a field with
+   * this name.
+   */
+  private static final String NESTED_PROPERTIES_KEY = "properties";
 
   private final BufferedReader reader;
   private final BatchRecord    record;
@@ -161,8 +180,29 @@ public class JsonlBatchRecordStream implements BatchRecordStream {
     for (final String key : json.keySet()) {
       if (META_KEYS.contains(key))
         continue;
-      record.addProperty(key, unwrap(json.get(key)));
+      final Object value = unwrap(json.get(key));
+      rejectReservedKey(key, value);
+      record.addProperty(key, value);
     }
+  }
+
+  /**
+   * Refuses the two keys that cannot be what they look like. Both used to fall through into the property list, where
+   * they produced a successful load holding data the client never meant to send (issue #7570).
+   */
+  private void rejectReservedKey(final String key, final Object value) {
+    if (!key.isEmpty() && key.charAt(0) == '@')
+      throw new IllegalArgumentException("Unknown control key '" + key + "' at line " + lineNumber
+          + ": the '@' prefix is reserved by the batch encoding and only " + META_KEY_LIST + " are understood. "
+          + "A property name cannot start with '@': rename the key, or drop it");
+
+    if (NESTED_PROPERTIES_KEY.equals(key) && value instanceof Map)
+      throw new IllegalArgumentException("Reserved key 'properties' at line " + lineNumber
+          + ": a batch line carries its properties flat, beside the '@' control keys, not nested under a "
+          + "'properties' object. Send {\"@type\":\"vertex\",\"@class\":\"Person\",\"name\":\"Alice\"} rather than "
+          + "{\"@type\":\"vertex\",\"@class\":\"Person\",\"properties\":{\"name\":\"Alice\"}}. Nested here, the object "
+          + "would be stored as a single property literally named 'properties' and nothing would fail until "
+          + "something queried for a field that was never written");
   }
 
   private static Object unwrap(final Object value) {

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -24,6 +24,7 @@ import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.Discriminator;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
@@ -116,6 +117,9 @@ public class CoreApiSpec implements OpenApiContributor {
     openAPI.getComponents().addSchemas("BatchError", createBatchErrorSchema());
     openAPI.getComponents().addSchemas("ProgressResponse", createProgressResponseSchema());
     openAPI.getComponents().addSchemas("NdJsonBatchEvent", createNdJsonBatchEventSchema());
+    openAPI.getComponents().addSchemas("BatchLine", createBatchLineSchema());
+    openAPI.getComponents().addSchemas("BatchVertexLine", createBatchVertexLineSchema());
+    openAPI.getComponents().addSchemas("BatchEdgeLine", createBatchEdgeLineSchema());
   }
 
   private PathItem createServerPath() {
@@ -439,23 +443,7 @@ public class CoreApiSpec implements OpenApiContributor {
     refMode.getSchema().setEnum(List.of("id", "ordinal"));
     post.addParametersItem(refMode);
 
-    final RequestBody body = new RequestBody();
-    body.setDescription("""
-        Vertices first, then edges. JSONL sends one JSON record per line; CSV sends a header row \
-        followed by data rows. Vertices may declare a temporary '@id' that edges reference through \
-        '@from' and '@to', or be referenced by position when refMode=ordinal. Edges may also \
-        reference existing RIDs in #bucket:position form.""");
-    body.setRequired(true);
-    final Content content = new Content();
-    final MediaType jsonl = new MediaType();
-    jsonl.setSchema(new Schema<>().type("string").description("One JSON object per line"));
-    content.addMediaType("application/x-ndjson", jsonl);
-    content.addMediaType("application/jsonl", jsonl);
-    final MediaType csv = new MediaType();
-    csv.setSchema(new Schema<>().type("string").description("Header row followed by data rows"));
-    content.addMediaType("text/csv", csv);
-    body.setContent(content);
-    post.setRequestBody(body);
+    post.setRequestBody(createBatchRequestBody());
 
     // 400 and 408 carry the partial-commit counts rather than the generic error body: a batch is
     // not atomic, so a client that cannot read how much was committed cannot reconcile before
@@ -467,8 +455,10 @@ public class CoreApiSpec implements OpenApiContributor {
     final MediaType ndjsonBatch = new MediaType();
     ndjsonBatch.setSchema(SpecBuilders.ref("NdJsonBatchEvent"));
     responses.get("200").getContent().addMediaType(NDJSON, ndjsonBatch);
-    responses.addApiResponse("400", SpecBuilders.jsonResponse(
-        "Client-input failure, with the counts attempted before it", "BatchError"));
+    responses.addApiResponse("400", SpecBuilders.jsonResponse("""
+        Client-input failure, with the counts attempted before it. Also the answer to a line that used a reserved \
+        key: an '@'-prefixed key outside the five control keys, or a 'properties' key carrying an object.""",
+        "BatchError"));
     responses.addApiResponse("408", SpecBuilders.jsonResponse(
         "The body ended before it was fully consumed, with the counts attempted before that", "BatchError"));
     responses.addApiResponse("401", SpecBuilders.errorResponse("Unauthorized"));
@@ -815,6 +805,142 @@ public class CoreApiSpec implements OpenApiContributor {
         False both when the database does not exist and when it exists but the caller is not \
         authorized to see it, since the response does not distinguish the two cases."""));
     return schema;
+  }
+
+  /**
+   * The payload of a bulk load (issue #7570). All three media types used to be declared as a bare {@code string}, so
+   * none of the five control keys appeared anywhere in the contract and every client in every language had to
+   * reverse-engineer the encoding - while the gRPC sibling {@code GraphBatchRecord} had been schematized since it
+   * shipped.
+   * <p>
+   * The JSON line encodings name the line schema rather than a string, which is the same convention this spec
+   * already uses for its NDJSON <em>responses</em> ({@code NdJsonQueryEvent}, {@code NdJsonBatchEvent}): OpenAPI 3.0
+   * cannot say "newline-delimited instances of this schema" for a body, so the media-type schema is the schema of one
+   * line and the description carries the line orientation.
+   */
+  private RequestBody createBatchRequestBody() {
+    final RequestBody body = new RequestBody();
+    body.setDescription("""
+        Vertices first, then edges. JSONL sends one JSON record per line; CSV sends a header row \
+        followed by data rows. Vertices may declare a temporary '@id' that edges reference through \
+        '@from' and '@to', or be referenced by position when refMode=ordinal. Edges may also \
+        reference existing RIDs in #bucket:position form.
+
+        The JSON schema below describes ONE LINE: the body is a sequence of them separated by newlines, not a JSON \
+        array, and a line that is an array is refused as such.
+
+        Properties sit FLAT beside the control keys - {"@type":"vertex","@class":"Person","name":"Alice"} - and are \
+        NOT nested under a 'properties' object. The '@' prefix is reserved: a key starting with '@' that is not one \
+        of @type, @class, @id, @from or @to is refused with a 400 naming the line, and so is a 'properties' key \
+        carrying an object, because both can only ever be a misread of this encoding.
+
+        A temporary id is resolved only within the request that declared it, and only if the vertex appeared \
+        earlier in the same payload: a vertex loaded by an EARLIER request has to be referenced by RID \
+        (#bucket:position). Under refMode=ordinal, use 'ordinalBase' to keep one position counter across a load \
+        split into several requests.""");
+    body.setRequired(true);
+
+    final Content content = new Content();
+    for (final String jsonLineMediaType : List.of(NDJSON, "application/jsonl")) {
+      final MediaType jsonl = new MediaType();
+      jsonl.setSchema(SpecBuilders.ref("BatchLine"));
+      jsonl.setExample("""
+          {"@type":"vertex","@class":"Person","@id":"p1","name":"Alice"}
+          {"@type":"vertex","@class":"Person","@id":"p2","name":"Bob"}
+          {"@type":"edge","@class":"Knows","@from":"p1","@to":"p2","since":2020}""");
+      content.addMediaType(jsonLineMediaType, jsonl);
+    }
+
+    final MediaType csv = new MediaType();
+    csv.setSchema(new Schema<>().type("string").description("""
+        A header row naming the columns, then one data row per record. The control keys are column names: @type and \
+        @class are required, @id names a vertex's temporary id, and @from and @to name an edge's endpoints. Every \
+        other column is a property, and the '@' prefix is reserved there too - an unrecognised '@' column is refused \
+        with a 400. A '---' row separates the vertex section from the edge section, and a new header row follows it. \
+        Values are typed by inspection: 'true'/'false' become booleans, numeric text becomes a number, an empty \
+        field sets no property at all. Quoting follows RFC 4180, single-line fields only."""));
+    csv.setExample("""
+        @type,@class,@id,name
+        vertex,Person,p1,Alice
+        vertex,Person,p2,Bob
+        ---
+        @type,@class,@from,@to,since
+        edge,Knows,p1,p2,2020""");
+    content.addMediaType("text/csv", csv);
+
+    body.setContent(content);
+    return body;
+  }
+
+  /**
+   * One line of the JSON batch encoding: a vertex or an edge, told apart by {@code @type}. The discriminator maps the
+   * short spellings as well, because the parsers accept {@code v} and {@code e} and a generated client that only knew
+   * the long ones would reject its own valid payloads.
+   */
+  private Schema<?> createBatchLineSchema() {
+    final Schema<Object> schema = SpecBuilders.object("""
+        One line of the JSON batch encoding. Vertices must appear before the edges that reference them.""");
+    schema.setType(null);
+    schema.setOneOf(List.of(SpecBuilders.ref("BatchVertexLine"), SpecBuilders.ref("BatchEdgeLine")));
+
+    final Discriminator discriminator = new Discriminator();
+    discriminator.setPropertyName("@type");
+    discriminator.mapping("vertex", "#/components/schemas/BatchVertexLine");
+    discriminator.mapping("v", "#/components/schemas/BatchVertexLine");
+    discriminator.mapping("edge", "#/components/schemas/BatchEdgeLine");
+    discriminator.mapping("e", "#/components/schemas/BatchEdgeLine");
+    schema.setDiscriminator(discriminator);
+    return schema;
+  }
+
+  private Schema<?> createBatchVertexLineSchema() {
+    final Schema<Object> schema = SpecBuilders.object("""
+        A vertex line. Its properties are the keys of this same object, flat beside the control keys below - they are \
+        NOT nested under a 'properties' key, and sending one carrying an object is refused with a 400.""");
+    schema.addProperty("@type", SpecBuilders.string("Discriminator. 'v' is accepted as a synonym of 'vertex'")
+        ._enum(List.of("vertex", "v")));
+    schema.addProperty("@class", SpecBuilders.string("""
+        Vertex type to create the record in. The type must already exist: a bulk load creates records, never \
+        types."""));
+    schema.addProperty("@id", SpecBuilders.string("""
+        Temporary id, resolved only against the edges of THIS request. Optional - a vertex needs one only if an edge \
+        in the same payload references it, and one that declares none is counted in 'verticesWithoutId'. Ignored \
+        under refMode=ordinal, where an edge names a vertex by its 0-based position instead."""));
+    schema.setRequired(List.of("@type", "@class"));
+    addFlatPropertyPolicy(schema);
+    return schema;
+  }
+
+  private Schema<?> createBatchEdgeLineSchema() {
+    final Schema<Object> schema = SpecBuilders.object("""
+        An edge line. Its properties are the keys of this same object, flat beside the control keys below - they are \
+        NOT nested under a 'properties' key, and sending one carrying an object is refused with a 400.""");
+    schema.addProperty("@type", SpecBuilders.string("Discriminator. 'e' is accepted as a synonym of 'edge'")
+        ._enum(List.of("edge", "e")));
+    schema.addProperty("@class", SpecBuilders.string("""
+        Edge type to create the record in. The type must already exist: a bulk load creates records, never \
+        types."""));
+    schema.addProperty("@from", SpecBuilders.string("""
+        Source vertex. Under refMode=id (the default) this is the '@id' a vertex declared EARLIER IN THIS PAYLOAD, \
+        or an existing RID in #bucket:position form; each request resolves only the ids of its own payload. Under \
+        refMode=ordinal it is the vertex's 0-based position, offset by 'ordinalBase'."""));
+    schema.addProperty("@to", SpecBuilders.string("Destination vertex, named the same way as '@from'"));
+    schema.setRequired(List.of("@type", "@class", "@from", "@to"));
+    addFlatPropertyPolicy(schema);
+    return schema;
+  }
+
+  /**
+   * Declares that any other key of the line is a property. This is what makes the encoding schemaless, and it is also
+   * what made the reserved-key refusals necessary: without a rule, a control key the loader does not understand is
+   * indistinguishable from a property whose name happens to start with '@' (issue #7570).
+   */
+  private void addFlatPropertyPolicy(final Schema<Object> schema) {
+    schema.setAdditionalProperties(SpecBuilders.object("""
+        One property of the record, keyed by its name. Any JSON scalar, array or nested object; a nested object is \
+        stored as an embedded document. The name may not start with '@' - that prefix is reserved for the control \
+        keys - and a property named 'properties' may not carry an object, because that is the nested-form misreading \
+        rather than data.""").type(null));
   }
 
   private Schema<?> createBatchResponseSchema() {

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -834,6 +834,10 @@ public class CoreApiSpec implements OpenApiContributor {
         of @type, @class, @id, @from or @to is refused with a 400 naming the line, and so is a 'properties' key \
         carrying an object, because both can only ever be a misread of this encoding.
 
+        The control keys and the '@type' values are matched case-sensitively: '@Type' is not '@type' and is refused \
+        as an unknown control key, and 'Vertex' is not 'vertex'. Only the CSV boolean literals 'true' and 'false' \
+        are matched ignoring case.
+
         A temporary id is resolved only within the request that declared it, and only if the vertex appeared \
         earlier in the same payload: a vertex loaded by an EARLIER request has to be referenced by RID \
         (#bucket:position). Under refMode=ordinal, use 'ordinalBase' to keep one position counter across a load \

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -79,6 +79,15 @@ public class CoreApiSpec implements OpenApiContributor {
       "Database not found, or the session id header names a transaction that no longer resolves "
           + "(\"Remote transaction session not found or expired\")";
 
+  // Shared by POST query and POST command: PostQueryHandler extends PostCommandHandler and overrides only
+  // executeCommand(), so both reach the very same requireStreamableStatement() call in execute() before the
+  // statement runs. Held in one place so the two operations cannot describe the same gate differently (issue #7569).
+  private static final String NDJSON_READ_ONLY_DESCRIPTION = """
+      When 'Accept' requests the ndjson encoding, only a statement provably read-only may stream: one that \
+      writes - INSERT, UPDATE, DELETE, DDL, or one this analysis cannot classify - is refused with 400 before \
+      it runs, because its rows would otherwise reach the client before the transaction that produced them \
+      commits. Request the buffered 'application/json' encoding for it instead.""";
+
   @Override
   public void contribute(final OpenAPI openAPI) {
     openAPI.getPaths().addPathItem("/api/v1/server", createServerPath());
@@ -246,7 +255,7 @@ public class CoreApiSpec implements OpenApiContributor {
 
     final Operation postOp = new Operation();
     postOp.setSummary("Execute query via POST");
-    postOp.setDescription("Executes a query using POST method with query in request body");
+    postOp.setDescription("Executes a query using POST method with query in request body. " + NDJSON_READ_ONLY_DESCRIPTION);
     postOp.setOperationId("executeQueryPost");
     postOp.addTagsItem("Query");
     postOp.addParametersItem(SpecBuilders.pathParam("database", "Database name"));
@@ -266,7 +275,7 @@ public class CoreApiSpec implements OpenApiContributor {
 
     final Operation postOp = new Operation();
     postOp.setSummary("Execute command");
-    postOp.setDescription("Executes a database command");
+    postOp.setDescription("Executes a database command. " + NDJSON_READ_ONLY_DESCRIPTION);
     postOp.setOperationId("executeCommand");
     postOp.addTagsItem("Command");
     postOp.addParametersItem(SpecBuilders.pathParam("database", "Database name"));

--- a/server/src/test/java/com/arcadedb/server/Issue7570BatchReservedKeyIT.java
+++ b/server/src/test/java/com/arcadedb/server/Issue7570BatchReservedKeyIT.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.Record;
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.io.DataOutputStream;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7570, the half that is not documentation: the reported payload
+ * <pre>{"@type":"vertex","@class":"Person","properties":{"name":"Alice"}}</pre>
+ * answered 200 with {@code verticesCreated: 1} and stored a property literally named {@code properties} holding the
+ * map. The counters were right and the data was wrong, and nothing failed until someone queried for {@code name} and
+ * found nothing.
+ * <p>
+ * The unit tests in {@code Issue7570ReservedBatchKeyTest} pin the parsers. This one proves the refusal survives the
+ * whole HTTP path - that it is reported as a 400 and not as the 408 a truncated body gets, that it carries the
+ * partial-commit accounting the other {@code /batch} failures carry, and above all that the database is left with
+ * nothing rather than with the wrong thing.
+ */
+class Issue7570BatchReservedKeyIT extends BaseGraphServerTest {
+
+  @Override
+  protected int getServerCount() {
+    return 1;
+  }
+
+  /** The payload copied from the issue. */
+  @Test
+  void nestingPropertiesUnderAPropertiesKeyIsRefusedInsteadOfStoredVerbatim() throws Exception {
+    createSchema("NestedProps");
+
+    final JSONObject error = postExpecting(400,
+        "{\"@type\":\"vertex\",\"@class\":\"NestedProps\",\"properties\":{\"name\":\"Alice\"}}\n",
+        "application/x-ndjson");
+
+    assertThat(error.getString("error"))
+        .contains("'properties'")
+        .contains("line 1")
+        .contains("flat");
+    assertThat(error.getLong("verticesCreated")).isZero();
+
+    final Database db = getServerDatabase(0, getDatabaseName());
+    assertThat(db.countType("NestedProps", false))
+        .as("the misread line must leave nothing behind, not a vertex carrying a 'properties' map")
+        .isZero();
+  }
+
+  /** A scalar of the same name is data, not a mistake, and still loads. */
+  @Test
+  void aScalarPropertiesValueStillLoads() throws Exception {
+    createSchema("ScalarProps");
+
+    final JSONObject result = post(200,
+        "{\"@type\":\"vertex\",\"@class\":\"ScalarProps\",\"@id\":\"s1\",\"properties\":\"public\"}\n",
+        "application/x-ndjson");
+
+    assertThat(result.getLong("verticesCreated")).isEqualTo(1);
+
+    final Database db = getServerDatabase(0, getDatabaseName());
+    final List<Object> stored = new ArrayList<>();
+    final Iterator<Record> records = db.iterateType("ScalarProps", false);
+    while (records.hasNext())
+      stored.add(records.next().asVertex().get("properties"));
+
+    assertThat(stored).as("a scalar under this name is data, and has to be stored under it")
+        .containsExactly("public");
+  }
+
+  /** An unrecognised control key used to be stored as a property whose name begins with {@code @}. */
+  @Test
+  void anUnknownAtPrefixedKeyIsRefused() throws Exception {
+    createSchema("UnknownAtKey");
+
+    final JSONObject error = postExpecting(400,
+        "{\"@type\":\"vertex\",\"@class\":\"UnknownAtKey\",\"@id\":\"u1\",\"@rid\":\"#1:0\"}\n",
+        "application/x-ndjson");
+
+    assertThat(error.getString("error")).contains("'@rid'").contains("line 1");
+  }
+
+  /**
+   * The refusal has to land as a 400 on a body that arrived whole. {@code PostBatchHandler} answers 408 for a
+   * {@code MalformedBatchRecordException} raised on a body that ended early, which is why the reserved-key throw is
+   * a plain {@code IllegalArgumentException}: a client sent a complete, well-formed line that the server declines,
+   * and telling it to go hunting for a truncated upload would send it to the wrong place.
+   */
+  @Test
+  void theRefusalKeepsTheAccountingAndTheLinesTheLoadHadReached() throws Exception {
+    createSchema("Accounting");
+
+    final String body = """
+        {"@type":"vertex","@class":"Accounting","@id":"a1","name":"Alice"}
+        {"@type":"vertex","@class":"Accounting","@id":"a2","name":"Bob"}
+        {"@type":"vertex","@class":"Accounting","@id":"a3","@cat":"v"}
+        """;
+
+    final JSONObject error = postExpecting(400, body, "application/x-ndjson");
+
+    assertThat(error.getString("error")).contains("'@cat'").contains("line 3");
+    assertThat(error.getLong("linesRead")).as("the failing line was read too").isEqualTo(3);
+    assertThat(error.getLong("linesSkipped")).isZero();
+    assertThat(error.has("partialCommit")).isTrue();
+  }
+
+  /**
+   * The streaming encoding answers 200 for a load that failed <em>after</em> it acknowledged a chunk, because the
+   * status line is already gone by then. A reserved key on line 1 is rejected before anything is acknowledged, so the
+   * request must still get its real 400 and the buffered error body - the guarantee the operation documents for its
+   * 400 and 408, which a refusal introduced on this path must not quietly break.
+   */
+  @Test
+  void theRefusalIsStillA400UnderTheStreamingEncoding() throws Exception {
+    createSchema("Streaming");
+
+    final JSONObject error = post(400,
+        "{\"@type\":\"vertex\",\"@class\":\"Streaming\",\"properties\":{\"name\":\"Alice\"}}\n",
+        "application/x-ndjson", "application/x-ndjson");
+
+    assertThat(error.getString("error")).contains("'properties'").contains("line 1");
+  }
+
+  /** Same defect, CSV spelling: the control keys are column names there, so the header is where it is caught. */
+  @Test
+  void anUnknownAtPrefixedCsvColumnIsRefused() throws Exception {
+    createSchema("CsvUnknownAtCol");
+
+    final String body = """
+        @type,@class,@id,@rid,name
+        vertex,CsvUnknownAtCol,c1,#1:0,Carol
+        """;
+
+    final JSONObject error = postExpecting(400, body, "text/csv");
+
+    assertThat(error.getString("error")).contains("'@rid'").contains("line 1");
+
+    final Database db = getServerDatabase(0, getDatabaseName());
+    assertThat(db.query("sql", "SELECT FROM CsvUnknownAtCol WHERE name = 'Carol'").stream().count()).isZero();
+  }
+
+  /** A CSV column named {@code properties} carries a scalar and is ordinary data, so it must keep working. */
+  @Test
+  void aCsvPropertiesColumnStillLoads() throws Exception {
+    createSchema("CsvScalarProps");
+
+    final String body = """
+        @type,@class,@id,properties
+        vertex,CsvScalarProps,c2,public
+        """;
+
+    final JSONObject result = post(200, body, "text/csv");
+
+    assertThat(result.getLong("verticesCreated")).isEqualTo(1);
+  }
+
+  /**
+   * Every test gets its own vertex type. The server database is shared across the methods of this class and the
+   * assertions here are about what a refused load left behind, so a type another method had already written to would
+   * make them pass or fail on execution order rather than on the fix.
+   */
+  private void createSchema(final String vertexType) {
+    final Database db = getServerDatabase(0, getDatabaseName());
+    if (!db.getSchema().existsType(vertexType))
+      db.getSchema().createVertexType(vertexType);
+  }
+
+  private JSONObject postExpecting(final int status, final String body, final String contentType) throws Exception {
+    return post(status, body, contentType);
+  }
+
+  private JSONObject post(final int expectedStatus, final String body, final String contentType) throws Exception {
+    return post(expectedStatus, body, contentType, null);
+  }
+
+  private JSONObject post(final int expectedStatus, final String body, final String contentType, final String accept)
+      throws Exception {
+    // Never a hardcoded 2480: the server binds the first free port of the configured range, and a port pinned to
+    // 2480 is answered by whatever else already listens there - which surfaces as a 403 rather than as a conflict.
+    final String url = "http://127.0.0.1:" + getServer(0).getHttpServer().getPort()
+        + "/api/v1/batch/" + getDatabaseName();
+
+    final HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
+    conn.setRequestMethod("POST");
+    conn.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+    conn.setRequestProperty("Content-Type", contentType);
+    if (accept != null)
+      conn.setRequestProperty("Accept", accept);
+    conn.setDoOutput(true);
+
+    final byte[] data = body.getBytes(StandardCharsets.UTF_8);
+    conn.setRequestProperty("Content-Length", Integer.toString(data.length));
+    try (final DataOutputStream out = new DataOutputStream(conn.getOutputStream())) {
+      out.write(data);
+    }
+    conn.connect();
+
+    try {
+      final int status = conn.getResponseCode();
+      final InputStream in = status < 400 ? conn.getInputStream() : conn.getErrorStream();
+      final String response = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+      assertThat(status).as("response: %s", response).isEqualTo(expectedStatus);
+      return new JSONObject(response);
+    } finally {
+      conn.disconnect();
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/batch/Issue7570ReservedBatchKeyTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/batch/Issue7570ReservedBatchKeyTest.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler.batch;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7570: the {@code /batch} encoding carries its control keys and its data in the same flat object, and the
+ * parsers used to treat "not one of the five control keys" and "is data" as the same predicate. A key the parser did
+ * not understand therefore became a property with that name, and the load answered 200.
+ * <p>
+ * The reported case is the one a reader of the gRPC sibling arrives at: {@code GraphBatchRecord} carries a
+ * {@code properties} map, so nesting the properties under a {@code properties} key is the obvious guess. It was
+ * accepted, and created a single property literally named {@code properties} holding the whole map - right counters,
+ * wrong data, and nothing failing until someone queried for a field that was never stored.
+ * <p>
+ * These tests pin the two shapes the parsers now refuse: an {@code @}-prefixed key outside the five they understand,
+ * and a {@code properties} key whose value is an object. They are unit tests on the parsers themselves;
+ * {@code Issue7570BatchReservedKeyIT} drives the same payloads through the HTTP endpoint to prove the refusal reaches
+ * the client as a 400.
+ */
+class Issue7570ReservedBatchKeyTest {
+
+  /**
+   * The reported payload. Before the fix this parsed into one property named {@code properties} holding a
+   * {@link Map}.
+   */
+  @Test
+  void jsonlRefusesPropertiesNestedUnderAPropertiesKeyOnAVertex() {
+    final String input = "{\"@type\":\"vertex\",\"@class\":\"Person\",\"properties\":{\"name\":\"Alice\"}}\n";
+
+    assertThatThrownBy(() -> drain(input))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("'properties'")
+        .hasMessageContaining("line 1")
+        .hasMessageContaining("flat");
+  }
+
+  /** Same misreading on an edge line: the map is just as wrong there, and just as quiet. */
+  @Test
+  void jsonlRefusesPropertiesNestedUnderAPropertiesKeyOnAnEdge() {
+    final String input = "{\"@type\":\"edge\",\"@class\":\"Knows\",\"@from\":\"p1\",\"@to\":\"p2\","
+        + "\"properties\":{\"since\":2020}}\n";
+
+    assertThatThrownBy(() -> drain(input))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("'properties'");
+  }
+
+  /**
+   * The refusal is keyed on the value being an object, because that is what identifies the nested-form mistake. A
+   * scalar under the same name is ordinary data - a domain is allowed a field called {@code properties} - and
+   * refusing it would break payloads that are not mistakes.
+   */
+  @Test
+  void jsonlKeepsAScalarPropertiesValueAsAnOrdinaryProperty() throws Exception {
+    final String input = "{\"@type\":\"vertex\",\"@class\":\"Person\",\"@id\":\"p1\",\"properties\":\"public\"}\n";
+
+    final BatchRecord record = first(input);
+
+    assertThat(record.propertyCount).isEqualTo(1);
+    assertThat(record.properties[0]).isEqualTo("properties");
+    assertThat(record.properties[1]).isEqualTo("public");
+  }
+
+  /**
+   * An unrecognised control key. {@code @rid} is what a client that round-trips a record it read back sends, and it
+   * used to be stored as a property whose name starts with {@code @}.
+   */
+  @Test
+  void jsonlRefusesAnUnknownAtPrefixedKey() {
+    final String input = "{\"@type\":\"vertex\",\"@class\":\"Person\",\"@id\":\"p1\",\"@rid\":\"#1:0\"}\n";
+
+    assertThatThrownBy(() -> drain(input))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("'@rid'")
+        .hasMessageContaining("line 1")
+        .hasMessageContaining("@type");
+  }
+
+  /**
+   * A typo in a control key is the same defect wearing a different hat: {@code @clas} used to be accepted as a
+   * property and the line then failed on the missing {@code @class} - or, with {@code @class} also present,
+   * succeeded and stored the typo.
+   */
+  @Test
+  void jsonlRefusesATypoedControlKey() {
+    final String input = "{\"@type\":\"vertex\",\"@class\":\"Person\",\"@clas\":\"Person\"}\n";
+
+    assertThatThrownBy(() -> drain(input))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("'@clas'");
+  }
+
+  /** The line number has to be the offending one, not the first: a batch failure is placed inside the file. */
+  @Test
+  void jsonlReportsTheOffendingLineNumber() {
+    final String input = """
+        {"@type":"vertex","@class":"Person","@id":"p1","name":"Alice"}
+        {"@type":"vertex","@class":"Person","@id":"p2","name":"Bob"}
+        {"@type":"vertex","@class":"Person","@id":"p3","@cat":"v"}
+        """;
+
+    assertThatThrownBy(() -> drain(input))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("line 3");
+  }
+
+  /**
+   * The refusal must not be a {@link MalformedBatchRecordException}: that subclass means "this line is not a JSON
+   * object at all", which {@code PostBatchHandler} reports as a 408 when the body also ended early, because a
+   * truncated upload produces exactly that. A reserved key is a well-formed line the server declines, and has to
+   * stay a 400.
+   */
+  @Test
+  void aReservedKeyIsNotReportedAsAMalformedLine() {
+    final String input = "{\"@type\":\"vertex\",\"@class\":\"Person\",\"@rid\":\"#1:0\"}\n";
+
+    assertThatThrownBy(() -> drain(input))
+        .isInstanceOf(IllegalArgumentException.class)
+        .isNotInstanceOf(MalformedBatchRecordException.class);
+  }
+
+  /** The five control keys and ordinary data still parse exactly as before. */
+  @Test
+  void jsonlStillAcceptsTheFiveControlKeysAndFlatProperties() throws Exception {
+    final BatchRecord vertex = first("{\"@type\":\"vertex\",\"@class\":\"Person\",\"@id\":\"p1\",\"name\":\"Alice\"}\n");
+    assertThat(vertex.kind).isEqualTo(BatchRecord.Kind.VERTEX);
+    assertThat(vertex.tempId).isEqualTo("p1");
+    assertThat(vertex.propertyCount).isEqualTo(1);
+    assertThat(vertex.properties[0]).isEqualTo("name");
+
+    final BatchRecord edge = first(
+        "{\"@type\":\"edge\",\"@class\":\"Knows\",\"@from\":\"p1\",\"@to\":\"p2\",\"since\":2020}\n");
+    assertThat(edge.kind).isEqualTo(BatchRecord.Kind.EDGE);
+    assertThat(edge.fromRef).isEqualTo("p1");
+    assertThat(edge.toRef).isEqualTo("p2");
+    assertThat(edge.propertyCount).isEqualTo(1);
+    assertThat(edge.properties[0]).isEqualTo("since");
+  }
+
+  /**
+   * An embedded document under any other name is still legitimate - issue #4069 made nested objects unwrap to a
+   * {@link Map} on purpose - so the refusal must be about the key, not about the value being an object.
+   */
+  @Test
+  void jsonlStillAcceptsANestedObjectUnderAnyOtherName() throws Exception {
+    final BatchRecord record = first(
+        "{\"@type\":\"vertex\",\"@class\":\"Person\",\"@id\":\"p1\",\"address\":{\"city\":\"Rome\"}}\n");
+
+    assertThat(record.propertyCount).isEqualTo(1);
+    assertThat(record.properties[0]).isEqualTo("address");
+    assertThat(record.properties[1]).isInstanceOf(Map.class);
+  }
+
+  /**
+   * CSV names its control keys in the header, so that is where the same defect lives: an unrecognised
+   * {@code @}-prefixed column used to become a property column.
+   */
+  @Test
+  void csvRefusesAnUnknownAtPrefixedHeaderColumn() {
+    final String input = """
+        @type,@class,@id,@rid,name
+        vertex,Person,p1,#1:0,Alice
+        """;
+
+    assertThatThrownBy(() -> drainCsv(input))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("'@rid'")
+        .hasMessageContaining("line 1")
+        .hasMessageContaining("@type");
+  }
+
+  /**
+   * The edge section gets its own header, so it gets its own check - and the line number reported has to be the
+   * second header's, not the first's.
+   */
+  @Test
+  void csvRefusesAnUnknownAtPrefixedColumnInTheEdgeSectionHeader() {
+    final String input = """
+        @type,@class,@id,name
+        vertex,Person,p1,Alice
+        vertex,Person,p2,Bob
+        ---
+        @type,@class,@from,@to,@weight
+        edge,Knows,p1,p2,3
+        """;
+
+    assertThatThrownBy(() -> drainCsv(input))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("'@weight'")
+        .hasMessageContaining("line 5");
+  }
+
+  /**
+   * CSV values are scalars - {@code parseValue} returns only Boolean, Long, Double, String or null, never a Map - so
+   * the nested-form misreading has no CSV spelling and a {@code properties} column is ordinary data. Refusing it
+   * would break payloads that are not mistakes.
+   */
+  @Test
+  void csvKeepsAPropertiesColumnAsAnOrdinaryProperty() throws Exception {
+    final String input = """
+        @type,@class,@id,properties
+        vertex,Person,p1,public
+        """;
+
+    final BatchRecord record = firstCsv(input);
+
+    assertThat(record.propertyCount).isEqualTo(1);
+    assertThat(record.properties[0]).isEqualTo("properties");
+    assertThat(record.properties[1]).isEqualTo("public");
+  }
+
+  /** The documented CSV shape still parses. */
+  @Test
+  void csvStillAcceptsTheDocumentedHeaderShape() throws Exception {
+    final String input = """
+        @type,@class,@id,name
+        vertex,Person,p1,Alice
+        """;
+
+    final BatchRecord record = firstCsv(input);
+
+    assertThat(record.kind).isEqualTo(BatchRecord.Kind.VERTEX);
+    assertThat(record.typeName).isEqualTo("Person");
+    assertThat(record.tempId).isEqualTo("p1");
+    assertThat(record.propertyCount).isEqualTo(1);
+    assertThat(record.properties[0]).isEqualTo("name");
+  }
+
+  private static void drain(final String input) throws Exception {
+    try (final JsonlBatchRecordStream stream = new JsonlBatchRecordStream(toStream(input))) {
+      while (stream.hasNext())
+        stream.next();
+    }
+  }
+
+  private static BatchRecord first(final String input) throws Exception {
+    try (final JsonlBatchRecordStream stream = new JsonlBatchRecordStream(toStream(input))) {
+      assertThat(stream.hasNext()).isTrue();
+      return stream.next();
+    }
+  }
+
+  private static void drainCsv(final String input) throws Exception {
+    try (final CsvBatchRecordStream stream = new CsvBatchRecordStream(toStream(input))) {
+      while (stream.hasNext())
+        stream.next();
+    }
+  }
+
+  private static BatchRecord firstCsv(final String input) throws Exception {
+    try (final CsvBatchRecordStream stream = new CsvBatchRecordStream(toStream(input))) {
+      assertThat(stream.hasNext()).isTrue();
+      return stream.next();
+    }
+  }
+
+  private static ByteArrayInputStream toStream(final String s) {
+    return new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
@@ -287,6 +287,45 @@ class CoreApiSpecTest {
     }
   }
 
+  /**
+   * Issue #7569: both operations declare 'application/x-ndjson' under their 200, but
+   * PostCommandHandler.requireStreamableStatement() refuses to stream a statement that is not
+   * provably read-only with a 400 before it ever runs - and nothing in the contract said so. A
+   * client author reading the contract alone had no way to know the restriction existed short of
+   * sending a mutating statement at a live server and reading the 400.
+   * <p>
+   * Checked on both /command and /query: PostQueryHandler extends PostCommandHandler and overrides
+   * only executeCommand(), so the very same requireStreamableStatement() call at execute() time
+   * guards both operations identically (the same sharing this file already pins down for 'limit'
+   * in commandRequestDeclaresLimitMatchingQueryRequest).
+   */
+  @Test
+  void commandAndQueryDescribeTheReadOnlyStreamingRestriction() {
+    // The literal text CoreApiSpec appends to both operations' description. Duplicated here rather
+    // than referencing the (private) production constant, matching how this file already pins other
+    // shared text verbatim (e.g. STALE_SESSION_404_DESCRIPTION's message in
+    // queryAndCommand404CoversAStaleSessionIdNotOnlyAMissingDatabase).
+    final String restriction = "only a statement provably read-only may stream";
+
+    final Operation command = openAPI.getPaths().get("/api/v1/command/{database}").getPost();
+    final Operation query = openAPI.getPaths().get("/api/v1/query/{database}").getPost();
+
+    for (final Operation operation : List.of(command, query)) {
+      assertThat(operation.getDescription())
+          .as(operation.getOperationId() + " must warn that the ndjson encoding is refused before "
+              + "it runs for a statement that is not provably read-only")
+          .contains(restriction)
+          .contains("400");
+    }
+
+    final String commandSuffix = command.getDescription().substring(command.getDescription().indexOf(restriction));
+    final String querySuffix = query.getDescription().substring(query.getDescription().indexOf(restriction));
+    assertThat(commandSuffix)
+        .as("both operations run through the exact same requireStreamableStatement() check, so the "
+            + "restriction text must not diverge between them and confuse a reader of the generated docs")
+        .isEqualTo(querySuffix);
+  }
+
   @Test
   void commandRequestDeclaresLanguageAsRequired() {
     final Schema<?> schema = openAPI.getComponents().getSchemas().get("CommandRequest");

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/Issue7570BatchRequestBodySchemaTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/Issue7570BatchRequestBodySchemaTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler.openapi;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7570: everything <em>about</em> a bulk load was documented - non-atomicity, the partial-commit counters,
+ * {@code bytesRead} verification, the streaming acknowledgement protocol - except what to send. All three request
+ * media types declared {@code type: string}, so none of {@code @type}, {@code @class}, {@code @id}, {@code @from} or
+ * {@code @to} appeared anywhere in the contract and every client in every language had to reverse-engineer the
+ * payload. The gRPC sibling {@code GraphBatchRecord} has been schematized since it shipped; only the HTTP encoding of
+ * the same model was not.
+ * <p>
+ * The two line shapes are now a {@code oneOf} discriminated on {@code @type}, following the convention the spec
+ * already uses for its NDJSON <em>responses</em> ({@code NdJsonQueryEvent}, {@code NdJsonBatchEvent}): the media-type
+ * schema is the schema of one line, because OpenAPI 3.0 cannot say "newline-delimited instances of this" for a
+ * request body.
+ */
+class Issue7570BatchRequestBodySchemaTest {
+  private static final String BATCH_PATH = "/api/v1/batch/{database}";
+
+  private final OpenAPI openAPI = new OpenAPI();
+
+  @BeforeEach
+  void contribute() {
+    openAPI.setPaths(new Paths());
+    openAPI.setComponents(new Components());
+    new CoreApiSpec().contribute(openAPI);
+  }
+
+  /** The defect as reported: three media types, one {@code type: string} between them. */
+  @Test
+  void theJsonLineMediaTypesReferenceTheLineSchemaInsteadOfAnOpaqueString() {
+    final Map<String, MediaType> content = batchOperation().getRequestBody().getContent();
+
+    assertThat(content).containsKeys("application/x-ndjson", "application/jsonl", "text/csv");
+
+    for (final String mediaType : List.of("application/x-ndjson", "application/jsonl")) {
+      final Schema<?> schema = content.get(mediaType).getSchema();
+      assertThat(schema.get$ref())
+          .as("%s must name the line schema so a generated client can type the payload", mediaType)
+          .isEqualTo("#/components/schemas/BatchLine");
+    }
+  }
+
+  /** A generated client picks the branch by the discriminator, so the mapping has to name every accepted spelling. */
+  @Test
+  void theLineSchemaIsAOneOfDiscriminatedOnAtType() {
+    final Schema<?> line = schema("BatchLine");
+
+    assertThat(line.getOneOf()).as("a vertex line and an edge line are different shapes").hasSize(2);
+    assertThat(line.getOneOf()).extracting(Schema::get$ref)
+        .containsExactly("#/components/schemas/BatchVertexLine", "#/components/schemas/BatchEdgeLine");
+
+    assertThat(line.getDiscriminator()).isNotNull();
+    assertThat(line.getDiscriminator().getPropertyName()).isEqualTo("@type");
+    assertThat(line.getDiscriminator().getMapping())
+        .as("the parsers accept the short spellings too, so the contract has to map them")
+        .containsEntry("vertex", "#/components/schemas/BatchVertexLine")
+        .containsEntry("v", "#/components/schemas/BatchVertexLine")
+        .containsEntry("edge", "#/components/schemas/BatchEdgeLine")
+        .containsEntry("e", "#/components/schemas/BatchEdgeLine");
+  }
+
+  /** The control keys the issue could not find anywhere in the contract. */
+  @Test
+  void theVertexLineNamesItsControlKeysAndRequiresTheOnesTheParserRequires() {
+    final Schema<?> vertex = schema("BatchVertexLine");
+
+    assertThat(vertex.getProperties()).containsKeys("@type", "@class", "@id");
+    assertThat(vertex.getRequired())
+        .as("JsonlBatchRecordStream.parseLine throws when either is missing")
+        .containsExactlyInAnyOrder("@type", "@class");
+    assertThat(vertex.getProperties().get("@type").getEnum()).containsExactly("vertex", "v");
+  }
+
+  @Test
+  void theEdgeLineNamesItsEndpointsAndRequiresThem() {
+    final Schema<?> edge = schema("BatchEdgeLine");
+
+    assertThat(edge.getProperties()).containsKeys("@type", "@class", "@from", "@to");
+    assertThat(edge.getRequired())
+        .as("an edge with no @from or no @to is refused at the line")
+        .containsExactlyInAnyOrder("@type", "@class", "@from", "@to");
+    assertThat(edge.getProperties().get("@type").getEnum()).containsExactly("edge", "e");
+  }
+
+  /**
+   * The half of the contract that turns the silent-corruption report into a document a client can read: properties
+   * sit flat beside the control keys, and the nested form the {@code GraphBatchRecord} {@code properties} map invites
+   * is refused rather than stored.
+   */
+  @Test
+  void bothLineShapesSayPropertiesAreFlatAndThatTheNestedFormIsRefused() {
+    for (final String name : List.of("BatchVertexLine", "BatchEdgeLine")) {
+      final Schema<?> line = schema(name);
+
+      assertThat(line.getAdditionalProperties())
+          .as("%s must allow the arbitrary property keys a schemaless load carries", name)
+          .isNotNull();
+      assertThat(line.getDescription())
+          .as("%s must say where the properties go", name)
+          .contains("flat")
+          .contains("properties");
+    }
+  }
+
+  /** An unrecognised control key is refused now, so the contract has to say the namespace is reserved. */
+  @Test
+  void theRequestBodyDescribesTheReservedAtPrefixAndTheCsvGrammar() {
+    final String description = batchOperation().getRequestBody().getDescription();
+
+    assertThat(description)
+        .as("the @ namespace is reserved and an unknown key in it is a 400")
+        .contains("@");
+
+    final Schema<?> csv = batchOperation().getRequestBody().getContent().get("text/csv").getSchema();
+    assertThat(csv.getDescription())
+        .as("'Header row followed by data rows' did not say how a header names @class or an edge's endpoints")
+        .contains("@type")
+        .contains("@class")
+        .contains("---");
+  }
+
+  /** The 400 already existed; it now has to name this cause, or a client cannot tell it from a malformed line. */
+  @Test
+  void theBadRequestResponseNamesTheReservedKeyRefusal() {
+    assertThat(batchOperation().getResponses().get("400").getDescription())
+        .contains("reserved");
+  }
+
+  private Operation batchOperation() {
+    return openAPI.getPaths().get(BATCH_PATH).getPost();
+  }
+
+  private Schema<?> schema(final String name) {
+    final Schema<?> schema = openAPI.getComponents().getSchemas().get(name);
+    assertThat(schema).as("component schema %s", name).isNotNull();
+    return schema;
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/Issue7570BatchRequestBodySchemaTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/Issue7570BatchRequestBodySchemaTest.java
@@ -143,6 +143,13 @@ class Issue7570BatchRequestBodySchemaTest {
         .as("the @ namespace is reserved and an unknown key in it is a 400")
         .contains("@");
 
+    // Both parsers match the control keys with equals() and an exact switch, while only the CSV boolean literals
+    // go through equalsIgnoreCase. A client cannot guess that asymmetry, and under the new refusal '@Type' is a
+    // 400 rather than a silently stored property, so the contract has to state it.
+    assertThat(description)
+        .as("control-key matching is case-sensitive and the contract must say so")
+        .contains("case-sensitiv");
+
     final Schema<?> csv = batchOperation().getRequestBody().getContent().get("text/csv").getSchema();
     assertThat(csv.getDescription())
         .as("'Header row followed by data rows' did not say how a header names @class or an edge's endpoints")

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -3385,6 +3385,19 @@ function renderTypeLink(typeName) {
 const LIGHTWEIGHT_EDGE_HINT = "LIGHTWEIGHT: edges are stored inside the vertices, so this type keeps no records. "
   + "Query them with SELECT FROM <type> or by traversing the vertices.";
 
+// A section header sums each type's record count for a rough total. A LIGHTWEIGHT edge type reports 0
+// records by construction (see LIGHTWEIGHT_EDGE_HINT above), so a section that contains one is a lower
+// bound, not the true count - marked with a trailing "+" rather than shown as if it were exact.
+function formatSectionTotal(items) {
+  let total = 0;
+  let hasLightweight = false;
+  for (let j = 0; j < items.length; j++) {
+    total += (items[j].records || 0);
+    if (items[j].lightweight === true) hasLightweight = true;
+  }
+  return total.toLocaleString() + (hasLightweight ? "+" : "");
+}
+
 function renderTypeSidebarBadge(row, color, action) {
   let name = escapeHtml(row.name);
   let lightweight = row.lightweight === true;
@@ -3514,11 +3527,8 @@ function displaySchema(onReady) {
       let sec = sections[s];
       let items = groups[sec.key];
 
-      let total = 0;
-      for (let j = 0; j < items.length; j++) total += (items[j].records || 0);
-
       html += "<div class='sidebar-section'>";
-      html += "<div class='sidebar-section-header'><i class='fa " + sec.icon + "'></i> " + sec.label + " <span class='sidebar-count'>(" + total.toLocaleString() + ")</span>";
+      html += "<div class='sidebar-section-header'><i class='fa " + sec.icon + "'></i> " + sec.label + " <span class='sidebar-count'>(" + formatSectionTotal(items) + ")</span>";
       if (sec.key == "timeseries")
         html += "<span class='sidebar-section-header-actions'><button onclick='createTimeSeriesType(); return false;' title='Create timeseries type'><i class='fa fa-plus'></i></button></span>";
       else
@@ -3804,13 +3814,11 @@ function populateQuerySidebar() {
   }
 
   let groups = { vertex: [], edge: [], document: [], timeseries: [] };
-  let totals = { vertex: 0, edge: 0, document: 0, timeseries: 0 };
 
   for (let i in globalSchemaTypes) {
     let row = globalSchemaTypes[i];
     let cat = row.type == "vertex" ? "vertex" : (row.type == "edge" ? "edge" : (row.type == "t" ? "timeseries" : "document"));
     groups[cat].push(row);
-    totals[cat] += (row.records || 0);
   }
 
   let html = "";
@@ -3826,7 +3834,7 @@ function populateQuerySidebar() {
     let items = groups[sec.key];
     if (items.length == 0) continue;
 
-    let totalFormatted = totals[sec.key].toLocaleString();
+    let totalFormatted = formatSectionTotal(items);
     html += "<div class='sidebar-section'>";
     html += "<div class='sidebar-section-header'><i class='fa " + sec.icon + "'></i> " + sec.label + " <span class='sidebar-count'>(" + totalFormatted + ")</span></div>";
     html += "<div class='sidebar-badges'>";

--- a/studio/test/sidebar-section-total.test.js
+++ b/studio/test/sidebar-section-total.test.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+
+// Regression test, from discussion #7473 (comment https://github.com/ArcadeData/arcadedb/discussions/7473#discussioncomment-18408772)
+// after issue #7477 was fixed: the sidebar badge of a LIGHTWEIGHT edge type correctly stopped showing its
+// record count (0) as its size, but the section header above it - "Edges (N)" - still summed the raw
+// `records` field of every type in the section. A LIGHTWEIGHT type reports 0 records by construction, so a
+// graph holding a million lightweight edges still showed "Edges (0)" at the top of the sidebar. The total is
+// now marked with a trailing "+" whenever the section holds a type it cannot count, instead of presenting a
+// wrong number as if it were exact.
+//
+// Run with:
+//
+//     node --test studio/test/sidebar-section-total.test.js
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const SRC_PATH = path.join(__dirname, "..", "src", "main", "resources", "static", "js", "studio-database.js");
+const src = fs.readFileSync(SRC_PATH, "utf8");
+
+function extractFn(name) {
+  const start = src.indexOf("function " + name + "(");
+  if (start < 0) throw new Error("function not found in studio-database.js: " + name);
+  let i = src.indexOf("{", start);
+  let depth = 1;
+  i++;
+  while (i < src.length && depth > 0) {
+    const c = src[i];
+    if (c === "{") depth++;
+    else if (c === "}") depth--;
+    i++;
+  }
+  return src.substring(start, i);
+}
+
+eval(extractFn("formatSectionTotal"));
+
+test("a section with only regular types shows the exact sum", () => {
+  const total = formatSectionTotal([{ records: 3 }, { records: 4 }]);
+  assert.equal(total, "7");
+});
+
+test("a section holding a LIGHTWEIGHT edge type marks its total as a lower bound", () => {
+  const total = formatSectionTotal([{ records: 0, lightweight: true }]);
+  assert.equal(total, "0+", "a graph full of lightweight edges must not read as an empty section");
+});
+
+test("a mixed section still adds the regular types' records and marks the total", () => {
+  const total = formatSectionTotal([{ records: 5, lightweight: false }, { records: 0, lightweight: true }]);
+  assert.equal(total, "5+");
+});
+
+test("an empty section shows a plain zero", () => {
+  const total = formatSectionTotal([]);
+  assert.equal(total, "0");
+});
+
+test("a type listing from an older server, with no lightweight flag, is unaffected", () => {
+  const total = formatSectionTotal([{ records: 7 }, { records: 3 }]);
+  assert.equal(total, "10");
+});


### PR DESCRIPTION
Closes #7570

## Summary

Everything *about* a bulk load was documented - non-atomicity, the partial-commit counters, `bytesRead` verification, the streaming acknowledgement protocol - except what to send. All three media types of `POST /api/v1/batch/{database}` declared the payload as `type: string`, so none of `@type`, `@class`, `@id`, `@from` or `@to` appeared anywhere in the contract, while the gRPC sibling `GraphBatchRecord` has been schematized since it shipped. And the misreading that gap invites was accepted: `GraphBatchRecord` carries a `properties` map, so nesting the properties under a `properties` key is the obvious guess, and the flat encoding stored it as a single property literally named `properties` and answered 200 with the right counters and the wrong data. The two parsers treated "not one of the five control keys" and "is data" as one predicate, so an unrecognised `@`-prefixed key (`@rid`, a typo'd `@clas`) fell through identically. This PR gives the JSON line encodings a real `BatchLine` schema - a `oneOf` of a vertex line and an edge line discriminated on `@type`, all four accepted spellings mapped, the control keys named and required where the parser requires them, and `additionalProperties` stating that properties sit flat - describes the CSV grammar it actually parses, and makes both parsers refuse a key they cannot read as data with a 400 naming the line.

## Breaking change

This tightens a **write** path: a payload carrying an `@`-prefixed key outside the five, or a nested `properties` object, used to load with a 200 and now answers 400. That 200 was the defect, but the change is a behaviour change and not only a documentation one.

The blast radius was measured, not assumed. Across every batch payload literal in the tree (`*.java`, `*.md`, `*.js`, `*.py`, `*.json`, `*.ts`), the only `@`-keys that occur are `@type` (86), `@class` (86), `@id` (46), `@to` (24), `@from` (24) and `@cat` (2) - and the two `@cat` hits are the new tests in this branch. Nothing shipped in this repository sends a payload the refusal would reject.

The rules are deliberately narrow, so they refuse mistakes and not data:

- a **scalar** `properties` value is ordinary data and still loads; only an object value is refused, because that is specifically the nested-form misreading;
- **CSV gets no `properties` rule at all**: `CsvBatchRecordStream.parseValue` returns only `Boolean`, `Long`, `Double`, `String` or `null`, never a `Map`, so the nested form has no CSV spelling and a `properties` column can only ever be data.

Reserving the `@` namespace is on evidence rather than taste: `MutableDocument.fromMap` and `set(Map)` already drop `@`-prefixed keys as metadata, and `set(String, Object)` - the path `GraphBatch` uses - was the one door that let one through.

## Test plan

- [x] `mvn -o -pl server test -Dtest='com.arcadedb.server.http.**'` - 856 tests, 0 failures (the packages this touches, in full)
- [x] `mvn -o -pl server verify -DskipITs=false -Dit.test='Issue7570BatchReservedKeyIT'` - 7 ITs driving the real HTTP endpoint
- [x] Reverting either parser change turns **15 of the 20** new unit assertions red - every refusal, on every entry point - while the five "this still works" guards stay green
- [x] `OpenApiSpecGenerationIT` parses the published spec with swagger-parser and asserts it carries no validation messages, which covers the new `oneOf`, discriminator and `$ref`s
- [x] Manual: `printf '{"@type":"vertex","@class":"Person","properties":{"name":"Alice"}}\n' | curl --data-binary @- -H 'Content-Type: application/x-ndjson' .../api/v1/batch/<db>` now answers 400 naming line 1 instead of 200

## Coverage

| Entry point | Fixed | Test |
|---|---|---|
| `application/x-ndjson` / `application/jsonl` -> `JsonlBatchRecordStream.parseLine`, unknown `@`-key | yes | `Issue7570ReservedBatchKeyTest`, `Issue7570BatchReservedKeyIT` |
| same -> `JsonlBatchRecordStream.parseLine`, nested `properties` object | yes | `Issue7570ReservedBatchKeyTest`, `Issue7570BatchReservedKeyIT` |
| `text/csv` -> `CsvBatchRecordStream.parseHeader`, unknown `@`-column (first header and post-`---` header alike) | yes | `Issue7570ReservedBatchKeyTest`, `Issue7570BatchReservedKeyIT` |
| The refusal under the streaming (`Accept: application/x-ndjson`) encoding - still a real 400, not an in-band `error` line under a 200 | yes | `Issue7570BatchReservedKeyIT` |
| OpenAPI contract for all three request media types | yes | `Issue7570BatchRequestBodySchemaTest` + swagger-parser validation in `OpenApiSpecGenerationIT` |

Argued, with evidence in the tracking doc:

- **gRPC `InsertBidirectional`** - `GraphBatchRecord` has typed `kind`/`type_name`/`temp_id`/`from_ref`/`to_ref` fields and a separate `map<string, GrpcValue> properties`. Control and data live in different fields, so no key can be mistaken for the other kind; the defect is specific to the flat HTTP encoding.
- **A CSV `properties` column** - see above; scalars only, so there is no mistake to prevent.
- **`{"properties": [...]}`** - the misreading comes from a `map` field, so a guessing client sends an object. Refusing a list too would break a domain whose `properties` field is genuinely a list.

### Known gaps

- **#7574** - a *known* control key used on the wrong kind of line (`@id` on an edge, `@from`/`@to` on a vertex) is still silently dropped. It is a silent drop rather than silent corruption, and CSV's workable shared-header form makes a placement rule genuinely ambiguous, so it needs a decision applied to both parsers rather than a quick throw.
- **#7573** - the AI chat `text/event-stream` response is still declared as one opaque `string`, the same defect this issue reports for the request. Different domain, a response rather than a request, and no silent-corruption half.

Both are named in the tracking doc and will be named in the issue-closing comment.

## Review follow-up (cycle 1)

`claude` reviewed `16bb1ef` and found no correctness bug and nothing blocking. `270082b` applies its one code-touching note: both parsers match the control keys and the `@type` values case-sensitively (`Set.of`+`contains`, `"vertex".equals(type)`, an exact `switch`) while only the CSV boolean literals use `equalsIgnoreCase`, so `@Type` now answers 400 as an unknown control key. That asymmetry is unguessable and the refusal makes it visible, so the request-body description states it, with an assertion pinning it. Its third note - that the two `@`-prefix checks are near-duplicate logic - it flagged as not worth extracting today, and I agree: the two inspect different things at different frequencies with different wording, share no base type, and merging them would push the JSONL and CSV messages toward one generic phrasing.

## Note for reviewers on CI

`RemoteGraphBatchIT.mapAndListPropertiesRoundTrip` failed once during local verification, in `endTest` on `RemoteServer.drop` with `EOFException`. It is not this change: the failure is in teardown, nothing here is on the `drop` path, the class hardcodes `127.0.0.1:2480` in 17 places (against the documented free-port rule) and a standing ArcadeDB server held that port on the machine, and the class is green when run alone. The new IT deliberately derives its port from `getServer(0).getHttpServer().getPort()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6gidX7u247f1WKYokvFqH

