### PR TITLE
fix(#7567): refuse property DDL a TIMESERIES type could never honour

### DIFF
--- a/docs/7567-timeseries-property-ddl-rejection.md
+++ b/docs/7567-timeseries-property-ddl-rejection.md
@@ -1,0 +1,179 @@
+# #7567 - CREATE PROPERTY / ALTER PROPERTY CUSTOM role silently drop time-series tag and field values
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/7567
+
+## Finding ledger
+
+- [x] 1. `CREATE PROPERTY <tsType>.<name> <TYPE>` on an existing TIMESERIES type is accepted, the column shows up in
+      the schema listing, and every write silently discards its value - **fixed**, refused at DDL time on every
+      `createProperty` entry point.
+- [x] 2. `ALTER PROPERTY <tsType>.<name> CUSTOM role = "FIELD"` is accepted and changes nothing: the write path never
+      reads a property's CUSTOM metadata - **fixed**, refused in `LocalProperty.setCustomValue`, with `= null`
+      (removal) still allowed so a database that already stored the key can clean it up.
+
+## Root cause
+
+A TIMESERIES type stores its columns in `LocalTimeSeriesType.tsColumns` (a `List<ColumnDefinition>`), which is
+populated exactly once, by `TimeSeriesTypeBuilder.create()` (`CREATE TIMESERIES TYPE`), and re-hydrated from
+`schema.json` by `LocalTimeSeriesType.fromJSON()`. The write path iterates that list and nothing else:
+
+```java
+// engine/src/main/java/com/arcadedb/query/sql/executor/SaveElementStep.java:213
+private void saveToTimeSeries(final LocalTimeSeriesType tsType, final TimeSeriesEngine engine, final Document doc, ...) {
+  final List<ColumnDefinition> columns = tsType.getTsColumns();
+  ...
+  for (int i = 0; i < columns.size(); i++) {
+    final ColumnDefinition col = columns.get(i);
+    final Object value = doc.get(col.getName());
+```
+
+`LocalDocumentType.createProperty()` writes to a completely different map (`properties`), which is what the schema
+listing renders. So a property created after the type exists is real as far as the listing is concerned and invisible
+to the engine, and the value that arrives under its name is dropped by the loop above without a word.
+
+`ALTER PROPERTY ... CUSTOM role` lands in `LocalProperty.setCustomValue()`, a free-form metadata map. Nothing in the
+time-series engine reads it - a column's role lives in `ColumnDefinition.getRole()`, fixed at creation.
+
+`addTsColumn()` has exactly one caller outside JSON restore, so there is no supported way to add a column to a
+TIMESERIES type after `CREATE TIMESERIES TYPE`:
+
+```
+$ grep -rn "addTsColumn" --include='*.java' . | grep -v '/test/'
+engine/src/main/java/com/arcadedb/schema/LocalTimeSeriesType.java:248:  public void addTsColumn(final ColumnDefinition column) {
+engine/src/main/java/com/arcadedb/schema/TimeSeriesTypeBuilder.java:142:      type.addTsColumn(col);
+```
+
+## Completeness
+
+### 1. Invariant
+
+> On a TIMESERIES type the declared schema properties are exactly the declared time-series columns: no DDL and no
+> schema API may add a property the write path cannot store, drop one it does store, or claim to change a column's
+> role - and a database or an export written before this rule still opens.
+
+### 2. Every way to violate it
+
+```
+$ grep -rn "\.createProperty(\|\.getOrCreateProperty(" --include='*.java' . | grep -v '/src/test/' | wc -l
+26
+$ grep -rn "\.createProperty(\|\.getOrCreateProperty(" --include='*.java' . | grep -v '/src/test/' | awk -F: '{print $1}' | sort | uniq -c | sort -rn
+   6 ./engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
+   3 ./integration/src/main/java/com/arcadedb/integration/importer/format/XMLImporterFormat.java
+   3 ./integration/src/main/java/com/arcadedb/integration/importer/AbstractImporter.java
+   2 ./integration/src/main/java/com/arcadedb/integration/importer/OrientDBImporter.java
+   2 ./integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
+   2 ./engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+   2 ./engine/src/main/java/com/arcadedb/schema/LocalEdgeType.java
+   1 ./integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
+   1 ./integration/src/main/java/com/arcadedb/integration/importer/format/RDFImporterFormat.java
+   1 ./integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
+   1 ./integration/src/main/java/com/arcadedb/integration/importer/format/JSONImporterFormat.java
+   1 ./engine/src/main/java/com/arcadedb/schema/TimeSeriesTypeBuilder.java
+   1 ./engine/src/main/java/com/arcadedb/query/sql/parser/CreatePropertyStatement.java
+```
+
+Every one of those reaches `LocalDocumentType.createProperty(String, Type, String)` - the other overloads, the
+`JSONObject` default method on `DocumentType` and all six `getOrCreateProperty` overloads delegate to it - so the
+funnel is a single method.
+
+```
+$ grep -rn "dropProperty(" --include='*.java' . | grep -v '/test/' | grep -v 'RemoteDocumentType\|MutableDocumentType'
+engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java:638:      dropProperty(propertyName);      <- getOrCreateProperty, on a type change
+engine/src/main/java/com/arcadedb/schema/LocalProperty.java:90:  (comment only)
+engine/src/main/java/com/arcadedb/schema/DocumentType.java:181:  Property dropProperty(String propertyName);
+engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java:526: schema.getType(typeName).dropProperty(propName);
+engine/src/main/java/com/arcadedb/query/sql/parser/DropPropertyStatement.java:100: sourceClass.dropProperty(propertyName.getStringValue());
+```
+
+Sibling shape - who else writes `CUSTOM` metadata a reader never consults:
+
+```
+$ grep -rn "setCustomValue(" --include='*.java' . | grep -v '/src/test/' | grep -v '/e2e/'
+engine/src/main/java/com/arcadedb/schema/DocumentType.java:160         (JSON restore of a property)
+engine/src/main/java/com/arcadedb/schema/LocalProperty.java:291        (the implementation)
+engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java:...    (type-level custom, not property-level)
+engine/src/main/java/com/arcadedb/query/sql/parser/AlterPropertyStatement.java:76
+engine/src/main/java/com/arcadedb/query/sql/parser/CreatePropertyStatement.java:114   (inline CUSTOM, issue #5409)
+integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java:297
+```
+
+### 3. Coverage table
+
+| Entry point | Covered by fix? | Covered by a test? |
+|---|---|---|
+| SQL `CREATE PROPERTY <ts>.<x>` -> `CreatePropertyStatement` -> `LocalDocumentType.createProperty(String,Type,String)` | yes | yes |
+| SQL `CREATE PROPERTY <ts>.<x> IF NOT EXISTS` (falls through to the same funnel when absent) | yes | yes |
+| Java API `type.createProperty(...)` / `getOrCreateProperty(...)`, every overload | yes | yes |
+| SQL `ALTER PROPERTY <ts>.<x> CUSTOM role = ...` -> `LocalProperty.setCustomValue` | yes | yes |
+| SQL `CREATE PROPERTY <ts>.<x> ... CUSTOM role = ...` inline (#5409) | argued - unreachable on a TIMESERIES type: a new name is refused by the row above before the CUSTOM loop runs, an existing name throws "already exists", and the `IF NOT EXISTS` form returns before applying CUSTOM (`CreatePropertyStatement.java:90-119`) | no |
+| SQL `ALTER PROPERTY <ts>.<x> CUSTOM role = null` (removal) | deliberately allowed - the only way to clear a key a pre-fix database already stored | yes |
+| Java API `property.setCustomValue("role", ...)` on a TIMESERIES column | yes | yes |
+| SQL `DROP PROPERTY <ts>.<declared column>` -> `LocalDocumentType.dropProperty` | yes | yes |
+| `TimeSeriesTypeBuilder.create()` registering the declared columns as properties | allowed by name match | yes |
+| `LocalSchema.readConfiguration()` opening a PRE-FIX database that already carries a stray property | tolerated + WARNING | yes |
+| `JsonlImporterFormat` restoring a PRE-FIX export (stray property, or `custom.role` on a column) | tolerated + WARNING | yes |
+| Remote `RemoteDocumentType.createProperty(...)` (HTTP/gRPC/Studio/console) | argued - emits `create property ...` SQL executed server-side through the same funnel (`network/src/main/java/com/arcadedb/remote/RemoteDocumentType.java:163-189`) | no (same funnel) |
+| `LocalSchema.copyType()` | argued - the target type is only ever `LocalDocumentType` or `LocalVertexType`; `LocalEdgeType` is rejected and no other class is accepted (`LocalSchema.java:940-949`), so the copy target is never a TIMESERIES type | no |
+| `OpenCypherQueryEngine` typed-property path | argued - same funnel (`createProperty`/`dropProperty` on the schema type) | no (same funnel) |
+| `ALTER TYPE <ts> SUPERTYPE +Other` -> `addSuperType` | **filed as #7581** - a different statement reaching the same silent drop through polymorphic properties; refusing a type hierarchy on a TIMESERIES type is a behaviour decision of its own scope | no |
+
+### 4. Tests per entry point
+
+`engine/src/test/java/com/arcadedb/engine/timeseries/Issue7567TimeSeriesPropertyDDLTest.java` (10 tests) drives each
+fixed row through its own entry point, plus three controls: the declared columns still round-trip, a DOCUMENT type is
+untouched, and a pre-fix database still opens.
+`integration/src/test/java/com/arcadedb/integration/importer/Issue7567PreFixTimeSeriesPropertyRestoreIT.java` covers
+the JSONL restore of a pre-fix export.
+
+Each rejection was proved able to fail: with the three guards neutralized, 6 of the 10 engine tests fail
+("Expecting code to raise a throwable") and the other 4 - the controls - stay green. Neutralizing only the
+`isReadingFromFile()` tolerance fails `preFixStrayPropertyStillOpensAndCanBeDropped` alone. Neutralizing the
+importer's two skips fails the IT with `ImportException`.
+
+### 5. Reachability
+
+`LocalDocumentType.createProperty(String, Type, String)` is the method `CREATE PROPERTY` calls on every live path
+(SQL, Cypher, importers, remote, HA replay). `LocalProperty.setCustomValue` is the method `ALTER PROPERTY ... CUSTOM`
+calls. Both are on the hot DDL path with no feature flag, and the tests below drive them through SQL rather than
+through the schema API only.
+
+### 6. Test runs
+
+| Suite | Result |
+|---|---|
+| `mvn -o -pl engine -am test -DexcludedGroups=benchmark,vector,slow` | 14920 run, **1 failure**, 22 skipped - the failure is `MultiColumnAggregationResultTest.emptySumAndCountStayZeroNotNaN`, red on `main` before this branch and unrelated to it (a pure in-memory unit test of classes this diff does not touch; it fails standalone too). Filed as **#7584** |
+| `mvn -o -pl integration verify -DskipITs=false -DexcludedGroups=benchmark,vector,slow` | 475 unit + 134 IT, all green, including the pre-existing `Issue7032JsonlRoundTripIT` |
+| `server` module | NOT run: port 2480 was held by another agent's server run for the whole session, and a server suite started against an occupied port reports authentication failures rather than a port conflict. It adds no new entry point - `RemoteDocumentType.createProperty` emits `create property ...` SQL that the server executes through the same `LocalDocumentType` funnel the engine suite covers |
+
+## Adversarial pass
+
+The skill's Phase 1.5 spawns a `general-purpose` subagent; the `Task` tool is not available in this nested session, so
+the pass was run directly instead, against the tree rather than against the reasoning above. Two findings, both
+verified by running code rather than by reading it:
+
+1. **The refusal also blocked REMOVING a stale `CUSTOM role`.** `ALTER PROPERTY x CUSTOM key = null` is the
+   documented removal form (`AlterPropertyExecutionTest:65`), and the first version of the guard threw on it - so a
+   database that had already stored `custom.role` could never clear it, which is precisely the database the fix is
+   supposed to help. Probe output before the fix:
+   `PROBE custom-role-null: REFUSED: Cannot set the custom value 'role' ...`.
+   **Real and in scope - fixed on this branch**, with `removingAStaleCustomRoleIsAllowed` pinning it.
+2. **`ALTER TYPE <ts> SUPERTYPE +Other` reaches the same silent drop.** Probe output:
+   `PROBE supertype-on-ts: ACCEPTED, polymorphic props=[s, v, humidity, ts]` - `humidity` comes from the super type,
+   the write path still walks `tsColumns` only, and the value is dropped exactly as in the reported case.
+   **Real and out of scope - filed as #7581**: it goes through `addSuperType`, which none of this patch's guards see,
+   and whether a TIMESERIES type may have a type hierarchy at all is a separate decision.
+
+### 7. Residual risk
+
+- A database created **before** this fix keeps whatever stray property it already has. It opens with a WARNING naming
+  the property and the type; the value is still dropped on write. Remediation is `DROP PROPERTY <ts>.<stray>`, which
+  stays allowed precisely because the stray name is not a declared column. Automatically deleting it at load would be
+  a silent schema mutation during open, which is worse. The same applies to a stale `custom.role`, which
+  `ALTER PROPERTY ... CUSTOM role = null` clears.
+- The fix does not add the ability to add a column to an existing TIMESERIES type. `addTsColumn` has one caller and
+  the sealed/mutable row formats are fixed-stride, so that is a feature with a storage-format question behind it, not
+  this bug.
+- `ALTER TYPE <ts> SUPERTYPE` still reaches the same silent drop - **#7581**.
+- `getTsColumn` reads `tsColumns` without a lock. That list is written only by `TimeSeriesTypeBuilder.create()` before
+  the type is registered and by `fromJSON` on the single-threaded schema-load path, so no reader can observe it being
+  mutated; this is stated as the reason the lock-free read is safe, not as a claim that the list is immutable.

--- a/docs/7567-timeseries-property-ddl-rejection.md
+++ b/docs/7567-timeseries-property-ddl-rejection.md
@@ -177,3 +177,29 @@ verified by running code rather than by reading it:
 - `getTsColumn` reads `tsColumns` without a lock. That list is written only by `TimeSeriesTypeBuilder.create()` before
   the type is registered and by `fromJSON` on the single-threaded schema-load path, so no reader can observe it being
   mutated; this is stated as the reason the lock-free read is safe, not as a claim that the list is immutable.
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/7585
+
+## Review cycles
+
+| Cycle | Head | Changes | Bot outcome |
+|---|---|---|---|
+| 1 | `abde77d9` | the branch as first pushed | `claude`: "Nothing blocking" - verified the funnel claim, the builder ordering, the schema-load ordering, the `copyType`/`dropType` arguments and the back-compat story against the source rather than the diff. Two style notes, one of which it advised leaving. Codacy: 1 minor CodeStyle notice (`LocalProperty.java:295`, a `private static final` declared mid-class) - the same point. CodeRabbit: rate-limited, posted no findings |
+| 2 | `3f164b23` | constant moved to the top of `LocalProperty`; deferred-items note added | `claude`: "No correctness bugs found", and it independently confirmed the unreachability argument for inline `CREATE PROPERTY ... CUSTOM role`, the `owner.getSchema().getEmbedded()` pattern, and the lock-free `getTsColumn` read. Codacy: pass, 0 issues. CodeRabbit: pass (still rate-limited) |
+
+One incidental hardening the second review named that the PR body had not: `getOrCreateProperty(name, type, ofType)`
+with a type different from the declared column's now throws at the `dropProperty` guard instead of silently dropping
+and recreating a declared TIMESERIES column under a different type.
+
+## Deferred items
+
+- [`docs/review-deferred-abde77d9.md`](review-deferred-abde77d9.md) - one item: run the `server` module before merge.
+  It is blocked by the environment rather than by judgement (port 2480 held all session by a server process this
+  branch did not start), and the reviewer's own assessment is that the module adds no entry point of its own.
+
+## Final state
+
+`deferred-items` - both reviews cleared the change with nothing blocking, every Codacy finding is addressed, and the
+one outstanding item is the `server`-module run the developer should do before merging. Merge remains the developer's.

--- a/docs/7569-openapi-command-ndjson-readonly-restriction.md
+++ b/docs/7569-openapi-command-ndjson-readonly-restriction.md
@@ -1,0 +1,137 @@
+# Issue #7569: OpenAPI /command declares application/x-ndjson but doesn't say streaming is read-only-only
+
+## Ledger (single finding, from the issue body)
+
+1. `POST /api/v1/command/{database}` declares `application/x-ndjson` as a `200` content type but
+   neither its `summary` nor `description` says that the ndjson response is available only for a
+   read-only statement, and that a mutating statement is refused with HTTP 400 before it runs.
+   Reporter also suggested (as an "ideally") a line noting that ndjson is selected via `Accept`.
+
+## Root cause
+
+`PostCommandHandler.requireStreamableStatement()` (server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java:492)
+refuses to stream any statement that is not provably read-only - `analyzed.isIdempotent()` and not
+DDL/CREATE/UPDATE/DELETE/SCHEMA - throwing `IllegalArgumentException` mapped to HTTP 400, before the
+statement runs. `CoreApiSpec.createCommandPath()` declares `application/x-ndjson` as a response
+media type (via `addNdJsonAlternative`) and the `Accept` parameter that selects it
+(`ndJsonAcceptParam()`), but the operation's own `description` never mentions the restriction.
+
+The `Accept`-header opt-in the reporter asked for as an "ideally" is already documented: `ndJsonAcceptParam()`
+attaches a description ("Send 'application/x-ndjson' to receive the result as a stream...") to the `Accept`
+parameter on GET query, POST query and POST command alike. That part of the ask is already satisfied - no
+change needed there.
+
+## Completeness sweep
+
+**Invariant:** every OpenAPI operation whose execution path can refuse the ndjson encoding with 400 for a
+non-read-only statement documents that restriction in its own `description`.
+
+Grep for every caller of the gate and every operation offering the ndjson media type:
+
+```
+$ grep -n "requireStreamableStatement" server/src/main/java/com/arcadedb/server/http/handler/*.java
+PostCommandHandler.java:199:      requireStreamableStatement(database, language, command);
+PostCommandHandler.java:492:  private static void requireStreamableStatement(...)
+
+$ grep -n "class PostQueryHandler" server/src/main/java/com/arcadedb/server/http/handler/PostQueryHandler.java
+public class PostQueryHandler extends PostCommandHandler {
+   // overrides only executeCommand() -> database.query(); execute() itself, including the streaming
+   // gate at line 199, is inherited unchanged.
+
+$ grep -n "requireStreamableStatement\|supportsNdJsonEncoding" server/src/main/java/com/arcadedb/server/http/handler/GetQueryHandler.java
+(no matches - GetQueryHandler streams unconditionally via a separately-implemented execute())
+```
+
+| Entry point | Calls the gate? | Status |
+|---|---|---|
+| `POST /api/v1/command/{database}` (`PostCommandHandler`) | Yes, directly | **Fixed here** - description now states the restriction |
+| `POST /api/v1/query/{database}` (`PostQueryHandler extends PostCommandHandler`) | Yes, inherited via the same `execute()` | **Fixed here** - same restriction, same shared description text, for parity with the existing `commandRequestDeclaresLimitMatchingQueryRequest` precedent of keeping shared-behavior text identical between the two operations |
+| `GET /api/v1/query/{database}/{language}/{command}` (`GetQueryHandler`) | No - separate `execute()`, calls `database.query()` directly with no analysis gate | **Filed as #7571** - there is no explicit read-only gate on this path, so nothing to document identically here; but the adversarial pass below found the absence is itself a divergence worth tracking (`BACKUP DATABASE` streams on GET while `POST /command` refuses it) |
+| `Accept` header opt-in (both POST operations, and GET query) | n/a | **Already covered** - `ndJsonAcceptParam()` already documents `Accept: application/x-ndjson` on all three operations |
+
+Every in-scope row is fixed in this PR; the one out-of-scope row is tracked by #7571.
+
+## Fix
+
+Added a shared `NDJSON_READ_ONLY_DESCRIPTION` constant to `CoreApiSpec` and appended it to the
+`description` of both `POST /api/v1/command/{database}` and `POST /api/v1/query/{database}`, kept
+byte-identical between the two operations (mirroring how `STALE_SESSION_404_DESCRIPTION` is shared).
+
+## Tests
+
+`CoreApiSpecTest.commandAndQueryDescribeTheReadOnlyStreamingRestriction()` (new) asserts:
+- both operations' `description` mention the 400 refusal and the read-only requirement;
+- the shared restriction text is identical between the two operations.
+
+## Test results
+
+`mvn -o -pl server -am test -Dtest=CoreApiSpecTest` - see run log in PR.
+
+## Residual risk
+
+This is a documentation-only change to the generated OpenAPI contract; no runtime behavior changed.
+
+The one thing this PR does NOT cover: `GET /api/v1/query/{database}/{language}/{command}` also offers
+`application/x-ndjson` and has no read-only gate at all, so it still streams a `BACKUP DATABASE` that
+`POST /command` refuses. Tracked by #7571 - see the adversarial pass below.
+
+## Adversarial pass (Phase 1.5)
+
+One finding, verified independently before filing:
+
+1. **GET `/api/v1/query/{database}/{language}/{command}` offers `application/x-ndjson` with no read-only
+   gate at all.** `GetQueryHandler.execute()` calls `database.query()` directly and never reaches
+   `PostCommandHandler.requireStreamableStatement()` (which is `private static` on a sibling class). Its
+   only stand-in is `SQLQueryEngine.query()`'s `if (!statement.isIdempotent()) throw
+   QueryNotIdempotentException`, which is strictly weaker: `BackupDatabaseStatement.isIdempotent()`
+   returns `true` while `getOperationTypes()` reports `{READ, CREATE}`, so `BACKUP DATABASE` streams on
+   GET while `POST /command` refuses it with 400.
+
+   Verified by reading `engine/src/main/java/com/arcadedb/query/sql/parser/BackupDatabaseStatement.java:56-72`
+   and `engine/src/main/java/com/arcadedb/query/sql/SQLQueryEngine.java:86-93`.
+
+   **Disposition: real, out of scope -> filed as #7571.** Out of scope because closing it means either a
+   behavior change on a third handler or a deliberate documentation of the divergence, neither of which
+   #7569 (documentation-only, about `/command`) asked for.
+
+   Narrower than the subagent framed it: the transactional hazards `requireStreamableStatement()`'s javadoc
+   describes are POST-only, since `GetQueryHandler.requiresTransaction()` returns `false` so there is no
+   auto-commit wrapper and no retry loop. #7571 says so explicitly rather than overstating the exposure.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/7572
+
+## Review cycles
+
+### Cycle 1 - 9463c26df5
+
+- **CodeRabbit:** "No actionable comments were generated." Merge risk: minimal. One pre-merge check
+  warning, "Docstring Coverage 16.67%" - **skipped as a nitpick**: the functions it counts are JUnit
+  test methods and private spec builders, and this repo documents intent in targeted javadoc/comments
+  (the new constant and the new test both carry one) rather than in per-method docstrings. Adding
+  boilerplate javadoc to satisfy a percentage would be noise.
+- **claude:** no blocking issues. Confirmed the new text matches
+  `requireStreamableStatement()`'s actual conditions, that sharing one constant between the two POST
+  operations is right, and that deferring the GET gap to #7571 keeps the PR narrow.
+- **claude, one non-blocking observation:** `requireStreamableStatement()` excludes
+  CREATE/UPDATE/DELETE/SCHEMA/DDL but not `OperationType.ADMIN`, so "if any statement reports ADMIN
+  while `isIdempotent()` returns true, it could still stream" - suggested as a possible follow-up.
+
+  **Assessed and NOT filed: the premise does not hold.** `OperationType.ADMIN` has exactly one
+  producer in the tree - `OpenCypherQueryEngine.analyze()` returns it for a `CypherAdminStatement`
+  (`engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java:116`) - and
+  `CypherAdminStatement.isReadOnly()` returns `false` unconditionally
+  (`engine/src/main/java/com/arcadedb/query/opencypher/ast/CypherAdminStatement.java:66-68`), which is
+  what `isIdempotent()` delegates to. So every ADMIN statement fails the gate's very first conjunct
+  and is refused before the operation-type set is consulted at all. There is no statement that is both
+  ADMIN and idempotent, so there is nothing to leak and no follow-up to file.
+
+  Verified by: `grep -rn "OperationType.ADMIN" --include="*.java" engine/src/main/java server/src/main/java`
+  (one hit) and reading `CypherAdminStatement`.
+
+No code changes were required by the review; no items were deferred.
+
+## Final state
+
+`clean-approval`

--- a/docs/review-deferred-abde77d9.md
+++ b/docs/review-deferred-abde77d9.md
@@ -1,0 +1,30 @@
+# Deferred review items - PR #7585, head abde77d9
+
+## 1. Run the `server` module before merge (claude review, cycle 1)
+
+> The `server` module wasn't run (port 2480 was occupied). Low risk since remote DDL goes through the same
+> `LocalDocumentType` funnel, but worth a green run before merge if the port frees up, since it's the one module this
+> PR doesn't have direct evidence for.
+
+**Deferred - blocked by the environment, not by judgement.** Port 2480 is held for the whole session by a long-running
+ArcadeDB server process (PID 41389, started 2026-09-11 16:36, `/opt/homebrew/opt/openjdk/bin/java -server ...`) that
+this branch did not start and must not kill. Server tests bind fixed ports from 2480 up, and a suite started against
+an occupied port fails as `403` / "Too many failed authentication attempts" rather than as a port conflict, so the run
+would be noise rather than evidence.
+
+The reviewer's own risk assessment is the one recorded in the PR body: `RemoteDocumentType.createProperty` emits
+`create property ...` SQL that the server executes through the same `LocalDocumentType` funnel the 14920-test engine
+run covers, so the module adds no entry point of its own. **Action for the developer: run
+`mvn -o -pl server -am test` once the port is free, before merging.**
+
+## Items considered and NOT deferred
+
+- *"`TIMESERIES_ROLE_CUSTOM_KEY` is declared mid-class rather than with other constants at the top"* (claude review,
+  and the single Codacy CodeStyle notice on `LocalProperty.java:295`). Applied rather than deferred - the field now
+  sits directly under the class declaration.
+- *"The Javadoc on the three new guard methods is long"* - the reviewer's own conclusion was to leave it ("the WHY
+  genuinely is non-obvious"), and the comments are what stop the next reader from removing a guard that looks
+  redundant. Left as written.
+- *"Worth confirming `LocalSchema.dropType()` was checked"* - it was, and the reviewer verified it independently:
+  `dropType()` discards indexes and buckets and removes the type from the `types` map without ever calling
+  `dropProperty`, so the new refusal cannot block dropping the type. No change needed.

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -537,6 +537,41 @@ public class LocalDocumentType implements DocumentType {
   }
 
   /**
+   * Refuses a property that a TIMESERIES type could never store.
+   * <p>
+   * A TIMESERIES type keeps its columns in {@code LocalTimeSeriesType.tsColumns}, filled once by
+   * {@code CREATE TIMESERIES TYPE}, and the write path reads the document under those names and no others. A
+   * property created afterwards lands in {@link #properties} instead, which is what the schema listing renders: the
+   * column looks declared, every write drops its value and nothing reports it (issue #7567). The declared columns
+   * themselves reach this method too - {@code TimeSeriesTypeBuilder.create()} registers each one as a property right
+   * after filling {@code tsColumns} - and pass, because by then the name is declared.
+   * <p>
+   * A database written before this rule may already carry such a property. Refusing it at schema load would make
+   * that database unopenable, so the load path only warns; {@code DROP PROPERTY} on the stray name is the remedy and
+   * stays allowed.
+   *
+   * @param propertyName the property about to be created
+   */
+  private void checkTimeSeriesColumnDeclared(final String propertyName) {
+    if (!(this instanceof LocalTimeSeriesType tsType) || tsType.isDeclaredColumn(propertyName))
+      return;
+
+    if (schema.isReadingFromFile()) {
+      LogManager.instance().log(this, Level.WARNING,
+          "Property '%s.%s' is not a declared TIMESERIES column (declared: %s): it was added to this database before "
+              + "issue #7567 was fixed and no write will ever populate it. Remove it with DROP PROPERTY `%s`.`%s`",
+          name, propertyName, tsType.getTsColumnNames(), name, propertyName);
+      return;
+    }
+
+    throw new SchemaException("Cannot create the property '" + propertyName + "' in type '" + name
+        + "' because the type is a TIMESERIES type and '" + propertyName + "' is not one of its declared columns "
+        + tsType.getTsColumnNames()
+        + ". A TIMESERIES type stores only the TIMESTAMP, TAGS and FIELDS named in CREATE TIMESERIES TYPE, so a "
+        + "property added afterwards would be silently ignored by every write");
+  }
+
+  /**
    * Creates a new property with type `propertyType`.
    *
    * @param propertyName Property name to remove
@@ -554,6 +589,8 @@ public class LocalDocumentType implements DocumentType {
       // creation path can never satisfy them.
       throw new SchemaException("Cannot create the property '" + propertyName + "' in type '" + name
           + "' because the type is declared LIGHTWEIGHT and its edges cannot have properties");
+
+    checkTimeSeriesColumnDeclared(propertyName);
 
     if (properties.containsKey(propertyName))
       throw new SchemaException(
@@ -650,6 +687,17 @@ public class LocalDocumentType implements DocumentType {
   @Override
   public Property dropProperty(final String propertyName) {
     checkForSchemaMutation();
+
+    if (this instanceof LocalTimeSeriesType tsType && tsType.isDeclaredColumn(propertyName))
+      // The column stays in the type's tsColumns list whatever happens to the schema property - nothing removes an
+      // entry from it - so the engine would keep storing and returning the column while the type stopped declaring
+      // it. Refusing here keeps the two descriptions of a TIMESERIES type from drifting apart (issue #7567). A
+      // property that is NOT a declared column is still droppable, which is how a database written before that
+      // issue gets rid of the stray one it may already carry.
+      throw new SchemaException("Cannot drop the property '" + propertyName + "' from type '" + name
+          + "' because it is a declared TIMESERIES column: the storage engine keeps reading and writing it. Drop the "
+          + "whole type to remove the column");
+
     for (final TypeIndex index : getAllIndexes(true)) {
       if (index.getPropertyNames().contains(propertyName))
         throw new SchemaException(

--- a/engine/src/main/java/com/arcadedb/schema/LocalProperty.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalProperty.java
@@ -29,6 +29,12 @@ import java.util.*;
 
 public class LocalProperty extends AbstractProperty {
 
+  /**
+   * The CUSTOM key a user reaches for when trying to turn an existing property into a time-series column, as in
+   * {@code ALTER PROPERTY Reading.value CUSTOM role = "FIELD"}.
+   */
+  private static final String TIMESERIES_ROLE_CUSTOM_KEY = "role";
+
   public LocalProperty(final LocalDocumentType owner, final String name, final Type type) {
     super(owner, name, type, owner.getSchema().getDictionary().getIdByName(name, true));
   }
@@ -287,12 +293,6 @@ public class LocalProperty extends AbstractProperty {
     }
     return this;
   }
-
-  /**
-   * The CUSTOM key a user reaches for when trying to turn an existing property into a time-series column, as in
-   * {@code ALTER PROPERTY Reading.value CUSTOM role = "FIELD"}.
-   */
-  private static final String TIMESERIES_ROLE_CUSTOM_KEY = "role";
 
   /**
    * Refuses {@code CUSTOM role} on a property of a TIMESERIES type.

--- a/engine/src/main/java/com/arcadedb/schema/LocalProperty.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalProperty.java
@@ -20,6 +20,7 @@ package com.arcadedb.schema;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.timeseries.ColumnDefinition;
 import com.arcadedb.exception.SchemaException;
 import com.arcadedb.query.sql.parser.Expression;
 import com.arcadedb.security.SecurityDatabaseUser;
@@ -287,9 +288,43 @@ public class LocalProperty extends AbstractProperty {
     return this;
   }
 
+  /**
+   * The CUSTOM key a user reaches for when trying to turn an existing property into a time-series column, as in
+   * {@code ALTER PROPERTY Reading.value CUSTOM role = "FIELD"}.
+   */
+  private static final String TIMESERIES_ROLE_CUSTOM_KEY = "role";
+
+  /**
+   * Refuses {@code CUSTOM role} on a property of a TIMESERIES type.
+   * <p>
+   * A column's role is {@code ColumnDefinition.getRole()}, fixed by {@code CREATE TIMESERIES TYPE} and never read
+   * back out of a property's CUSTOM map by anything in the engine. Accepting the key stored a value that looked like
+   * it had reconfigured the column and had no effect whatsoever - the second half of issue #7567. Every other CUSTOM
+   * key stays free-form, here as everywhere else.
+   * <p>
+   * Two cases are deliberately let through, because in both the caller is getting RID of the claim rather than
+   * making it: a {@code null} value, which is how {@code ALTER PROPERTY ... CUSTOM role = null} removes the key and
+   * therefore the only way a database written before this rule can clean up the one it already stored; and the
+   * schema load itself, so such a database opens at all.
+   */
+  private void checkTimeSeriesRoleNotCustomised(final String key, final Object value) {
+    if (!(owner instanceof LocalTimeSeriesType tsType) || !TIMESERIES_ROLE_CUSTOM_KEY.equalsIgnoreCase(key))
+      return;
+
+    if (value == null || tsType.getSchema().getEmbedded().isReadingFromFile())
+      return;
+
+    final ColumnDefinition column = tsType.getTsColumn(name);
+    throw new SchemaException("Cannot set the custom value '" + key + "' on property '" + tsType.getName() + "." + name
+        + "' because the type is a TIMESERIES type: a column's role is fixed by CREATE TIMESERIES TYPE and is never "
+        + "read from property metadata"
+        + (column != null ? ", the role of '" + name + "' is " + column.getRole() : ""));
+  }
+
   @Override
   public Object setCustomValue(final String key, final Object value) {
     checkForSchemaMutation();
+    checkTimeSeriesRoleNotCustomised(key, value);
     final Object prev;
     if (value == null)
       prev = custom.remove(key);

--- a/engine/src/main/java/com/arcadedb/schema/LocalTimeSeriesType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalTimeSeriesType.java
@@ -249,6 +249,45 @@ public class LocalTimeSeriesType extends LocalDocumentType {
     tsColumns.add(column);
   }
 
+  /**
+   * The declared time-series column named {@code columnName} - the TIMESTAMP, a TAG or a FIELD named in
+   * {@code CREATE TIMESERIES TYPE} - or {@code null} when the type declares no such column.
+   * <p>
+   * This list is the only thing the write path consults: {@code SaveElementStep#saveToTimeSeries} walks
+   * {@link #getTsColumns()} and reads the document under each column's name, so a value arriving under any other
+   * name is discarded without a word (issue #7567). The list is filled once, by {@link TimeSeriesTypeBuilder#create()}
+   * or by {@link #fromJSON(JSONObject)}, and there is no supported way to extend it afterwards.
+   */
+  public ColumnDefinition getTsColumn(final String columnName) {
+    // Indexed over the ArrayList rather than an enhanced for: this runs on the DDL path for every property
+    // validation and a column list is a handful of entries, so the iterator allocation buys nothing.
+    for (int i = 0; i < tsColumns.size(); i++) {
+      final ColumnDefinition col = tsColumns.get(i);
+      if (col.getName().equals(columnName))
+        return col;
+    }
+    return null;
+  }
+
+  /**
+   * Whether {@code columnName} is one of this type's declared time-series columns. See {@link #getTsColumn(String)}
+   * for why a schema property outside that set can never hold a value.
+   */
+  public boolean isDeclaredColumn(final String columnName) {
+    return getTsColumn(columnName) != null;
+  }
+
+  /**
+   * The declared column names, in declaration order, for error messages that have to tell the user what the type
+   * actually accepts.
+   */
+  public List<String> getTsColumnNames() {
+    final List<String> names = new ArrayList<>(tsColumns.size());
+    for (int i = 0; i < tsColumns.size(); i++)
+      names.add(tsColumns.get(i).getName());
+    return names;
+  }
+
   public List<DownsamplingTier> getDownsamplingTiers() {
     return downsamplingTiers;
   }

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue7567TimeSeriesPropertyDDLTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue7567TimeSeriesPropertyDDLTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.schema.Property;
+import com.arcadedb.schema.Type;
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #7567: a TIMESERIES type's columns live in {@code LocalTimeSeriesType.tsColumns}, filled once by
+ * {@code CREATE TIMESERIES TYPE}, and the write path reads a document under those names and no others. A property
+ * added afterwards with {@code CREATE PROPERTY} landed in the type's ordinary property map instead: it showed up in
+ * the schema listing, and every write silently dropped whatever arrived under its name. {@code ALTER PROPERTY ...
+ * CUSTOM role = "FIELD"} was the second half of the same misunderstanding - a column's role is fixed at creation and
+ * is never read back out of property metadata.
+ * <p>
+ * Both are now refused at DDL time, which is the closest point to the mistake. The mirror case is refused with them:
+ * dropping a declared column's property would leave the engine storing a column the type no longer declares.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue7567TimeSeriesPropertyDDLTest extends TestHelper {
+
+  private static final String TYPE = "Reading";
+
+  private void createReadingType() {
+    database.command("sql", "CREATE TIMESERIES TYPE " + TYPE + " TIMESTAMP ts TAGS (sensor STRING) FIELDS (value DOUBLE)");
+  }
+
+  /**
+   * The shape the reporter expected to work: everything declared inline is stored and read back. This is the control
+   * for every rejection below - the rejections must not be the reason the values survive.
+   */
+  @Test
+  void declaredColumnsAreStoredAndReadBack() {
+    createReadingType();
+
+    database.transaction(() -> database.command("sql", "INSERT INTO " + TYPE + " SET ts = 1000, sensor = 'a', value = 7.5"));
+
+    final ResultSet rs = database.query("sql", "SELECT FROM " + TYPE);
+    assertThat(rs.hasNext()).isTrue();
+    final Result row = rs.next();
+    assertThat(row.<String>getProperty("sensor")).isEqualTo("a");
+    assertThat(((Number) row.getProperty("value")).doubleValue()).isEqualTo(7.5);
+  }
+
+  /**
+   * Entry point 1: SQL {@code CREATE PROPERTY} on a TIMESERIES type.
+   */
+  @Test
+  void sqlCreatePropertyOnTimeSeriesTypeIsRefused() {
+    createReadingType();
+
+    assertThatThrownBy(() -> database.command("sql", "CREATE PROPERTY " + TYPE + ".humidity DOUBLE"))
+        .hasMessageContaining("humidity")
+        .hasMessageContaining("TIMESERIES");
+
+    assertThat(database.getSchema().getType(TYPE).existsProperty("humidity")).isFalse();
+  }
+
+  /**
+   * Entry point 2: the {@code IF NOT EXISTS} form. A name that is NOT a declared column still has to be refused - it
+   * reaches the same funnel - while a name that IS one keeps the documented no-op behaviour of issue #7143.
+   */
+  @Test
+  void sqlCreatePropertyIfNotExistsOnTimeSeriesTypeIsRefused() {
+    createReadingType();
+
+    assertThatThrownBy(() -> database.command("sql", "CREATE PROPERTY " + TYPE + ".humidity IF NOT EXISTS DOUBLE"))
+        .hasMessageContaining("humidity")
+        .hasMessageContaining("TIMESERIES");
+
+    assertThat(database.getSchema().getType(TYPE).existsProperty("humidity")).isFalse();
+
+    final ResultSet existing = database.command("sql", "CREATE PROPERTY " + TYPE + ".value IF NOT EXISTS DOUBLE");
+    assertThat(existing.next().<Boolean>getProperty("created")).isFalse();
+  }
+
+  /**
+   * Entry point 3: the schema API. Every {@code createProperty}/{@code getOrCreateProperty} overload delegates to
+   * {@code createProperty(String, Type, String)}, so both spellings below exercise the one funnel that the SQL
+   * statement above also reaches.
+   */
+  @Test
+  void schemaApiCreatePropertyOnTimeSeriesTypeIsRefused() {
+    createReadingType();
+    final DocumentType type = database.getSchema().getType(TYPE);
+
+    assertThatThrownBy(() -> type.createProperty("humidity", Type.DOUBLE))
+        .hasMessageContaining("humidity")
+        .hasMessageContaining("TIMESERIES");
+
+    assertThatThrownBy(() -> type.getOrCreateProperty("humidity", Type.DOUBLE))
+        .hasMessageContaining("humidity")
+        .hasMessageContaining("TIMESERIES");
+
+    assertThat(type.existsProperty("humidity")).isFalse();
+  }
+
+  /**
+   * Entry point 4: {@code ALTER PROPERTY ... CUSTOM role}, the second route in the issue. Any other CUSTOM key stays
+   * free-form - the refusal is about the one key that pretends to reconfigure the column.
+   */
+  @Test
+  void sqlAlterPropertyCustomRoleOnTimeSeriesTypeIsRefused() {
+    createReadingType();
+
+    assertThatThrownBy(() -> database.command("sql", "ALTER PROPERTY " + TYPE + ".value CUSTOM role = 'TAG'"))
+        .hasMessageContaining("role")
+        .hasMessageContaining("TIMESERIES");
+
+    assertThat(database.getSchema().getType(TYPE).getProperty("value").getCustomValue("role")).isNull();
+
+    assertThatCode(() -> database.command("sql", "ALTER PROPERTY " + TYPE + ".value CUSTOM unit = 'celsius'"))
+        .doesNotThrowAnyException();
+    assertThat(database.getSchema().getType(TYPE).getProperty("value").getCustomValue("unit")).isEqualTo("celsius");
+  }
+
+  /**
+   * Entry point 5: the same key through the schema API, and spelled in any case - SQL lower-cases nothing on the way
+   * in, so {@code CUSTOM ROLE} reaches the setter verbatim.
+   */
+  @Test
+  void schemaApiSetCustomRoleOnTimeSeriesTypeIsRefused() {
+    createReadingType();
+    final Property value = database.getSchema().getType(TYPE).getProperty("value");
+
+    assertThatThrownBy(() -> value.setCustomValue("role", "TAG"))
+        .hasMessageContaining("TIMESERIES")
+        .hasMessageContaining("FIELD");
+
+    assertThatThrownBy(() -> value.setCustomValue("ROLE", "TAG"))
+        .hasMessageContaining("TIMESERIES");
+
+    assertThat(value.getCustomValue("role")).isNull();
+  }
+
+  /**
+   * Removing the key is not making the claim. A database written before this fix can carry a CUSTOM {@code role} it
+   * can no longer set, so the refusal must not also be what stops it being cleaned up: {@code = null} is the
+   * documented removal form and stays allowed.
+   */
+  @Test
+  void removingAStaleCustomRoleIsAllowed() throws Exception {
+    createReadingType();
+    final String databasePath = database.getDatabasePath();
+    database.close();
+
+    final File schemaFile = new File(databasePath, "schema.json");
+    final JSONObject schema = new JSONObject(Files.readString(schemaFile.toPath(), StandardCharsets.UTF_8));
+    final JSONObject value = schema.getJSONObject("types").getJSONObject(TYPE).getJSONObject("properties")
+        .getJSONObject("value");
+    value.put("custom", new JSONObject().put("role", "TAG"));
+    Files.writeString(schemaFile.toPath(), schema.toString(), StandardCharsets.UTF_8);
+
+    database = factory.open();
+    assertThat(database.getSchema().getType(TYPE).getProperty("value").getCustomValue("role")).isEqualTo("TAG");
+
+    database.command("sql", "ALTER PROPERTY " + TYPE + ".value CUSTOM role = null");
+    assertThat(database.getSchema().getType(TYPE).getProperty("value").getCustomValue("role")).isNull();
+  }
+
+  /**
+   * Entry point 6: the mirror case. Dropping a declared column's property would leave the engine storing a column the
+   * type had stopped declaring - the same divergence seen from the other side.
+   */
+  @Test
+  void sqlDropPropertyOfDeclaredColumnIsRefused() {
+    createReadingType();
+
+    for (final String column : new String[] { "ts", "sensor", "value" })
+      assertThatThrownBy(() -> database.command("sql", "DROP PROPERTY " + TYPE + "." + column))
+          .as("dropping the declared column '%s' must be refused", column)
+          .hasMessageContaining(column)
+          .hasMessageContaining("TIMESERIES");
+
+    assertThat(database.getSchema().getType(TYPE).getPropertyNames()).contains("ts", "sensor", "value");
+  }
+
+  /**
+   * Back-compat: a database created BEFORE this fix can already carry a stray property, because nothing refused it.
+   * Refusing it at schema load would make that database unopenable, so the load path warns and carries on - and
+   * {@code DROP PROPERTY} on the stray name stays allowed, which is how the database is cleaned up.
+   * <p>
+   * The stray property is injected straight into {@code schema.json} because there is, deliberately, no longer an
+   * API that can produce one.
+   */
+  @Test
+  void preFixStrayPropertyStillOpensAndCanBeDropped() throws Exception {
+    createReadingType();
+    final String databasePath = database.getDatabasePath();
+    database.close();
+
+    final File schemaFile = new File(databasePath, "schema.json");
+    final JSONObject schema = new JSONObject(Files.readString(schemaFile.toPath(), StandardCharsets.UTF_8));
+    final JSONObject properties = schema.getJSONObject("types").getJSONObject(TYPE).getJSONObject("properties");
+    properties.put("humidity", new JSONObject().put("type", "DOUBLE"));
+    Files.writeString(schemaFile.toPath(), schema.toString(), StandardCharsets.UTF_8);
+
+    database = factory.open();
+
+    final DocumentType reopened = database.getSchema().getType(TYPE);
+    assertThat(reopened).isInstanceOf(LocalTimeSeriesType.class);
+    assertThat(reopened.existsProperty("humidity")).as("the stray property must survive the open").isTrue();
+    assertThat(((LocalTimeSeriesType) reopened).isDeclaredColumn("humidity")).isFalse();
+
+    database.command("sql", "DROP PROPERTY " + TYPE + ".humidity");
+    assertThat(database.getSchema().getType(TYPE).existsProperty("humidity")).isFalse();
+
+    // And the type still works after the cleanup.
+    database.transaction(() -> database.command("sql", "INSERT INTO " + TYPE + " SET ts = 2000, sensor = 'b', value = 1.25"));
+    final List<Result> rows = database.query("sql", "SELECT FROM " + TYPE).stream().toList();
+    assertThat(rows).hasSize(1);
+    assertThat(((Number) rows.getFirst().getProperty("value")).doubleValue()).isEqualTo(1.25);
+  }
+
+  /**
+   * A plain DOCUMENT type is untouched: the refusals are scoped to TIMESERIES types and nothing else.
+   */
+  @Test
+  void documentTypePropertyDDLIsUnaffected() {
+    database.command("sql", "CREATE DOCUMENT TYPE Note");
+    database.command("sql", "CREATE PROPERTY Note.body STRING");
+    database.command("sql", "ALTER PROPERTY Note.body CUSTOM role = 'whatever'");
+
+    assertThat(database.getSchema().getType("Note").getProperty("body").getCustomValue("role")).isEqualTo("whatever");
+
+    database.command("sql", "DROP PROPERTY Note.body");
+    assertThat(database.getSchema().getType("Note").existsProperty("body")).isFalse();
+  }
+}

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
@@ -293,9 +293,29 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
                   // still the export's to restore - it is not something the builder can know.
                   if (property.has("custom")) {
                     final JSONObject custom = property.getJSONObject("custom");
-                    for (final String key : custom.keySet())
+                    for (final String key : custom.keySet()) {
+                      if (docType instanceof LocalTimeSeriesType && "role".equalsIgnoreCase(key)) {
+                        // Exported from a database written before issue #7567, where ALTER PROPERTY ... CUSTOM role
+                        // was accepted and did nothing. Setting it now throws, and a restore that refuses turns a
+                        // usable backup into an unusable one, so the key is dropped with a warning instead - the
+                        // column's real role travels in the type definition, which is already restored.
+                        LogManager.instance().log(this, Level.WARNING,
+                            "Ignored the CUSTOM 'role' recorded on TIMESERIES property '%s.%s': a column's role comes "
+                                + "from the type definition, not from property metadata", typeName, propertyName);
+                        continue;
+                      }
                       docType.getProperty(propertyName).setCustomValue(key, custom.get(key));
+                    }
                   }
+                  return;
+                }
+                if (docType instanceof LocalTimeSeriesType tsType && !tsType.isDeclaredColumn(propertyName)) {
+                  // Same provenance: a property added to a TIMESERIES type with CREATE PROPERTY before issue #7567
+                  // was fixed. No sample in this export carries a value for it - the exporter writes the declared
+                  // columns - so skipping it loses nothing and keeps the restore from failing.
+                  LogManager.instance().log(this, Level.WARNING,
+                      "Skipped property '%s.%s' from the export: it is not a declared column of the TIMESERIES type "
+                          + "and no write could ever populate it", typeName, propertyName);
                   return;
                 }
                 docType.createProperty(propertyName, property);

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue7567PreFixTimeSeriesPropertyRestoreIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue7567PreFixTimeSeriesPropertyRestoreIT.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.integration.TestHelper;
+import com.arcadedb.integration.exporter.Exporter;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7567, the restore side. {@code CREATE PROPERTY} on a TIMESERIES type and
+ * {@code ALTER PROPERTY ... CUSTOM role} are now refused, and a database written before that was true can carry
+ * both. Its JSONL export carries them too, and the importer restores a type's properties through exactly the API
+ * that now refuses them - so a restore that simply passed the export through would fail on precisely the databases
+ * that have the defect, turning a usable backup into an unusable one.
+ * <p>
+ * The importer therefore drops both on the way in, with a warning, and finishes the restore. The stray property
+ * never held a value (no exported sample carries one - the exporter writes the declared columns) and the CUSTOM
+ * {@code role} never meant anything, so nothing is lost with them.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class Issue7567PreFixTimeSeriesPropertyRestoreIT {
+  private static final String SOURCE_PATH = "target/databases/issue7567-jsonl-source";
+  private static final String TARGET_PATH = "target/databases/issue7567-jsonl-target";
+  private static final String FILE        = "target/issue7567-jsonl.jsonl.tgz";
+
+  @BeforeEach
+  @AfterEach
+  void clean() {
+    TestHelper.checkActiveDatabases();
+    FileUtils.deleteRecursively(new File(SOURCE_PATH));
+    FileUtils.deleteRecursively(new File(TARGET_PATH));
+    new File(FILE).delete();
+  }
+
+  @Test
+  void aPreFixExportStillRestores() throws Exception {
+    createSourceDatabase();
+    new Exporter(("-f " + FILE + " -d " + SOURCE_PATH + " -o -format jsonl").split(" ")).exportDatabase();
+
+    rewriteSchemaLineAsWrittenBeforeTheFix();
+
+    new Importer(("-url " + new File(FILE).getAbsolutePath() + " -database " + TARGET_PATH
+        + " -forceDatabaseCreate true").split(" ")).load();
+
+    try (final Database target = new DatabaseFactory(TARGET_PATH).open()) {
+      final DocumentType restored = target.getSchema().getType("Sensor");
+      assertThat(restored).isInstanceOf(LocalTimeSeriesType.class);
+
+      final LocalTimeSeriesType tsType = (LocalTimeSeriesType) restored;
+      assertThat(tsType.getTsColumnNames()).containsExactly("ts", "host", "value");
+
+      assertThat(restored.existsProperty("humidity"))
+          .as("a property no column backs must not be restored onto a TIMESERIES type").isFalse();
+      assertThat(restored.getProperty("value").getCustomValue("role"))
+          .as("the meaningless CUSTOM role must be dropped").isNull();
+      assertThat(restored.getProperty("value").getCustomValue("unit"))
+          .as("every other CUSTOM key is still restored").isEqualTo("celsius");
+
+      assertThat(target.query("sql", "SELECT count(*) AS c FROM Sensor").next().<Number>getProperty("c").longValue())
+          .isEqualTo(3L);
+    }
+  }
+
+  private void createSourceDatabase() throws Exception {
+    try (final Database source = new DatabaseFactory(SOURCE_PATH).create()) {
+      source.command("sql", "CREATE TIMESERIES TYPE Sensor TIMESTAMP ts TAGS (host STRING) FIELDS (value DOUBLE) SHARDS 1");
+      source.command("sql", "ALTER PROPERTY Sensor.value CUSTOM unit = 'celsius'");
+
+      final LocalTimeSeriesType tsType = (LocalTimeSeriesType) source.getSchema().getType("Sensor");
+      source.begin();
+      tsType.getEngine().appendSamples(new long[] { 1_000L, 2_000L, 3_000L },
+          new Object[] { "h1", "h1", "h2" },
+          new Object[] { 1.5, 2.5, 3.5 });
+      source.commit();
+    }
+  }
+
+  /**
+   * Puts back into the export exactly what a pre-fix database would have carried: a property on the TIMESERIES type
+   * that no column backs, and a CUSTOM {@code role} on a column that does. Both are injected rather than created
+   * through the API, because the API no longer produces either.
+   */
+  private void rewriteSchemaLineAsWrittenBeforeTheFix() throws Exception {
+    final List<String> lines = new ArrayList<>();
+    boolean patched = false;
+    for (final String line : readExportedLines()) {
+      final JSONObject json = new JSONObject(line);
+      if ("schema".equals(json.getString("t"))) {
+        final JSONObject sensor = json.getJSONObject("c").getJSONObject("types").getJSONObject("Sensor");
+        final JSONObject properties = sensor.getJSONObject("properties");
+        properties.put("humidity", new JSONObject().put("type", "DOUBLE"));
+        properties.getJSONObject("value").getJSONObject("custom").put("role", "TAG");
+        lines.add(json.toString());
+        patched = true;
+      } else
+        lines.add(line);
+    }
+    assertThat(patched).as("the export must carry a schema line to patch").isTrue();
+    writeExportedLines(lines);
+  }
+
+  private void writeExportedLines(final List<String> lines) throws Exception {
+    try (final Writer writer = new OutputStreamWriter(new GZIPOutputStream(new FileOutputStream(FILE)),
+        StandardCharsets.UTF_8)) {
+      for (final String line : lines)
+        writer.write(line + "\n");
+    }
+  }
+
+  private List<String> readExportedLines() throws Exception {
+    final List<String> lines = new ArrayList<>();
+    try (final BufferedReader reader = new BufferedReader(
+        new InputStreamReader(new GZIPInputStream(new FileInputStream(FILE)), StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = reader.readLine()) != null)
+        lines.add(line);
+    }
+    return lines;
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -79,6 +79,15 @@ public class CoreApiSpec implements OpenApiContributor {
       "Database not found, or the session id header names a transaction that no longer resolves "
           + "(\"Remote transaction session not found or expired\")";
 
+  // Shared by POST query and POST command: PostQueryHandler extends PostCommandHandler and overrides only
+  // executeCommand(), so both reach the very same requireStreamableStatement() call in execute() before the
+  // statement runs. Held in one place so the two operations cannot describe the same gate differently (issue #7569).
+  private static final String NDJSON_READ_ONLY_DESCRIPTION = """
+      When 'Accept' requests the ndjson encoding, only a statement provably read-only may stream: one that \
+      writes - INSERT, UPDATE, DELETE, DDL, or one this analysis cannot classify - is refused with 400 before \
+      it runs, because its rows would otherwise reach the client before the transaction that produced them \
+      commits. Request the buffered 'application/json' encoding for it instead.""";
+
   @Override
   public void contribute(final OpenAPI openAPI) {
     openAPI.getPaths().addPathItem("/api/v1/server", createServerPath());
@@ -246,7 +255,7 @@ public class CoreApiSpec implements OpenApiContributor {
 
     final Operation postOp = new Operation();
     postOp.setSummary("Execute query via POST");
-    postOp.setDescription("Executes a query using POST method with query in request body");
+    postOp.setDescription("Executes a query using POST method with query in request body. " + NDJSON_READ_ONLY_DESCRIPTION);
     postOp.setOperationId("executeQueryPost");
     postOp.addTagsItem("Query");
     postOp.addParametersItem(SpecBuilders.pathParam("database", "Database name"));
@@ -266,7 +275,7 @@ public class CoreApiSpec implements OpenApiContributor {
 
     final Operation postOp = new Operation();
     postOp.setSummary("Execute command");
-    postOp.setDescription("Executes a database command");
+    postOp.setDescription("Executes a database command. " + NDJSON_READ_ONLY_DESCRIPTION);
     postOp.setOperationId("executeCommand");
     postOp.addTagsItem("Command");
     postOp.addParametersItem(SpecBuilders.pathParam("database", "Database name"));

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
@@ -287,6 +287,45 @@ class CoreApiSpecTest {
     }
   }
 
+  /**
+   * Issue #7569: both operations declare 'application/x-ndjson' under their 200, but
+   * PostCommandHandler.requireStreamableStatement() refuses to stream a statement that is not
+   * provably read-only with a 400 before it ever runs - and nothing in the contract said so. A
+   * client author reading the contract alone had no way to know the restriction existed short of
+   * sending a mutating statement at a live server and reading the 400.
+   * <p>
+   * Checked on both /command and /query: PostQueryHandler extends PostCommandHandler and overrides
+   * only executeCommand(), so the very same requireStreamableStatement() call at execute() time
+   * guards both operations identically (the same sharing this file already pins down for 'limit'
+   * in commandRequestDeclaresLimitMatchingQueryRequest).
+   */
+  @Test
+  void commandAndQueryDescribeTheReadOnlyStreamingRestriction() {
+    // The literal text CoreApiSpec appends to both operations' description. Duplicated here rather
+    // than referencing the (private) production constant, matching how this file already pins other
+    // shared text verbatim (e.g. STALE_SESSION_404_DESCRIPTION's message in
+    // queryAndCommand404CoversAStaleSessionIdNotOnlyAMissingDatabase).
+    final String restriction = "only a statement provably read-only may stream";
+
+    final Operation command = openAPI.getPaths().get("/api/v1/command/{database}").getPost();
+    final Operation query = openAPI.getPaths().get("/api/v1/query/{database}").getPost();
+
+    for (final Operation operation : List.of(command, query)) {
+      assertThat(operation.getDescription())
+          .as(operation.getOperationId() + " must warn that the ndjson encoding is refused before "
+              + "it runs for a statement that is not provably read-only")
+          .contains(restriction)
+          .contains("400");
+    }
+
+    final String commandSuffix = command.getDescription().substring(command.getDescription().indexOf(restriction));
+    final String querySuffix = query.getDescription().substring(query.getDescription().indexOf(restriction));
+    assertThat(commandSuffix)
+        .as("both operations run through the exact same requireStreamableStatement() check, so the "
+            + "restriction text must not diverge between them and confuse a reader of the generated docs")
+        .isEqualTo(querySuffix);
+  }
+
   @Test
   void commandRequestDeclaresLanguageAsRequired() {
     final Schema<?> schema = openAPI.getComponents().getSchemas().get("CommandRequest");

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -3385,6 +3385,19 @@ function renderTypeLink(typeName) {
 const LIGHTWEIGHT_EDGE_HINT = "LIGHTWEIGHT: edges are stored inside the vertices, so this type keeps no records. "
   + "Query them with SELECT FROM <type> or by traversing the vertices.";
 
+// A section header sums each type's record count for a rough total. A LIGHTWEIGHT edge type reports 0
+// records by construction (see LIGHTWEIGHT_EDGE_HINT above), so a section that contains one is a lower
+// bound, not the true count - marked with a trailing "+" rather than shown as if it were exact.
+function formatSectionTotal(items) {
+  let total = 0;
+  let hasLightweight = false;
+  for (let j = 0; j < items.length; j++) {
+    total += (items[j].records || 0);
+    if (items[j].lightweight === true) hasLightweight = true;
+  }
+  return total.toLocaleString() + (hasLightweight ? "+" : "");
+}
+
 function renderTypeSidebarBadge(row, color, action) {
   let name = escapeHtml(row.name);
   let lightweight = row.lightweight === true;
@@ -3514,11 +3527,8 @@ function displaySchema(onReady) {
       let sec = sections[s];
       let items = groups[sec.key];
 
-      let total = 0;
-      for (let j = 0; j < items.length; j++) total += (items[j].records || 0);
-
       html += "<div class='sidebar-section'>";
-      html += "<div class='sidebar-section-header'><i class='fa " + sec.icon + "'></i> " + sec.label + " <span class='sidebar-count'>(" + total.toLocaleString() + ")</span>";
+      html += "<div class='sidebar-section-header'><i class='fa " + sec.icon + "'></i> " + sec.label + " <span class='sidebar-count'>(" + formatSectionTotal(items) + ")</span>";
       if (sec.key == "timeseries")
         html += "<span class='sidebar-section-header-actions'><button onclick='createTimeSeriesType(); return false;' title='Create timeseries type'><i class='fa fa-plus'></i></button></span>";
       else
@@ -3804,13 +3814,11 @@ function populateQuerySidebar() {
   }
 
   let groups = { vertex: [], edge: [], document: [], timeseries: [] };
-  let totals = { vertex: 0, edge: 0, document: 0, timeseries: 0 };
 
   for (let i in globalSchemaTypes) {
     let row = globalSchemaTypes[i];
     let cat = row.type == "vertex" ? "vertex" : (row.type == "edge" ? "edge" : (row.type == "t" ? "timeseries" : "document"));
     groups[cat].push(row);
-    totals[cat] += (row.records || 0);
   }
 
   let html = "";
@@ -3826,7 +3834,7 @@ function populateQuerySidebar() {
     let items = groups[sec.key];
     if (items.length == 0) continue;
 
-    let totalFormatted = totals[sec.key].toLocaleString();
+    let totalFormatted = formatSectionTotal(items);
     html += "<div class='sidebar-section'>";
     html += "<div class='sidebar-section-header'><i class='fa " + sec.icon + "'></i> " + sec.label + " <span class='sidebar-count'>(" + totalFormatted + ")</span></div>";
     html += "<div class='sidebar-badges'>";

--- a/studio/test/sidebar-section-total.test.js
+++ b/studio/test/sidebar-section-total.test.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+
+// Regression test, from discussion #7473 (comment https://github.com/ArcadeData/arcadedb/discussions/7473#discussioncomment-18408772)
+// after issue #7477 was fixed: the sidebar badge of a LIGHTWEIGHT edge type correctly stopped showing its
+// record count (0) as its size, but the section header above it - "Edges (N)" - still summed the raw
+// `records` field of every type in the section. A LIGHTWEIGHT type reports 0 records by construction, so a
+// graph holding a million lightweight edges still showed "Edges (0)" at the top of the sidebar. The total is
+// now marked with a trailing "+" whenever the section holds a type it cannot count, instead of presenting a
+// wrong number as if it were exact.
+//
+// Run with:
+//
+//     node --test studio/test/sidebar-section-total.test.js
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const SRC_PATH = path.join(__dirname, "..", "src", "main", "resources", "static", "js", "studio-database.js");
+const src = fs.readFileSync(SRC_PATH, "utf8");
+
+function extractFn(name) {
+  const start = src.indexOf("function " + name + "(");
+  if (start < 0) throw new Error("function not found in studio-database.js: " + name);
+  let i = src.indexOf("{", start);
+  let depth = 1;
+  i++;
+  while (i < src.length && depth > 0) {
+    const c = src[i];
+    if (c === "{") depth++;
+    else if (c === "}") depth--;
+    i++;
+  }
+  return src.substring(start, i);
+}
+
+eval(extractFn("formatSectionTotal"));
+
+test("a section with only regular types shows the exact sum", () => {
+  const total = formatSectionTotal([{ records: 3 }, { records: 4 }]);
+  assert.equal(total, "7");
+});
+
+test("a section holding a LIGHTWEIGHT edge type marks its total as a lower bound", () => {
+  const total = formatSectionTotal([{ records: 0, lightweight: true }]);
+  assert.equal(total, "0+", "a graph full of lightweight edges must not read as an empty section");
+});
+
+test("a mixed section still adds the regular types' records and marks the total", () => {
+  const total = formatSectionTotal([{ records: 5, lightweight: false }, { records: 0, lightweight: true }]);
+  assert.equal(total, "5+");
+});
+
+test("an empty section shows a plain zero", () => {
+  const total = formatSectionTotal([]);
+  assert.equal(total, "0");
+});
+
+test("a type listing from an older server, with no lightweight flag, is unaffected", () => {
+  const total = formatSectionTotal([{ records: 7 }, { records: 3 }]);
+  assert.equal(total, "10");
+});


### PR DESCRIPTION
Closes #7567

A TIMESERIES type keeps its columns in `LocalTimeSeriesType.tsColumns`, filled once by `CREATE TIMESERIES TYPE`, and `SaveElementStep#saveToTimeSeries` reads a document under those names and no others. `CREATE PROPERTY Reading.humidity DOUBLE` landed in the type's ordinary property map instead, so the column showed up in the schema listing while every write dropped its value without an error at DDL time, at write time or at read time; `ALTER PROPERTY ... CUSTOM role = "FIELD"` was the same misunderstanding from the other side, since a column's role is `ColumnDefinition.getRole()` and is never read back out of property metadata. Both are now refused at DDL time - the closest point to the mistake - on the single funnel every `createProperty`/`getOrCreateProperty` overload delegates to and in `LocalProperty.setCustomValue`, and dropping a declared column's property is refused with them because it would leave the engine storing a column the type had stopped declaring. Because a database written before this rule can already carry either, neither refusal fires while the schema is loading (the load warns instead, naming the property), `CUSTOM role = null` still clears a stale key, `DROP PROPERTY` on a stray name stays allowed as the remedy, and the JSONL importer drops both on the way in rather than turning a usable backup into an unusable one on exactly the databases that have the defect.

## Test plan

- [ ] `mvn -o -pl engine -am test -Dtest=Issue7567TimeSeriesPropertyDDLTest` - 10 tests green.
- [ ] `mvn -o -pl integration verify -DskipITs=false -Dit.test=Issue7567PreFixTimeSeriesPropertyRestoreIT -Dfailsafe.failIfNoSpecifiedTests=false` - the pre-fix export still restores.
- [ ] Manually: `CREATE TIMESERIES TYPE Reading TIMESTAMP ts TAGS (sensor STRING) FIELDS (value DOUBLE)`, then `CREATE PROPERTY Reading.humidity DOUBLE` - now refused naming the declared columns, where it used to return success and then silently discard every value written under `humidity`.
- [ ] Manually: `ALTER PROPERTY Reading.value CUSTOM role = 'TAG'` - refused, naming the column's real role; `ALTER PROPERTY Reading.value CUSTOM unit = 'celsius'` still works.
- [ ] Regression: `mvn -o -pl engine -am test -DexcludedGroups=benchmark,vector,slow` (14920 run) and `mvn -o -pl integration verify -DskipITs=false -DexcludedGroups=benchmark,vector,slow` (475 unit + 134 IT).

## Coverage

Fixed, each with a test driving it through its own entry point:

| Entry point | Test |
|---|---|
| SQL `CREATE PROPERTY <ts>.<x>` -> `CreatePropertyStatement` -> `LocalDocumentType.createProperty(String,Type,String)` | `sqlCreatePropertyOnTimeSeriesTypeIsRefused` |
| SQL `CREATE PROPERTY <ts>.<x> IF NOT EXISTS` (same funnel when the name is absent; still a no-op for a declared column, per #7143) | `sqlCreatePropertyIfNotExistsOnTimeSeriesTypeIsRefused` |
| Schema API `createProperty` / `getOrCreateProperty`, every overload | `schemaApiCreatePropertyOnTimeSeriesTypeIsRefused` |
| SQL `ALTER PROPERTY <ts>.<x> CUSTOM role = ...` -> `LocalProperty.setCustomValue` | `sqlAlterPropertyCustomRoleOnTimeSeriesTypeIsRefused` |
| Schema API `setCustomValue("role"/"ROLE", ...)` | `schemaApiSetCustomRoleOnTimeSeriesTypeIsRefused` |
| SQL `DROP PROPERTY <ts>.<declared column>` -> `LocalDocumentType.dropProperty` | `sqlDropPropertyOfDeclaredColumnIsRefused` |
| `ALTER PROPERTY <ts>.<x> CUSTOM role = null` - deliberately still allowed, the only way to clear a key a pre-fix database stored | `removingAStaleCustomRoleIsAllowed` |
| `LocalSchema.readConfiguration()` opening a pre-fix database - tolerated with a WARNING | `preFixStrayPropertyStillOpensAndCanBeDropped` |
| `JsonlImporterFormat` restoring a pre-fix export - tolerated with a WARNING | `Issue7567PreFixTimeSeriesPropertyRestoreIT` |
| `TimeSeriesTypeBuilder.create()` registering the declared columns, and a plain DOCUMENT type | `declaredColumnsAreStoredAndReadBack`, `documentTypePropertyDDLIsUnaffected` |

Argued rather than tested, with the evidence in the tracking doc: `RemoteDocumentType.createProperty` emits `create property ...` SQL the server executes through this same funnel; `LocalSchema.copyType()` only ever creates a `LocalDocumentType` or `LocalVertexType` target; the openCypher typed-property path calls the same two methods; and inline `CREATE PROPERTY ... CUSTOM role` is unreachable on a TIMESERIES type because the property refusal fires before the CUSTOM loop.

Each rejection was proved able to fail: with the three guards neutralized, 6 of the 10 engine tests fail and the 4 controls stay green; neutralizing only the schema-load tolerance fails the back-compat test alone; neutralizing the importer's two skips fails the IT.

### Known gaps

- **#7581** - `ALTER TYPE <timeseries> SUPERTYPE +Other` is accepted and gives the type polymorphic properties the write path drops, the same defect reached through a statement none of these guards see. Found by this PR's adversarial pass (verified: `polymorphic props=[s, v, humidity, ts]`), filed rather than fixed here because refusing a type hierarchy on a TIMESERIES type is a behaviour decision of its own scope.
- A database created before this fix keeps the stray property it already has - it opens with a warning naming it, and the value is still dropped on write until someone runs `DROP PROPERTY`. Removing it automatically at open would be a silent schema mutation during a database open, which is worse; no migration is offered.
- Adding a column to an existing TIMESERIES type remains impossible. That is a feature with a storage-format question behind it (fixed-stride mutable rows, sealed blocks), not this bug.

### Unrelated, found while running the suite

- **#7584** - `MultiColumnAggregationResultTest.emptySumAndCountStayZeroNotNaN` is red on `main` (empty SUM answers `NaN`, not `0`). It is the one failure in the 14920-test engine run, it fails standalone, and it is a pure in-memory unit test of classes this diff does not touch.

### Not run

The `server` module: port 2480 was held by another process for the whole session, and a server suite started against an occupied port reports authentication failures rather than a port conflict. It adds no entry point of its own - remote schema DDL is the same SQL executed by the same funnel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6gidX7u247f1WKYokvFqH