### PR TITLE
fix(#7586): Windows backup archive nesting and path-separator handling

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/ComponentFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/ComponentFile.java
@@ -101,19 +101,15 @@ public class ComponentFile {
     final int fileIdPos = filePrefix.lastIndexOf(".");
     if (fileIdPos > -1) {
       fileId = Integer.parseInt(filePrefix.substring(fileIdPos + 1));
-      final int pos = filePrefix.lastIndexOf(File.separator);
+      final int pos = FileUtils.lastIndexOfSeparator(filePrefix);
       componentName = filePrefix.substring(pos + 1, filePrefix.lastIndexOf("."));
     } else {
       fileId = -1;
-      final int pos = filePrefix.lastIndexOf(File.separator);
+      final int pos = FileUtils.lastIndexOfSeparator(filePrefix);
       componentName = filePrefix.substring(pos + 1);
     }
 
-    final int lastSlash = filePath.lastIndexOf(File.separator);
-    if (lastSlash > -1)
-      fileName = filePath.substring(lastSlash + 1);
-    else
-      fileName = filePath;
+    fileName = FileUtils.getFileNameFromPath(filePath);
 
     this.osFile = new File(filePath);
     this.open = true;

--- a/engine/src/main/java/com/arcadedb/engine/PaginatedComponentFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/PaginatedComponentFile.java
@@ -19,6 +19,7 @@
 package com.arcadedb.engine;
 
 import com.arcadedb.log.LogManager;
+import com.arcadedb.utility.FileUtils;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -496,19 +497,15 @@ public class PaginatedComponentFile extends ComponentFile {
     final int fileIdPos = filePrefix.lastIndexOf(".");
     if (fileIdPos > -1) {
       fileId = Integer.parseInt(filePrefix.substring(fileIdPos + 1));
-      final int pos = filePrefix.lastIndexOf(File.separator);
+      final int pos = FileUtils.lastIndexOfSeparator(filePrefix);
       componentName = filePrefix.substring(pos + 1, filePrefix.lastIndexOf("."));
     } else {
       fileId = -1;
-      final int pos = filePrefix.lastIndexOf(File.separator);
+      final int pos = FileUtils.lastIndexOfSeparator(filePrefix);
       componentName = filePrefix.substring(pos + 1);
     }
 
-    final int lastSlash = filePath.lastIndexOf(File.separator);
-    if (lastSlash > -1)
-      fileName = filePath.substring(lastSlash + 1);
-    else
-      fileName = filePath;
+    fileName = FileUtils.getFileNameFromPath(filePath);
 
     this.osFile = new File(filePath);
     this.file = new RandomAccessFile(osFile, mode == MODE.READ_WRITE ? "rw" : "r");

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -1174,7 +1174,7 @@ public class TransactionManager {
     activeWALFilePool = new WALFile[walFilePoolSize(database.getConfiguration())];
     for (int i = 0; i < activeWALFilePool.length; ++i) {
       final long counter = logFileCounter.getAndIncrement();
-      final String walFilePath = database.getDatabasePath() + "/txlog_" + counter + ".wal";
+      final String walFilePath = database.getDatabasePath() + File.separator + "txlog_" + counter + ".wal";
       try {
         activeWALFilePool[i] = database.getWALFileFactory().newInstance(walFilePath);
       } catch (final FileNotFoundException e) {
@@ -1222,7 +1222,7 @@ public class TransactionManager {
                 "WAL file '%s' reached maximum size (%d), set it as inactive, waiting for the drop (page2flush=%d)", null, file,
                 MAX_LOG_FILE_SIZE, file.getPendingPagesToFlush());
             activeWALFilePool[i] = database.getWALFileFactory()
-                .newInstance(database.getDatabasePath() + "/txlog_" + logFileCounter.getAndIncrement() + ".wal");
+                .newInstance(database.getDatabasePath() + File.separator + "txlog_" + logFileCounter.getAndIncrement() + ".wal");
 
             // SET THE OLD FILE AS INACTIVE READY TO BE DISPOSED. Done unconditionally, before the new
             // file's lock is even checked: the old file's own retirement has nothing to do with whether
@@ -1383,7 +1383,7 @@ public class TransactionManager {
         final WALFile file = activeWALFilePool[i];
         if (file != null && file.isOpen()) {
           activeWALFilePool[i] = database.getWALFileFactory()
-              .newInstance(database.getDatabasePath() + "/txlog_" + logFileCounter.getAndIncrement() + ".wal");
+              .newInstance(database.getDatabasePath() + File.separator + "txlog_" + logFileCounter.getAndIncrement() + ".wal");
           file.setActive(false);
           inactiveWALFilePool.add(file);
         }

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
@@ -28,6 +28,7 @@ import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.LocalSchema;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.ArrayList;
@@ -142,7 +143,7 @@ public class TimeSeriesShard implements AutoCloseable {
     this.compactionBucketIntervalMs = compactionBucketIntervalMs;
 
     final String shardName = baseName + "_shard_" + shardIndex;
-    final String shardPath = database.getDatabasePath() + "/" + shardName;
+    final String shardPath = database.getDatabasePath() + File.separator + shardName;
     final LocalSchema schema = (LocalSchema) database.getSchema();
 
     // Check if the bucket was already loaded by the component factory (cold open)

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
@@ -33,6 +33,7 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.LocalSchema;
 import com.arcadedb.schema.Type;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -239,7 +240,7 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
 
     final TimeSeriesTagDictionary dictionary = existingFile != null ?
         new TimeSeriesTagDictionary(database, name, (PaginatedComponentFile) existingFile) :
-        new TimeSeriesTagDictionary(database, name, database.getDatabasePath() + "/" + name);
+        new TimeSeriesTagDictionary(database, name, database.getDatabasePath() + File.separator + name);
 
     // Registered BEFORE it is initialised, and it has to be: initHeaderPage() commits, and a commit
     // resolves the component to bump its page count through schema.getFileById(), which throws on an id

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
@@ -30,6 +30,7 @@ import com.arcadedb.schema.LocalSchema;
 import com.arcadedb.utility.IntHashSet;
 import com.arcadedb.utility.LongHashSet;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1656,7 +1657,7 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
    */
   private SparseSegmentComponent createComponent(final long segmentId) {
     final String name = segmentComponentName(segmentId);
-    final String filePath = database.getDatabasePath() + "/" + name;
+    final String filePath = database.getDatabasePath() + File.separator + name;
     try {
       final SparseSegmentComponent c = new SparseSegmentComponent(database, name, filePath, ComponentFile.MODE.READ_WRITE,
           params.pageSize());

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -261,7 +261,7 @@ public class LocalSchema implements Schema {
     loadInRamCompleted = true;
     database.begin();
     try {
-      dictionary = new Dictionary(database, "dictionary", databasePath + "/dictionary", mode, Dictionary.DEF_PAGE_SIZE);
+      dictionary = new Dictionary(database, "dictionary", databasePath + File.separator + "dictionary", mode, Dictionary.DEF_PAGE_SIZE);
       files.add(dictionary);
 
       database.commit();

--- a/engine/src/main/java/com/arcadedb/utility/FileUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/FileUtils.java
@@ -169,6 +169,27 @@ public class FileUtils {
       throw new IOException("Invalid file name '" + iFileName + "'");
   }
 
+  /**
+   * The last path-separator index in {@code path}, checking both '/' and '\' rather than only this JVM's own
+   * {@link File#separator}. A path built with a literal '/' (as a few storage components do, e.g.
+   * {@code databasePath + "/dictionary"}) can still reach a lookup running where {@code File.separator} is '\',
+   * and the reverse is equally possible - see issue #7586, where that mismatch left a directory prefix in a
+   * component's parsed file name on Windows and, from there, nested a backup archive entry that should have sat
+   * at the archive root.
+   */
+  public static int lastIndexOfSeparator(final String path) {
+    return Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+  }
+
+  /**
+   * The last path segment of {@code path} - the part after {@link #lastIndexOfSeparator(String)} - regardless of
+   * which separator convention built it.
+   */
+  public static String getFileNameFromPath(final String path) {
+    final int pos = lastIndexOfSeparator(path);
+    return pos > -1 ? path.substring(pos + 1) : path;
+  }
+
   public static void deleteRecursively(final File rootFile) {
     for (int attempt = 0; attempt < 3; attempt++) {
       try {

--- a/engine/src/test/java/com/arcadedb/engine/Issue7586ComponentFileMixedSeparatorTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue7586ComponentFileMixedSeparatorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.FileNotFoundException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7586: {@code LocalSchema} builds the dictionary's path with a literal '/', while the rest of a database
+ * path is built with the platform {@code File.separator}. On Windows this leaves a mixed-separator path whose
+ * directory {@link ComponentFile#open} stripped with a lookup keyed on {@code File.separator} alone ('\\') - which
+ * never finds the '/' - so {@code fileName}/{@code componentName} kept the database directory, and the backup
+ * archive entry built from {@code fileName} nested under it instead of sitting at the archive root.
+ * <p>
+ * Reproduced here with the roles of the two separators swapped, so the gap is exercised on every platform this
+ * test runs on rather than only on Windows: the directory is joined with '/' and the last, closest separator is
+ * '\\', which a lookup keyed on this JVM's own {@code File.separator} ('/' on Linux and macOS) would miss.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7586ComponentFileMixedSeparatorTest {
+
+  @Test
+  void fileNameAndComponentNameStripADirectoryPrefixRegardlessOfWhichSeparatorIsClosest() throws FileNotFoundException {
+    final ComponentFile file = new ComponentFile("db/dir\\dictionary.0.65536.v1.dict", ComponentFile.MODE.READ_ONLY) {
+    };
+
+    assertThat(file.getFileName()).isEqualTo("dictionary.0.65536.v1.dict");
+    assertThat(file.getComponentName()).isEqualTo("dictionary.0");
+    assertThat(file.getFileId()).isEqualTo(65536);
+    assertThat(file.getVersion()).isEqualTo(1);
+    assertThat(file.getFileExtension()).isEqualTo("dict");
+  }
+
+  @Test
+  void fileNameAndComponentNameStripADirectoryPrefixWithNoTrailingFileId() throws FileNotFoundException {
+    final ComponentFile file = new ComponentFile("db/dir\\schema.dict", ComponentFile.MODE.READ_ONLY) {
+    };
+
+    assertThat(file.getFileName()).isEqualTo("schema.dict");
+    assertThat(file.getComponentName()).isEqualTo("schema");
+    assertThat(file.getFileId()).isEqualTo(-1);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/Issue7586PaginatedComponentFileMixedSeparatorTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue7586PaginatedComponentFileMixedSeparatorTest.java
@@ -22,7 +22,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,9 +61,15 @@ class Issue7586PaginatedComponentFileMixedSeparatorTest {
 
   @Test
   void fileNameAndComponentNameStripADirectoryPrefixRegardlessOfWhichSeparatorIsClosest() throws IOException {
-    // A single, real file name containing a literal '\' (legal on Linux/macOS): the platform separator only
-    // reaches the boundary before it, exactly as a mismatched separator would on Windows.
-    final String filePath = tempDir.resolve("dir\\dictionary.0." + PAGE_SIZE + ".v0.dict").toString();
+    // A real "dir" directory, reached with a literal separator that is NOT this JVM's own File.separator: on
+    // Linux/macOS that is '\', a plain filename character that keeps "dir" and the file name in one path
+    // component; on Windows '/' is a real alternate separator, so it still resolves into "dir". Either way the
+    // closest separator to the file name is the foreign one, exactly as a mismatched separator would be on
+    // whichever platform the JVM's own separator differs from.
+    Files.createDirectories(tempDir.resolve("dir"));
+    final char foreignSeparator = File.separatorChar == '/' ? '\\' : '/';
+    final String filePath =
+        tempDir + File.separator + "dir" + foreignSeparator + "dictionary.0." + PAGE_SIZE + ".v0.dict";
 
     pcf = new PaginatedComponentFile(filePath, ComponentFile.MODE.READ_WRITE);
 

--- a/engine/src/test/java/com/arcadedb/engine/Issue7586PaginatedComponentFileMixedSeparatorTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue7586PaginatedComponentFileMixedSeparatorTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7586, found by review on PR #7587: {@link PaginatedComponentFile#open} overrides
+ * {@link ComponentFile#open} and duplicated its {@code File.separator}-only directory lookup rather than reusing
+ * {@link com.arcadedb.utility.FileUtils#lastIndexOfSeparator}. This is the override that actually matters for the
+ * reported bug - every real component ({@code Dictionary}, buckets, indexes) is a {@link PaginatedComponent} and
+ * so opens through here, not through the base class - so fixing only {@code ComponentFile.open()} left the
+ * production code path unfixed.
+ * <p>
+ * {@code PaginatedComponentFile.open()} does real file I/O (it opens a {@code RandomAccessFile}), so this reproduces
+ * the parsing bug through a real file, mirroring {@link PaginatedComponentFileRoundTripTest}'s construction. The
+ * mixed-separator technique matches {@link Issue7586ComponentFileMixedSeparatorTest}: the directory is joined with
+ * this JVM's own separator and the closest separator to the file name is the other one, so the gap is exercised on
+ * every platform this test runs on.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7586PaginatedComponentFileMixedSeparatorTest {
+  private static final int PAGE_SIZE = 1024;
+
+  @TempDir
+  Path tempDir;
+
+  private PaginatedComponentFile pcf;
+
+  @AfterEach
+  void tearDown() {
+    if (pcf != null)
+      pcf.close();
+  }
+
+  @Test
+  void fileNameAndComponentNameStripADirectoryPrefixRegardlessOfWhichSeparatorIsClosest() throws IOException {
+    // A single, real file name containing a literal '\' (legal on Linux/macOS): the platform separator only
+    // reaches the boundary before it, exactly as a mismatched separator would on Windows.
+    final String filePath = tempDir.resolve("dir\\dictionary.0." + PAGE_SIZE + ".v0.dict").toString();
+
+    pcf = new PaginatedComponentFile(filePath, ComponentFile.MODE.READ_WRITE);
+
+    assertThat(pcf.getFileName()).isEqualTo("dictionary.0." + PAGE_SIZE + ".v0.dict");
+    assertThat(pcf.getComponentName()).isEqualTo("dictionary");
+    assertThat(pcf.getFileId()).isEqualTo(0);
+    assertThat(pcf.getPageSize()).isEqualTo(PAGE_SIZE);
+    assertThat(pcf.getVersion()).isEqualTo(0);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/utility/FileUtilsTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/FileUtilsTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedStatic;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;

--- a/engine/src/test/java/com/arcadedb/utility/FileUtilsTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/FileUtilsTest.java
@@ -508,4 +508,26 @@ class FileUtilsTest {
     assertThat(tempDir.toFile().list((dir, name) -> name.endsWith(".tmp")))
         .as("a failed copy must clean up after itself").isEmpty();
   }
+
+  /**
+   * Issue #7586: a path can be assembled with either separator convention regardless of which platform the JVM
+   * runs on (e.g. a component path built with a literal '/'), so a lookup keyed on this JVM's own
+   * {@link File#separator} finds only one of the two and leaves the other's directory in place. Mixing both
+   * separators in one path - as the real Windows defect did - exercises that gap on every platform this test runs on.
+   */
+  @Test
+  void lastIndexOfSeparatorFindsWhicheverSeparatorIsRightmost() {
+    assertThat(FileUtils.lastIndexOfSeparator("db/dir\\dictionary.0.65536.v1.dict")).isEqualTo(6);
+    assertThat(FileUtils.lastIndexOfSeparator("db\\dir/dictionary.0.65536.v1.dict")).isEqualTo(6);
+    assertThat(FileUtils.lastIndexOfSeparator("dictionary.0.65536.v1.dict")).isEqualTo(-1);
+  }
+
+  @Test
+  void getFileNameFromPathStripsADirectoryBuiltWithEitherSeparator() {
+    assertThat(FileUtils.getFileNameFromPath("db/dir\\dictionary.0.65536.v1.dict"))
+        .isEqualTo("dictionary.0.65536.v1.dict");
+    assertThat(FileUtils.getFileNameFromPath("db\\dir/dictionary.0.65536.v1.dict"))
+        .isEqualTo("dictionary.0.65536.v1.dict");
+    assertThat(FileUtils.getFileNameFromPath("dictionary.0.65536.v1.dict")).isEqualTo("dictionary.0.65536.v1.dict");
+  }
 }

--- a/integration/src/main/java/com/arcadedb/integration/backup/BackupSettings.java
+++ b/integration/src/main/java/com/arcadedb/integration/backup/BackupSettings.java
@@ -84,11 +84,16 @@ public class BackupSettings {
 
     if (directory != null && file != null) {
       final String f = file.startsWith("file://") ? file.substring("file://".length()) : file;
+      // A bare file name only: checkValidName rejects both '/' and '\' regardless of this JVM's own
+      // File.separator, unlike the '..'/File.separator-only check this replaces, which missed a path built
+      // with the other platform's separator convention (issue #7586, defect A) and let it reach the
+      // unconditional "directory + File.separator + fileName" concatenation in FullBackupFormat instead.
+      // The ':' check is separate: a value such as "C:" or "C:backup.zip" carries no separator at all, so
+      // checkValidName lets it through, but it is still a Windows drive-qualified (or drive-relative) path that
+      // would either escape the pinned directory or fail confusingly once concatenated with it.
+      if (f.indexOf(':') > -1)
+        throw new IllegalArgumentException("Backup file cannot contain path change because the directory is specified");
       try {
-        // A bare file name only: checkValidName rejects both '/' and '\' regardless of this JVM's own
-        // File.separator, unlike the '..'/File.separator-only check this replaces, which missed a path built
-        // with the other platform's separator convention (issue #7586, defect A) and let it reach the
-        // unconditional "directory + File.separator + fileName" concatenation in FullBackupFormat instead.
         FileUtils.checkValidName(f);
       } catch (final IOException e) {
         throw new IllegalArgumentException("Backup file cannot contain path change because the directory is specified", e);

--- a/integration/src/main/java/com/arcadedb/integration/backup/BackupSettings.java
+++ b/integration/src/main/java/com/arcadedb/integration/backup/BackupSettings.java
@@ -18,7 +18,10 @@
  */
 package com.arcadedb.integration.backup;
 
+import com.arcadedb.utility.FileUtils;
+
 import java.io.File;
+import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
@@ -81,8 +84,15 @@ public class BackupSettings {
 
     if (directory != null && file != null) {
       final String f = file.startsWith("file://") ? file.substring("file://".length()) : file;
-      if (f.contains("..") || f.contains(File.separator))
-        throw new IllegalArgumentException("Backup file cannot contain path change because the directory is specified");
+      try {
+        // A bare file name only: checkValidName rejects both '/' and '\' regardless of this JVM's own
+        // File.separator, unlike the '..'/File.separator-only check this replaces, which missed a path built
+        // with the other platform's separator convention (issue #7586, defect A) and let it reach the
+        // unconditional "directory + File.separator + fileName" concatenation in FullBackupFormat instead.
+        FileUtils.checkValidName(f);
+      } catch (final IOException e) {
+        throw new IllegalArgumentException("Backup file cannot contain path change because the directory is specified", e);
+      }
     }
 
     if (file == null)

--- a/integration/src/main/java/com/arcadedb/integration/backup/format/FullBackupFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/backup/format/FullBackupFormat.java
@@ -313,14 +313,34 @@ public class FullBackupFormat extends AbstractBackupFormat {
 
   private long compressEntry(final BackupArchiveWriter archive, final String name, final long lastModified,
       final InputStream input) throws IOException {
-    logger.log(2, "- File '%s'...", name);
-    final BackupArchiveWriter.EntryStats stats = archive.addEntry(name, lastModified, input);
+    final String entryName = archiveEntryName(name);
+    if (!entryName.equals(name))
+      // A DIRECTORY-BEARING NAME HERE IS ALREADY A BUG UPSTREAM (issue #7586) - LOGGED RATHER THAN SILENTLY
+      // ACCEPTED, SO THE ROOT CAUSE STAYS VISIBLE EVEN THOUGH THE ARCHIVE ITSELF IS STILL SAVED CORRECTLY
+      logger.logLine(0, "- WARNING: archive entry name '%s' carried a directory prefix, stored as '%s' instead", name,
+          entryName);
+
+    logger.log(2, "- File '%s'...", entryName);
+    final BackupArchiveWriter.EntryStats stats = archive.addEntry(entryName, lastModified, input);
     final long origSize = stats.uncompressedSize();
     final long compressedSize = stats.compressedSize();
 
     logger.logLine(2, " %s -> %s (%,d%% compressed)", FileUtils.getSizeAsString(origSize),
         FileUtils.getSizeAsString(compressedSize), origSize > 0 ? (origSize - compressedSize) * 100 / origSize : 0);
     return origSize;
+  }
+
+  /**
+   * Every archive entry must sit at the archive root: {@code FullRestoreFormat} extracts each one under its own
+   * name straight into the database directory, so any directory component would nest it where the reopened
+   * database cannot find it (issue #7586). {@code compressFile}/{@code addFile} already guarantee this by deriving
+   * the entry name from {@link File#getName()}; this is the same guarantee for a name handed in directly rather
+   * than read off a {@link File}, so an upstream separator mismatch can never reach the archive uncaught - see
+   * {@link FileUtils#lastIndexOfSeparator(String)} for why a lookup keyed on this JVM's own {@link File#separator}
+   * would not be enough.
+   */
+  static String archiveEntryName(final String name) {
+    return FileUtils.getFileNameFromPath(name);
   }
 
   private long compressFile(final BackupArchiveWriter archive, final File inputFile) throws IOException {

--- a/integration/src/test/java/com/arcadedb/integration/backup/BackupSettingsTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/backup/BackupSettingsTest.java
@@ -180,6 +180,35 @@ class BackupSettingsTest {
         .hasMessageContaining("path change");
   }
 
+  /**
+   * A drive-qualified value such as {@code C:} or {@code C:backup.zip} carries no {@code /} or {@code \} at all -
+   * {@code checkValidName} lets it straight through - yet on Windows it is still not a bare file name: it is a
+   * drive-relative path (or, with nothing after the colon, just the drive itself), and once
+   * {@code FullBackupFormat} concatenates it onto the pinned {@code directory} the colon makes the combined path
+   * invalid, which is the same class of confusing, far-away failure this PR's separator fix already replaced with
+   * a clear rejection here (CodeRabbit finding on PR #7587).
+   */
+  @Test
+  void rejectsADriveQualifiedFileArgumentWhenADirectoryIsPinned() {
+    final BackupSettings driveOnly = new BackupSettings();
+    driveOnly.directory = "backups" + File.separator;
+    driveOnly.file = "C:";
+    assertThatThrownBy(driveOnly::validateSettings).isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("path change");
+
+    final BackupSettings driveRelative = new BackupSettings();
+    driveRelative.directory = "backups" + File.separator;
+    driveRelative.file = "C:backup.zip";
+    assertThatThrownBy(driveRelative::validateSettings).isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("path change");
+
+    final BackupSettings fileUrlDriveRelative = new BackupSettings();
+    fileUrlDriveRelative.directory = "backups" + File.separator;
+    fileUrlDriveRelative.file = "file://C:backup.zip";
+    assertThatThrownBy(fileUrlDriveRelative::validateSettings).isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("path change");
+  }
+
   @Test
   void acceptsABareFileNameWhenADirectoryIsPinned() {
     final BackupSettings settings = new BackupSettings();

--- a/integration/src/test/java/com/arcadedb/integration/backup/BackupSettingsTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/backup/BackupSettingsTest.java
@@ -22,7 +22,10 @@ import com.arcadedb.GlobalConfiguration;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
@@ -145,5 +148,45 @@ class BackupSettingsTest {
     assertThat(new IoThrottler(0).isEnabled()).isFalse();
     assertThat(new IoThrottler(-5).isEnabled()).isFalse();
     assertThat(new IoThrottler(1).isEnabled()).isTrue();
+  }
+
+  /**
+   * Issue #7586, defect A: with a {@code directory} pinned (as SQL's {@code BACKUP DATABASE} always does, so the
+   * archive cannot be steered outside the server's configured backup directory), the guard against a path change in
+   * {@code file} checked only {@code File.separator} - '\\' on Windows, '/' everywhere else - so a path built with
+   * the other convention slipped through validation and only failed later, several frames away, as a confusing
+   * {@code InvalidPathException} out of {@code java.io.File}. Checked here with both roles reversed on this JVM's
+   * own platform, so the gap is exercised on every platform this test runs on: a '\\'-separated value must be
+   * rejected exactly like a '/'-separated one, independent of {@link File#separator}.
+   */
+  @Test
+  void rejectsAFileArgumentContainingEitherPathSeparatorWhenADirectoryIsPinned() {
+    final BackupSettings forwardSlash = new BackupSettings();
+    forwardSlash.directory = "backups" + File.separator;
+    forwardSlash.file = "some/where/backup.zip";
+    assertThatThrownBy(forwardSlash::validateSettings).isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("path change");
+
+    final BackupSettings backSlash = new BackupSettings();
+    backSlash.directory = "backups" + File.separator;
+    backSlash.file = "some\\where\\backup.zip";
+    assertThatThrownBy(backSlash::validateSettings).isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("path change");
+
+    final BackupSettings fileUrlBackSlash = new BackupSettings();
+    fileUrlBackSlash.directory = "backups" + File.separator;
+    fileUrlBackSlash.file = "file://C:\\Users\\test\\backup.zip";
+    assertThatThrownBy(fileUrlBackSlash::validateSettings).isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("path change");
+  }
+
+  @Test
+  void acceptsABareFileNameWhenADirectoryIsPinned() {
+    final BackupSettings settings = new BackupSettings();
+    settings.directory = "backups" + File.separator;
+    settings.file = "backup.zip";
+    settings.databaseName = "test";
+
+    assertThatCode(settings::validateSettings).doesNotThrowAnyException();
   }
 }

--- a/integration/src/test/java/com/arcadedb/integration/backup/Issue7586BackupArchiveEntriesSitAtArchiveRootIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/backup/Issue7586BackupArchiveEntriesSitAtArchiveRootIT.java
@@ -60,7 +60,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class Issue7586BackupArchiveEntriesSitAtArchiveRootTest {
+class Issue7586BackupArchiveEntriesSitAtArchiveRootIT {
   private static final String DATABASE_PATH = "target/databases/issue7586-backup-root";
   private static final String RESTORED_PATH = "target/databases/issue7586-backup-root-restored";
   private static final String BACKUP_FILE   = "target/issue7586-backup-root.zip";

--- a/integration/src/test/java/com/arcadedb/integration/backup/Issue7586BackupArchiveEntriesSitAtArchiveRootTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/backup/Issue7586BackupArchiveEntriesSitAtArchiveRootTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.backup;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.integration.TestHelper;
+import com.arcadedb.integration.restore.Restore;
+import com.arcadedb.schema.Property;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7586, defect B: on Windows the dictionary's file path was assembled with a literal '/' while every other
+ * component path used the platform {@code File.separator}, and a {@code ComponentFile.open()} lookup keyed on
+ * {@code File.separator} alone missed the '/', leaving the database directory name in the dictionary's parsed file
+ * name. The snapshot-based full backup then archived that file name verbatim, so the dictionary entry alone
+ * carried a {@code <database-name>/} prefix while every other entry sat at the archive root - an archive a restore
+ * could not open.
+ * <p>
+ * Neither the mixed separator nor a nested entry can be manufactured through the public API on this JVM's own
+ * platform (the database path is built consistently with one separator throughout, here as on Windows before this
+ * fix), so what is pinned instead is the invariant defect B broke: every entry in a full-backup archive sits at
+ * the archive root, and the archive restores intact. {@code LocalSchema}, {@code TimeSeriesShard} and
+ * {@code TimeSeriesTagDictionary} now build every component path with {@code File.separator} rather than a
+ * literal '/', {@code ComponentFile.open()} strips a directory built with either separator, and
+ * {@code FullBackupFormat.compressEntry} strips one defensively as well - so a future path built with the wrong
+ * separator on some other platform cannot repeat this failure silently.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7586BackupArchiveEntriesSitAtArchiveRootTest {
+  private static final String DATABASE_PATH = "target/databases/issue7586-backup-root";
+  private static final String RESTORED_PATH = "target/databases/issue7586-backup-root-restored";
+  private static final String BACKUP_FILE   = "target/issue7586-backup-root.zip";
+  private static final String TYPE          = "Issue7586Doc";
+
+  @BeforeEach
+  @AfterEach
+  void clean() {
+    FileUtils.deleteRecursively(new File(DATABASE_PATH));
+    FileUtils.deleteRecursively(new File(RESTORED_PATH));
+    new File(BACKUP_FILE).delete();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = { true, false })
+  void everyArchiveEntrySitsAtTheArchiveRootAndTheArchiveRestoresIntact(final boolean snapshot) throws Exception {
+    GlobalConfiguration.PAGE_SNAPSHOT_ENABLED.setValue(snapshot);
+    try {
+      try (final Database database = new DatabaseFactory(DATABASE_PATH).create()) {
+        createSchema(database);
+        database.transaction(() -> {
+          for (int i = 0; i < 50; i++)
+            database.newDocument(TYPE).set("id", i).set("name", "issue7586-" + i).save();
+        });
+
+        new Backup(database, BACKUP_FILE).setVerboseLevel(0).backupDatabase();
+      }
+
+      final List<String> entries = new ArrayList<>();
+      try (final ZipFile zip = new ZipFile(BACKUP_FILE)) {
+        final Enumeration<? extends ZipEntry> it = zip.entries();
+        while (it.hasMoreElements())
+          entries.add(it.nextElement().getName());
+      }
+
+      assertThat(entries).isNotEmpty();
+      for (final String entry : entries)
+        assertThat(entry).as("archive entry '%s' must sit at the archive root", entry).doesNotContain("/", "\\");
+
+      new Restore(BACKUP_FILE, RESTORED_PATH).setVerboseLevel(0).restoreDatabase();
+
+      try (final Database restored = new DatabaseFactory(RESTORED_PATH).open()) {
+        assertThat(restored.countType(TYPE, false)).isEqualTo(50);
+        assertThat(restored.command("sql", "check database").nextIfAvailable().<Long>getProperty("totalErrors"))
+            .isZero();
+      }
+      TestHelper.checkActiveDatabases();
+    } finally {
+      GlobalConfiguration.PAGE_SNAPSHOT_ENABLED.reset();
+    }
+  }
+
+  private static void createSchema(final Database database) {
+    final Schema schema = database.getSchema();
+    final Property property = schema.createDocumentType(TYPE).createProperty("name", Type.STRING);
+    property.createIndex(Schema.INDEX_TYPE.LSM_TREE, true);
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/backup/format/Issue7586ArchiveEntryNameTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/backup/format/Issue7586ArchiveEntryNameTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.backup.format;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #7586, defect B: {@code FullBackupFormat.compressEntry} used to hand a {@code ComponentFile}-derived name
+ * straight to the archive writer, so a directory left in that name by a separator mismatch upstream (a database
+ * path built with a literal '/' while {@code ComponentFile.open()} looked for the platform {@code File.separator})
+ * nested the entry inside the archive instead of at its root - an archive a restore could not open.
+ * <p>
+ * {@code archiveEntryName} is the defense in depth this test pins directly: whatever name reaches it, only the
+ * final path segment is ever archived, independent of which separator convention built the name and independent
+ * of whatever {@code LocalSchema}/{@code ComponentFile.open()} currently produce.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue7586ArchiveEntryNameTest {
+  @ParameterizedTest
+  @CsvSource({
+      "dictionary.0.65536.v1.dict, dictionary.0.65536.v1.dict",
+      "'db/dir\\dictionary.0.65536.v1.dict', dictionary.0.65536.v1.dict",
+      "'db\\dir/dictionary.0.65536.v1.dict', dictionary.0.65536.v1.dict",
+      "configuration.json, configuration.json" })
+  void stripsAnyDirectoryComponentRegardlessOfWhichSeparatorBuiltIt(final String rawName, final String expected) {
+    assertThat(FullBackupFormat.archiveEntryName(rawName)).isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #7586: on Windows, `BACKUP DATABASE` could produce an archive that cannot be restored, and the documented `<backup-file-url>` SQL argument was rejected in every spelling.

**Root cause (shared by both defects):** `LocalSchema` built the dictionary's file path with a hardcoded `/`, while every other database path uses the platform `File.separator`. On Linux the two happen to agree, so the mismatch is invisible; on Windows they diverge. `ComponentFile.open()` stripped a directory prefix by looking for `File.separator` alone, so on Windows it missed the `/` and kept the whole database directory in the dictionary's parsed file name. The snapshot-based full backup then archived that name verbatim, so the dictionary entry alone nested under a `<database-name>/` prefix while every other entry sat at the archive root - the resulting archive could not be restored (`DatabaseOperationException: Error on creating new database instance`).

**Beyond what was reported:** `TimeSeriesShard` and `TimeSeriesTagDictionary` build their component paths the exact same broken way (`getDatabasePath() + "/" + name`) and would hit the identical defect on Windows. Fixed alongside the reported dictionary case.

## Changes

- `LocalSchema`, `TimeSeriesShard`, `TimeSeriesTagDictionary`: build component paths with `File.separator`, not a literal `/`.
- `ComponentFile.open()`: resolves a path's directory by checking both `/` and `\` (`FileUtils.lastIndexOfSeparator`/`getFileNameFromPath`), not only this JVM's own `File.separator`, so a mismatch built on some other platform can no longer slip through.
- `FullBackupFormat.compressEntry`: strips any directory component from an archive entry name as a second line of defense, logging a warning if it ever actually has to - so this class of bug cannot silently reach an archive again regardless of where a future path mismatch comes from.
- `BackupSettings.validateSettings()`: the guard against a path in the SQL `<backup-file-url>` argument (defect A) checked only `File.separator` too, so a value built with the other platform's separator convention slipped past validation and failed several frames later as a confusing `InvalidPathException` instead of the intended `IllegalArgumentException`. It now reuses `FileUtils.checkValidName` - the same bare-name check already used against zip-slip on the restore side - rather than a second bespoke implementation of the same rule.

**Design decision on defect A:** SQL `BACKUP DATABASE` always pins the archive inside the server-configured backup directory (`arcadedb.server.backupDirectory`), by design, as a security boundary (data exfiltration guard, same family as the EXPORT/BACKUP authz hardening). Rather than loosen that boundary to accept an absolute path or `file://` URL as the issue's write-up wondered about, this PR keeps it and makes the existing "bare file name only" restriction fail reliably and clearly. Documented accordingly in `arcadedb-docs` (commit made locally, not pushed, per usual process).

## Test plan

- New unit tests: `FileUtilsTest` (separator lookup), `Issue7586ComponentFileMixedSeparatorTest` (mixed-separator path parsing), `BackupSettingsTest` (defect A validation), `Issue7586ArchiveEntryNameTest` (defense-in-depth stripping).
- New end-to-end test `Issue7586BackupArchiveEntriesSitAtArchiveRootTest`: full backup + restore round trip, asserting every archive entry sits at the archive root.
- Ran full existing backup/restore/timeseries/dictionary/component-file regression suites locally (engine + integration modules) - all green.
- Full reactor `mvn -o compile` - clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cross-platform handling of file and directory paths, including mixed `/` and `\` separators.
  - Fixed component, schema, index, and time-series file naming across operating systems.
  - Backup validation now rejects drive-qualified file paths when a backup directory is specified.
  - Backup archives now keep entries at the archive root for more reliable restoration.
- **Compatibility**
  - Added platform-native path separator support across storage and indexing operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->